### PR TITLE
feat: add screenshot-story MCP tool

### DIFF
--- a/packages/addon-mcp/package.json
+++ b/packages/addon-mcp/package.json
@@ -47,14 +47,19 @@
 	"devDependencies": {
 		"@storybook/addon-a11y": "catalog:",
 		"@storybook/addon-vitest": "catalog:",
+		"playwright": "^1.50.0",
 		"storybook": "catalog:"
 	},
 	"peerDependencies": {
 		"@storybook/addon-vitest": "^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0",
+		"playwright": "^1.50.0",
 		"storybook": "^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0"
 	},
 	"peerDependenciesMeta": {
 		"@storybook/addon-vitest": {
+			"optional": true
+		},
+		"playwright": {
 			"optional": true
 		}
 	},

--- a/packages/addon-mcp/pnpm-lock.yaml
+++ b/packages/addon-mcp/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@storybook/addon-vitest':
         specifier: 'catalog:'
         version: 10.3.0-alpha.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      playwright:
+        specifier: ^1.50.0
+        version: 1.58.2
       storybook:
         specifier: 'catalog:'
         version: 10.3.0-alpha.12(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -410,6 +413,11 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
@@ -458,6 +466,16 @@ packages:
 
   picoquery@2.5.0:
     resolution: {integrity: sha512-j1kgOFxtaCyoFCkpoYG2Oj3OdGakadO7HZ7o5CqyRazlmBekKhbDoUnNnXASE07xSY4nDImWZkrZv7toSxMi/g==}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -840,6 +858,9 @@ snapshots:
 
   esprima@4.0.1: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   indent-string@4.0.0: {}
 
   is-docker@3.0.0: {}
@@ -874,6 +895,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picoquery@2.5.0: {}
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pretty-format@27.5.1:
     dependencies:

--- a/packages/addon-mcp/src/mcp-handler.ts
+++ b/packages/addon-mcp/src/mcp-handler.ts
@@ -18,6 +18,7 @@ import type { AddonContext, AddonOptionsOutput } from './types.ts';
 import { logger } from 'storybook/internal/node-logger';
 import { getManifestStatus } from './tools/is-manifest-available.ts';
 import { addRunStoryTestsTool } from './tools/run-story-tests.ts';
+import { addScreenshotStoryTool } from './tools/screenshot-story.ts';
 import { estimateTokens } from './utils/estimate-tokens.ts';
 import { isAddonA11yEnabled } from './utils/is-addon-a11y-enabled.ts';
 import type { CompositionAuth } from './auth/index.ts';
@@ -57,6 +58,7 @@ const initializeMCPServer = async (options: Options, multiSource?: boolean) => {
 	// Register dev addon tools
 	await addPreviewStoriesTool(server);
 	await addGetUIBuildingInstructionsTool(server);
+	await addScreenshotStoryTool(server);
 
 	// Register test addon tools
 	a11yEnabled = await isAddonA11yEnabled(options);

--- a/packages/addon-mcp/src/tools/screenshot-story.test.ts
+++ b/packages/addon-mcp/src/tools/screenshot-story.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { McpServer } from 'tmcp';
+import { ValibotJsonSchemaAdapter } from '@tmcp/adapter-valibot';
+import { addScreenshotStoryTool } from './screenshot-story.ts';
+import type { AddonContext } from '../types.ts';
+import smallStoryIndexFixture from '../../fixtures/small-story-index.fixture.json' with { type: 'json' };
+import * as fetchStoryIndex from '../utils/fetch-story-index.ts';
+import { SCREENSHOT_STORY_TOOL_NAME } from './tool-names.ts';
+
+vi.mock('storybook/internal/csf', () => ({
+	storyNameFromExport: (exportName: string) => exportName,
+}));
+
+vi.mock('../utils/browser-manager.ts', () => ({
+	isPlaywrightAvailable: vi.fn().mockResolvedValue(true),
+	takeScreenshot: vi.fn().mockResolvedValue(Buffer.from('fake-png-data')),
+}));
+
+const mockScreenshotBuffer = Buffer.from('fake-png-data');
+
+describe('screenshotStoryTool', () => {
+	let server: McpServer<any, AddonContext>;
+	let fetchStoryIndexSpy: any;
+	let takeScreenshotSpy: any;
+	const testContext: AddonContext = {
+		origin: 'http://localhost:6006',
+		options: {} as any,
+		disableTelemetry: true,
+	};
+
+	beforeEach(async () => {
+		const { takeScreenshot } = await import('../utils/browser-manager.ts');
+		takeScreenshotSpy = takeScreenshot;
+
+		const adapter = new ValibotJsonSchemaAdapter();
+		server = new McpServer(
+			{
+				name: 'test-server',
+				version: '1.0.0',
+				description: 'Test server for screenshot-story tool',
+			},
+			{
+				adapter,
+				capabilities: {
+					tools: { listChanged: true },
+				},
+			},
+		).withContext<AddonContext>();
+
+		await server.receive(
+			{
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'initialize',
+				params: {
+					protocolVersion: '2025-06-18',
+					capabilities: {},
+					clientInfo: { name: 'test', version: '1.0.0' },
+				},
+			},
+			{
+				sessionId: 'test-session',
+			},
+		);
+
+		await addScreenshotStoryTool(server);
+
+		fetchStoryIndexSpy = vi.spyOn(fetchStoryIndex, 'fetchStoryIndex');
+		fetchStoryIndexSpy.mockResolvedValue(smallStoryIndexFixture);
+	});
+
+	it('should return a screenshot for a valid storyId', async () => {
+		const request = {
+			jsonrpc: '2.0' as const,
+			id: 1,
+			method: 'tools/call',
+			params: {
+				name: SCREENSHOT_STORY_TOOL_NAME,
+				arguments: {
+					story: { storyId: 'button--primary' },
+				},
+			},
+		};
+
+		const response = await server.receive(request, {
+			sessionId: 'test-session',
+			custom: testContext,
+		});
+
+		expect(response.result?.content).toEqual([
+			{
+				type: 'image',
+				data: mockScreenshotBuffer.toString('base64'),
+				mimeType: 'image/png',
+			},
+			{
+				type: 'text',
+				text: 'Screenshot of story "Button / Primary" (button--primary)',
+			},
+		]);
+
+		expect(takeScreenshotSpy).toHaveBeenCalledWith({
+			url: 'http://localhost:6006/iframe.html?id=button--primary&viewMode=story',
+			viewport: undefined,
+			omitBackground: undefined,
+			fullPage: undefined,
+		});
+	});
+
+	it('should return a screenshot for a valid path-based input', async () => {
+		const request = {
+			jsonrpc: '2.0' as const,
+			id: 1,
+			method: 'tools/call',
+			params: {
+				name: SCREENSHOT_STORY_TOOL_NAME,
+				arguments: {
+					story: {
+						exportName: 'Primary',
+						absoluteStoryPath: `${process.cwd()}/src/Button.stories.tsx`,
+					},
+				},
+			},
+		};
+
+		const response = await server.receive(request, {
+			sessionId: 'test-session',
+			custom: testContext,
+		});
+
+		expect(response.result?.content[0]).toEqual({
+			type: 'image',
+			data: mockScreenshotBuffer.toString('base64'),
+			mimeType: 'image/png',
+		});
+		expect(response.result?.content[1]).toEqual({
+			type: 'text',
+			text: 'Screenshot of story "Button / Primary" (button--primary)',
+		});
+	});
+
+	it('should pass custom props as args in the iframe URL', async () => {
+		const request = {
+			jsonrpc: '2.0' as const,
+			id: 1,
+			method: 'tools/call',
+			params: {
+				name: SCREENSHOT_STORY_TOOL_NAME,
+				arguments: {
+					story: {
+						storyId: 'button--primary',
+						props: { label: 'Custom Label', disabled: true },
+					},
+				},
+			},
+		};
+
+		await server.receive(request, {
+			sessionId: 'test-session',
+			custom: testContext,
+		});
+
+		expect(takeScreenshotSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: 'http://localhost:6006/iframe.html?id=button--primary&viewMode=story&args=label:Custom+Label;disabled:!true',
+			}),
+		);
+	});
+
+	it('should pass globals in the iframe URL', async () => {
+		const request = {
+			jsonrpc: '2.0' as const,
+			id: 1,
+			method: 'tools/call',
+			params: {
+				name: SCREENSHOT_STORY_TOOL_NAME,
+				arguments: {
+					story: {
+						storyId: 'button--primary',
+						globals: { theme: 'dark' },
+					},
+				},
+			},
+		};
+
+		await server.receive(request, {
+			sessionId: 'test-session',
+			custom: testContext,
+		});
+
+		expect(takeScreenshotSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: 'http://localhost:6006/iframe.html?id=button--primary&viewMode=story&globals=theme:dark',
+			}),
+		);
+	});
+
+	it('should pass custom viewport to takeScreenshot', async () => {
+		const request = {
+			jsonrpc: '2.0' as const,
+			id: 1,
+			method: 'tools/call',
+			params: {
+				name: SCREENSHOT_STORY_TOOL_NAME,
+				arguments: {
+					story: { storyId: 'button--primary' },
+					viewport: { width: 800, height: 600 },
+				},
+			},
+		};
+
+		await server.receive(request, {
+			sessionId: 'test-session',
+			custom: testContext,
+		});
+
+		expect(takeScreenshotSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				viewport: { width: 800, height: 600 },
+			}),
+		);
+	});
+
+	it('should return error for story not found', async () => {
+		const request = {
+			jsonrpc: '2.0' as const,
+			id: 1,
+			method: 'tools/call',
+			params: {
+				name: SCREENSHOT_STORY_TOOL_NAME,
+				arguments: {
+					story: { storyId: 'nonexistent--story' },
+				},
+			},
+		};
+
+		const response = await server.receive(request, {
+			sessionId: 'test-session',
+			custom: testContext,
+		});
+
+		expect(response.result).toEqual({
+			content: [
+				{
+					type: 'text',
+					text: 'No story found for story ID "nonexistent--story"',
+				},
+			],
+			isError: true,
+		});
+	});
+
+	it('should return error when origin is missing', async () => {
+		const request = {
+			jsonrpc: '2.0' as const,
+			id: 1,
+			method: 'tools/call',
+			params: {
+				name: SCREENSHOT_STORY_TOOL_NAME,
+				arguments: {
+					story: { storyId: 'button--primary' },
+				},
+			},
+		};
+
+		const response = await server.receive(request, {
+			sessionId: 'test-session',
+			custom: {
+				options: {} as any,
+				disableTelemetry: true,
+			} as any,
+		});
+
+		expect(response.result).toEqual({
+			content: [
+				{
+					type: 'text',
+					text: 'Error: Origin is required in addon context',
+				},
+			],
+			isError: true,
+		});
+	});
+
+	it('should collect telemetry when enabled', async () => {
+		const { telemetry } = await import('storybook/internal/telemetry');
+
+		const request = {
+			jsonrpc: '2.0' as const,
+			id: 1,
+			method: 'tools/call',
+			params: {
+				name: SCREENSHOT_STORY_TOOL_NAME,
+				arguments: {
+					story: { storyId: 'button--primary' },
+				},
+			},
+		};
+
+		await server.receive(request, {
+			sessionId: 'test-session',
+			custom: {
+				origin: 'http://localhost:6006',
+				options: {} as any,
+				disableTelemetry: false,
+			},
+		});
+
+		expect(telemetry).toHaveBeenCalledWith(
+			'addon-mcp',
+			expect.objectContaining({
+				event: 'tool:screenshotStory',
+				mcpSessionId: 'test-session',
+				toolset: 'dev',
+			}),
+		);
+	});
+});

