### PR TITLE
chore(ci): probe Windows runner for Copilot setup

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -16,8 +16,9 @@ runs:
             const workspaceRoot = process.env.GITHUB_WORKSPACE || process.cwd();
             const workspaceFilePath = path.join(workspaceRoot, 'pnpm-workspace.yaml');
             const workspaceConfig = fs.readFileSync(workspaceFilePath, 'utf8');
+            const normalizedWorkspaceConfig = workspaceConfig.replace(/\\r\\n/g, '\\n');
 
-            const playwrightVersion = workspaceConfig.match(
+            const playwrightVersion = normalizedWorkspaceConfig.match(
               /(?:^|\\n)catalog:\\n(?: {2}[^\\n]*\\n)*? {2}playwright:\\s*([^#\\s]+)\\s*(?:#.*)?(?:\\n|$)/,
             )?.[1];
 

--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -57,4 +57,9 @@ runs:
     - name: Install Playwright Dependencies
       shell: bash
       if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: pnpm exec playwright install --with-deps --only-shell
+      run: |
+        if [ "$RUNNER_OS" = "Linux" ]; then
+          pnpm exec playwright install --with-deps --only-shell
+        else
+          pnpm exec playwright install --only-shell
+        fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,8 +43,12 @@ jobs:
         run: pnpm turbo run build-storybook
 
   test:
-    name: Test
-    runs-on: ubuntu-latest
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     permissions:
       id-token: write # used to upload artifacts to codecov
     steps:
@@ -63,6 +67,7 @@ jobs:
         run: pnpm turbo run test:ci
 
       - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
           use_oidc: true
@@ -72,7 +77,7 @@ jobs:
 
       - name: Upload test results to Codecov
         uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
-        if: always()
+        if: always() && matrix.os == 'ubuntu-latest'
         with:
           use_oidc: true
           fail_ci_if_error: true

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     # Set the permissions to the lowest permissions possible needed for your steps.
     # Copilot will be given its own token for its operations.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     # Set the permissions to the lowest permissions possible needed for your steps.
     # Copilot will be given its own token for its operations.

--- a/apps/internal-storybook/pnpm-lock.yaml
+++ b/apps/internal-storybook/pnpm-lock.yaml
@@ -7,20 +7,20 @@ settings:
 catalogs:
   default:
     '@storybook/addon-a11y':
-      specifier: 10.3.0-alpha.12
-      version: 10.3.0-alpha.12
+      specifier: 10.3.0-alpha.15
+      version: 10.3.0-alpha.15
     '@storybook/addon-docs':
-      specifier: 10.3.0-alpha.12
-      version: 10.3.0-alpha.12
+      specifier: 10.3.0-alpha.15
+      version: 10.3.0-alpha.15
     '@storybook/addon-themes':
-      specifier: 10.3.0-alpha.12
-      version: 10.3.0-alpha.12
+      specifier: 10.3.0-alpha.15
+      version: 10.3.0-alpha.15
     '@storybook/addon-vitest':
-      specifier: 10.3.0-alpha.12
-      version: 10.3.0-alpha.12
+      specifier: 10.3.0-alpha.15
+      version: 10.3.0-alpha.15
     '@storybook/react-vite':
-      specifier: 10.3.0-alpha.12
-      version: 10.3.0-alpha.12
+      specifier: 10.3.0-alpha.15
+      version: 10.3.0-alpha.15
     '@vitest/browser-playwright':
       specifier: 4.0.6
       version: 4.0.6
@@ -28,8 +28,8 @@ catalogs:
       specifier: 1.56.1
       version: 1.56.1
     storybook:
-      specifier: 10.3.0-alpha.12
-      version: 10.3.0-alpha.12
+      specifier: 10.3.0-alpha.15
+      version: 10.3.0-alpha.15
     vite:
       specifier: 7.2.2
       version: 7.2.2
@@ -43,22 +43,22 @@ importers:
     devDependencies:
       '@storybook/addon-a11y':
         specifier: 'catalog:'
-        version: 10.3.0-alpha.12(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 10.3.0-alpha.15(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-docs':
         specifier: 'catalog:'
-        version: 10.3.0-alpha.12(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+        version: 10.3.0-alpha.15(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
       '@storybook/addon-mcp':
         specifier: workspace:*
         version: link:../../packages/addon-mcp
       '@storybook/addon-themes':
         specifier: 'catalog:'
-        version: 10.3.0-alpha.12(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 10.3.0-alpha.15(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-vitest':
         specifier: 'catalog:'
-        version: 10.3.0-alpha.12(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)
+        version: 10.3.0-alpha.15(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 10.3.0-alpha.12(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)
+        version: 10.3.0-alpha.15(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)
       '@types/react':
         specifier: ^18.2.65
         version: 18.3.28
@@ -82,7 +82,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       storybook:
         specifier: 'catalog:'
-        version: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tinyexec:
         specifier: ^1.0.2
         version: 1.0.2
@@ -684,28 +684,28 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@storybook/addon-a11y@10.3.0-alpha.12':
-    resolution: {integrity: sha512-HZr34G5U3o664D7AcF1+gudn2A+X/+FlaXyiMAJKsMISxA5gzxRFrPNpQzN5znEatQC5qkgfMqxXNkObgFefMQ==}
+  '@storybook/addon-a11y@10.3.0-alpha.15':
+    resolution: {integrity: sha512-mSy8JCRRCuzFyaE5BgntTh6M9QkorDsYgKGF9y03Y2IoTHufeR9di1+dnVZgSFiidaGQFBZZmgGtPz3AXmNcHg==}
     peerDependencies:
-      storybook: ^10.3.0-alpha.12
+      storybook: ^10.3.0-alpha.15
 
-  '@storybook/addon-docs@10.3.0-alpha.12':
-    resolution: {integrity: sha512-sdLO4qRkeVND4sqCOlLjEVcd5bdit6a3JdQZjfuu7QFSFfUNbbaiaomEcworLxewKGe6yZj9NoVPVYB7AysyTg==}
+  '@storybook/addon-docs@10.3.0-alpha.15':
+    resolution: {integrity: sha512-yiR09cdRgYPa7SgSZZCxrnlofsaAm/zHBaVXDaGMmupVYu1knZVS7jrHKR3ycps94gaKyxtm1ma3A8gsOrfdXA==}
     peerDependencies:
-      storybook: ^10.3.0-alpha.12
+      storybook: ^10.3.0-alpha.15
 
-  '@storybook/addon-themes@10.3.0-alpha.12':
-    resolution: {integrity: sha512-MVAK+veXzEGxdn9LGGWsjlPUkd5TB6SeDkNrWCZeprdWi0KBisIFt+7YkU05vy2RJtDlDUTJIPMA2vsHdSqSPA==}
+  '@storybook/addon-themes@10.3.0-alpha.15':
+    resolution: {integrity: sha512-DoxkPVi094FEO/8aX4MiM+wmANjFZ4hCy99Kb/AtfSmeexw0mKQtR9vAIIwIEmQVVJrNK9NEPqm5n1ZTIZLU2w==}
     peerDependencies:
-      storybook: ^10.3.0-alpha.12
+      storybook: ^10.3.0-alpha.15
 
-  '@storybook/addon-vitest@10.3.0-alpha.12':
-    resolution: {integrity: sha512-mzelRSVuB3Ydc4TDWy6Jqp6odr03ihD1AG5TOvLL59s4IE2o/3z96PQYOxPYIR7cJyDXdl1+e82YzfJUcmsX/A==}
+  '@storybook/addon-vitest@10.3.0-alpha.15':
+    resolution: {integrity: sha512-KZZ/QQvcHyQeVcArT2uctRSjh4mM8BqPzJdJRU6wspB5RqXpjnSxkqJraGH29ZDUbZEFmP63pBIYd9ed3/47OA==}
     peerDependencies:
       '@vitest/browser': ^3.0.0 || ^4.0.0
       '@vitest/browser-playwright': ^4.0.0
       '@vitest/runner': ^3.0.0 || ^4.0.0
-      storybook: ^10.3.0-alpha.12
+      storybook: ^10.3.0-alpha.15
       vitest: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       '@vitest/browser':
@@ -717,18 +717,18 @@ packages:
       vitest:
         optional: true
 
-  '@storybook/builder-vite@10.3.0-alpha.12':
-    resolution: {integrity: sha512-obqNR9K/mLgkKvYz6kp65jXUkt/4iEwMlBAlh5eXR9kqn1o/r0gwp+6Ig7ez4NohxdxLlbzNN0mBRZSgIH3qmg==}
+  '@storybook/builder-vite@10.3.0-alpha.15':
+    resolution: {integrity: sha512-+9cFmDtQBXQkr7UBDkOUWQWRrWVGqr/cn20f7BCZ5qT9MDe52WdXSvQlNpGQwOHPe2JF7wlSUuPjpcNgQWa4oQ==}
     peerDependencies:
-      storybook: ^10.3.0-alpha.12
+      storybook: ^10.3.0-alpha.15
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@storybook/csf-plugin@10.3.0-alpha.12':
-    resolution: {integrity: sha512-FBFrNhqw1EdQGSWGYyglofAqCuaw9GRqxUcYl5+AmjRIf1Pj3uHjKUDof5wJCOhl51fFq42QvfBUrFs4piyhDw==}
+  '@storybook/csf-plugin@10.3.0-alpha.15':
+    resolution: {integrity: sha512-COjxThj65/E6ERjn2qXsV4a+xM8whW7oxIVsBk/0QMVV/MsgWhJBM9gfrfjTszK9+N3ru02WAkWF41sMR9czEQ==}
     peerDependencies:
       esbuild: '*'
       rollup: '*'
-      storybook: ^10.3.0-alpha.12
+      storybook: ^10.3.0-alpha.15
       vite: '*'
       webpack: '*'
     peerDependenciesMeta:
@@ -750,27 +750,27 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@storybook/react-dom-shim@10.3.0-alpha.12':
-    resolution: {integrity: sha512-MpPOVbzUf/AhJ1u0RQGbCBNoWga8YWvG54KLFW6CR8YqyPQPEl5mb75ivmJfaz+XAQ0rs8ON1zbQe0ZLqkr4SQ==}
+  '@storybook/react-dom-shim@10.3.0-alpha.15':
+    resolution: {integrity: sha512-mF41mlMnW797LAfrEC4fkiTwc6tHn7GAuM7xQLwyYeyGhlomxu/B4K/DDTsVxvOmEkwaMkkdNqSscVKkT0YCIg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.3.0-alpha.12
+      storybook: ^10.3.0-alpha.15
 
-  '@storybook/react-vite@10.3.0-alpha.12':
-    resolution: {integrity: sha512-4UFhPUm23H4+hLQ5T/LCOD2LFjfaSxX8w1i1/lG2YzwPHfQgYoQBBuGXbnLrRYQnys9H7rtRQZ3elO8gDWUngg==}
+  '@storybook/react-vite@10.3.0-alpha.15':
+    resolution: {integrity: sha512-eZeHF/7mn4eu/P2LQnMCpOxlouQqLLK04YIV4PmSs0fqQyuX/AGq4XfDLXX6A/a2P/ZFkMYjhqv4UTJlKMTL9g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.3.0-alpha.12
+      storybook: ^10.3.0-alpha.15
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@storybook/react@10.3.0-alpha.12':
-    resolution: {integrity: sha512-78fcVLDd69n161/i/MuRb3Cg6obPr9DVmNGw6b045TccOcHuJDiY2e56Kc9bfrV3IXrUplxwTSpA/o9zF6kQBg==}
+  '@storybook/react@10.3.0-alpha.15':
+    resolution: {integrity: sha512-hQpBKKjDTjye8xLLi8v1tn4cHk7fvHnqHqBIGpAiYJ2jbMmDF5tAOTRMUb/tKDoQ4dZ6q+w0t0c9oCw+/8Gg7Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.3.0-alpha.12
+      storybook: ^10.3.0-alpha.15
       typescript: '>= 4.9.x'
     peerDependenciesMeta:
       typescript:
@@ -1302,8 +1302,8 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
-  storybook@10.3.0-alpha.12:
-    resolution: {integrity: sha512-DX/AtoRxT44bpQKmLHywLIS7MVV3IE2Iep60Ylk8ciUFhVKhhYP3E6xF4Vn+3HUK1eTkDuEl1EnYyVKUVgboTw==}
+  storybook@10.3.0-alpha.15:
+    resolution: {integrity: sha512-EzyEpAKnk9E52NVy7LVyK8+iYkx5XB5Y4juZCISSugAo6AKEvlW/XicNg7d+JWbn8N6zVQZhatV3k7lg2nbF9Q==}
     hasBin: true
     peerDependencies:
       prettier: ^2 || ^3
@@ -1888,21 +1888,21 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-a11y@10.3.0-alpha.12(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-a11y@10.3.0-alpha.15(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.1
-      storybook: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@storybook/addon-docs@10.3.0-alpha.12(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
+  '@storybook/addon-docs@10.3.0-alpha.15(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@storybook/csf-plugin': 10.3.0-alpha.12(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+      '@storybook/csf-plugin': 10.3.0-alpha.15(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
       '@storybook/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/react-dom-shim': 10.3.0-alpha.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/react-dom-shim': 10.3.0-alpha.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -1911,16 +1911,16 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-themes@10.3.0-alpha.12(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-themes@10.3.0-alpha.15(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
-      storybook: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-vitest@10.3.0-alpha.12(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)':
+  '@storybook/addon-vitest@10.3.0-alpha.15(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      storybook: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       '@vitest/browser': 4.0.6(vite@7.2.2)(vitest@4.0.6)
       '@vitest/browser-playwright': 4.0.6(playwright@1.56.1)(vite@7.2.2)(vitest@4.0.6)
@@ -1930,10 +1930,10 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.3.0-alpha.12(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
+  '@storybook/builder-vite@10.3.0-alpha.15(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
     dependencies:
-      '@storybook/csf-plugin': 10.3.0-alpha.12(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
-      storybook: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/csf-plugin': 10.3.0-alpha.15(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+      storybook: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
       vite: 7.2.2
     transitivePeerDependencies:
@@ -1941,9 +1941,9 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.0-alpha.12(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
+  '@storybook/csf-plugin@10.3.0-alpha.15(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
     dependencies:
-      storybook: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.3
@@ -1957,25 +1957,25 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/react-dom-shim@10.3.0-alpha.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/react-dom-shim@10.3.0-alpha.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@storybook/react-vite@10.3.0-alpha.12(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)':
+  '@storybook/react-vite@10.3.0-alpha.15(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@7.2.2)
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
-      '@storybook/builder-vite': 10.3.0-alpha.12(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
-      '@storybook/react': 10.3.0-alpha.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+      '@storybook/builder-vite': 10.3.0-alpha.15(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+      '@storybook/react': 10.3.0-alpha.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 18.3.1
       react-docgen: 8.0.2
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.11
-      storybook: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tsconfig-paths: 4.2.0
       vite: 7.2.2
     transitivePeerDependencies:
@@ -1985,15 +1985,15 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.3.0-alpha.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
+  '@storybook/react@10.3.0-alpha.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.3.0-alpha.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/react-dom-shim': 10.3.0-alpha.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-docgen: 8.0.2
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -2577,7 +2577,7 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/apps/internal-storybook/tests/helpers.ts
+++ b/apps/internal-storybook/tests/helpers.ts
@@ -1,6 +1,7 @@
 import { x } from 'tinyexec';
 
 export const STORYBOOK_DIR = new URL('..', import.meta.url).pathname;
+type StorybookProcess = ReturnType<typeof x>;
 
 export function createMCPRequestBody(method: string, params: any = {}, id: number = 1) {
 	return {
@@ -20,32 +21,70 @@ export async function parseMCPResponse(response: Response) {
 
 export async function waitForMcpEndpoint(
 	endpoint: string,
-	options: { maxAttempts?: number; interval?: number; acceptStatuses?: number[] } = {},
+	options: {
+		maxAttempts?: number;
+		interval?: number;
+		acceptStatuses?: number[];
+		debugLabel?: string;
+		storybookProcess?: StorybookProcess | null;
+	} = {},
 ): Promise<void> {
-	const { maxAttempts = 120, interval = 500, acceptStatuses = [] } = options;
+	const {
+		maxAttempts = 120,
+		interval = 500,
+		acceptStatuses = [],
+		debugLabel = 'mcp',
+		storybookProcess,
+	} = options;
 	const { promise, resolve, reject } = Promise.withResolvers<void>();
 	let attempts = 0;
+	let lastStatus: number | null = null;
+	let lastErrorMessage: string | null = null;
 
 	const intervalId = setInterval(async () => {
 		attempts++;
 		try {
+			const storybookPid = storybookProcess?.process?.pid;
+			const storybookExitCode = storybookProcess?.process?.exitCode;
+			if (storybookPid && storybookExitCode !== null) {
+				clearInterval(intervalId);
+				reject(
+					new Error(
+						`[${debugLabel}] Storybook exited before MCP became ready (pid=${storybookPid}, exitCode=${storybookExitCode})`,
+					),
+				);
+				return;
+			}
+
 			const response = await fetch(endpoint, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify(createMCPRequestBody('tools/list')),
 			});
+			lastStatus = response.status;
+			console.log(
+				`[${debugLabel}] MCP probe #${attempts}/${maxAttempts}: status=${response.status}`,
+			);
 			if (response.ok || acceptStatuses.includes(response.status)) {
 				clearInterval(intervalId);
+				console.log(
+					`[${debugLabel}] MCP endpoint ready after ${attempts} probes (status=${response.status})`,
+				);
 				resolve();
 				return;
 			}
-		} catch {
-			// Server not ready yet
+		} catch (error) {
+			lastErrorMessage = error instanceof Error ? error.message : String(error);
+			console.log(`[${debugLabel}] MCP probe #${attempts}/${maxAttempts}: ${lastErrorMessage}`);
 		}
 
 		if (attempts >= maxAttempts) {
 			clearInterval(intervalId);
-			reject(new Error('MCP endpoint failed to start within the timeout period'));
+			reject(
+				new Error(
+					`[${debugLabel}] MCP endpoint failed to start in time (attempts=${attempts}, lastStatus=${lastStatus ?? 'none'}, lastError=${lastErrorMessage ?? 'none'})`,
+				),
+			);
 		}
 	}, interval);
 
@@ -73,6 +112,40 @@ export function startStorybook(configDir: string, port: number): ReturnType<type
 		nodeOptions: {
 			cwd: STORYBOOK_DIR,
 		},
+	});
+}
+
+export function attachStorybookDebugLogging(
+	storybookProcess: StorybookProcess | null,
+	label: string,
+): void {
+	if (!storybookProcess?.process) {
+		console.log(`[${label}] Storybook process missing`);
+		return;
+	}
+	const proc = storybookProcess.process;
+	console.log(`[${label}] Storybook started (pid=${proc.pid ?? 'unknown'})`);
+	proc.stdout?.setEncoding('utf8');
+	proc.stderr?.setEncoding('utf8');
+	proc.stdout?.on('data', (chunk: string) => {
+		for (const line of chunk.split('\n')) {
+			if (line.trim()) {
+				console.log(`[${label}] stdout: ${line}`);
+			}
+		}
+	});
+	proc.stderr?.on('data', (chunk: string) => {
+		for (const line of chunk.split('\n')) {
+			if (line.trim()) {
+				console.log(`[${label}] stderr: ${line}`);
+			}
+		}
+	});
+	proc.on('exit', (code, signal) => {
+		console.log(`[${label}] Storybook exited (code=${code}, signal=${signal ?? 'none'})`);
+	});
+	proc.on('error', (error) => {
+		console.log(`[${label}] Storybook process error: ${error.message}`);
 	});
 }
 

--- a/apps/internal-storybook/tests/helpers.ts
+++ b/apps/internal-storybook/tests/helpers.ts
@@ -80,8 +80,27 @@ export async function stopStorybook(storybookProcess: ReturnType<typeof x> | nul
 	if (!storybookProcess || !storybookProcess.process) {
 		return;
 	}
-	const kill = Promise.withResolvers<void>();
-	storybookProcess.process.on('exit', kill.resolve);
+	const processToStop = storybookProcess.process;
+	if (processToStop.exitCode !== null || !processToStop.pid) {
+		return;
+	}
+
+	const waitForExit = Promise.withResolvers<void>();
+	processToStop.once('exit', () => waitForExit.resolve());
+
 	storybookProcess.kill('SIGTERM');
-	await kill.promise;
+	const timeout = setTimeout(async () => {
+		try {
+			if (process.platform === 'win32') {
+				await x('taskkill', ['/pid', String(processToStop.pid), '/t', '/f']);
+			} else {
+				processToStop.kill('SIGKILL');
+			}
+		} catch {
+			// Process may already be gone.
+		}
+	}, 5_000);
+
+	await waitForExit.promise;
+	clearTimeout(timeout);
 }

--- a/apps/internal-storybook/tests/helpers.ts
+++ b/apps/internal-storybook/tests/helpers.ts
@@ -1,6 +1,7 @@
+import { fileURLToPath } from 'node:url';
 import { x } from 'tinyexec';
 
-export const STORYBOOK_DIR = new URL('..', import.meta.url).pathname;
+export const STORYBOOK_DIR = fileURLToPath(new URL('..', import.meta.url));
 type StorybookProcess = ReturnType<typeof x>;
 
 export function createMCPRequestBody(method: string, params: any = {}, id: number = 1) {

--- a/apps/internal-storybook/tests/helpers.ts
+++ b/apps/internal-storybook/tests/helpers.ts
@@ -26,17 +26,10 @@ export async function waitForMcpEndpoint(
 		maxAttempts?: number;
 		interval?: number;
 		acceptStatuses?: number[];
-		debugLabel?: string;
 		storybookProcess?: StorybookProcess | null;
 	} = {},
 ): Promise<void> {
-	const {
-		maxAttempts = 120,
-		interval = 500,
-		acceptStatuses = [],
-		debugLabel = 'mcp',
-		storybookProcess,
-	} = options;
+	const { maxAttempts = 120, interval = 500, acceptStatuses = [], storybookProcess } = options;
 	const { promise, resolve, reject } = Promise.withResolvers<void>();
 	let attempts = 0;
 	let lastStatus: number | null = null;
@@ -51,7 +44,7 @@ export async function waitForMcpEndpoint(
 				clearInterval(intervalId);
 				reject(
 					new Error(
-						`[${debugLabel}] Storybook exited before MCP became ready (pid=${storybookPid}, exitCode=${storybookExitCode})`,
+						`Storybook exited before MCP became ready (pid=${storybookPid}, exitCode=${storybookExitCode})`,
 					),
 				);
 				return;
@@ -63,27 +56,20 @@ export async function waitForMcpEndpoint(
 				body: JSON.stringify(createMCPRequestBody('tools/list')),
 			});
 			lastStatus = response.status;
-			console.log(
-				`[${debugLabel}] MCP probe #${attempts}/${maxAttempts}: status=${response.status}`,
-			);
 			if (response.ok || acceptStatuses.includes(response.status)) {
 				clearInterval(intervalId);
-				console.log(
-					`[${debugLabel}] MCP endpoint ready after ${attempts} probes (status=${response.status})`,
-				);
 				resolve();
 				return;
 			}
 		} catch (error) {
 			lastErrorMessage = error instanceof Error ? error.message : String(error);
-			console.log(`[${debugLabel}] MCP probe #${attempts}/${maxAttempts}: ${lastErrorMessage}`);
 		}
 
 		if (attempts >= maxAttempts) {
 			clearInterval(intervalId);
 			reject(
 				new Error(
-					`[${debugLabel}] MCP endpoint failed to start in time (attempts=${attempts}, lastStatus=${lastStatus ?? 'none'}, lastError=${lastErrorMessage ?? 'none'})`,
+					`MCP endpoint failed to start in time (attempts=${attempts}, lastStatus=${lastStatus ?? 'none'}, lastError=${lastErrorMessage ?? 'none'})`,
 				),
 			);
 		}
@@ -113,40 +99,6 @@ export function startStorybook(configDir: string, port: number): ReturnType<type
 		nodeOptions: {
 			cwd: STORYBOOK_DIR,
 		},
-	});
-}
-
-export function attachStorybookDebugLogging(
-	storybookProcess: StorybookProcess | null,
-	label: string,
-): void {
-	if (!storybookProcess?.process) {
-		console.log(`[${label}] Storybook process missing`);
-		return;
-	}
-	const proc = storybookProcess.process;
-	console.log(`[${label}] Storybook started (pid=${proc.pid ?? 'unknown'})`);
-	proc.stdout?.setEncoding('utf8');
-	proc.stderr?.setEncoding('utf8');
-	proc.stdout?.on('data', (chunk: string) => {
-		for (const line of chunk.split('\n')) {
-			if (line.trim()) {
-				console.log(`[${label}] stdout: ${line}`);
-			}
-		}
-	});
-	proc.stderr?.on('data', (chunk: string) => {
-		for (const line of chunk.split('\n')) {
-			if (line.trim()) {
-				console.log(`[${label}] stderr: ${line}`);
-			}
-		}
-	});
-	proc.on('exit', (code, signal) => {
-		console.log(`[${label}] Storybook exited (code=${code}, signal=${signal ?? 'none'})`);
-	});
-	proc.on('error', (error) => {
-		console.log(`[${label}] Storybook process error: ${error.message}`);
 	});
 }
 

--- a/apps/internal-storybook/tests/mcp-composition-auth.e2e.test.ts
+++ b/apps/internal-storybook/tests/mcp-composition-auth.e2e.test.ts
@@ -12,7 +12,8 @@ import {
 const PORT = 6008;
 const MCP_ENDPOINT = `http://localhost:${PORT}/mcp`;
 const WELL_KNOWN_ENDPOINT = `http://localhost:${PORT}/.well-known/oauth-protected-resource`;
-const STARTUP_TIMEOUT = 30_000;
+const STARTUP_TIMEOUT = 60_000;
+const SHUTDOWN_TIMEOUT = 30_000;
 
 let storybookProcess: ReturnType<typeof x> | null = null;
 
@@ -41,7 +42,7 @@ describe('MCP Composition Auth E2E Tests', () => {
 	afterAll(async () => {
 		await stopStorybook(storybookProcess);
 		storybookProcess = null;
-	});
+	}, SHUTDOWN_TIMEOUT);
 
 	describe('OAuth Discovery', () => {
 		it('should expose .well-known/oauth-protected-resource for private refs', async () => {

--- a/apps/internal-storybook/tests/mcp-composition-auth.e2e.test.ts
+++ b/apps/internal-storybook/tests/mcp-composition-auth.e2e.test.ts
@@ -7,7 +7,6 @@ import {
 	killPort,
 	startStorybook,
 	stopStorybook,
-	attachStorybookDebugLogging,
 } from './helpers';
 
 const PORT = 6008;
@@ -35,25 +34,18 @@ async function mcpRequest(method: string, params: any = {}, token?: string) {
 
 describe('MCP Composition Auth E2E Tests', () => {
 	beforeAll(async () => {
-		console.log('[mcp-composition-auth] Starting setup');
 		await killPort(PORT);
-		console.log('[mcp-composition-auth] Port cleanup completed');
 		storybookProcess = startStorybook('.storybook-composition-auth', PORT);
-		attachStorybookDebugLogging(storybookProcess, 'mcp-composition-auth');
 		await waitForMcpEndpoint(MCP_ENDPOINT, {
 			maxAttempts: 80,
 			acceptStatuses: [401],
-			debugLabel: 'mcp-composition-auth',
 			storybookProcess,
 		});
-		console.log('[mcp-composition-auth] MCP endpoint is ready');
 	}, STARTUP_TIMEOUT);
 
 	afterAll(async () => {
-		console.log('[mcp-composition-auth] Starting teardown');
 		await stopStorybook(storybookProcess);
 		storybookProcess = null;
-		console.log('[mcp-composition-auth] Teardown completed');
 	}, SHUTDOWN_TIMEOUT);
 
 	describe('OAuth Discovery', () => {

--- a/apps/internal-storybook/tests/mcp-composition-auth.e2e.test.ts
+++ b/apps/internal-storybook/tests/mcp-composition-auth.e2e.test.ts
@@ -7,12 +7,13 @@ import {
 	killPort,
 	startStorybook,
 	stopStorybook,
+	attachStorybookDebugLogging,
 } from './helpers';
 
 const PORT = 6008;
 const MCP_ENDPOINT = `http://localhost:${PORT}/mcp`;
 const WELL_KNOWN_ENDPOINT = `http://localhost:${PORT}/.well-known/oauth-protected-resource`;
-const STARTUP_TIMEOUT = 60_000;
+const STARTUP_TIMEOUT = 45_000;
 const SHUTDOWN_TIMEOUT = 30_000;
 
 let storybookProcess: ReturnType<typeof x> | null = null;
@@ -34,14 +35,25 @@ async function mcpRequest(method: string, params: any = {}, token?: string) {
 
 describe('MCP Composition Auth E2E Tests', () => {
 	beforeAll(async () => {
+		console.log('[mcp-composition-auth] Starting setup');
 		await killPort(PORT);
+		console.log('[mcp-composition-auth] Port cleanup completed');
 		storybookProcess = startStorybook('.storybook-composition-auth', PORT);
-		await waitForMcpEndpoint(MCP_ENDPOINT, { acceptStatuses: [401] });
+		attachStorybookDebugLogging(storybookProcess, 'mcp-composition-auth');
+		await waitForMcpEndpoint(MCP_ENDPOINT, {
+			maxAttempts: 80,
+			acceptStatuses: [401],
+			debugLabel: 'mcp-composition-auth',
+			storybookProcess,
+		});
+		console.log('[mcp-composition-auth] MCP endpoint is ready');
 	}, STARTUP_TIMEOUT);
 
 	afterAll(async () => {
+		console.log('[mcp-composition-auth] Starting teardown');
 		await stopStorybook(storybookProcess);
 		storybookProcess = null;
+		console.log('[mcp-composition-auth] Teardown completed');
 	}, SHUTDOWN_TIMEOUT);
 
 	describe('OAuth Discovery', () => {

--- a/apps/internal-storybook/tests/mcp-composition.e2e.test.ts
+++ b/apps/internal-storybook/tests/mcp-composition.e2e.test.ts
@@ -11,7 +11,8 @@ import {
 
 const PORT = 6007;
 const MCP_ENDPOINT = `http://localhost:${PORT}/mcp`;
-const STARTUP_TIMEOUT = 30_000;
+const STARTUP_TIMEOUT = 60_000;
+const SHUTDOWN_TIMEOUT = 30_000;
 
 let storybookProcess: ReturnType<typeof x> | null = null;
 
@@ -39,7 +40,7 @@ describe('MCP Composition E2E Tests', () => {
 	afterAll(async () => {
 		await stopStorybook(storybookProcess);
 		storybookProcess = null;
-	});
+	}, SHUTDOWN_TIMEOUT);
 
 	describe('Multi-Source Documentation', () => {
 		it('should list documentation from both local and remote sources', async () => {

--- a/apps/internal-storybook/tests/mcp-composition.e2e.test.ts
+++ b/apps/internal-storybook/tests/mcp-composition.e2e.test.ts
@@ -7,11 +7,12 @@ import {
 	killPort,
 	startStorybook,
 	stopStorybook,
+	attachStorybookDebugLogging,
 } from './helpers';
 
 const PORT = 6007;
 const MCP_ENDPOINT = `http://localhost:${PORT}/mcp`;
-const STARTUP_TIMEOUT = 60_000;
+const STARTUP_TIMEOUT = 45_000;
 const SHUTDOWN_TIMEOUT = 30_000;
 
 let storybookProcess: ReturnType<typeof x> | null = null;
@@ -32,14 +33,24 @@ async function mcpRequest(method: string, params: any = {}) {
 
 describe('MCP Composition E2E Tests', () => {
 	beforeAll(async () => {
+		console.log('[mcp-composition] Starting setup');
 		await killPort(PORT);
+		console.log('[mcp-composition] Port cleanup completed');
 		storybookProcess = startStorybook('.storybook-composition', PORT);
-		await waitForMcpEndpoint(MCP_ENDPOINT);
+		attachStorybookDebugLogging(storybookProcess, 'mcp-composition');
+		await waitForMcpEndpoint(MCP_ENDPOINT, {
+			maxAttempts: 80,
+			debugLabel: 'mcp-composition',
+			storybookProcess,
+		});
+		console.log('[mcp-composition] MCP endpoint is ready');
 	}, STARTUP_TIMEOUT);
 
 	afterAll(async () => {
+		console.log('[mcp-composition] Starting teardown');
 		await stopStorybook(storybookProcess);
 		storybookProcess = null;
+		console.log('[mcp-composition] Teardown completed');
 	}, SHUTDOWN_TIMEOUT);
 
 	describe('Multi-Source Documentation', () => {

--- a/apps/internal-storybook/tests/mcp-composition.e2e.test.ts
+++ b/apps/internal-storybook/tests/mcp-composition.e2e.test.ts
@@ -7,7 +7,6 @@ import {
 	killPort,
 	startStorybook,
 	stopStorybook,
-	attachStorybookDebugLogging,
 } from './helpers';
 
 const PORT = 6007;
@@ -33,24 +32,17 @@ async function mcpRequest(method: string, params: any = {}) {
 
 describe('MCP Composition E2E Tests', () => {
 	beforeAll(async () => {
-		console.log('[mcp-composition] Starting setup');
 		await killPort(PORT);
-		console.log('[mcp-composition] Port cleanup completed');
 		storybookProcess = startStorybook('.storybook-composition', PORT);
-		attachStorybookDebugLogging(storybookProcess, 'mcp-composition');
 		await waitForMcpEndpoint(MCP_ENDPOINT, {
 			maxAttempts: 80,
-			debugLabel: 'mcp-composition',
 			storybookProcess,
 		});
-		console.log('[mcp-composition] MCP endpoint is ready');
 	}, STARTUP_TIMEOUT);
 
 	afterAll(async () => {
-		console.log('[mcp-composition] Starting teardown');
 		await stopStorybook(storybookProcess);
 		storybookProcess = null;
-		console.log('[mcp-composition] Teardown completed');
 	}, SHUTDOWN_TIMEOUT);
 
 	describe('Multi-Source Documentation', () => {

--- a/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
+++ b/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
@@ -7,7 +7,6 @@ import {
 	killPort,
 	startStorybook,
 	stopStorybook,
-	attachStorybookDebugLogging,
 } from './helpers';
 
 const PORT = 6006;
@@ -33,25 +32,18 @@ async function mcpRequest(method: string, params: any = {}, id: number = 1) {
 
 describe('MCP Endpoint E2E Tests', () => {
 	beforeAll(async () => {
-		console.log('[mcp-endpoint] Starting setup');
 		await killPort(PORT);
-		console.log('[mcp-endpoint] Port cleanup completed');
 		storybookProcess = startStorybook('.storybook', PORT);
-		attachStorybookDebugLogging(storybookProcess, 'mcp-endpoint');
 
 		await waitForMcpEndpoint(MCP_ENDPOINT, {
 			maxAttempts: 80,
-			debugLabel: 'mcp-endpoint',
 			storybookProcess,
 		});
-		console.log('[mcp-endpoint] MCP endpoint is ready');
 	}, STARTUP_TIMEOUT);
 
 	afterAll(async () => {
-		console.log('[mcp-endpoint] Starting teardown');
 		await stopStorybook(storybookProcess);
 		storybookProcess = null;
-		console.log('[mcp-endpoint] Teardown completed');
 	}, SHUTDOWN_TIMEOUT);
 
 	describe('Session Initialization', () => {

--- a/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
+++ b/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { x } from 'tinyexec';
 import {
-	STORYBOOK_DIR,
 	createMCPRequestBody,
 	parseMCPResponse,
 	waitForMcpEndpoint,
 	killPort,
+	startStorybook,
 	stopStorybook,
 	attachStorybookDebugLogging,
 } from './helpers';
@@ -36,11 +36,7 @@ describe('MCP Endpoint E2E Tests', () => {
 		console.log('[mcp-endpoint] Starting setup');
 		await killPort(PORT);
 		console.log('[mcp-endpoint] Port cleanup completed');
-		storybookProcess = x('pnpm', ['storybook'], {
-			nodeOptions: {
-				cwd: STORYBOOK_DIR,
-			},
-		});
+		storybookProcess = startStorybook('.storybook', PORT);
 		attachStorybookDebugLogging(storybookProcess, 'mcp-endpoint');
 
 		await waitForMcpEndpoint(MCP_ENDPOINT, {

--- a/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
+++ b/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
@@ -7,11 +7,12 @@ import {
 	waitForMcpEndpoint,
 	killPort,
 	stopStorybook,
+	attachStorybookDebugLogging,
 } from './helpers';
 
 const PORT = 6006;
 const MCP_ENDPOINT = `http://localhost:${PORT}/mcp`;
-const STARTUP_TIMEOUT = 60_000;
+const STARTUP_TIMEOUT = 45_000;
 const SHUTDOWN_TIMEOUT = 30_000;
 
 let storybookProcess: ReturnType<typeof x> | null = null;
@@ -32,19 +33,29 @@ async function mcpRequest(method: string, params: any = {}, id: number = 1) {
 
 describe('MCP Endpoint E2E Tests', () => {
 	beforeAll(async () => {
+		console.log('[mcp-endpoint] Starting setup');
 		await killPort(PORT);
+		console.log('[mcp-endpoint] Port cleanup completed');
 		storybookProcess = x('pnpm', ['storybook'], {
 			nodeOptions: {
 				cwd: STORYBOOK_DIR,
 			},
 		});
+		attachStorybookDebugLogging(storybookProcess, 'mcp-endpoint');
 
-		await waitForMcpEndpoint(MCP_ENDPOINT);
+		await waitForMcpEndpoint(MCP_ENDPOINT, {
+			maxAttempts: 80,
+			debugLabel: 'mcp-endpoint',
+			storybookProcess,
+		});
+		console.log('[mcp-endpoint] MCP endpoint is ready');
 	}, STARTUP_TIMEOUT);
 
 	afterAll(async () => {
+		console.log('[mcp-endpoint] Starting teardown');
 		await stopStorybook(storybookProcess);
 		storybookProcess = null;
+		console.log('[mcp-endpoint] Teardown completed');
 	}, SHUTDOWN_TIMEOUT);
 
 	describe('Session Initialization', () => {

--- a/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
+++ b/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
@@ -11,7 +11,8 @@ import {
 
 const PORT = 6006;
 const MCP_ENDPOINT = `http://localhost:${PORT}/mcp`;
-const STARTUP_TIMEOUT = 30_000;
+const STARTUP_TIMEOUT = 60_000;
+const SHUTDOWN_TIMEOUT = 30_000;
 
 let storybookProcess: ReturnType<typeof x> | null = null;
 
@@ -44,7 +45,7 @@ describe('MCP Endpoint E2E Tests', () => {
 	afterAll(async () => {
 		await stopStorybook(storybookProcess);
 		storybookProcess = null;
-	});
+	}, SHUTDOWN_TIMEOUT);
 
 	describe('Session Initialization', () => {
 		it('should successfully initialize an MCP session', async () => {

--- a/apps/internal-storybook/vitest.config.ts
+++ b/apps/internal-storybook/vitest.config.ts
@@ -6,11 +6,14 @@ import { defineConfig } from 'vitest/config';
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 import { playwright } from '@vitest/browser-playwright';
 
+const isWindows = process.platform === 'win32';
+const defaultTimeout = isWindows ? 30_000 : 15_000;
+
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
 	test: {
-		testTimeout: 15_000,
-		hookTimeout: 15_000,
+		testTimeout: defaultTimeout,
+		hookTimeout: defaultTimeout,
 		projects: [
 			// E2E tests project (for MCP endpoint testing)
 			{

--- a/eval/pnpm-lock.yaml
+++ b/eval/pnpm-lock.yaml
@@ -7,17 +7,17 @@ settings:
 catalogs:
   default:
     '@storybook/addon-a11y':
-      specifier: 10.3.0-alpha.12
-      version: 10.3.0-alpha.12
+      specifier: 10.3.0-alpha.15
+      version: 10.3.0-alpha.15
     '@storybook/react-vite':
-      specifier: 10.3.0-alpha.12
-      version: 10.3.0-alpha.12
+      specifier: 10.3.0-alpha.15
+      version: 10.3.0-alpha.15
     playwright:
       specifier: 1.56.1
       version: 1.56.1
     storybook:
-      specifier: 10.3.0-alpha.12
-      version: 10.3.0-alpha.12
+      specifier: 10.3.0-alpha.15
+      version: 10.3.0-alpha.15
     valibot:
       specifier: 1.2.0
       version: 1.2.0
@@ -49,13 +49,13 @@ importers:
         version: 1.1.11(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/addon-a11y':
         specifier: 'catalog:'
-        version: 10.3.0-alpha.12(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 10.3.0-alpha.15(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/mcp':
         specifier: workspace:*
         version: link:../packages/mcp
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 10.3.0-alpha.12(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))
+        version: 10.3.0-alpha.15(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))
       '@tsconfig/node-ts':
         specifier: ^23.6.1
         version: 23.6.3
@@ -127,10 +127,10 @@ importers:
         version: 5.83.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook:
         specifier: 'catalog:'
-        version: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook-addon-test-codegen:
         specifier: ^3.0.0
-        version: 3.0.1(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 3.0.1(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       tinyexec:
         specifier: ^1.0.1
         version: 1.0.2
@@ -1509,23 +1509,23 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@storybook/addon-a11y@10.3.0-alpha.12':
-    resolution: {integrity: sha512-HZr34G5U3o664D7AcF1+gudn2A+X/+FlaXyiMAJKsMISxA5gzxRFrPNpQzN5znEatQC5qkgfMqxXNkObgFefMQ==}
+  '@storybook/addon-a11y@10.3.0-alpha.15':
+    resolution: {integrity: sha512-mSy8JCRRCuzFyaE5BgntTh6M9QkorDsYgKGF9y03Y2IoTHufeR9di1+dnVZgSFiidaGQFBZZmgGtPz3AXmNcHg==}
     peerDependencies:
-      storybook: ^10.3.0-alpha.12
+      storybook: ^10.3.0-alpha.15
 
-  '@storybook/builder-vite@10.3.0-alpha.12':
-    resolution: {integrity: sha512-obqNR9K/mLgkKvYz6kp65jXUkt/4iEwMlBAlh5eXR9kqn1o/r0gwp+6Ig7ez4NohxdxLlbzNN0mBRZSgIH3qmg==}
+  '@storybook/builder-vite@10.3.0-alpha.15':
+    resolution: {integrity: sha512-+9cFmDtQBXQkr7UBDkOUWQWRrWVGqr/cn20f7BCZ5qT9MDe52WdXSvQlNpGQwOHPe2JF7wlSUuPjpcNgQWa4oQ==}
     peerDependencies:
-      storybook: ^10.3.0-alpha.12
+      storybook: ^10.3.0-alpha.15
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@storybook/csf-plugin@10.3.0-alpha.12':
-    resolution: {integrity: sha512-FBFrNhqw1EdQGSWGYyglofAqCuaw9GRqxUcYl5+AmjRIf1Pj3uHjKUDof5wJCOhl51fFq42QvfBUrFs4piyhDw==}
+  '@storybook/csf-plugin@10.3.0-alpha.15':
+    resolution: {integrity: sha512-COjxThj65/E6ERjn2qXsV4a+xM8whW7oxIVsBk/0QMVV/MsgWhJBM9gfrfjTszK9+N3ru02WAkWF41sMR9czEQ==}
     peerDependencies:
       esbuild: '*'
       rollup: '*'
-      storybook: ^10.3.0-alpha.12
+      storybook: ^10.3.0-alpha.15
       vite: '*'
       webpack: '*'
     peerDependenciesMeta:
@@ -1547,27 +1547,27 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@storybook/react-dom-shim@10.3.0-alpha.12':
-    resolution: {integrity: sha512-MpPOVbzUf/AhJ1u0RQGbCBNoWga8YWvG54KLFW6CR8YqyPQPEl5mb75ivmJfaz+XAQ0rs8ON1zbQe0ZLqkr4SQ==}
+  '@storybook/react-dom-shim@10.3.0-alpha.15':
+    resolution: {integrity: sha512-mF41mlMnW797LAfrEC4fkiTwc6tHn7GAuM7xQLwyYeyGhlomxu/B4K/DDTsVxvOmEkwaMkkdNqSscVKkT0YCIg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.3.0-alpha.12
+      storybook: ^10.3.0-alpha.15
 
-  '@storybook/react-vite@10.3.0-alpha.12':
-    resolution: {integrity: sha512-4UFhPUm23H4+hLQ5T/LCOD2LFjfaSxX8w1i1/lG2YzwPHfQgYoQBBuGXbnLrRYQnys9H7rtRQZ3elO8gDWUngg==}
+  '@storybook/react-vite@10.3.0-alpha.15':
+    resolution: {integrity: sha512-eZeHF/7mn4eu/P2LQnMCpOxlouQqLLK04YIV4PmSs0fqQyuX/AGq4XfDLXX6A/a2P/ZFkMYjhqv4UTJlKMTL9g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.3.0-alpha.12
+      storybook: ^10.3.0-alpha.15
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@storybook/react@10.3.0-alpha.12':
-    resolution: {integrity: sha512-78fcVLDd69n161/i/MuRb3Cg6obPr9DVmNGw6b045TccOcHuJDiY2e56Kc9bfrV3IXrUplxwTSpA/o9zF6kQBg==}
+  '@storybook/react@10.3.0-alpha.15':
+    resolution: {integrity: sha512-hQpBKKjDTjye8xLLi8v1tn4cHk7fvHnqHqBIGpAiYJ2jbMmDF5tAOTRMUb/tKDoQ4dZ6q+w0t0c9oCw+/8Gg7Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.3.0-alpha.12
+      storybook: ^10.3.0-alpha.15
       typescript: '>= 4.9.x'
     peerDependenciesMeta:
       typescript:
@@ -2873,8 +2873,8 @@ packages:
     peerDependencies:
       storybook: ^0.0.0-0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0
 
-  storybook@10.3.0-alpha.12:
-    resolution: {integrity: sha512-DX/AtoRxT44bpQKmLHywLIS7MVV3IE2Iep60Ylk8ciUFhVKhhYP3E6xF4Vn+3HUK1eTkDuEl1EnYyVKUVgboTw==}
+  storybook@10.3.0-alpha.15:
+    resolution: {integrity: sha512-EzyEpAKnk9E52NVy7LVyK8+iYkx5XB5Y4juZCISSugAo6AKEvlW/XicNg7d+JWbn8N6zVQZhatV3k7lg2nbF9Q==}
     hasBin: true
     peerDependencies:
       prettier: ^2 || ^3
@@ -4309,16 +4309,16 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/addon-a11y@10.3.0-alpha.12(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/addon-a11y@10.3.0-alpha.15(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.1
-      storybook: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/builder-vite@10.3.0-alpha.12(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
+  '@storybook/builder-vite@10.3.0-alpha.15(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.0-alpha.12(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
-      storybook: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@storybook/csf-plugin': 10.3.0-alpha.15(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
+      storybook: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
       vite: 7.3.1(@types/node@24.10.12)
     transitivePeerDependencies:
@@ -4326,9 +4326,9 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.0-alpha.12(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
+  '@storybook/csf-plugin@10.3.0-alpha.15(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
     dependencies:
-      storybook: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.3
@@ -4342,25 +4342,25 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/react-dom-shim@10.3.0-alpha.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/react-dom-shim@10.3.0-alpha.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/react-vite@10.3.0-alpha.12(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))':
+  '@storybook/react-vite@10.3.0-alpha.15(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
-      '@storybook/builder-vite': 10.3.0-alpha.12(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
-      '@storybook/react': 10.3.0-alpha.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+      '@storybook/builder-vite': 10.3.0-alpha.15(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
+      '@storybook/react': 10.3.0-alpha.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 19.2.4
       react-docgen: 8.0.2
       react-dom: 19.2.4(react@19.2.4)
       resolve: 1.22.11
-      storybook: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tsconfig-paths: 4.2.0
       vite: 7.3.1(@types/node@24.10.12)
     transitivePeerDependencies:
@@ -4370,15 +4370,15 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.3.0-alpha.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
+  '@storybook/react@10.3.0-alpha.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.3.0-alpha.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@storybook/react-dom-shim': 10.3.0-alpha.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react: 19.2.4
       react-docgen: 8.0.2
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5720,11 +5720,11 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  storybook-addon-test-codegen@3.0.1(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+  storybook-addon-test-codegen@3.0.1(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
-      storybook: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
 		"vite-tsconfig-paths": "^5.1.4",
 		"vitest": "4.0.6"
 	},
-	"packageManager": "pnpm@10.29.2+sha512.bef43fa759d91fd2da4b319a5a0d13ef7a45bb985a3d7342058470f9d2051a3ba8674e629672654686ef9443ad13a82da2beb9eeb3e0221c87b8154fff9d74b8"
+	"packageManager": "pnpm@10.32.0+sha512.9b2634bb3fed5601c33633f2d92593f506270a3963b8c51d2b2d6a828da615ce4e9deebef9614ccebbc13ac8d3c0f9c9ccceb583c69c8578436fa477dbb20d70"
 }

--- a/packages/addon-mcp/pnpm-lock.yaml
+++ b/packages/addon-mcp/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     '@storybook/addon-a11y':
-      specifier: 10.3.0-alpha.12
-      version: 10.3.0-alpha.12
+      specifier: 10.3.0-alpha.15
+      version: 10.3.0-alpha.15
     '@storybook/addon-vitest':
-      specifier: 10.3.0-alpha.12
-      version: 10.3.0-alpha.12
+      specifier: 10.3.0-alpha.15
+      version: 10.3.0-alpha.15
     '@tmcp/adapter-valibot':
       specifier: ^0.1.4
       version: 0.1.5
@@ -19,8 +19,8 @@ catalogs:
       specifier: ^0.8.0
       version: 0.8.4
     storybook:
-      specifier: 10.3.0-alpha.12
-      version: 10.3.0-alpha.12
+      specifier: 10.3.0-alpha.15
+      version: 10.3.0-alpha.15
     tmcp:
       specifier: ^1.16.0
       version: 1.19.2
@@ -53,13 +53,13 @@ importers:
     devDependencies:
       '@storybook/addon-a11y':
         specifier: 'catalog:'
-        version: 10.3.0-alpha.12(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 10.3.0-alpha.15(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/addon-vitest':
         specifier: 'catalog:'
-        version: 10.3.0-alpha.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 10.3.0-alpha.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       storybook:
         specifier: 'catalog:'
-        version: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
 packages:
 
@@ -237,18 +237,18 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@storybook/addon-a11y@10.3.0-alpha.12':
-    resolution: {integrity: sha512-HZr34G5U3o664D7AcF1+gudn2A+X/+FlaXyiMAJKsMISxA5gzxRFrPNpQzN5znEatQC5qkgfMqxXNkObgFefMQ==}
+  '@storybook/addon-a11y@10.3.0-alpha.15':
+    resolution: {integrity: sha512-mSy8JCRRCuzFyaE5BgntTh6M9QkorDsYgKGF9y03Y2IoTHufeR9di1+dnVZgSFiidaGQFBZZmgGtPz3AXmNcHg==}
     peerDependencies:
-      storybook: ^10.3.0-alpha.12
+      storybook: ^10.3.0-alpha.15
 
-  '@storybook/addon-vitest@10.3.0-alpha.12':
-    resolution: {integrity: sha512-mzelRSVuB3Ydc4TDWy6Jqp6odr03ihD1AG5TOvLL59s4IE2o/3z96PQYOxPYIR7cJyDXdl1+e82YzfJUcmsX/A==}
+  '@storybook/addon-vitest@10.3.0-alpha.15':
+    resolution: {integrity: sha512-KZZ/QQvcHyQeVcArT2uctRSjh4mM8BqPzJdJRU6wspB5RqXpjnSxkqJraGH29ZDUbZEFmP63pBIYd9ed3/47OA==}
     peerDependencies:
       '@vitest/browser': ^3.0.0 || ^4.0.0
       '@vitest/browser-playwright': ^4.0.0
       '@vitest/runner': ^3.0.0 || ^4.0.0
-      storybook: ^10.3.0-alpha.12
+      storybook: ^10.3.0-alpha.15
       vitest: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       '@vitest/browser':
@@ -502,8 +502,8 @@ packages:
   sqids@0.3.0:
     resolution: {integrity: sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==}
 
-  storybook@10.3.0-alpha.12:
-    resolution: {integrity: sha512-DX/AtoRxT44bpQKmLHywLIS7MVV3IE2Iep60Ylk8ciUFhVKhhYP3E6xF4Vn+3HUK1eTkDuEl1EnYyVKUVgboTw==}
+  storybook@10.3.0-alpha.15:
+    resolution: {integrity: sha512-EzyEpAKnk9E52NVy7LVyK8+iYkx5XB5Y4juZCISSugAo6AKEvlW/XicNg7d+JWbn8N6zVQZhatV3k7lg2nbF9Q==}
     hasBin: true
     peerDependencies:
       prettier: ^2 || ^3
@@ -658,17 +658,17 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-a11y@10.3.0-alpha.12(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/addon-a11y@10.3.0-alpha.15(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.1
-      storybook: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/addon-vitest@10.3.0-alpha.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/addon-vitest@10.3.0-alpha.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      storybook: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -913,7 +913,7 @@ snapshots:
 
   sqids@0.3.0: {}
 
-  storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  storybook@10.3.0-alpha.15(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,16 +6,16 @@ packages:
   - '!eval/tasks/*/trials/*/project'
 
 catalog:
-  '@storybook/addon-a11y': 10.3.0-alpha.12
-  '@storybook/addon-docs': 10.3.0-alpha.12
-  '@storybook/addon-vitest': 10.3.0-alpha.12
-  '@storybook/react-vite': 10.3.0-alpha.12
-  '@storybook/addon-themes': 10.3.0-alpha.12
+  '@storybook/addon-a11y': 10.3.0-alpha.15
+  '@storybook/addon-docs': 10.3.0-alpha.15
+  '@storybook/addon-vitest': 10.3.0-alpha.15
+  '@storybook/react-vite': 10.3.0-alpha.15
+  '@storybook/addon-themes': 10.3.0-alpha.15
   '@tmcp/adapter-valibot': ^0.1.4
   '@tmcp/transport-http': ^0.8.0
   '@tmcp/transport-stdio': ^0.4.1
-  eslint-plugin-storybook: 10.3.0-alpha.12
-  storybook: 10.3.0-alpha.12
+  eslint-plugin-storybook: 10.3.0-alpha.15
+  storybook: 10.3.0-alpha.15
   tmcp: ^1.16.0
   tsdown: ^0.15.12
   typescript: ^5.9.3
@@ -28,10 +28,10 @@ catalog:
 catalogs:
   trials:
     '@eslint/js': 9.39.1
-    '@storybook/addon-a11y': 10.3.0-alpha.12
-    '@storybook/addon-docs': 10.3.0-alpha.12
-    '@storybook/addon-vitest': 10.3.0-alpha.12
-    '@storybook/react-vite': 10.3.0-alpha.12
+    '@storybook/addon-a11y': 10.3.0-alpha.15
+    '@storybook/addon-docs': 10.3.0-alpha.15
+    '@storybook/addon-vitest': 10.3.0-alpha.15
+    '@storybook/react-vite': 10.3.0-alpha.15
     '@types/node': 24.10.1
     '@types/react': 19.2.6
     '@types/react-dom': 19.2.3
@@ -40,11 +40,11 @@ catalogs:
     eslint: 9.39.1
     eslint-plugin-react-hooks: 7.0.1
     eslint-plugin-react-refresh: 0.4.24
-    eslint-plugin-storybook: 10.3.0-alpha.12
+    eslint-plugin-storybook: 10.3.0-alpha.15
     globals: 16.5.0
     react: 19.2.0
     react-dom: 19.2.0
-    storybook: 10.3.0-alpha.12
+    storybook: 10.3.0-alpha.15
     typescript: 5.9.3
     typescript-eslint: 8.47.0
     vite: 7.2.2


### PR DESCRIPTION
This PR temporarily switches the Copilot setup workflow to **windows-latest** so cloud Copilot runs can validate Windows-compatible CI commands.\n\nFollow-up expected in this same PR:\n- update  to run  on ubuntu + windows via matrix\n- keep non-test jobs ubuntu-only\n- if needed, guard Playwright install flags by OS\n- restore  back to ubuntu-latest before merge\n