### PR TITLE
Add changeset for react-docgen-typescript support

### DIFF
--- a/.changeset/react-docgen-typescript.md
+++ b/.changeset/react-docgen-typescript.md
@@ -1,0 +1,5 @@
+---
+'@storybook/mcp': minor
+---
+
+Add react-docgen-typescript support for component manifest parsing.


### PR DESCRIPTION
Adds the missing changeset for PR #167 (react-docgen-typescript support) so it can be released.