--- a/packages/addon-mcp/src/tools/screenshot-story.ts
+++ b/packages/addon-mcp/src/tools/screenshot-story.ts
@@ -1,0 +1,143 @@
+import type { McpServer } from 'tmcp';
+import * as v from 'valibot';
+import { collectTelemetry } from '../telemetry.ts';
+import { buildArgsParam } from '../utils/build-args-param.ts';
+import { fetchStoryIndex } from '../utils/fetch-story-index.ts';
+import { findStoryIds } from '../utils/find-story-ids.ts';
+import { errorToMCPContent } from '../utils/errors.ts';
+import { isPlaywrightAvailable, takeScreenshot } from '../utils/browser-manager.ts';
+import type { AddonContext } from '../types.ts';
+import { StoryInput } from '../types.ts';
+import { SCREENSHOT_STORY_TOOL_NAME } from './tool-names.ts';
+
+const ScreenshotStoryInput = v.object({
+	story: v.pipe(
+		StoryInput,
+		v.description(
+			`Story to screenshot.
+Prefer { storyId } when you don't already have story file context, since this avoids filesystem discovery.
+Use { storyId } when IDs were discovered from documentation tools.
+Use { absoluteStoryPath + exportName } only when you're already working in a specific .stories.* file and already have that context.`,
+		),
+	),
+	viewport: v.optional(
+		v.pipe(
+			v.object({
+				width: v.pipe(v.number(), v.integer(), v.minValue(1)),
+				height: v.pipe(v.number(), v.integer(), v.minValue(1)),
+			}),
+			v.description('Viewport size for the screenshot. Defaults to 1280x720.'),
+		),
+	),
+	omitBackground: v.optional(
+		v.pipe(
+			v.boolean(),
+			v.description(
+				'Whether to hide the default white background and capture with transparency. Defaults to false.',
+			),
+		),
+	),
+	fullPage: v.optional(
+		v.pipe(
+			v.boolean(),
+			v.description(
+				'Whether to capture the full scrollable page instead of the viewport. Defaults to false.',
+			),
+		),
+	),
+});
+
+export async function addScreenshotStoryTool(server: McpServer<any, AddonContext>) {
+	const playwrightAvailable = await isPlaywrightAvailable();
+
+	server.tool(
+		{
+			name: SCREENSHOT_STORY_TOOL_NAME,
+			title: 'Screenshot a story',
+			description: `Use this tool to capture a PNG screenshot of a rendered Storybook story.
+Returns an image of the component as it appears in the browser, useful for visual verification.
+Requires Playwright to be installed.`,
+			schema: ScreenshotStoryInput,
+			enabled: () => {
+				if (!playwrightAvailable) {
+					return false;
+				}
+				return server.ctx.custom?.toolsets?.dev ?? true;
+			},
+		},
+		async (input) => {
+			try {
+				const { origin, disableTelemetry } = server.ctx.custom ?? {};
+
+				if (!origin) {
+					throw new Error('Origin is required in addon context');
+				}
+
+				const index = await fetchStoryIndex(origin);
+				const resolvedStories = findStoryIds(index, [input.story]);
+				const resolved = resolvedStories[0]!;
+
+				if ('errorMessage' in resolved) {
+					return {
+						content: [{ type: 'text', text: resolved.errorMessage }],
+						isError: true,
+					};
+				}
+
+				const indexEntry = index.entries[resolved.id];
+				if (!indexEntry) {
+					return {
+						content: [
+							{ type: 'text', text: `No story found for story ID "${resolved.id}"` },
+						],
+						isError: true,
+					};
+				}
+
+				// Build iframe URL for isolated story rendering
+				let iframeUrl = `${origin}/iframe.html?id=${resolved.id}&viewMode=story`;
+
+				const argsParam = buildArgsParam(input.story.props ?? {});
+				if (argsParam) {
+					iframeUrl += `&args=${argsParam}`;
+				}
+
+				const globalsParam = buildArgsParam(input.story.globals ?? {});
+				if (globalsParam) {
+					iframeUrl += `&globals=${globalsParam}`;
+				}
+
+				const screenshot = await takeScreenshot({
+					url: iframeUrl,
+					viewport: input.viewport,
+					omitBackground: input.omitBackground,
+					fullPage: input.fullPage,
+				});
+
+				if (!disableTelemetry) {
+					await collectTelemetry({
+						event: 'tool:screenshotStory',
+						server,
+						toolset: 'dev',
+					});
+				}
+
+				return {
+					content: [
+						{
+							type: 'image',
+							data: screenshot.toString('base64'),
+							mimeType: 'image/png',
+						},
+						{
+							type: 'text',
+							text: `Screenshot of story "${indexEntry.title} / ${indexEntry.name}" (${resolved.id})`,
+						},
+					],
+				};
+			} catch (error) {
+				return errorToMCPContent(error);
+			}
+		},
+	);
+}

--- a/packages/addon-mcp/src/tools/tool-names.ts
+++ b/packages/addon-mcp/src/tools/tool-names.ts
@@ -5,3 +5,4 @@
 export const PREVIEW_STORIES_TOOL_NAME = 'preview-stories';
 export const GET_UI_BUILDING_INSTRUCTIONS_TOOL_NAME = 'get-storybook-story-instructions';
 export const RUN_STORY_TESTS_TOOL_NAME = 'run-story-tests';
+export const SCREENSHOT_STORY_TOOL_NAME = 'screenshot-story';

--- a/packages/addon-mcp/src/utils/browser-manager.test.ts
+++ b/packages/addon-mcp/src/utils/browser-manager.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockScreenshot = Buffer.from('mock-screenshot');
+const mockPage = {
+	goto: vi.fn().mockResolvedValue(undefined),
+	waitForSelector: vi.fn().mockResolvedValue(undefined),
+	screenshot: vi.fn().mockResolvedValue(mockScreenshot),
+	close: vi.fn().mockResolvedValue(undefined),
+};
+const mockBrowser = {
+	newPage: vi.fn().mockResolvedValue(mockPage),
+	close: vi.fn().mockResolvedValue(undefined),
+	isConnected: vi.fn().mockReturnValue(true),
+};
+
+vi.mock('playwright', () => ({
+	chromium: {
+		launch: vi.fn().mockResolvedValue(mockBrowser),
+	},
+}));
+
+describe('browser-manager', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should take a screenshot with default options', async () => {
+		// Re-import to get fresh module state
+		const { takeScreenshot } = await import('./browser-manager.ts');
+
+		const result = await takeScreenshot({
+			url: 'http://localhost:6006/iframe.html?id=button--primary&viewMode=story',
+		});
+
+		expect(mockBrowser.newPage).toHaveBeenCalledWith({
+			viewport: { width: 1280, height: 720 },
+		});
+		expect(mockPage.goto).toHaveBeenCalledWith(
+			'http://localhost:6006/iframe.html?id=button--primary&viewMode=story',
+			{ waitUntil: 'load' },
+		);
+		expect(mockPage.waitForSelector).toHaveBeenCalledWith('#storybook-root > *', {
+			timeout: 10_000,
+		});
+		expect(mockPage.screenshot).toHaveBeenCalledWith({
+			omitBackground: false,
+			fullPage: false,
+			type: 'png',
+		});
+		expect(mockPage.close).toHaveBeenCalled();
+		expect(result).toEqual(Buffer.from(mockScreenshot));
+	});
+
+	it('should use custom viewport', async () => {
+		const { takeScreenshot } = await import('./browser-manager.ts');
+
+		await takeScreenshot({
+			url: 'http://localhost:6006/iframe.html?id=button--primary&viewMode=story',
+			viewport: { width: 800, height: 600 },
+		});
+
+		expect(mockBrowser.newPage).toHaveBeenCalledWith({
+			viewport: { width: 800, height: 600 },
+		});
+	});
+
+	it('should pass omitBackground and fullPage options', async () => {
+		const { takeScreenshot } = await import('./browser-manager.ts');
+
+		await takeScreenshot({
+			url: 'http://localhost:6006/iframe.html?id=button--primary&viewMode=story',
+			omitBackground: true,
+			fullPage: true,
+		});
+
+		expect(mockPage.screenshot).toHaveBeenCalledWith({
+			omitBackground: true,
+			fullPage: true,
+			type: 'png',
+		});
+	});
+
+	it('should close the page even when navigation fails', async () => {
+		const { takeScreenshot } = await import('./browser-manager.ts');
+
+		mockPage.goto.mockRejectedValueOnce(new Error('Navigation timeout'));
+
+		await expect(
+			takeScreenshot({
+				url: 'http://localhost:6006/iframe.html?id=button--primary&viewMode=story',
+			}),
+		).rejects.toThrow('Navigation timeout');
+
+		expect(mockPage.close).toHaveBeenCalled();
+	});
+
+	it('should check if Playwright is available', async () => {
+		const { isPlaywrightAvailable } = await import('./browser-manager.ts');
+
+		const result = await isPlaywrightAvailable();
+		expect(result).toBe(true);
+	});
+
+	it('should close browser on cleanup', async () => {
+		const { closeBrowser, takeScreenshot } = await import('./browser-manager.ts');
+
+		// Ensure browser is launched
+		await takeScreenshot({
+			url: 'http://localhost:6006/iframe.html?id=button--primary&viewMode=story',
+		});
+
+		await closeBrowser();
+		expect(mockBrowser.close).toHaveBeenCalled();
+	});
+});

--- a/packages/addon-mcp/src/utils/browser-manager.ts
+++ b/packages/addon-mcp/src/utils/browser-manager.ts
@@ -1,0 +1,85 @@
+import type { Browser, Page } from 'playwright';
+
+let browser: Browser | undefined;
+let launchPromise: Promise<Browser> | undefined;
+
+export interface ScreenshotOptions {
+	url: string;
+	viewport?: { width: number; height: number };
+	omitBackground?: boolean;
+	fullPage?: boolean;
+}
+
+async function getBrowser(): Promise<Browser> {
+	if (browser?.isConnected()) {
+		return browser;
+	}
+
+	// Concurrent-launch protection: reuse the same launch promise
+	if (launchPromise) {
+		return launchPromise;
+	}
+
+	launchPromise = (async () => {
+		const { chromium } = await import('playwright');
+		browser = await chromium.launch();
+		return browser;
+	})();
+
+	try {
+		return await launchPromise;
+	} finally {
+		launchPromise = undefined;
+	}
+}
+
+export async function takeScreenshot({
+	url,
+	viewport = { width: 1280, height: 720 },
+	omitBackground = false,
+	fullPage = false,
+}: ScreenshotOptions): Promise<Buffer> {
+	const browserInstance = await getBrowser();
+	let page: Page | undefined;
+
+	try {
+		page = await browserInstance.newPage({ viewport });
+		await page.goto(url, { waitUntil: 'load' });
+
+		// Wait for story content to render
+		await page.waitForSelector('#storybook-root > *', { timeout: 10_000 });
+
+		const screenshot = await page.screenshot({
+			omitBackground,
+			fullPage,
+			type: 'png',
+		});
+
+		return Buffer.from(screenshot);
+	} finally {
+		await page?.close();
+	}
+}
+
+export async function closeBrowser(): Promise<void> {
+	if (browser) {
+		await browser.close();
+		browser = undefined;
+	}
+}
+
+/**
+ * Check if Playwright is available by attempting a dynamic import.
+ */
+export async function isPlaywrightAvailable(): Promise<boolean> {
+	try {
+		await import('playwright');
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+process.on('exit', () => {
+	browser?.close().catch(() => {});
+});


### PR DESCRIPTION
## Summary
- Adds a `screenshot-story` MCP tool that renders a Storybook story in a headless browser (Playwright) and returns a PNG screenshot as MCP image content
- Creates a `browser-manager` utility with lazy singleton browser, concurrent-launch protection, and cleanup guards
- Playwright is an optional peer dependency — the tool is automatically hidden when Playwright is not installed

## Test plan
- [x] `pnpm build` — project builds cleanly
- [x] `pnpm vitest --project=@storybook/addon-mcp --run` — all 192 tests pass (14 new tests added)
- [x] `pnpm typecheck` — no type errors
- [ ] Manual: start Storybook, use MCP Inspector to call `screenshot-story` with a story ID and verify a PNG image is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)