### PR TITLE
Update Reshaped manifests to be generated via RDT

### DIFF
--- a/eval/tasks/000-flight-booking-simple-reshaped/manifests/components.json
+++ b/eval/tasks/000-flight-booking-simple-reshaped/manifests/components.json
@@ -7,46 +7,201 @@
 			"path": "./src/components/ActionBar/tests/ActionBar.stories.tsx",
 			"stories": [
 				{
-					"name": "positionRelative",
+					"id": "components-actionbar--position-relative",
+					"name": "position, positionType: relative",
 					"snippet": "const positionRelative = () => (\n    <Example>\n        <Example.Item title=\"position: top\">\n            <ActionBar position=\"top\">\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <ActionBar position=\"bottom\">\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positionAbsolute",
+					"id": "components-actionbar--position-absolute",
+					"name": "position, positionType: absolute",
 					"snippet": "const positionAbsolute = () => (\n    <Example>\n        <Example.Item title=\"position: top-start\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top-start\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: top\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: top-end\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top-end\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom-start\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom-start\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom-end\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positionFixed",
+					"id": "components-actionbar--position-fixed",
+					"name": "position, positionType: fixed",
 					"snippet": "const positionFixed = () => (\n    <>\n        <ActionBar padding={2} position=\"top-start\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"top\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"top-end\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom-start\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom-end\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <div style={{ height: 2000 }} />\n    </>\n);"
 				},
 				{
+					"id": "components-actionbar--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated, position: top\">\n            <ActionBar position=\"top\" elevated>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"elevated, position: bottom\">\n            <ActionBar elevated>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"auto elevated, position: bottom\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-actionbar--offset",
 					"name": "offset",
 					"snippet": "const offset = () => (\n    <Example>\n        <Example.Item title=\"offset 2, position: top\">\n            <Fixtures.Container>\n                <ActionBar position=\"top\" positionType=\"absolute\" offset={2}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"offset 2, position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\" offset={2}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"offset s: 2, m: 4, position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\" offset={{ s: 2, m: 4 }}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-actionbar--active",
 					"name": "active",
 					"snippet": "const active = () => {\n    const barToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => barToggle.toggle()}>Toggle</Button>\n            <ActionBar active={barToggle.active} positionType=\"fixed\" position=\"top-end\">\n                <Fixtures.Actions />\n            </ActionBar>\n        </>\n    );\n};"
 				},
 				{
-					"name": "padding",
+					"id": "components-actionbar--padding",
+					"name": "padding, paddingBlock, paddingInline",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 6\">\n            <ActionBar padding={6}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"paddingBlock: 2, paddingInline: 4\">\n            <ActionBar paddingBlock={2} paddingInline={4}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"padding: [s] 4, [m+] 6\">\n            <ActionBar padding={{ s: 4, m: 6 }}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-actionbar--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ActionBar className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </ActionBar>\n    </div>\n);"
 				}
 			],
 			"import": "import { ActionBar, Button, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ActionBar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ActionBar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ActionBar/ActionBar.tsx",
-				"actualName": "ActionBar",
+				"methods": [],
+				"props": {
+					"paddingBlock": {
+						"defaultValue": null,
+						"description": "Padding block, base unit token number multiplier",
+						"name": "paddingBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingInline": {
+						"defaultValue": null,
+						"description": "Padding inline, base unit token number multiplier",
+						"name": "paddingInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Padding style for all sides, base unit token number multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Show or hide the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"offset": {
+						"defaultValue": null,
+						"description": "Offset from the container bounds",
+						"name": "offset",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"position": {
+						"defaultValue": { "value": "\"bottom\"" },
+						"description": "Position based on the container bounds",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"top-end\" | \"top-start\" | \"bottom\" | \"bottom-start\" | \"bottom-end\"",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" }
+							]
+						}
+					},
+					"positionType": {
+						"defaultValue": null,
+						"description": "CSS position style",
+						"name": "positionType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"relative\" | \"absolute\" | \"fixed\">" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Display above the content with elevated shadow and background",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -56,30 +211,138 @@
 			"path": "./src/components/Alert/tests/Alert.stories.tsx",
 			"stories": [
 				{
+					"id": "components-alert--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        {([\"neutral\", \"primary\", \"critical\", \"positive\", \"warning\"] as const).map((color) => (\n            <Example.Item title={`color: ${color}`} key={color}>\n                <Alert\n                    color={color}\n                    title=\"Alert title goes here\"\n                    icon={IconZap}\n                    actionsSlot={\n                        <>\n                            <Link\n                                variant=\"plain\"\n                                color={color === \"neutral\" ? \"primary\" : color}\n                                onClick={() => {}}\n                            >\n                                View now\n                            </Link>\n                            <Link\n                                variant=\"plain\"\n                                color={color === \"neutral\" ? \"primary\" : color}\n                                onClick={() => {}}\n                            >\n                                Dismiss\n                            </Link>\n                        </>\n                    }\n                >\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard\n                </Alert>\n            </Example.Item>\n        ))}\n    </Example>\n);"
 				},
 				{
+					"id": "components-alert--inline",
 					"name": "inline",
 					"snippet": "const inline = () => (\n    <Example>\n        <Example.Item title=\"inline: true\">\n            <Alert\n                inline\n                title=\"Alert title goes here\"\n                icon={IconZap}\n                actionsSlot={\n                    <>\n                        <Link variant=\"plain\" onClick={() => {}}>\n                            View now\n                        </Link>\n                        <Link variant=\"plain\" onClick={() => {}}>\n                            Dismiss\n                        </Link>\n                    </>\n                }\n            >\n                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has\n                been the industry's standard\n            </Alert>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-alert--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4\">\n            <Alert bleed={4} icon={IconZap}>\n                Content\n            </Alert>\n        </Example.Item>\n        <Example.Item title=\"bleed: [s] 4, [m+] 0\">\n            <Alert bleed={{ s: 4, m: 0 }} icon={IconZap}>\n                Content\n            </Alert>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-alert--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Alert className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </Alert>\n    </div>\n);"
 				}
 			],
 			"import": "import { Alert, Example, Link, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Alert/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Alert",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Alert/Alert.tsx",
-				"actualName": "Alert",
+				"methods": [],
+				"props": {
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"title": {
+						"defaultValue": null,
+						"description": "Title slot",
+						"name": "title",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Slot for rendering the main content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"actionsSlot": {
+						"defaultValue": null,
+						"description": "Actions slot, usually used for Buttons and Links, automatically adds a gap between the actions",
+						"name": "actionsSlot",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Color scheme of the alert elements",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"inline": {
+						"defaultValue": null,
+						"description": "Display action to the right of the content",
+						"name": "inline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margin and remove side borders, base unit token number multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -89,35 +352,573 @@
 			"path": "./src/components/Autocomplete/tests/Autocomplete.stories.tsx",
 			"stories": [
 				{
-					"name": "active",
+					"id": "components-autocomplete--active",
+					"name": "active, onOpen, onClose",
 					"snippet": "const active = (args) => {\n    const toggle = useToggle(true);\n\n    return (\n        <Example>\n            <Example.Item title=\"active, onOpen, onClose\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete\n                        name=\"fruit\"\n                        placeholder=\"Pick your food\"\n                        active={toggle.active}\n                        onOpen={() => {\n                            args.handleOpen();\n                            toggle.activate();\n                        }}\n                        onClose={() => {\n                            args.handleClose();\n                            toggle.deactivate();\n                        }}\n                        onChange={(args) => console.log(args)}\n                    >\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "base",
+					"id": "components-autocomplete--base",
+					"name": "onInput, onItemSelect, onBackspace",
 					"snippet": "const base = () => {\n    const [value, setValue] = React.useState(\"\");\n\n    return (\n        <Example>\n            <Example.Item title=\"Base\">\n                <FormControl>\n                    <FormControl.Label>Food</FormControl.Label>\n                    <Autocomplete\n                        name=\"fruit\"\n                        placeholder=\"Pick your food\"\n                        value={value}\n                        onChange={(args) => setValue(args.value)}\n                        onBackspace={fn()}\n                        onItemSelect={fn()}>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "itemData",
+					"id": "components-autocomplete--item-data",
+					"name": "item data",
 					"snippet": "const itemData = () => {\n    return (\n        <Example>\n            <Example.Item title=\"item data\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete name=\"fruit\" placeholder=\"Pick your food\" onItemSelect={fn()} active>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v} data={i === 1 ? { foo: true } : undefined}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "itemDisabled",
+					"id": "components-autocomplete--item-disabled",
+					"name": "item disabled",
 					"snippet": "const itemDisabled = () => {\n    return (\n        <Example>\n            <Example.Item title=\"item disabled\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete name=\"fruit\" placeholder=\"Pick your food\" active>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v} disabled={i === 1}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "multiselect",
+					"id": "components-autocomplete--multiselect",
+					"name": "test: multiselect",
 					"snippet": "const multiselect = () => {\n    const options = [\n        \"Pizza\",\n        \"Pie\",\n        \"Ice-cream\",\n        \"Fries\",\n        \"Salad\",\n        \"Option 4\",\n        \"Option 5\",\n        \"Option 6\",\n    ];\n\n    const inputRef = React.useRef<HTMLInputElement>(null);\n    const [values, setValues] = React.useState<string[]>([\n        \"Option 4\",\n        \"Option 5\",\n        \"Option 6\",\n        \"Pizza\",\n        \"Ice-cream\",\n    ]);\n    const [query, setQuery] = React.useState(\"\");\n\n    const handleDismiss = (dismissedValue: string) => {\n        const nextValues = values.filter((value) => value !== dismissedValue);\n        setValues(nextValues);\n        inputRef.current?.focus();\n    };\n\n    const valuesNode = values.map((value) => (\n        <Badge dismissAriaLabel=\"Dismiss value\" onDismiss={() => handleDismiss(value)} key={value}>\n            {value}\n        </Badge>\n    ));\n\n    return (\n        <FormControl>\n            <FormControl.Label>Food</FormControl.Label>\n            <Autocomplete\n                name=\"fruit\"\n                value={query}\n                placeholder=\"Pick your food\"\n                startSlot={valuesNode}\n                multiline\n                inputAttributes={{ ref: inputRef }}\n                onChange={(args) => setQuery(args.value)}\n                onBackspace={() => {\n                    if (query.length === 0) {\n                        setValues((prev) => prev.slice(0, -1));\n                    }\n                }}\n                onItemSelect={(args) => {\n                    setQuery(\"\");\n                    setValues((prev) => [...prev, args.value]);\n                }}\n            >\n                {options.map((v) => {\n                    if (!v.toLowerCase().includes(query.toLowerCase())) return;\n                    if (values.includes(v)) return;\n\n                    return (\n                        <Autocomplete.Item key={v} value={v}>\n                            {v}\n                        </Autocomplete.Item>\n                    );\n                })}\n            </Autocomplete>\n        </FormControl>\n    );\n};"
 				}
 			],
 			"import": "import { Autocomplete, Badge, Example, FormControl } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Autocomplete/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Autocomplete",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Autocomplete/Autocomplete.tsx",
-				"actualName": "Autocomplete",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"multiline": {
+						"defaultValue": null,
+						"description": "Enable multiline text field wrapping",
+						"name": "multiline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to be fully rounded",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content after the text field value",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text field value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the text field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the text field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"onInput": {
+						"defaultValue": null,
+						"description": "Callback for when value changes from user input",
+						"name": "onInput",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onItemSelect": {
+						"defaultValue": null,
+						"description": "Callback for when an item is selected in the dropdown",
+						"name": "onItemSelect",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: SelectArgs) => void)" }
+					},
+					"onBackspace": {
+						"defaultValue": null,
+						"description": "Callback for when the backspace key is pressed while the input is focused",
+						"name": "onBackspace",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onEnter": {
+						"defaultValue": null,
+						"description": "Callback for when the enter key is pressed while the input is focused",
+						"name": "onEnter",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Slot for rendering the Autocomplete.Item components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					}
+				},
+				"exportName": "Autocomplete"
 			}
 		},
 		"components-avatar": {
@@ -126,46 +927,230 @@
 			"path": "./src/components/Avatar/tests/Avatar.stories.tsx",
 			"stories": [
 				{
-					"name": "src",
+					"id": "components-avatar--src",
+					"name": "src, alt",
 					"snippet": "const src = () => (\n    <Example>\n        <Example.Item title=\"src, alt\">\n            <Avatar\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n                alt=\"Amsterdam canal\"\n                size={12}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"src\">\n            <Avatar src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "initials",
+					"id": "components-avatar--initials",
+					"name": "initials, icon",
 					"snippet": "const initials = () => (\n    <Example>\n        <Example.Item title=\"initials\">\n            <Avatar initials=\"RS\" />\n        </Example.Item>\n\n        <Example.Item title=\"icon\">\n            <Avatar icon={IconZap} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-avatar--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: 6\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={6} icon={IconZap} />\n                <Avatar size={6} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: 15\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={15} icon={IconZap} />\n                <Avatar size={15} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: 40\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={40} icon={IconZap} />\n                <Avatar size={40} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] 10\", \"[m+] 20\"]}>\n            <View direction=\"row\" gap={3}>\n                <Avatar size={{ s: 10, m: 20 }} icon={IconZap} />\n                <Avatar size={{ s: 10, m: 20 }} icon={IconZap} squared />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-avatar--squared",
 					"name": "squared",
 					"snippet": "const squared = () => (\n    <Example>\n        <Example.Item title=\"squared, with image\">\n            <Avatar\n                squared\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n            />\n        </Example.Item>\n        <Example.Item title=\"squared, with initials\">\n            <Avatar squared initials=\"RS\" />\n        </Example.Item>\n        <Example.Item title=\"squared, with initials\">\n            <Avatar squared icon={IconZap} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "colors",
+					"id": "components-avatar--colors",
+					"name": "color, variant",
 					"snippet": "const colors = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"neutral\" icon={IconZap} />\n                <Avatar color=\"neutral\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"primary\" icon={IconZap} />\n                <Avatar color=\"primary\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"positive\" icon={IconZap} />\n                <Avatar color=\"positive\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"warning\" icon={IconZap} />\n                <Avatar color=\"warning\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"critical\" icon={IconZap} />\n                <Avatar color=\"critical\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "fallback",
+					"id": "components-avatar--fallback",
+					"name": "test: fallback",
 					"snippet": "const fallback = (args) => {\n    const [error, setError] = useState(false);\n\n    return (\n        <Avatar\n            src={error ? undefined : \"/foo\"}\n            icon={IconZap}\n            imageAttributes={{\n                onError: () => {\n                    setError(true);\n                    args.handleError();\n                },\n            }}\n        />\n    );\n};"
 				},
 				{
+					"id": "components-avatar--render-image",
 					"name": "renderImage",
 					"snippet": "const renderImage = () => (\n    <Example>\n        <Example.Item title=\"renderImage\">\n            <Avatar\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n                alt=\"Amsterdam canal\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image\" />}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-avatar--class-name",
+					"name": "className, attributes, imageAttributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Avatar\n            src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            imageAttributes={{ id: \"test-image-id\", alt: \"test image\" }}\n        />\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Avatar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Avatar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Avatar/Avatar.tsx",
-				"actualName": "Avatar",
+				"methods": [],
+				"props": {
+					"src": {
+						"defaultValue": null,
+						"description": "Image URL",
+						"name": "src",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"alt": {
+						"defaultValue": null,
+						"description": "Image alt text",
+						"name": "alt",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"imageAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the image element",
+						"name": "imageAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"img\">" }
+					},
+					"renderImage": {
+						"defaultValue": null,
+						"description": "Render prop for the image element, useful for integrating with the Image component from third party frameworks",
+						"name": "renderImage",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Omit<Attributes<\"img\">, \"src\" | \"alt\"> & { src: string; alt: string; }) => ReactNode)"
+						}
+					},
+					"initials": {
+						"defaultValue": null,
+						"description": "Initials to display if no image is provided",
+						"name": "initials",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon, used when no image is provided",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"squared": {
+						"defaultValue": null,
+						"description": "Change the shape to rounded square",
+						"name": "squared",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"faded\"",
+							"value": [{ "value": "\"solid\"" }, { "value": "\"faded\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "12" },
+						"description": "Size of the component, base unit token number multiplier",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -175,63 +1160,273 @@
 			"path": "./src/components/Badge/tests/Badge.stories.tsx",
 			"stories": [
 				{
+					"id": "components-badge--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Badge>Badge</Badge>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <Badge variant=\"faded\">Badge</Badge>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <Badge variant=\"outline\">Badge</Badge>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"primary\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"primary\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"primary\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: positive, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"positive\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"positive\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"positive\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: critical, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"critical\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"critical\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"critical\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: warning, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"warning\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"warning\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"warning\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"small\">Badge</Badge>\n                <Badge rounded size=\"small\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge>Badge</Badge>\n                <Badge rounded>Badge</Badge>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"large\">Badge</Badge>\n                <Badge rounded size=\"large\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={3} direction=\"row\">\n                <Badge icon={IconCheckmark} endIcon={IconChevronRight} size=\"small\">\n                    Badge\n                </Badge>\n                <Badge icon={IconCheckmark} size=\"small\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={3} direction=\"row\">\n                <Badge icon={IconCheckmark} endIcon={IconChevronRight}>\n                    Badge\n                </Badge>\n                <Badge icon={IconCheckmark} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"large\" icon={IconCheckmark} endIcon={IconChevronRight}>\n                    Badge\n                </Badge>\n\n                <Badge icon={IconCheckmark} size=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onDismiss",
+					"id": "components-badge--on-dismiss",
+					"name": "onDismiss, dismissAriaLabel",
 					"snippet": "const onDismiss = () => <Example>\n    <Example.Item title=\"onDismiss\">\n        <Badge onDismiss={fn()} dismissAriaLabel=\"Dismiss\">Badge\n                            </Badge>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-badge--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded>Badge</Badge>\n                <Badge rounded variant=\"faded\">\n                    Badge\n                </Badge>\n                <Badge rounded variant=\"outline\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"rounded, all sizes, color: critical\", \"one character, renders as circle\"]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Badge rounded color=\"critical\" size=\"small\">\n                    2\n                </Badge>\n                <Badge rounded color=\"critical\">\n                    2\n                </Badge>\n                <Badge rounded color=\"critical\" size=\"large\">\n                    2\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--empty",
 					"name": "empty",
 					"snippet": "const empty = () => (\n    <Example>\n        <Example.Item title=\"empty, not rounded, all sizes, color: critical\">\n            <View direction=\"row\" gap={3}>\n                <Badge size=\"small\" color=\"critical\" />\n                <Badge color=\"critical\" />\n                <Badge size=\"large\" color=\"critical\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"empty, rounded, all sizes, color: critical\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded size=\"small\" color=\"critical\" />\n                <Badge rounded color=\"critical\" />\n                <Badge rounded size=\"large\" color=\"critical\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"empty, rounded, all sizes, color: neutral\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded size=\"small\" color=\"neutral\" />\n                <Badge rounded />\n                <Badge rounded size=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--highlighted",
 					"name": "highlighted",
 					"snippet": "const highlighted = () => (\n    <Example>\n        <Example.Item title=\"highlighted, color: neutral\">\n            <View gap={3} direction=\"row\">\n                <Badge highlighted>Badge</Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--container",
 					"name": "container",
 					"snippet": "const container = () => {\n    const [hidden, setHidden] = React.useState(false);\n\n    return (\n        <Example title={<Button onClick={() => setHidden(!hidden)}>Toggle badges</Button>}>\n            <Example.Item title=\"position: top-end\">\n                <Badge.Container>\n                    <Badge color=\"primary\" hidden={hidden}>\n                        5\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: bottom-end\">\n                <Badge.Container position=\"bottom-end\">\n                    <Badge color=\"primary\" hidden={hidden}>\n                        5\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: top-end, rounded, multiple digits\">\n                <Badge.Container>\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        123\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: top-end, rounded, empty\">\n                <Badge.Container>\n                    <Badge color=\"primary\" rounded hidden={hidden} />\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: top-end, overlap\", \"should cover the circular avatar\"]}>\n                <Badge.Container overlap>\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        2\n                    </Badge>\n                    <Avatar initials=\"A\" />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: bottom-end, overlap\", \"should cover the circular avatar\"]}>\n                <Badge.Container overlap position=\"bottom-end\">\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        2\n                    </Badge>\n                    <Avatar initials=\"A\" />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: top-end, overlap\", \"should cover the icon\"]}>\n                <Badge.Container overlap position=\"top-end\">\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden} />\n                    <Icon svg={IconCheckmark} size={5} />\n                </Badge.Container>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-badge--href",
 					"name": "href",
 					"snippet": "const href = () => (\n    <Badge href=\"https://reshaped.so\" dismissAriaLabel=\"Dismiss\">\n        Badge\n    </Badge>\n);"
 				},
 				{
+					"id": "components-badge--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Badge onClick={fn()}>Badge</Badge>;"
 				},
 				{
-					"name": "className",
+					"id": "components-badge--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Badge color=\"primary\" className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Badge, Button, Example, Icon, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Badge/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Badge",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Badge/Badge.tsx",
-				"actualName": "Badge",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"large\" | \"medium\"",
+							"value": [
+								{ "value": "\"small\"" },
+								{ "value": "\"large\"" },
+								{ "value": "\"medium\"" }
+							]
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "highlighted",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hidden": {
+						"defaultValue": null,
+						"description": "Transition the component to hidden state",
+						"name": "hidden",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting text or other content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"onDismiss": {
+						"defaultValue": null,
+						"description": "Callback triggered when the dismiss button is pressed",
+						"name": "onDismiss",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"dismissAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the dismiss button",
+						"name": "dismissAriaLabel",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "Badge"
 			}
 		},
 		"components-breadcrumbs": {
@@ -240,51 +1435,185 @@
 			"path": "./src/components/Breadcrumbs/tests/Breadcrumbs.stories.tsx",
 			"stories": [
 				{
+					"id": "components-breadcrumbs--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <Breadcrumbs ariaLabel=\"breadcrumb neutral\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"color: primary\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb primary\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "item",
+					"id": "components-breadcrumbs--item",
+					"name": "item, disabled",
 					"snippet": "const item = () => (\n    <Example>\n        <Example.Item title=\"disabled item\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb disabled\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}} disabled>\n                    Disabled item 2\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "icon",
+					"id": "components-breadcrumbs--icon",
+					"name": "item, icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"item with icon\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb with icon\">\n                <Breadcrumbs.Item icon={IconZap} onClick={() => {}}>\n                    Item 1\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "slots",
+					"id": "components-breadcrumbs--slots",
+					"name": "separator, children",
 					"snippet": "const slots = () => (\n    <Example>\n        <Example.Item title=\"slot: separator\">\n            <Breadcrumbs color=\"primary\" separator=\"/\" ariaLabel=\"breadcrumb with separator\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"custom child content\">\n            <Breadcrumbs ariaLabel=\"breadcrumb with custom children\">\n                <Breadcrumbs.Item onClick={() => {}}>\n                    <Badge>Item 1</Badge>\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>\n                    <Badge>Item 2</Badge>\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-breadcrumbs--collapsed",
 					"name": "collapsed",
 					"snippet": "const collapsed = () => (\n    <Example>\n        <Example.Item title=\"collapsed, 3 items shown by default\">\n            <Breadcrumbs\n                defaultVisibleItems={3}\n                ariaLabel=\"breadcrumbs one\"\n                expandAriaLabel=\"Expand items\"\n            >\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"collapsed, 4 items shown by default\">\n            <Breadcrumbs\n                defaultVisibleItems={4}\n                ariaLabel=\"breadcrumb two\"\n                expandAriaLabel=\"Expand items\"\n            >\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"collapsed, 3 items shown by default, not expandable\">\n            <Breadcrumbs defaultVisibleItems={3} ariaLabel=\"breadcrumb three\" disableExpand>\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "multiline",
+					"id": "components-breadcrumbs--multiline",
+					"name": "composition, multiline",
 					"snippet": "const multiline = () => (\n    <Example>\n        <Example.Item title=\"wraps content when multiline\">\n            <Breadcrumbs ariaLabel=\"breadcrumb multiline\">\n                {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((i) => (\n                    <Breadcrumbs.Item onClick={() => {}} key={i}>\n                        Item {i}\n                    </Breadcrumbs.Item>\n                ))}\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onClick",
+					"id": "components-breadcrumbs--on-click",
+					"name": "item, onClick, disabled",
 					"snippet": "const onClick = () => <Breadcrumbs>\n    <Breadcrumbs.Item onClick={fn()}>Trigger</Breadcrumbs.Item>\n    <Breadcrumbs.Item onClick={fn()} disabled>Trigger\n                    </Breadcrumbs.Item>\n</Breadcrumbs>;"
 				},
 				{
-					"name": "href",
+					"id": "components-breadcrumbs--href",
+					"name": "item, href",
 					"snippet": "const href = () => (\n    <Breadcrumbs>\n        <Breadcrumbs.Item href=\"https://reshaped.so\">Trigger</Breadcrumbs.Item>\n    </Breadcrumbs>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-breadcrumbs--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Breadcrumbs className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Breadcrumbs.Item>Trigger</Breadcrumbs.Item>\n        </Breadcrumbs>\n    </div>\n);"
 				}
 			],
 			"import": "import { Badge, Breadcrumbs, Example } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Breadcrumbs/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Breadcrumbs",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Breadcrumbs/Breadcrumbs.tsx",
-				"actualName": "Breadcrumbs",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children to position items",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ReactElement<unknown, string | JSXElementConstructor<any>>[]"
+						}
+					},
+					"separator": {
+						"defaultValue": null,
+						"description": "Node for defining custom separator between items",
+						"name": "separator",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"neutral\"",
+							"value": [{ "value": "\"primary\"" }, { "value": "\"neutral\"" }]
+						}
+					},
+					"defaultVisibleItems": {
+						"defaultValue": null,
+						"description": "Number of items to show by default, others will be hidden and can be expanded",
+						"name": "defaultVisibleItems",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"expandAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the expand button",
+						"name": "expandAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disableExpand": {
+						"defaultValue": null,
+						"description": "Turn expand button into static text and disable the expand functionality",
+						"name": "disableExpand",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the component",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"nav\">" }
+					}
+				},
+				"exportName": "Breadcrumbs"
 			}
 		},
 		"components-button": {
@@ -293,87 +1622,599 @@
 			"path": "./src/components/Button/tests/Button.stories.tsx",
 			"stories": [
 				{
-					"name": "variantAndColor",
+					"id": "components-button--variant-and-color",
+					"name": "variant, color",
 					"snippet": "const variantAndColor = () => (\n    <Example>\n        <Example.Item title=\"variant: solid\">\n            <View gap={4} direction=\"row\">\n                <Button onClick={() => {}}>Button</Button>\n                <Button onClick={() => {}} color=\"primary\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"faded\">\n                    Button\n                </Button>\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"outline\">\n                    Button\n                </Button>\n\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: ghost\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"ghost\">\n                    Button\n                </Button>\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: media\">\n            <View backgroundColor=\"primary\" borderRadius=\"medium\" padding={4} direction=\"row\" gap={4}>\n                <Button onClick={() => {}} color=\"media\">\n                    Button\n                </Button>\n\n                <Button onClick={() => {}} color=\"media\" variant=\"faded\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Button onClick={() => {}} icon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"endIcon\">\n            <Button onClick={() => {}} endIcon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"icon, endIcon\">\n            <Button onClick={() => {}} icon={IconZap} endIcon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"icon only\">\n            <Button onClick={() => {}} icon={IconZap} attributes={{ \"aria-label\": \"Action\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"small\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"small\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Button icon={IconZap}>Button</Button>\n                <Button variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"large\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"large\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"xlarge\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"xlarge\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"xlarge\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large, [m+] medium\">\n            <Button size={{ s: \"large\", m: \"medium\" }} icon={IconZap}>\n                Responsive\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated, color: neutral\">\n            <View direction=\"row\" gap={4}>\n                <Button elevated onClick={() => {}}>\n                    Button\n                </Button>\n                <Button elevated variant=\"outline\" onClick={() => {}}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"elevated, color\">\n            <View direction=\"row\" gap={4}>\n                <Button elevated color=\"primary\">\n                    Button\n                </Button>\n                <Button elevated variant=\"outline\" color=\"primary\">\n                    Button\n                </Button>\n                <View backgroundColor=\"primary\" padding={4} borderRadius=\"medium\">\n                    <Button color=\"media\" elevated>\n                        Button\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded, size: small, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, size: medium, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, size: large, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, icon only, all sizes\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"small\" icon={IconZap} />\n                <Button rounded icon={IconZap} />\n                <Button rounded size=\"large\" icon={IconZap} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--full-width",
 					"name": "fullWidth",
 					"snippet": "const fullWidth = () => (\n    <Example>\n        <Example.Item title=\"fullWidth, all variants\">\n            <View gap={3}>\n                <Button fullWidth>Neutral</Button>\n                <Button fullWidth variant=\"faded\">\n                    Faded\n                </Button>\n                <Button fullWidth variant=\"outline\">\n                    Outline\n                </Button>\n                <Button fullWidth variant=\"ghost\">\n                    Ghost\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive fullWidth\", \"[s] true\", \"[m+] false\"]}>\n            <Button fullWidth={{ s: true, m: false }}>Button</Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--loading",
 					"name": "loading",
 					"snippet": "const loading = () => (\n    <Example>\n        <Example.Item title=\"loading, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"loading, color critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"loading, color positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"loading, color: media\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n\n                <div style={{ position: \"absolute\", top: 16, left: 16 }}>\n                    <View gap={3} direction=\"row\">\n                        <Button color=\"media\" loading loadingAriaLabel=\"Loading\">\n                            Button\n                        </Button>\n                        <Button color=\"media\" variant=\"faded\" loading loadingAriaLabel=\"Loading\">\n                            Button\n                        </Button>\n                    </View>\n                </div>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"loading, long button text\", \"button size should stay the same\"]}>\n            <Button loading loadingAriaLabel=\"Loading\" color=\"primary\">\n                Long button text\n            </Button>\n        </Example.Item>\n\n        <Example.Item title={[\"loading, icon only\", \"button keep square 1/1 ratio\"]}>\n            <Button icon={IconZap} rounded loading loadingAriaLabel=\"Loading\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--highlighted",
 					"name": "highlighted",
 					"snippet": "const highlighted = () => (\n    <Example>\n        <Example.Item title=\"highlighted, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"highlighted, color: critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted color=\"critical\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"highlighted, color: positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted color=\"positive\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled icon={IconZap} onClick={() => {}}>\n                    Button\n                </Button>\n                <Button disabled variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"disabled, color: critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled color=\"critical\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"disabled, color: positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled color=\"positive\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"disabled, color: media\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n\n                <div style={{ position: \"absolute\", top: 16, left: 16 }}>\n                    <View gap={3} direction=\"row\">\n                        <Button color=\"media\" disabled>\n                            Button\n                        </Button>\n                        <Button color=\"media\" variant=\"faded\" disabled>\n                            Button\n                        </Button>\n                    </View>\n                </div>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner: all\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>Content</View.Item>\n                <Button.Aligner>\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: top\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"top\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: top and end\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side={[\"top\", \"end\"]}>\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: bottom\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2} align=\"end\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"bottom\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: start\">\n            <View padding={4} borderColor=\"neutral-faded\" gap={2} align=\"start\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"start\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: end\">\n            <View padding={4} borderColor=\"neutral-faded\" gap={2} align=\"end\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"end\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "components-button--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"slot gap\">\n            <Button variant=\"outline\">\n                <Avatar size={6} initials=\"RS\" />\n                Label\n                <Hotkey>B</Hotkey>\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--href",
 					"name": "href",
 					"snippet": "const href = () => <Button href=\"https://reshaped.so\">Trigger</Button>;"
 				},
 				{
+					"id": "components-button--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Button onClick={fn()}>Trigger</Button>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-button--href-on-click",
+					"name": "href, onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <Button\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </Button>\n);"
 				},
 				{
+					"id": "components-button--as",
 					"name": "as",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"as: span\">\n            <Button onClick={() => {}} as=\"span\">\n                Trigger\n            </Button>\n        </Example.Item>\n        <Example.Item title=\"render, disabled\">\n            <Button\n                disabled\n                onClick={() => {}}\n                render={(props) => <section {...props} />}\n                attributes={{ \"data-testid\": \"render-el\" }}\n            >\n                Trigger\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-button--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Button className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Button>\n    </div>\n);"
 				},
 				{
+					"id": "components-button--group",
 					"name": "group",
 					"snippet": "const group = () => (\n    <Example>\n        <Example.Item title=\"with icon\">\n            <Button.Group>\n                <Button rounded>Submit</Button>\n                <Button rounded icon={IconZap} />\n            </Button.Group>\n        </Example.Item>\n        <Example.Item title=\"variant: solid\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\", \"media\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color}>One</Button>\n                        <Button color={color}>Two</Button>\n                        <Button color={color}>Three</Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"outline\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"outline\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"outline\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\", \"media\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"faded\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"faded\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"faded\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"variant: ghost\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"ghost\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"ghost\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"ghost\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "groupClassName",
+					"id": "components-button--group-class-name",
+					"name": "group className, attributes",
 					"snippet": "const groupClassName = () => (\n    <div data-testid=\"root\">\n        <Button.Group className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Button>Trigger</Button>\n        </Button.Group>\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Button, Example, Hotkey, Image, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Button/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Button",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Button/Button.tsx",
-				"actualName": "Button",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"ghost\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"ghost\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loading": {
+						"defaultValue": null,
+						"description": "Show loading state",
+						"name": "loading",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loadingAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the loading indicator",
+						"name": "loadingAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Make the component take the full width of the parent element",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "highlighted",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Button"
 			}
 		},
 		"components-calendar": {
@@ -382,54 +2223,363 @@
 			"path": "./src/components/Calendar/tests/Calendar.stories.tsx",
 			"stories": [
 				{
+					"id": "components-calendar--default-month",
 					"name": "defaultMonth",
 					"snippet": "const defaultMonth = () => (\n    <Example>\n        <Example.Item title=\"defaultMonth: 2020 January\">\n            <Calendar defaultMonth={new Date(2020, 0)} range />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "uncontrolled",
+					"id": "components-calendar--uncontrolled",
+					"name": "defaultValue, range",
 					"snippet": "const uncontrolled = () => <Example>\n    <Example.Item title=\"defaultValue\">\n        <Calendar\n            defaultMonth={new Date(2020, 0)}\n            defaultValue={new Date(2020, 0, 10)}\n            onChange={fn()} />\n    </Example.Item>\n    <Example.Item title=\"defaultValue, range\">\n        <Calendar\n            range\n            defaultMonth={new Date(2020, 0)}\n            defaultValue={{ start: new Date(2020, 0, 10), end: new Date(2020, 0, 15) }}\n            onChange={fn()} />\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "controlled",
+					"id": "components-calendar--controlled",
+					"name": "value, range",
 					"snippet": "const controlled = () => <Example>\n    <Example.Item title=\"value\">\n        <Calendar\n            defaultMonth={new Date(2020, 0)}\n            value={new Date(2020, 0, 10)}\n            onChange={fn()} />\n    </Example.Item>\n    <Example.Item title=\"defaultValue, range\">\n        <Calendar\n            range\n            defaultMonth={new Date(2020, 0)}\n            value={{ start: new Date(2020, 0, 10), end: new Date(2020, 0, 15) }}\n            onChange={fn()} />\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-calendar--selected-dates",
 					"name": "selectedDates",
 					"snippet": "const selectedDates = () => (\n    <Example>\n        <Example.Item title=\"selectedDates: [4,8]\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                value={null}\n                selectedDates={[new Date(2020, 0, 4), new Date(2020, 0, 8)]}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "minMax",
+					"id": "components-calendar--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <Example>\n        <Example.Item title=\"min: 4, max: 20\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                min={new Date(2020, 0, 4)}\n                max={new Date(2020, 0, 20)}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-calendar--first-week-day",
 					"name": "firstWeekDay",
 					"snippet": "const firstWeekDay = () => (\n    <Example>\n        <Example.Item title=\"firstWeekDay: 3 (Wed)\">\n            <Calendar defaultMonth={new Date(2020, 0)} firstWeekDay={3} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "translation",
+					"id": "components-calendar--translation",
+					"name": "render functions",
 					"snippet": "const translation = () => (\n    <Example>\n        <Example.Item title=\"translated to NL\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                renderMonthLabel={({ date }) => date.toLocaleDateString(\"nl\", { month: \"short\" })}\n                renderSelectedMonthLabel={({ date }) =>\n                    date.toLocaleDateString(\"nl\", { month: \"long\", year: \"numeric\" })\n                }\n                renderWeekDay={({ date }) => date.toLocaleDateString(\"nl\", { weekday: \"short\" })}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "ariaLabels",
+					"id": "components-calendar--aria-labels",
+					"name": "aria labels",
 					"snippet": "const ariaLabels = () => (\n    <Example>\n        <Example.Item title=\"aria labels\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                nextYearAriaLabel=\"Test next year\"\n                nextMonthAriaLabel=\"Test next month\"\n                renderDateAriaLabel={() => \"Test date\"}\n                renderMonthAriaLabel={() => \"Test month\"}\n                previousYearAriaLabel=\"Test previous year\"\n                previousMonthAriaLabel=\"Test previous month\"\n                monthSelectionAriaLabel=\"Test month selection\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "monthSelection",
+					"id": "components-calendar--month-selection",
+					"name": "test: month selection",
 					"snippet": "const monthSelection = () => (\n    <Example>\n        <Example.Item title=\"month selection\">\n            <Calendar defaultMonth={new Date(2020, 1)} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "keyboardNavigation",
+					"id": "components-calendar--keyboard-navigation",
+					"name": "test: keyboard navigation",
 					"snippet": "const keyboardNavigation = () => (\n    <Example>\n        <Example.Item title=\"keyboard navigation\">\n            <Calendar defaultMonth={new Date(2020, 0)} />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Calendar, Example } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Calendar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Calendar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Calendar/Calendar.tsx",
-				"actualName": "Calendar",
+				"methods": [],
+				"props": {
+					"range": {
+						"defaultValue": null,
+						"description": "Disable range selection\nEnable range selection",
+						"name": "range",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Current selected date value, enables controlled mode\nCurrent selected range value, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date | RangeValue | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default selected date value, enables uncontrolled mode\nDefault selected range value, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date | RangeValue" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when date selection changes\nCallback when range selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { value: Date; }) => void) | ((args: { value: Date; }) => void) | ((args: { value: RangeValue; }) => void) | ((args: { value: RangeValue; }) => void)"
+						}
+					},
+					"defaultMonth": {
+						"defaultValue": { "value": "Date.now()" },
+						"description": "Default month to display",
+						"name": "defaultMonth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum date that can be selected",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum date that can be selected",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"firstWeekDay": {
+						"defaultValue": { "value": "1, Monday" },
+						"description": "First day of the week",
+						"name": "firstWeekDay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"selectedDates": {
+						"defaultValue": null,
+						"description": "Dates that are selected",
+						"name": "selectedDates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date[]" }
+					},
+					"renderWeekDay": {
+						"defaultValue": null,
+						"description": "Render a custom weekday label, can be used for localization",
+						"name": "renderWeekDay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { weekDay: number; date: Date; }) => string)" }
+					},
+					"renderSelectedMonthLabel": {
+						"defaultValue": null,
+						"description": "Render a custom month label, can be used for localization",
+						"name": "renderSelectedMonthLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { date: Date; }) => string)" }
+					},
+					"renderMonthLabel": {
+						"defaultValue": null,
+						"description": "Render a custom month label, can be used for localization",
+						"name": "renderMonthLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { month: number; date: Date; }) => string)" }
+					},
+					"previousMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the previous month button",
+						"name": "previousMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"nextMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "",
+						"name": "nextMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"previousYearAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the previous year button",
+						"name": "previousYearAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"nextYearAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the next year button",
+						"name": "nextYearAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"monthSelectionAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the month selection button",
+						"name": "monthSelectionAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"renderDateAriaLabel": {
+						"defaultValue": null,
+						"description": "Dynamic aria label applied to each date cell based on the arguments",
+						"name": "renderDateAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { date: Date; }) => string)" }
+					},
+					"renderMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "Dynamic aria label applied to each month element based on the arguments",
+						"name": "renderMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { month: number; }) => string)" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -439,50 +2589,356 @@
 			"path": "./src/components/Card/tests/Card.stories.tsx",
 			"stories": [
 				{
+					"id": "components-card--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: default\">\n            <Card>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title=\"padding: 2\">\n            <Card padding={2}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title=\"padding: 0\">\n            <Card padding={0}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive padding\", \"[s] 4\", \"[m+] 8\"]}>\n            <Card padding={{ s: 4, m: 8 }}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--selected",
 					"name": "selected",
 					"snippet": "const selected = () => (\n    <Example>\n        <Example.Item title=\"selected\">\n            <Card selected>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated\">\n            <Card elevated>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4\">\n            <Card bleed={4}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n        <Example.Item title={[\"responsive bleed\", \"[s] 4\", \"[m+] 0\"]}>\n            <Card bleed={{ s: 4, m: 0 }}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--height",
 					"name": "height",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"height: 200px\">\n            <Card height=\"200px\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Card onClick={fn()}>Trigger</Card>;"
 				},
 				{
+					"id": "components-card--href",
 					"name": "href",
 					"snippet": "const href = () => <Card href=\"https://reshaped.so\">Trigger</Card>;"
 				},
 				{
+					"id": "components-card--as",
 					"name": "as",
 					"snippet": "const as = () => <Card as=\"span\" attributes={{ \"data-testid\": \"root\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-card--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Card className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Card, Example, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Card/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Card",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Card/Card.tsx",
-				"actualName": "Card",
+				"methods": [],
+				"props": {
+					"padding": {
+						"defaultValue": null,
+						"description": "Component padding, base unit multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Remove side borders and apply negative margins, base unit multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"selected": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "selected",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when the component is clicked, turns component into a button",
+						"name": "onClick",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL to navigate to when the component is clicked, turns component into a link",
+						"name": "href",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"as": {
+						"defaultValue": { "value": "\"div\"" },
+						"description": "Custom component tag name",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(Attributes<keyof IntrinsicElements> & (Attributes))" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -492,56 +2948,181 @@
 			"path": "./src/components/Carousel/tests/Carousel.stories.tsx",
 			"stories": [
 				{
+					"id": "components-carousel--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Carousel attributes={{ \"data-testid\": \"test-id\" }} visibleItems={3}>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n    </Carousel>\n);"
 				},
 				{
+					"id": "components-carousel--visible-items",
 					"name": "visibleItems",
 					"snippet": "const visibleItems = () => (\n    <Example>\n        <Example.Item title=\"visibleItems: 3\">\n            <Carousel visibleItems={3}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive visibleItems\", \"s: 2, m+ 3\"]}>\n            <Carousel visibleItems={{ s: 2, m: 3 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title=\"visibleItems: auto\">\n            <Carousel>\n                <Placeholder h={100} />\n                <Placeholder h={100} w={200} />\n                <Placeholder h={100} w={300} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 2, visibleItems 3\">\n            <Carousel visibleItems={3} gap={2}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"gap: responsive, visibleItems: 3\", \"s: 2, l: 8\"]}>\n            <Carousel visibleItems={3} gap={{ s: 2, l: 8 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4, visibleItems: 3\">\n            <Carousel visibleItems={3} bleed={4}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive bleed, visibleItems: 3\", \"[s] 4, [l+] 0\"]}>\n            <Carousel visibleItems={3} bleed={{ s: 4, l: 0 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--navigation-display",
 					"name": "navigationDisplay",
 					"snippet": "const navigationDisplay = () => (\n    <Example>\n        <Example.Item title=\"navigationDisplay: hidden\">\n            <Carousel\n                visibleItems={3}\n                navigationDisplay=\"hidden\"\n                attributes={{ \"data-testid\": \"test-id\" }}\n            >\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "instanceRef",
+					"id": "components-carousel--instance-ref",
+					"name": "instanceRef, onChange",
 					"snippet": "const instanceRef = (args) => {\n    const carouselRef = React.useRef<CarouselInstanceRef>(null);\n    const [index, setIndex] = React.useState(0);\n\n    return (\n        <Example>\n            <Example.Item title=\"instanceRef, onChange\">\n                <View gap={3}>\n                    <View gap={3} direction=\"row\" align=\"center\">\n                        <Button onClick={() => carouselRef.current?.navigateBack()}>Back</Button>\n                        <Button onClick={() => carouselRef.current?.navigateForward()}>Forward</Button>\n                        <Button onClick={() => carouselRef.current?.navigateTo(3)}>To 3</Button>\n                        <View.Item>Index: {index}</View.Item>\n                    </View>\n                    <Carousel\n                        visibleItems={2}\n                        instanceRef={carouselRef}\n                        navigationDisplay=\"hidden\"\n                        onChange={(changeArgs) => {\n                            args.handleChange(changeArgs);\n                            setIndex(changeArgs.index);\n                        }}\n                    >\n                        <Placeholder h={100}>Item 0</Placeholder>\n                        <Placeholder h={100}>Item 1</Placeholder>\n                        <Placeholder h={100}>Item 2</Placeholder>\n                        <Placeholder h={100}>Item 3</Placeholder>\n                        <Placeholder h={100}>Item 4</Placeholder>\n                        <Placeholder h={100}>Item 5</Placeholder>\n                    </Carousel>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-carousel--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Carousel visibleItems={2} className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder h={100}>Item 0</Placeholder>\n            <Placeholder h={100}>Item 1</Placeholder>\n            <Placeholder h={100}>Item 2</Placeholder>\n            <Placeholder h={100}>Item 3</Placeholder>\n            <Placeholder h={100}>Item 4</Placeholder>\n            <Placeholder h={100}>Item 5</Placeholder>\n        </Carousel>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Carousel, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Carousel/index.ts",
 				"description": "",
-				"methods": [
-					{
-						"name": "navigateTo",
-						"docblock": null,
-						"modifiers": [],
-						"params": [
+				"displayName": "Carousel",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, each child is rendered as a carousel item",
+						"name": "children",
+						"declarations": [
 							{
-								"name": "index",
-								"optional": false,
-								"type": { "name": "number" }
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
 							}
 						],
-						"returns": null
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"visibleItems": {
+						"defaultValue": null,
+						"description": "Number of items visible at once in the container",
+						"name": "visibleItems",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between items in the container, base unit multiplier",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margins, base unit multiplier, can be used to make sure the items don't get clipped when scrolling",
+						"name": "bleed",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"navigationDisplay": {
+						"defaultValue": null,
+						"description": "Hide navigation controls",
+						"name": "navigationDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"hidden\"", "value": [{ "value": "\"hidden\"" }] }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the carousel methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the first visible carousel index changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { index: number; }) => void)" }
+					},
+					"onScroll": {
+						"defaultValue": null,
+						"description": "Callback when the carousel scrolls",
+						"name": "onScroll",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: UIEvent<HTMLUListElement, UIEvent>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
 					}
-				],
-				"displayName": "Carousel",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Carousel/Carousel.tsx",
-				"actualName": "Carousel",
+				},
 				"exportName": "default"
 			}
 		},
@@ -551,46 +3132,259 @@
 			"path": "./src/components/Checkbox/tests/Checkbox.stories.tsx",
 			"stories": [
 				{
-					"name": "render",
+					"id": "components-checkbox--render",
+					"name": "name, value",
 					"snippet": "const render = () => (\n    <Checkbox name=\"test-name\" value=\"test-value\">\n        Content\n    </Checkbox>\n);"
 				},
 				{
+					"id": "components-checkbox--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"small\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"small\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"medium\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"medium\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"large\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"large\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: responsive, s: small, m: large\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size={{ s: \"small\", m: \"large\" }} defaultChecked>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-checkbox--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Checkbox name=\"animal\" value=\"dog\" hasError>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-checkbox--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n        <Example.Item title=\"disabled, checked\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled checked>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n        <Example.Item title=\"disabled, indeterminate\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled indeterminate>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "checked",
+					"id": "components-checkbox--checked",
+					"name": "checked, controlled",
 					"snippet": "const checked = () => <Checkbox name=\"test-name\" value=\"test-value\" checked onChange={fn()}>Content\n            </Checkbox>;"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-checkbox--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Checkbox name=\"test-name\" value=\"test-value\" defaultChecked onChange={fn()}>Content\n            </Checkbox>;"
 				},
 				{
+					"id": "components-checkbox--indeterminate",
 					"name": "indeterminate",
 					"snippet": "const indeterminate = () => (\n    <Checkbox name=\"test-name\" value=\"test-value\" indeterminate>\n        Content\n    </Checkbox>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-checkbox--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Checkbox className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Checkbox>\n    </div>\n);"
 				}
 			],
 			"import": "import { Checkbox, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Checkbox/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Checkbox",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Checkbox/Checkbox.tsx",
-				"actualName": "Checkbox",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the label",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Component name attribute",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the component",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Component value used for form submission",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"indeterminate": {
+						"defaultValue": null,
+						"description": "Show a indeterminate state, used for \"select all\" checkboxes with some of the individual checkboxes selected",
+						"name": "indeterminate",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the component is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the component is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Component checked state, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default checked state, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -600,26 +3394,143 @@
 			"path": "./src/components/CheckboxGroup/tests/CheckboxGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "value",
+					"id": "components-checkboxgroup--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <View gap={2}>\n    <CheckboxGroup name=\"test-name\" value={[\"1\"]} onChange={fn()}>\n        {/* checked should be ignored */}\n        <Checkbox value=\"1\" checked={false}>Content\n                            </Checkbox>\n        <Checkbox value=\"2\">Content 2</Checkbox>\n    </CheckboxGroup>\n</View>;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-checkboxgroup--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <View gap={2}>\n    <CheckboxGroup name=\"test-name\" defaultValue={[\"1\"]} onChange={fn()}>\n        {/* checked should be ignored */}\n        <Checkbox value=\"1\" checked={false}>Content\n                            </Checkbox>\n        <Checkbox value=\"2\">Content 2</Checkbox>\n    </CheckboxGroup>\n</View>;"
 				},
 				{
+					"id": "components-checkboxgroup--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <CheckboxGroup name=\"test-name\" disabled>\n        <Checkbox value=\"test-value\">Item 1</Checkbox>\n        <Checkbox value=\"test-value-2\">Item 2</Checkbox>\n    </CheckboxGroup>\n);"
 				}
 			],
 			"import": "import { Checkbox, CheckboxGroup, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/CheckboxGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "CheckboxGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/CheckboxGroup/CheckboxGroup.tsx",
-				"actualName": "CheckboxGroup",
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Component id attribute",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting checkboxes or custom layout components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the component from form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Component name attribute",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string[], ChangeEvent<HTMLInputElement>>" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Component value, enables controlled mode\nComponent value, enables uncontrolled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -629,23 +3540,346 @@
 			"path": "./src/components/ContextMenu/tests/ContextMenu.stories.tsx",
 			"stories": [
 				{
+					"id": "components-contextmenu--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"base\">\n            <div style={{ height: 200, overflow: \"auto\" }}>\n                <ContextMenu>\n                    <View height=\"400px\" backgroundColor=\"neutral-faded\" borderRadius=\"medium\" />\n\n                    <ContextMenu.Content>\n                        <ContextMenu.Item>Item 1</ContextMenu.Item>\n                        <ContextMenu.Item>Item 2</ContextMenu.Item>\n                    </ContextMenu.Content>\n                </ContextMenu>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "components-contextmenu--handlers",
+					"name": "handleOpen, handleClose",
 					"snippet": "const handlers = () => <div style={{ height: 200, overflow: \"auto\" }} data-testid=\"scroll\">\n    <ContextMenu onOpen={fn()} onClose={fn()}>\n        <View\n            height=\"400px\"\n            backgroundColor=\"neutral-faded\"\n            borderRadius=\"medium\"\n            attributes={{ \"data-testid\": \"root\" }} />\n        <ContextMenu.Content>\n            <ContextMenu.Item>Item</ContextMenu.Item>\n        </ContextMenu.Content>\n    </ContextMenu>\n</div>;"
 				}
 			],
 			"import": "import { ContextMenu, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ContextMenu/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ContextMenu",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ContextMenu/ContextMenu.tsx",
-				"actualName": "ContextMenu",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/DropdownMenu/DropdownMenu.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | \"action-menu\" | \"selection-menu\"" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					}
+				},
+				"exportName": "ContextMenu"
 			}
 		},
 		"components-divider": {
@@ -654,30 +3888,118 @@
 			"path": "./src/components/Divider/tests/Divider.stories.tsx",
 			"stories": [
 				{
-					"name": "rendering",
+					"id": "components-divider--rendering",
+					"name": "base",
 					"snippet": "const rendering = () => (\n    <Example>\n        <Example.Item title=\"default rendering\">\n            <Divider />\n        </Example.Item>\n\n        <Example.Item title={[\"blank rendering\", \"box should overlap with divider\"]}>\n            <View width=\"40px\" height=\"10px\" backgroundColor=\"primary\" />\n            <Divider blank />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-divider--vertical",
 					"name": "vertical",
 					"snippet": "const vertical = () => (\n    <Example>\n        <Example.Item title=\"vertical\">\n            <View gap={3} direction=\"row\" align=\"stretch\">\n                <Placeholder />\n                <View.Item>\n                    <Divider vertical />\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive vertical\", \"[s] true\", \"[m+]: false\"]}>\n            <View gap={3} direction={{ s: \"row\", m: \"column\" }} align=\"stretch\">\n                <Placeholder />\n                <View.Item>\n                    <Divider vertical={{ s: true, m: false }} />\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "label",
+					"id": "components-divider--label",
+					"name": "children, contentPosition",
 					"snippet": "const label = () => {\n    return (\n        <Example>\n            <Example.Item title=\"alignment\">\n                <View gap={4}>\n                    <Divider>Centered label</Divider>\n                    <Divider contentPosition=\"start\">Start label</Divider>\n                    <Divider contentPosition=\"end\">End label</Divider>\n                </View>\n            </Example.Item>\n\n            <Example.Item title=\"responsive\">\n                <View gap={3} direction={{ s: \"column\", m: \"row\" }} align=\"stretch\">\n                    <Placeholder />\n                    <View.Item>\n                        <Divider vertical={{ s: false, m: true }}>or pick second option</Divider>\n                    </View.Item>\n                    <Placeholder />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-divider--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Divider className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Divider, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Divider/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Divider",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Divider/Divider.tsx",
-				"actualName": "Divider",
+				"methods": [],
+				"props": {
+					"blank": {
+						"defaultValue": null,
+						"description": "Change component to take no space, useful for using it as a border in components like Tabs",
+						"name": "blank",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"vertical": {
+						"defaultValue": null,
+						"description": "Change component to render vertically",
+						"name": "vertical",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"contentPosition": {
+						"defaultValue": null,
+						"description": "Position for rendering children",
+						"name": "contentPosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"center\" | \"start\" | \"end\"",
+							"value": [{ "value": "\"center\"" }, { "value": "\"start\"" }, { "value": "\"end\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting text labels or custom components as a part of divider",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"hr\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -687,51 +4009,415 @@
 			"path": "./src/components/DropdownMenu/tests/DropdownMenu.stories.tsx",
 			"stories": [
 				{
+					"id": "components-dropdownmenu--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: default\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <DropdownMenu position=\"end\">\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n\n        <Example.Item title={[\"position: top-start\", \"should change to top-start to fit viewport\"]}>\n            <DropdownMenu position=\"top-end\">\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n        <div style={{ height: 2000 }} />\n    </Example>\n);"
 				},
 				{
+					"id": "components-dropdownmenu--sections",
 					"name": "sections",
 					"snippet": "const sections = () => (\n    <Example>\n        <Example.Item title=\"2 sections\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Section>\n                        <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                    </DropdownMenu.Section>\n\n                    <DropdownMenu.Section>\n                        <DropdownMenu.Item>Item 3</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 4</DropdownMenu.Item>\n                    </DropdownMenu.Section>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-dropdownmenu--submenu",
 					"name": "submenu",
 					"snippet": "const submenu = () => (\n    <Example>\n        <Example.Item title=\"submenu\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item onClick={() => {}}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger>Item 2</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger>Item 3</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2-1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2-2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger disabled>Item 4, disabled</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 3-1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 3-2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-dropdownmenu--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <DropdownMenu onOpen={fn()} onClose={fn()} defaultActive>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "active",
+					"id": "components-dropdownmenu--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <DropdownMenu onOpen={fn()} onClose={fn()} active>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "components-dropdownmenu--active-false",
+					"name": "active false, controlled",
 					"snippet": "const activeFalse = () => <DropdownMenu onOpen={fn()} onClose={fn()} active={false}>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "className",
+					"id": "components-dropdownmenu--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <DropdownMenu active>\n            <DropdownMenu.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </DropdownMenu.Trigger>\n            <DropdownMenu.Content className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n                <DropdownMenu.Item>Item</DropdownMenu.Item>\n            </DropdownMenu.Content>\n        </DropdownMenu>\n    </div>\n);"
 				},
 				{
-					"name": "testScroll",
+					"id": "components-dropdownmenu--test-scroll",
+					"name": "test: scroll",
 					"snippet": "const testScroll = () => (\n    <Example>\n        <Example.Item title=\"Scrolls on page mount to the dropdown\">\n            <div style={{ height: 1000 }} />\n            <DropdownMenu position=\"end\" key=\"scroll\" defaultActive>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testTheme",
+					"id": "components-dropdownmenu--test-theme",
+					"name": "test: theme",
 					"snippet": "const testTheme = () => (\n    <Example>\n        <Example.Item title=\"switch color mode while dropdown is active and check that it still works\">\n            <ThemeSwitching />\n        </Example.Item>\n        <Example.Item title=\"dropdown inherits multiple themes\">\n            <ThemeMultiple />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, DropdownMenu, Example, Theme, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/DropdownMenu/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "DropdownMenu",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/DropdownMenu/DropdownMenu.tsx",
-				"actualName": "DropdownMenu",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/DropdownMenu/DropdownMenu.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | \"action-menu\" | \"selection-menu\"" }
+					}
+				},
+				"exportName": "DropdownMenu"
 			}
 		},
 		"components-fileupload": {
@@ -740,35 +4426,165 @@
 			"path": "./src/components/FileUpload/tests/FileUpload.stories.tsx",
 			"stories": [
 				{
+					"id": "components-fileupload--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"Base upload with previews\">\n            <Demo />\n        </Example.Item>\n        <Example.Item title=\"With trigger\">\n            <FileUpload name=\"file\">\n                <div>\n                    Drop files to attach, or{\" \"}\n                    <FileUpload.Trigger>\n                        <Link variant=\"plain\">browse</Link>\n                    </FileUpload.Trigger>\n                </div>\n            </FileUpload>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "inline",
+					"id": "components-fileupload--inline",
+					"name": "inline, variant, render props",
 					"snippet": "const inline = () => {\n    return (\n        <Example>\n            <Example.Item title=\"inline\">\n                <FileUpload name=\"file\" inline onChange={console.log}>\n                    <View padding={2} paddingInline={3}>\n                        Upload\n                    </View>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"variant headless\">\n                <FileUpload name=\"file2\" variant=\"headless\" onChange={console.log}>\n                    <Button variant=\"outline\" fullWidth>\n                        Upload\n                    </Button>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"variant headless, inline\">\n                <FileUpload name=\"file2\" variant=\"headless\" inline onChange={console.log}>\n                    <Button>Upload</Button>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"inline, render props\">\n                <FileUpload name=\"file3\" variant=\"headless\" inline onChange={console.log}>\n                    {(props) => <Button highlighted={props.highlighted}>Upload</Button>}\n                </FileUpload>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-fileupload--height",
 					"name": "height",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"Custom height\">\n            <FileUpload name=\"file\" height=\"300px\">\n                <View gap={3}>\n                    <Icon svg={IconMic} size={8} />\n                    Drop files to attach\n                </View>\n            </FileUpload>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onChange",
+					"id": "components-fileupload--on-change",
+					"name": "name, onChange",
 					"snippet": "const onChange = () => <div data-testid=\"root\">\n    <FileUpload name=\"test-name\" onChange={fn()}>Content\n                    </FileUpload>\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "components-fileupload--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <FileUpload\n            name=\"name\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ id: \"test-input-id\" }}\n        >\n            Content\n        </FileUpload>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, FileUpload, Icon, Image, Link, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/FileUpload/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "FileUpload",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/FileUpload/FileUpload.tsx",
-				"actualName": "FileUpload",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, can be a render function that receives component state",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode | ((props: { highlighted?: boolean; }) => ReactNode)" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component value is changed",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ChangeHandler<File[], ChangeEvent<HTMLInputElement> | DragEvent<HTMLDivElement>>"
+						}
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Component height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component variant, headless variant is useful for rendering custom triggers like a Button",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"headless\"",
+							"value": [{ "value": "\"outline\"" }, { "value": "\"headless\"" }]
+						}
+					},
+					"inline": {
+						"defaultValue": null,
+						"description": "Change component to render inline making it more compact",
+						"name": "inline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					}
+				},
+				"exportName": "FileUpload"
 			}
 		},
 		"components-hotkey": {
@@ -777,22 +4593,78 @@
 			"path": "./src/components/Hotkey/tests/Hotkey.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "components-hotkey--base",
+					"name": "Base",
 					"snippet": "const base = () => (\n\t<Example>\n\t\t<Example.Item title=\"Base\">\n\t\t\t<Demo />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"Active\">\n\t\t\t<Hotkey active>⌘K</Hotkey>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"Inside input slot\">\n\t\t\t<View width=\"300px\">\n\t\t\t\t<TextField\n\t\t\t\t\tname=\"hey\"\n\t\t\t\t\tendSlot={<Demo />}\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"hotkey test\" }}\n\t\t\t\t/>\n\t\t\t</View>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-hotkey--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Hotkey className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            ⌘K\n        </Hotkey>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Hotkey, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Hotkey/Hotkey.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Hotkey",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Hotkey/Hotkey.tsx",
-				"actualName": "Hotkey",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Highlight the component, can be used to show when hotkey is pressed",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -802,54 +4674,241 @@
 			"path": "./src/components/Link/tests/Link.stories.tsx",
 			"stories": [
 				{
+					"id": "components-link--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: underline\">\n            <Link href=\"http://reshaped.so\" attributes={{ target: \"_blank\" }}>\n                Reshaped\n            </Link>\n        </Example.Item>\n        <Example.Item title=\"variant: plain\">\n            <Link onClick={() => {}} variant=\"plain\">\n                Link\n            </Link>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary\">\n            <Link color=\"primary\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Link color=\"critical\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Link color=\"positive\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <Link color=\"warning\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <Link color=\"inherit\">Link</Link>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon, variant: underline\">\n            <Link icon={IconZap}>Link</Link>\n        </Example.Item>\n        <Example.Item title=\"icon, variant: plain\">\n            <Link icon={IconZap} variant=\"plain\">\n                Link\n            </Link>\n        </Example.Item>\n        <Example.Item\n            title={[\"icon, variant: underline\", \"should inherit display-1 size from the parent\"]}\n        >\n            <Text variant=\"title-3\">\n                <Link icon={IconZap} variant=\"underline\">\n                    Instant delivery\n                </Link>\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--href",
 					"name": "href",
 					"snippet": "const href = () => <Link href=\"https://reshaped.so\">Trigger</Link>;"
 				},
 				{
+					"id": "components-link--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Link onClick={fn()}>Trigger</Link>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-link--href-on-click",
+					"name": "href + onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <Link\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </Link>\n);"
 				},
 				{
+					"id": "components-link--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Link disabled onClick={() => {}}>\n        Trigger\n    </Link>\n);"
 				},
 				{
+					"id": "components-link--render",
 					"name": "render",
 					"snippet": "const render = () => <Link render={(props) => <section {...props} />}>Trigger</Link>;"
 				},
 				{
-					"name": "className",
+					"id": "components-link--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Link className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Link>\n    </div>\n);"
 				},
 				{
-					"name": "testMultilineInText",
+					"id": "components-link--test-multiline-in-text",
+					"name": "test: multiline",
 					"snippet": "const testMultilineInText = () => (\n    <Example>\n        <Example.Item title=\"should wrap inside the text\">\n            <div>\n                Someone asked me to write this text that is boring to ready for everyone and to add&nbsp;\n                <Link href=\"/\">this very very long link</Link> to it.\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Link, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Link/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Link",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Link/Link.tsx",
-				"actualName": "Link",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon at the start position",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"primary\"" },
+						"description": "Link color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"inherit\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"inherit\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"underline\"" },
+						"description": "Link render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"plain\" | \"underline\"",
+							"value": [{ "value": "\"plain\"" }, { "value": "\"underline\"" }]
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -859,30 +4918,110 @@
 			"path": "./src/components/Loader/tests/Loader.stories.tsx",
 			"stories": [
 				{
+					"id": "components-loader--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: medium\">\n                <Loader size=\"medium\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title=\"size: small\">\n                <Loader size=\"small\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title=\"size: large\">\n                <Loader size=\"large\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title={[\"responsive size\", \"[s] small\", \"[m+] medium\"]}>\n                <Loader size={{ s: \"small\", m: \"medium\" }} ariaLabel=\"Loading\" />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-loader--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary\">\n            <Loader ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Loader color=\"critical\" ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Loader color=\"positive\" ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <Loader color=\"inherit\" ariaLabel=\"Loading\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-loader--aria-label",
 					"name": "ariaLabel",
 					"snippet": "const ariaLabel = () => <Loader ariaLabel=\"Loading\" attributes={{ \"data-testid\": \"root\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-loader--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Loader className=\"test-classname\" attributes={{ id: \"test-id\" }} ariaLabel=\"Loading\" />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Loader } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Loader/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Loader",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Loader/Loader.tsx",
-				"actualName": "Loader",
+				"methods": [],
+				"props": {
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"inherit\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -892,67 +5031,504 @@
 			"path": "./src/components/MenuItem/tests/MenuItem.stories.tsx",
 			"stories": [
 				{
+					"id": "components-menuitem--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <MenuItem size=\"small\" icon={IconZap} onClick={() => {}} endSlot={<Hotkey>⌘K</Hotkey>}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <MenuItem icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <MenuItem size=\"large\" icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title={[\"responsive size\", \"[s] small\", \"[m] medium\", \"[l+] large\"]}>\n            <MenuItem size={{ s: \"small\", m: \"medium\", l: \"large\" }} icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <MenuItem color=\"neutral\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <MenuItem color=\"primary\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <MenuItem color=\"critical\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--selected",
 					"name": "selected",
 					"snippet": "const selected = () => (\n    <Example>\n        <Example.Item title=\"selected, color: neutral\">\n            <MenuItem color=\"neutral\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"selected, color: primary\">\n            <MenuItem color=\"primary\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"selected, color: critical\">\n            <MenuItem color=\"critical\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--rounded-corners",
 					"name": "roundedCorners",
 					"snippet": "const roundedCorners = () => (\n    <Example>\n        <Example.Item title=\"roundedCorners\">\n            <MenuItem roundedCorners selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive roundedCorners\", \"[s]: false\", \"[m+]: true\"]}>\n            <MenuItem roundedCorners={{ s: false, m: true }} selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "slots",
+					"id": "components-menuitem--slots",
+					"name": "startSlot, endSlot",
 					"snippet": "const slots = () => (\n    <Example>\n        <Example.Item title=\"startSlot, endSlot, selected\">\n            <MenuItem startSlot={<Placeholder h={20} />} endSlot={<Placeholder h={20} />} selected>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem size=\"small\" selected onClick={() => {}}>\n                        Menu item\n                    </MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem selected>Menu item</MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem size=\"large\" selected>\n                        Menu item\n                    </MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--href",
 					"name": "href",
 					"snippet": "const href = () => <MenuItem href=\"https://reshaped.so\">Trigger</MenuItem>;"
 				},
 				{
+					"id": "components-menuitem--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <MenuItem onClick={fn()}>Trigger</MenuItem>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-menuitem--href-on-click",
+					"name": "href + onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <MenuItem\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </MenuItem>\n);"
 				},
 				{
+					"id": "components-menuitem--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <MenuItem disabled onClick={() => {}}>\n        Trigger\n    </MenuItem>\n);"
 				},
 				{
-					"name": "as",
+					"id": "components-menuitem--as",
+					"name": "as, render",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"render, disabled\">\n            <MenuItem\n                disabled\n                onClick={() => {}}\n                render={(props) => <section {...props} />}\n                attributes={{ \"data-testid\": \"render-el\" }}\n            >\n                Trigger\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-menuitem--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <MenuItem className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </MenuItem>\n    </div>\n);"
 				},
 				{
-					"name": "alignerClassName",
+					"id": "components-menuitem--aligner-class-name",
+					"name": "aligner, className, attributes",
 					"snippet": "const alignerClassName = () => (\n    <div data-testid=\"root\">\n        <MenuItem.Aligner className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <MenuItem>Trigger</MenuItem>\n        </MenuItem.Aligner>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Hotkey, MenuItem, Placeholder, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/MenuItem/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "MenuItem",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/MenuItem/MenuItem.tsx",
-				"actualName": "MenuItem",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content\nNode for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"neutral\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"neutral\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content at the start side of the component",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content at the end side of the component",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component as hovered or focused. For example, when displaying currently focused item in Autocomplete",
+						"name": "highlighted",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"selected": {
+						"defaultValue": null,
+						"description": "Highlight the component as selected",
+						"name": "selected",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"roundedCorners": {
+						"defaultValue": null,
+						"description": "Round the corners of the component",
+						"name": "roundedCorners",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					}
+				},
+				"exportName": "MenuItem"
 			}
 		},
 		"components-modal": {
@@ -961,67 +5537,301 @@
 			"path": "./src/components/Modal/tests/Modal.stories.tsx",
 			"stories": [
 				{
+					"id": "components-modal--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title={[\"responsive position\", \"[s] full-screen\", \"[m] center\", \"[l] end\"]}>\n            <Demo position={{ s: \"full-screen\", m: \"center\", l: \"end\" }} />\n        </Example.Item>\n        <Example.Item title=\"position: center\">\n            <Demo position=\"center\" />\n        </Example.Item>\n        <Example.Item title=\"position: bottom\">\n            <Demo position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"position: start\">\n            <Demo position=\"start\" />\n        </Example.Item>\n        <Example.Item title=\"position: end\">\n            <Demo position=\"end\" />\n        </Example.Item>\n        <Example.Item title=\"position: full-screen\">\n            <Demo position=\"full-screen\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: default\">\n                <Demo />\n            </Example.Item>\n            <Example.Item title=\"size: 300px\">\n                <Demo size=\"300px\" />\n            </Example.Item>\n            <Example.Item\n                title={[\"size: 800px\", \"should have max width of 100% minus gaps on the sides\"]}\n            >\n                <Demo size=\"800px\" />\n            </Example.Item>\n            <Example.Item\n                title={[\n                    \"responsive size, responsive position\",\n                    \"[s] auto\",\n                    \"[m+] 600px\",\n                    \"bottom position changes height instead of width\",\n                ]}\n            >\n                <Demo\n                    position={{ s: \"bottom\", m: \"center\", l: \"end\" }}\n                    size={{ s: \"auto\", m: \"600px\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-modal--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 0\">\n            <Demo padding={0} />\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <Demo padding={6} />\n        </Example.Item>\n        <Example.Item title={[\"responsive padding\", \"[s] 2\", \"[m+]: 6\"]}>\n            <Demo padding={{ s: 2, m: 6 }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--overflow",
 					"name": "overflow",
 					"snippet": "const overflow = () => (\n    <Example>\n        <Example.Item title=\"default overflow\">\n            <Demo>\n                <div\n                    style={{\n                        position: \"absolute\",\n                        top: -32,\n                        left: -32,\n                        height: 100,\n                        width: 100,\n                        background: \"tomato\",\n                    }}\n                />\n            </Demo>\n        </Example.Item>\n\n        <Example.Item title=\"overflow: visible\">\n            <Demo overflow=\"visible\">\n                <div\n                    style={{\n                        position: \"absolute\",\n                        top: -32,\n                        left: -32,\n                        height: 100,\n                        width: 100,\n                        background: \"tomato\",\n                    }}\n                />\n            </Demo>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--composition",
 					"name": "composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"title, subtitle, dismissible\">\n            <Demo title=\"Modal title\" subtitle=\"Modal subtitle\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--overlay",
 					"name": "overlay",
 					"snippet": "const overlay = () => (\n    <Example>\n        <Example.Item title=\"transparentOverlay, doesn't lock scroll\">\n            <Demo transparentOverlay />\n        </Example.Item>\n        <Example.Item title=\"blurredOverlay\">\n            <Demo blurredOverlay />\n        </Example.Item>\n        <View height=\"1000px\" />\n    </Example>\n);"
 				},
 				{
-					"name": "flags",
+					"id": "components-modal--flags",
+					"name": "disableCloseOnOutsideClick",
 					"snippet": "const flags = () => {\n    return (\n        <Example>\n            <Example.Item title=\"disableCloseOnOutsideClick\">\n                <Demo disableCloseOnOutsideClick onClose={fn()} active />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-modal--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const containerRef2 = React.useRef<HTMLDivElement>(null);\n    const toggle = useToggle();\n    const toggle2 = useToggle();\n\n    return (\n        <Example>\n            <Example.Item title={[\"in scrollable container\", \"scroll and then open\"]}>\n                <View\n                    attributes={{ ref: containerRef2 }}\n                    borderRadius=\"medium\"\n                    height=\"400px\"\n                    overflow=\"auto\"\n                    backgroundColor=\"neutral-faded\"\n                    padding={4}\n                >\n                    <View gap={4} align=\"start\">\n                        <Button onClick={toggle2.activate}>Open modal</Button>\n                        <View height=\"500px\" backgroundColor=\"primary\" width=\"500px\" borderRadius=\"medium\" />\n                    </View>\n                    <Modal\n                        containerRef={containerRef2}\n                        active={toggle2.active}\n                        onClose={toggle2.deactivate}\n                        position=\"end\"\n                    >\n                        <Placeholder />\n                    </Modal>\n                </View>\n            </Example.Item>\n            <Example.Item title=\"in static container\">\n                <View\n                    attributes={{ ref: containerRef }}\n                    borderRadius=\"medium\"\n                    height=\"400px\"\n                    overflow=\"hidden\"\n                    backgroundColor=\"neutral-faded\"\n                    padding={4}\n                >\n                    <Button onClick={toggle.activate}>Open modal</Button>\n                    <Modal\n                        containerRef={containerRef}\n                        active={toggle.active}\n                        onClose={toggle.deactivate}\n                        position=\"end\"\n                    >\n                        <Placeholder />\n                    </Modal>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "renderProps",
+					"id": "components-modal--render-props",
+					"name": "children, render props",
 					"snippet": "const renderProps = () => (\n    <Modal active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        <Modal.Title>Title</Modal.Title>\n        Content\n    </Modal>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "components-modal--handlers",
+					"name": "onOpen, onClose, onAfterOpen, onAfterClose",
 					"snippet": "const handlers = () => {\n    const overlayToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => overlayToggle.toggle()}>Open overlay</Button>\n            <Modal\n                active={overlayToggle.active}\n                onClose={(closeArgs) => {\n                    overlayToggle.deactivate();\n                    args.handleClose(closeArgs);\n                }}\n                onOpen={fn()}\n                onAfterOpen={fn()}\n                onAfterClose={fn()}>\n                <Modal.Title>Title</Modal.Title>Content\n                                </Modal>\n        </>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-modal--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <Modal active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        <Modal.Title>Title</Modal.Title>\n        Content\n    </Modal>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-modal--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => {\n    const menuModalToggle = useToggle();\n    const menuModalToggleInner = useToggle();\n    const scrollModalToggle = useToggle();\n    const inputRef = React.useRef<HTMLInputElement>(null);\n\n    return (\n        <Example>\n            <Example.Item title=\"Scrolls with long content on touch devices\">\n                <Demo position=\"center\">\n                    <Button onClick={() => {}}>Action</Button>\n                    <View height=\"2000px\" backgroundColor=\"primary-faded\" />\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"keyboard focus stays on the modal first\">\n                <Demo title=\"Modal title\" autoFocus={false} />\n            </Example.Item>\n            <Example.Item title=\"trap focus works with custom children components\">\n                <Demo title=\"Modal title\">\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <Switch name=\"switch\" />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"focus moves to the input\">\n                <Demo\n                    title=\"Modal title\"\n                    onOpen={() => {\n                        inputRef.current?.focus();\n                    }}\n                >\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <TextField name=\"name\" inputAttributes={{ ref: inputRef }} />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"Focus moves to the input with autoFocus\">\n                <Demo title=\"Modal title\">\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <TextField\n                            name=\"name\"\n                            placeholder=\"autofocus\"\n                            inputAttributes={{ autoFocus: true }}\n                        />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"scrollable area in modal ignores swipe-to-close\">\n                <View gap={3} direction=\"row\">\n                    <Button onClick={scrollModalToggle.activate}>Open</Button>\n                    <Modal\n                        active={scrollModalToggle.active}\n                        onClose={scrollModalToggle.deactivate}\n                        size=\"300px\"\n                        position=\"bottom\"\n                    >\n                        <View\n                            height=\"1000px\"\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            padding={4}\n                        >\n                            Content\n                        </View>\n                    </Modal>\n                </View>\n            </Example.Item>\n            <Example.Item\n                title={[\n                    \"trap focus works correctly when it was already trapped\",\n                    \"focus return back to the dropdown trigger on modal close\",\n                    \"closing dropdown inside the modal doesn't close the modal\",\n                ]}\n            >\n                <DropdownMenu>\n                    <DropdownMenu.Trigger>\n                        {(attributes) => <Button attributes={attributes}>Open menu</Button>}\n                    </DropdownMenu.Trigger>\n                    <DropdownMenu.Content>\n                        <DropdownMenu.Item onClick={menuModalToggle.activate}>Open dialog</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                    </DropdownMenu.Content>\n                </DropdownMenu>\n                <Modal active={menuModalToggle.active} onClose={menuModalToggle.deactivate}>\n                    <View gap={3}>\n                        <DropdownMenu>\n                            <DropdownMenu.Trigger>\n                                {(attributes) => <Button attributes={attributes}>Open menu</Button>}\n                            </DropdownMenu.Trigger>\n                            <DropdownMenu.Content>\n                                <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                                <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                            </DropdownMenu.Content>\n                        </DropdownMenu>\n                        <Button onClick={menuModalToggleInner.activate}>Open dialog</Button>\n                        <Button onClick={menuModalToggle.deactivate}>Close</Button>\n                        <Modal active={menuModalToggleInner.active} onClose={menuModalToggleInner.deactivate}>\n                            <Button onClick={menuModalToggleInner.deactivate}>Close</Button>\n                        </Modal>\n                    </View>\n                </Modal>\n            </Example.Item>\n\n            <Example.Item title=\"disableSwipeGesture\">\n                <Demo disableSwipeGesture position=\"start\" />\n            </Example.Item>\n\n            <Example.Item title=\"scroll locks on open\">\n                <Demo />\n                <View height=\"1000px\" />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "trapFocusEdgeCases",
+					"id": "components-modal--trap-focus-edge-cases",
+					"name": "test: trap focus edge cases",
 					"snippet": "const trapFocusEdgeCases = () => {\n    const toggle = useToggle();\n\n    return (\n        <Example>\n            <Example.Item title=\"Radio should be navigatable with arrow keys\">\n                <Button onClick={toggle.activate}>Open modal</Button>\n                <Modal active={toggle.active} onClose={toggle.deactivate}>\n                    <View gap={2}>\n                        <Button onClick={() => {}}>Action 1</Button>\n                        <Radio name=\"radio\" value=\"1\">\n                            Option 1\n                        </Radio>\n                        <Radio name=\"radio\" value=\"2\">\n                            Option 2\n                        </Radio>\n                        <Button onClick={() => {}}>Action 2</Button>\n                    </View>\n                </Modal>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import {\n    Button,\n    Dismissible,\n    DropdownMenu,\n    Example,\n    Modal,\n    Placeholder,\n    Radio,\n    Switch,\n    TextField,\n    View,\n} from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Modal/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Modal",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Modal/Modal.tsx",
-				"actualName": "Modal",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Component position on the screen",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<\"bottom\" | \"center\" | \"start\" | \"end\" | \"full-screen\">"
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size, literal css value",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Component padding, unit token multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Remove overflow from the component content",
+						"name": "overflow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"visible\"", "value": [{ "value": "\"visible\"" }] }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is closed",
+						"name": "onClose",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((args: { reason: CloseReason | \"drag\"; }) => void)" }
+					},
+					"transparentOverlay": {
+						"defaultValue": null,
+						"description": "Make the overlay transparent",
+						"name": "transparentOverlay",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"blurredOverlay": {
+						"defaultValue": null,
+						"description": "Make the overlay blurred",
+						"name": "blurredOverlay",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableSwipeGesture": {
+						"defaultValue": null,
+						"description": "Disable swipe gesture to close the component on touch devices",
+						"name": "disableSwipeGesture",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable closing the component on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Focus the first focusable element in the component when it is opened, when false, focus will be set on the component content container",
+						"name": "autoFocus",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element, useful when there is no visible title",
+						"name": "ariaLabel",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"overlayClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the overlay element",
+						"name": "overlayClassName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "(Attributes<\"div\"> & { ref?: RefObject<HTMLDivElement | null>; })"
+						}
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the visibility of the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the component is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"containerRef": {
+						"defaultValue": null,
+						"description": "Element to render the component in",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"onAfterOpen": {
+						"defaultValue": null,
+						"description": "Callback after the component open transition is complete",
+						"name": "onAfterOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onAfterClose": {
+						"defaultValue": null,
+						"description": "Callback after the component close transition is complete",
+						"name": "onAfterClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					}
+				},
+				"exportName": "Modal"
 			}
 		},
 		"components-numberfield": {
@@ -1030,54 +5840,450 @@
 			"path": "./src/components/NumberField/tests/NumberField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-numberfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => {\n    return (\n        <Example>\n            <Example.Item title=\"variant: outline\">\n                <NumberField\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"variant: faded\">\n                <NumberField\n                    variant=\"faded\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"variant: headless\">\n                <NumberField\n                    variant=\"headless\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-numberfield--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: small\">\n                <NumberField\n                    size=\"small\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    suffix=\"m2\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: medium\">\n                <NumberField\n                    size=\"medium\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: large\">\n                <NumberField\n                    size=\"large\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: xlarge\">\n                <NumberField\n                    size=\"xlarge\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-numberfield--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <NumberField\n    name=\"test-name\"\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    disabled\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-numberfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <NumberField\n    name=\"test-name\"\n    defaultValue={2}\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-numberfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <NumberField\n    name=\"test-name\"\n    value={2}\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "minMax",
+					"id": "components-numberfield--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <NumberField\n        name=\"test-name\"\n        defaultValue={6}\n        min={5}\n        max={10}\n        increaseAriaLabel=\"Increase\"\n        decreaseAriaLabel=\"Decrease\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-numberfield--step",
 					"name": "step",
 					"snippet": "const step = () => (\n    <NumberField\n        name=\"test-name\"\n        defaultValue={6}\n        step={0.5}\n        increaseAriaLabel=\"Increase\"\n        decreaseAriaLabel=\"Decrease\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-numberfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <NumberField\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n            increaseAriaLabel=\"Increase\"\n            decreaseAriaLabel=\"Decrease\"\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-numberfield--form-control",
+					"name": "test: FormControl",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"FormControl\">\n            <FormControl>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"FormControl, disabled\">\n            <FormControl disabled>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"FormControl, error\">\n            <FormControl hasError>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "valueChanges",
+					"id": "components-numberfield--value-changes",
+					"name": "test: keyboard",
 					"snippet": "const valueChanges = () => (\n    <Example>\n        <Example.Item title=\"keyboard\">\n            <NumberField\n                name=\"name\"\n                increaseAriaLabel=\"Increase\"\n                decreaseAriaLabel=\"Decrease\"\n                inputAttributes={{ \"aria-label\": \"Label\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, FormControl, NumberField } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/NumberField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "NumberField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/NumberField/NumberField.tsx",
-				"actualName": "NumberField",
+				"methods": [],
+				"props": {
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component value is changed",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<number, ChangeEvent<HTMLInputElement>>" }
+					},
+					"increaseAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the increase button",
+						"name": "increaseAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"decreaseAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the decrease button",
+						"name": "decreaseAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum value supported in the form field",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum value supported in the form field",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"step": {
+						"defaultValue": null,
+						"description": "Step at which the value will increase or decrease when clicking the button controls",
+						"name": "step",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the form field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the form field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1087,34 +6293,166 @@
 			"path": "./src/components/Pagination/tests/Pagination.stories.tsx",
 			"stories": [
 				{
+					"id": "components-pagination--truncate",
 					"name": "truncate",
 					"snippet": "const truncate = () => {\n    return (\n        <Example>\n            <Example.Item title=\"start\">\n                <Pagination\n                    total={10}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"middle\">\n                <Pagination\n                    total={10}\n                    defaultPage={5}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"end\">\n                <Pagination\n                    total={10}\n                    defaultPage={10}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"no truncation\">\n                <Pagination\n                    total={4}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "render",
+					"id": "components-pagination--render",
+					"name": "rendering",
 					"snippet": "const render = () => (\n    <div data-testid=\"root\">\n        <Pagination\n            total={10}\n            previousAriaLabel=\"Previous\"\n            nextAriaLabel=\"Next\"\n            pageAriaLabel={(args) => `Page ${args.page}`}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "defaultPage",
+					"id": "components-pagination--default-page",
+					"name": "defaultPage, uncontrolled",
 					"snippet": "const defaultPage = () => <div data-testid=\"root\">\n    <Pagination\n        total={10}\n        defaultPage={2}\n        onChange={fn()}\n        previousAriaLabel=\"Previous\"\n        nextAriaLabel=\"Next\" />\n</div>;"
 				},
 				{
-					"name": "page",
+					"id": "components-pagination--page",
+					"name": "page, controlled",
 					"snippet": "const page = () => <div data-testid=\"root\">\n    <Pagination\n        total={10}\n        page={2}\n        onChange={fn()}\n        previousAriaLabel=\"Previous\"\n        nextAriaLabel=\"Next\" />\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "components-pagination--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Pagination\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            total={10}\n            previousAriaLabel=\"Previous\"\n            nextAriaLabel=\"Next\"\n        />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Pagination } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Pagination/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Pagination",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Pagination/Pagination.tsx",
-				"actualName": "Pagination",
+				"methods": [],
+				"props": {
+					"total": {
+						"defaultValue": null,
+						"description": "Total number of pages available",
+						"name": "total",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "number" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the current page changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { page: number; }) => void)" }
+					},
+					"pageAriaLabel": {
+						"defaultValue": null,
+						"description": "Function to dynamically get an aria-label for each page",
+						"name": "pageAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { page: number; }) => string)" }
+					},
+					"previousAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the previous page button",
+						"name": "previousAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"nextAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the next page button",
+						"name": "nextAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"page": {
+						"defaultValue": null,
+						"description": "Currently selected page number, starts with 1, enables controlled mode",
+						"name": "page",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultPage": {
+						"defaultValue": null,
+						"description": "Default selected page number, starts with 1, enables uncontrolled mode",
+						"name": "defaultPage",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1124,54 +6462,229 @@
 			"path": "./src/components/PinField/tests/PinField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-pinfield--base",
 					"name": "base",
 					"snippet": "const base = () => <PinField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-pinfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <PinField name=\"pin\" variant=\"faded\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-pinfield--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <PinField name=\"pin\" size=\"small\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <PinField name=\"pin\" size=\"medium\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <PinField name=\"pin\" size=\"large\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <PinField name=\"pin\" size=\"xlarge\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: responsive, s: medium, m+: xlarge\">\n            <PinField\n                name=\"pin\"\n                size={{ s: \"medium\", m: \"xlarge\" }}\n                inputAttributes={{ \"aria-label\": \"Pin\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-pinfield--value-length",
 					"name": "valueLength",
 					"snippet": "const valueLength = () => (\n    <PinField name=\"test-name\" valueLength={6} inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-pinfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <PinField\n    name=\"test-name\"\n    onChange={fn()}\n    defaultValue=\"12\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-pinfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <PinField\n    name=\"test-name\"\n    onChange={fn()}\n    value=\"12\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-pinfield--pattern",
 					"name": "pattern",
 					"snippet": "const pattern = () => <PinField\n    name=\"test-name\"\n    pattern=\"alphabetic\"\n    defaultValue=\"ab\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-pinfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <PinField\n            name=\"test-name\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ \"aria-label\": \"Label\", id: \"test-input-id\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-pinfield--form-control",
+					"name": "test: with FormControl",
 					"snippet": "const formControl = () => (\n    <FormControl>\n        <FormControl.Label>Label</FormControl.Label>\n        <PinField name=\"test-name\" />\n    </FormControl>\n);"
 				},
 				{
-					"name": "keyboard",
+					"id": "components-pinfield--keyboard",
+					"name": "test: keyboard navigation",
 					"snippet": "const keyboard = () => <PinField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				}
 			],
 			"import": "import { Example, FormControl, PinField } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/PinField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "PinField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/PinField/PinField.tsx",
-				"actualName": "PinField",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"valueLength": {
+						"defaultValue": null,
+						"description": "Amount of characters in the pin",
+						"name": "valueLength",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"pattern": {
+						"defaultValue": null,
+						"description": "Character pattern used in the input value",
+						"name": "pattern",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"numeric\" | \"alphabetic\" | \"alphanumeric\"",
+							"value": [
+								{ "value": "\"numeric\"" },
+								{ "value": "\"alphabetic\"" },
+								{ "value": "\"alphanumeric\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Input fields render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\"",
+							"value": [{ "value": "\"outline\"" }, { "value": "\"faded\"" }]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the input element, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1181,75 +6694,514 @@
 			"path": "./src/components/Popover/tests/Popover.stories.tsx",
 			"stories": [
 				{
+					"id": "components-popover--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: bottom\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"bottom-start\" />\n                <Demo position=\"bottom\" />\n                <Demo position=\"bottom-end\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: top\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"top-start\" />\n                <Demo position=\"top\" />\n                <Demo position=\"top-end\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: start\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"start-top\" />\n                <Demo position=\"start\" />\n                <Demo position=\"start-bottom\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: end\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"end-top\" />\n                <Demo position=\"end\" />\n                <Demo position=\"end-bottom\" defaultActive />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "widthNumber",
+					"id": "components-popover--width-number",
+					"name": "width: px",
 					"snippet": "const widthNumber = () => <Demo width=\"400px\" defaultActive />;"
 				},
 				{
-					"name": "widthFull",
+					"id": "components-popover--width-full",
+					"name": "width: 100%",
 					"snippet": "const widthFull = () => <Demo width=\"100%\" defaultActive />;"
 				},
 				{
+					"id": "components-popover--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 0\">\n            <Demo padding={0} />\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <Demo padding={6} defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-popover--elevation",
 					"name": "elevation",
 					"snippet": "const elevation = () => (\n    <Example>\n        <Example.Item title=\"elevation: raised\">\n            <Demo elevation=\"raised\" defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-popover--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <Popover onOpen={fn()} onClose={fn()} defaultActive>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "active",
+					"id": "components-popover--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <Popover onOpen={fn()} onClose={fn()} active>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "components-popover--active-false",
+					"name": "active false, controlled",
 					"snippet": "const activeFalse = () => <Popover onOpen={fn()} onClose={fn()} active={false}>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "dismissible",
+					"id": "components-popover--dismissible",
+					"name": "dismissible, onClose, className, attributes, closeAriaLabel",
 					"snippet": "const dismissible = () => <Popover onClose={fn()} defaultActive>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>\n        <Popover.Dismissible\n            closeAriaLabel=\"Close\"\n            attributes={{ \"data-testid\": \"test-id\" }}\n            className=\"test-classname\">Content\n                            </Popover.Dismissible>\n    </Popover.Content>\n</Popover>;"
 				},
 				{
+					"id": "components-popover--auto-focus",
 					"name": "autoFocus",
 					"snippet": "const autoFocus = () => (\n    <Example>\n        <Example.Item title=\"autoFocus=false\">\n            <Demo autoFocus={false} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-popover--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Popover active>\n            <Popover.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </Popover.Trigger>\n            <Popover.Content className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n                Content\n            </Popover.Content>\n        </Popover>\n    </div>\n);"
 				},
 				{
-					"name": "testNested",
+					"id": "components-popover--test-nested",
+					"name": "test: nested",
 					"snippet": "const testNested = () => (\n    <Popover position=\"bottom\">\n        <Popover.Trigger>\n            {(attributes) => <Button attributes={attributes}>Open</Button>}\n        </Popover.Trigger>\n        <Popover.Content>\n            <View gap={2} align=\"start\">\n                Popover content\n                <Popover>\n                    <Popover.Trigger>\n                        {(attributes) => <Button attributes={attributes}>Open</Button>}\n                    </Popover.Trigger>\n                    <Popover.Content>Hello</Popover.Content>\n                </Popover>\n            </View>\n        </Popover.Content>\n    </Popover>\n);"
 				},
 				{
-					"name": "testWithTooltip",
+					"id": "components-popover--test-with-tooltip",
+					"name": "test: with tooltip",
 					"snippet": "const testWithTooltip = () => (\n    <View paddingTop={10}>\n        <Tooltip position=\"top\" text=\"Hello\">\n            {(tooltipAttributes) => (\n                <Popover position=\"bottom\">\n                    <Popover.Trigger>\n                        {(attributes) => (\n                            <Button\n                                attributes={{\n                                    ...attributes,\n                                    ...tooltipAttributes,\n                                }}\n                            >\n                                Open\n                            </Button>\n                        )}\n                    </Popover.Trigger>\n                    <Popover.Content>\n                        <View gap={2} align=\"start\">\n                            Popover content\n                            <Button onClick={() => {}}>Button</Button>\n                        </View>\n                    </Popover.Content>\n                </Popover>\n            )}\n        </Tooltip>\n    </View>\n);"
 				},
 				{
-					"name": "testContentEditable",
+					"id": "components-popover--test-content-editable",
+					"name": "test: contenteditable",
 					"snippet": "const testContentEditable = () => {\n    const [active, setActive] = useState(false);\n\n    return (\n        <Popover>\n            <Popover.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </Popover.Trigger>\n            <Popover.Content>\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={() => {}}>Hello</Button>\n                    </View.Item>\n\n                    <ScrollArea height=\"100px\">\n                        <div\n                            style={{ height: \"200px\" }}\n                            contentEditable\n                            tabIndex={0}\n                            onInput={(e) => {\n                                setActive(e.currentTarget.innerText.startsWith(\"@\"));\n                            }}\n                            onKeyDown={(e) => {\n                                console.log(e.key);\n                                if (e.key === \"Enter\" && active) {\n                                    e.preventDefault();\n                                    e.currentTarget.innerText = \"@hello\";\n                                    setActive(false);\n                                }\n                            }}\n                        />\n                    </ScrollArea>\n\n                    <Popover\n                        active={active}\n                        onClose={() => setActive(false)}\n                        originCoordinates={{ x: 300, y: 300 }}\n                        trapFocusMode=\"selection-menu\"\n                    >\n                        <Popover.Content>\n                            <View gap={4}>\n                                <MenuItem onClick={() => {}}>Action</MenuItem>\n                                <MenuItem onClick={() => {}}>Close</MenuItem>\n                            </View>\n                        </Popover.Content>\n                    </Popover>\n                </View>\n            </Popover.Content>\n        </Popover>\n    );\n};"
 				},
 				{
-					"name": "variant",
+					"id": "components-popover--variant",
+					"name": "variant [deprecated]",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: headless\">\n            <Popover variant=\"headless\" defaultActive position=\"bottom-start\">\n                <Popover.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </Popover.Trigger>\n                <Popover.Content>\n                    <View\n                        height=\"100px\"\n                        width=\"100px\"\n                        borderColor=\"primary\"\n                        borderRadius=\"medium\"\n                        backgroundColor=\"primary-faded\"\n                    />\n                </Popover.Content>\n            </Popover>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, MenuItem, Popover, ScrollArea, Tooltip, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Popover/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Popover",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Popover/Popover.tsx",
-				"actualName": "Popover",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Automatically focus the first focusable element in the content, when false the content container will be focused instead",
+						"name": "autoFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | TrapMode" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Content element padding, unit token multiplier",
+						"name": "padding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "@deprecated use Flyout utility instead, will be removed in v4",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"elevated\" | \"headless\"",
+							"value": [{ "value": "\"elevated\"" }, { "value": "\"headless\"" }]
+						}
+					}
+				},
+				"exportName": "Popover"
 			}
 		},
 		"components-progress": {
@@ -1258,38 +7210,177 @@
 			"path": "./src/components/Progress/tests/Progress.stories.tsx",
 			"stories": [
 				{
+					"id": "components-progress--value",
 					"name": "value",
 					"snippet": "const value = () => (\n    <Example>\n        <Example.Item title=\"value: 50\">\n            <Progress value={50} ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"value: 20, min: 0, max: 40\">\n            <Progress value={20} min={0} max={40} ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"value: 50, min: 0, max: 40\">\n            <Progress value={50} min={0} max={40} ariaLabel=\"rating value\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small, value: 50\">\n            <Progress value={50} size=\"small\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"size: medium, value: 50\">\n            <Progress value={50} size=\"medium\" ariaLabel=\"rating value\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: critical, value: 50\">\n            <Progress value={50} color=\"critical\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: warning, value: 50\">\n            <Progress value={50} color=\"warning\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive, value: 50\">\n            <Progress value={50} color=\"positive\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: media, value: 50\">\n            <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                <Progress value={50} color=\"media\" ariaLabel=\"rating value\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--duration",
 					"name": "duration",
 					"snippet": "const duration = () => {\n    const [active, setActive] = React.useState(false);\n\n    const handleChange = () => {\n        setActive((state) => !state);\n    };\n\n    return (\n        <Example>\n            <Example.Item title=\"duration: 2000\">\n                <View gap={3}>\n                    <View.Item>\n                        <Button onClick={handleChange}>Change</Button>\n                    </View.Item>\n\n                    <Progress value={active ? 100 : 0} duration={2000} ariaLabel=\"rating value\" />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "render",
+					"id": "components-progress--render",
+					"name": "rendering",
 					"snippet": "const render = () => <Progress value={75} min={50} max={100} ariaLabel=\"progress\" />;"
 				},
 				{
-					"name": "className",
+					"id": "components-progress--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Progress className=\"test-classname\" attributes={{ id: \"test-id\" }} ariaLabel=\"progress\" />\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, Progress, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Progress/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Progress",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Progress/Progress.tsx",
-				"actualName": "Progress",
+				"methods": [],
+				"props": {
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the progress bar controlling the size of the fill",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Lower value boundary of the progress bar",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Upper value boundary of the progress bar",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"warning\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"duration": {
+						"defaultValue": null,
+						"description": "Duration of the progress bar animation in milliseconds",
+						"name": "duration",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1299,30 +7390,135 @@
 			"path": "./src/components/ProgressIndicator/tests/ProgressIndicator.stories.tsx",
 			"stories": [
 				{
+					"id": "components-progressindicator--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const [activeIndex, setActiveIndex] = React.useState(0);\n    const total = 10;\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <View gap={4}>\n                    <View direction=\"row\" gap={2} align=\"center\">\n                        <Button\n                            onClick={() => {\n                                setActiveIndex((prev) => Math.max(0, prev - 1));\n                            }}\n                        >\n                            Previous\n                        </Button>\n                        <Button\n                            onClick={() => {\n                                setActiveIndex((prev) => Math.min(total - 1, prev + 1));\n                            }}\n                        >\n                            Next\n                        </Button>\n                        <Text weight=\"medium\">Index: {activeIndex}</Text>\n                    </View>\n\n                    <View borderRadius=\"medium\" overflow=\"hidden\" width=\"300px\">\n                        <Scrim\n                            position=\"bottom\"\n                            backgroundSlot={<View aspectRatio={16 / 9} backgroundColor=\"neutral-faded\" />}\n                        >\n                            <View align=\"center\">\n                                <ProgressIndicator total={total} activeIndex={activeIndex} color=\"media\" />\n                            </View>\n                        </Scrim>\n                    </View>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-progressindicator--color",
 					"name": "color",
 					"snippet": "const color = () => {\n    return (\n        <Example>\n            <Example.Item title=\"color: primary\">\n                <ProgressIndicator total={10} activeIndex={5} color=\"primary\" />\n            </Example.Item>\n            <Example.Item title=\"color: media\">\n                <View borderRadius=\"medium\" overflow=\"hidden\" width=\"300px\">\n                    <Scrim\n                        position=\"bottom\"\n                        backgroundSlot={<View aspectRatio={16 / 9} backgroundColor=\"neutral-faded\" />}\n                    >\n                        <View align=\"center\">\n                            <ProgressIndicator total={10} activeIndex={5} color=\"media\" />\n                        </View>\n                    </Scrim>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-progressindicator--aria-label",
 					"name": "ariaLabel",
 					"snippet": "const ariaLabel = () => <ProgressIndicator total={10} className=\"test-classname\" ariaLabel=\"Progress\" />;"
 				},
 				{
-					"name": "className",
+					"id": "components-progressindicator--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ProgressIndicator total={10} className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, ProgressIndicator, Scrim, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ProgressIndicator/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ProgressIndicator",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ProgressIndicator/ProgressIndicator.tsx",
-				"actualName": "ProgressIndicator",
+				"methods": [],
+				"props": {
+					"total": {
+						"defaultValue": null,
+						"description": "Total amount of progress indicator dots",
+						"name": "total",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "number" }
+					},
+					"activeIndex": {
+						"defaultValue": null,
+						"description": "Index of the active progress indicator dot",
+						"name": "activeIndex",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\"",
+							"value": [{ "value": "\"media\"" }, { "value": "\"primary\"" }]
+						}
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1332,50 +7528,203 @@
 			"path": "./src/components/Radio/tests/Radio.stories.tsx",
 			"stories": [
 				{
+					"id": "components-radio--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"small\" defaultChecked>\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"medium\">\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"large\">\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: responsive, s: small, m: large\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size={{ s: \"small\", m: \"large\" }}>\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-radio--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Radio name=\"error\" value=\"dog\" hasError>\n                Radio\n            </Radio>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-radio--render",
+					"name": "name, value",
 					"snippet": "const render = () => (\n    <Radio name=\"test-name\" value=\"test-value\">\n        Content\n    </Radio>\n);"
 				},
 				{
-					"name": "checked",
+					"id": "components-radio--checked",
+					"name": "checked, controlled",
 					"snippet": "const checked = () => <Radio name=\"test-name\" value=\"test-value\" checked onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "checkedFalse",
+					"id": "components-radio--checked-false",
+					"name": "checked false, controlled",
 					"snippet": "const checkedFalse = () => <Radio name=\"test-name\" value=\"test-value\" checked={false} onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-radio--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Radio name=\"test-name\" value=\"test-value\" defaultChecked onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "defaultCheckedFalse",
+					"id": "components-radio--default-checked-false",
+					"name": "defaultChecked false, uncontrolled",
 					"snippet": "const defaultCheckedFalse = () => <Radio name=\"test-name\" value=\"test-value\" onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
+					"id": "components-radio--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Radio name=\"test-name\" value=\"test-value\" disabled>\n        Content\n    </Radio>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-radio--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Radio className=\"test-classname\" attributes={{ id: \"test-id\" }} value=\"value\">\n            Content\n        </Radio>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Radio, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Radio/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Radio",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Radio/Radio.tsx",
-				"actualName": "Radio",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the form field from the form submission",
+						"name": "disabled",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Indicate that the form field has an error",
+						"name": "hasError",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element",
+						"name": "value",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the input is focused",
+						"name": "onFocus",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the input is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "",
+						"name": "checked",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultChecked",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1385,26 +7734,169 @@
 			"path": "./src/components/RadioGroup/tests/RadioGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "value",
+					"id": "components-radiogroup--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <RadioGroup name=\"test-name\" value=\"1\" onChange={fn()}>\n    {/* checked should be ignored */}\n    <Radio value=\"1\" checked={false}>Content\n                    </Radio>\n    <Radio value=\"2\">Content 2</Radio>\n</RadioGroup>;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-radiogroup--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <RadioGroup name=\"test-name\" defaultValue=\"1\" onChange={fn()}>\n    {/* checked should be ignored */}\n    <Radio value=\"1\" checked={false}>Content\n                    </Radio>\n    <Radio value=\"2\">Content 2</Radio>\n</RadioGroup>;"
 				},
 				{
+					"id": "components-radiogroup--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <RadioGroup name=\"test-name\" disabled>\n        <Radio value=\"test-value\">Content</Radio>\n    </RadioGroup>\n);"
 				}
 			],
 			"import": "import { Radio, RadioGroup } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/RadioGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "RadioGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/RadioGroup/RadioGroup.tsx",
-				"actualName": "RadioGroup",
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the radio group",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the form field from the form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Indicate that the form field has an error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the input element, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1414,39 +7906,131 @@
 			"path": "./src/components/Resizable/tests/Resizable.stories.tsx",
 			"stories": [
 				{
+					"id": "components-resizable--direction",
 					"name": "direction",
 					"snippet": "const direction = () => {\n    return (\n        <Example>\n            <Example.Item title=\"row\">\n                <Resizable height=\"200px\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n            <Example.Item title=\"column\">\n                <Resizable height=\"400px\" direction=\"column\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n\n            {/* Test that page doesn't scroll on dragging */}\n            <div style={{ height: 2000 }} />\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-resizable--children",
 					"name": "children",
 					"snippet": "const children = () => {\n    return (\n        <Example>\n            <Example.Item title=\"render props, row\">\n                <Resizable height=\"200px\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n            <Example.Item title=\"render props, column\">\n                <Resizable height=\"400px\" direction=\"column\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-resizable--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"bordered, row\">\n            <Resizable height=\"200px\" variant=\"bordered\">\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n            </Resizable>\n        </Example.Item>\n        <Example.Item title=\"bordered, column\">\n            <Resizable height=\"400px\" direction=\"column\" variant=\"bordered\">\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n            </Resizable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "components-resizable--size",
+					"name": "minSize, maxSize, defaultSize",
 					"snippet": "const size = () => (\n    <Resizable className=\"test-classname\" attributes={{ id: \"test-id\" }} height=\"200px\">\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n        <Resizable.Handle />\n        <Resizable.Item minSize=\"200px\" maxSize=\"500px\" defaultSize=\"300px\">\n            <Panel />\n        </Resizable.Item>\n    </Resizable>\n);"
 				},
 				{
-					"name": "layout",
+					"id": "components-resizable--layout",
+					"name": "height, gap",
 					"snippet": "const layout = () => (\n    <Resizable height=\"100px\" gap={8}>\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n        <Resizable.Handle />\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n    </Resizable>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-resizable--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Resizable className=\"test-classname\" attributes={{ id: \"test-id\" }} height=\"200px\">\n            <Resizable.Item>\n                <Panel />\n            </Resizable.Item>\n            <Resizable.Handle />\n            <Resizable.Item>\n                <Panel />\n            </Resizable.Item>\n        </Resizable>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, Resizable, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Resizable/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Resizable",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Resizable/Resizable.tsx",
-				"actualName": "Resizable",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Resizable/Resizable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"bordered\" | \"borderless\"",
+							"value": [{ "value": "\"bordered\"" }, { "value": "\"borderless\"" }]
+						}
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Component content direction with the resize handle rendered in between the chidlren",
+						"name": "direction",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Resizable/Resizable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between children, base unit token number multiplier",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					}
+				},
+				"exportName": "Resizable"
 			}
 		},
 		"components-scrim": {
@@ -1455,26 +8039,101 @@
 			"path": "./src/components/Scrim/tests/Scrim.stories.tsx",
 			"stories": [
 				{
+					"id": "components-scrim--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: center\">\n            <Scrim backgroundSlot={<Placeholder h={200} />}>Scrim</Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <Scrim position=\"bottom\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: top\">\n            <Scrim position=\"top\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: start\">\n            <Scrim position=\"start\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <Scrim position=\"end\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-scrim--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Scrim className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Scrim>\n    </div>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "components-scrim--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"without backgroundSlot, size is based on the parent component\">\n            <div style={{ height: 300, position: \"relative\" }}>\n                <Scrim>Text</Scrim>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Placeholder, Scrim } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Scrim/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Scrim",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Scrim/Scrim.tsx",
-				"actualName": "Scrim",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"backgroundSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting background content behind the scrim",
+						"name": "backgroundSlot",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Component content position",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"bottom\" | \"start\" | \"end\" | \"full\"",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"full\"" }
+							]
+						}
+					},
+					"scrimClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the scrim element",
+						"name": "scrimClassName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1484,79 +8143,398 @@
 			"path": "./src/components/Select/tests/Select.stories.tsx",
 			"stories": [
 				{
-					"name": "nativeRender",
+					"id": "components-select--native-render",
+					"name": "native rendering, options, name, id",
 					"snippet": "const nativeRender = () => (\n    <Example>\n        <Example.Item title=\"native with options prop\">\n            <Select\n                name=\"animal\"\n                id=\"animal-1\"\n                placeholder=\"Select an animal\"\n                options={[\n                    { label: \"Dog\", value: \"dog\" },\n                    { label: \"Turtle\", value: \"turtle\" },\n                ]}\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            />\n        </Example.Item>\n        <Example.Item title=\"native with option tags\">\n            <Select\n                name=\"animal\"\n                id=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "customRender",
+					"id": "components-select--custom-render",
+					"name": "custom rendering, name, id, option groups",
 					"snippet": "const customRender = () => (\n    <Example>\n        <Example.Item title=\"custom with options\">\n            <Select.Custom\n                name=\"animal\"\n                id=\"animal-1\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"native with option tags\">\n            <Select.Custom\n                name=\"animal-2\"\n                id=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Group label=\"Birds\">\n                    <Select.Option value=\"pigeon\">Pigeon</Select.Option>\n                    <Select.Option value=\"parrot\">Parrot</Select.Option>\n                </Select.Group>\n                <Select.Group label=\"Sea Mammals\">\n                    <Select.Option value=\"whale\">Whale</Select.Option>\n                    <Select.Option value=\"dolphin\">Dolphin</Select.Option>\n                </Select.Group>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "nativeHandlers",
+					"id": "components-select--native-handlers",
+					"name": "native, controlled, uncontrolled, onFocus, onBlur, onChange",
 					"snippet": "const nativeHandlers = () => <Example>\n    <Example.Item title=\"native, uncontrolled, onChange\">\n        <Select\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n    <Example.Item title=\"native, controlled, onChange\">\n        <Select\n            name=\"animal-2\"\n            placeholder=\"Select an animal\"\n            value=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n    <Example.Item title=\"native, onFocus, onBlur, onClick\">\n        <Select\n            name=\"animal-3\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onFocus={fn()}\n            onBlur={fn()}\n            onClick={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "customHandlers",
+					"id": "components-select--custom-handlers",
+					"name": "custom, controlled, uncontrolled, onFocus, onBlur, onChange",
 					"snippet": "const customHandlers = () => <Example>\n    <Example.Item title=\"custom, uncontrolled, onChange\">\n        <Select.Custom\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n    <Example.Item title=\"custom, controlled, onChange\">\n        <Select.Custom\n            name=\"animal-2\"\n            placeholder=\"Select an animal\"\n            value=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n    <Example.Item title=\"native, onFocus, onBlur, onClick\">\n        <Select.Custom\n            name=\"animal-3\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onFocus={fn()}\n            onBlur={fn()}\n            onClick={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "triggerOnly",
+					"id": "components-select--trigger-only",
+					"name": "trigger only, onClick",
 					"snippet": "const triggerOnly = (args) => {\n    const toggle = useToggle();\n    const [value, setValue] = React.useState(\"Dog\");\n\n    const handleClick: SelectProps[\"onClick\"] = (e) => {\n        args.handleClick(e);\n        toggle.toggle();\n    };\n\n    return (\n        <Example>\n            <Example.Item title=\"trigger only, onClick\">\n                <Select\n                    name=\"animal\"\n                    placeholder=\"Select an animal\"\n                    onClick={handleClick}\n                    value=\"dog\"\n                    inputAttributes={{\n                        \"aria-label\": \"Select an animal\",\n                    }}\n                >\n                    {value}\n                </Select>\n                <Modal\n                    active={toggle.active}\n                    onClose={toggle.deactivate}\n                    position=\"bottom\"\n                    padding={2}\n                    attributes={{ \"aria-label\": \"Select an animal\" }}\n                >\n                    <div role=\"listbox\" aria-label=\"Select an animal\">\n                        <MenuItem\n                            roundedCorners\n                            onClick={() => {\n                                setValue(\"Dog\");\n                                toggle.deactivate();\n                            }}\n                            attributes={{\n                                role: \"option\",\n                            }}\n                        >\n                            Dog\n                        </MenuItem>\n                        <MenuItem\n                            roundedCorners\n                            attributes={{\n                                role: \"option\",\n                            }}\n                            onClick={() => {\n                                setValue(\"Turtle\");\n                                toggle.deactivate();\n                            }}\n                        >\n                            Turtle\n                        </MenuItem>\n                    </div>\n                </Modal>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-select--multiple",
 					"name": "multiple",
 					"snippet": "const multiple = () => <Example>\n    <Example.Item title=\"multiple\">\n        <Select.Custom\n            multiple\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue={[\"dog\"]}\n            onChange={fn()}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-select--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded, native\">\n            <Select\n                variant=\"faded\"\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n\n        <Example.Item title=\"variant: faded, custom\">\n            <Select.Custom\n                variant=\"faded\"\n                name=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless, native\">\n            <Select\n                variant=\"headless\"\n                name=\"animal-3\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless, custom\">\n            <Select.Custom\n                variant=\"headless\"\n                name=\"animal-4\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <Select.Custom size=\"small\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <Select.Custom size=\"medium\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <Select.Custom size=\"large\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: xlarge\">\n            <Select.Custom size=\"xlarge\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "startSlot",
+					"id": "components-select--start-slot",
+					"name": "icon,startSlot",
 					"snippet": "const startSlot = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Select.Custom name=\"animal\" placeholder=\"Select an animal\" icon={IconZap}>\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n\n        <Example.Item title=\"startSlot\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                startSlot={<Placeholder h={20} />}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--render-value",
 					"name": "renderValue",
 					"snippet": "const renderValue = () => {\n    const options = [\n        {\n            value: \"1\",\n            label: \"Title 1\",\n            subtitle: \"Subtitle 1\",\n        },\n        {\n            value: \"2\",\n            label: \"Title 2\",\n            subtitle: \"Subtitle 2\",\n        },\n    ];\n\n    return (\n        <Example>\n            <Example.Item title=\"default renderer, single\">\n                <Select.Custom name=\"animal\" defaultValue=\"1\" placeholder=\"Nothing selected\">\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"default renderer, multiple\">\n                <Select.Custom name=\"animal\" defaultValue={[\"1\"]} multiple placeholder=\"Nothing selected\">\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"renderValue, single\">\n                <Select.Custom\n                    name=\"animal\"\n                    defaultValue=\"1\"\n                    placeholder=\"Nothing selected\"\n                    renderValue={(args) => <Badge>Title {args.value}</Badge>}\n                >\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"renderValue, multiple\">\n                <Select.Custom\n                    name=\"animal\"\n                    defaultValue={[\"1\"]}\n                    multiple\n                    placeholder=\"Nothing selected\"\n                    renderValue={(args) => <Badge>Titles {args.value.join(\", \")}</Badge>}\n                >\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-select--error",
 					"name": "error",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Select.Custom name=\"animal\" placeholder=\"Select an animal\" hasError>\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, native\">\n            <Select\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                disabled\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n        <Example.Item title=\"disabled, custom\">\n            <Select.Custom\n                name=\"animal-2\"\n                placeholder=\"Select an animal\"\n                disabled\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-select--class-name",
+					"name": "className, attributes, inputAttributes",
 					"snippet": "const className = () => (\n    <Example>\n        <Example.Item title=\"native, className, attributes, inputAttributes\">\n            <Select\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                className=\"native-class\"\n                attributes={{ id: \"test-id\" }}\n                inputAttributes={{ \"aria-label\": \"test-label\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n        <Example.Item title=\"custom, className, attributes, inputAttributes\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                className=\"custom-class\"\n                attributes={{ id: \"test-id\" }}\n                inputAttributes={{ \"aria-label\": \"test-label\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "fallback",
+					"id": "components-select--fallback",
+					"name": "test: fallbackAdjustLayout",
 					"snippet": "const fallback = () => (\n    <Example>\n        <Example.Item title=\"fallback\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                {[...Array(100)].map((_, index) => (\n                    <Select.Option key={index} value={`item-${index}`}>\n                        Item {index + 1}\n                    </Select.Option>\n                ))}\n            </Select.Custom>\n            <div style={{ height: \"1000px\" }}></div>\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                {[...Array(100)].map((_, index) => (\n                    <Select.Option key={index} value={`item-${index}`}>\n                        Item {index + 1}\n                    </Select.Option>\n                ))}\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-select--form-control",
+					"name": "test: with FormControl",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"FormControl\">\n            <FormControl hasError>\n                <FormControl.Label>Animal</FormControl.Label>\n                <Select.Custom name=\"animal\" placeholder=\"Select an animal\">\n                    <Select.Option value=\"dog\">Dog</Select.Option>\n                    <Select.Option value=\"turtle\">Turtle</Select.Option>\n                </Select.Custom>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "components-select--test-composition",
+					"name": "test: composition",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item title=\"custom with options\">\n            <Select.Custom\n                name=\"animal\"\n                id=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Group>\n                    <Select.Option value=\"dog\">Dog</Select.Option>\n                    <Select.Option value=\"turtle\">Turtle</Select.Option>\n                </Select.Group>\n                <Select.Group>Hello</Select.Group>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Badge, Example, FormControl, MenuItem, Modal, Placeholder, Select, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Select/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Select",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Select/Select.tsx",
-				"actualName": "Select",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the select user interaction and form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value selected",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon to display in the select start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the select value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when the trigger is clicked",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"options": {
+						"defaultValue": null,
+						"description": "@deprecated Use <option /> children instead",
+						"name": "options",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NativeOption[]" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the input is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLSelectElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the input is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLSelectElement, Element>) => void)" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"select\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"renderValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "renderValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "undefined" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLSelectElement>>" }
+					}
+				},
+				"exportName": "Select"
 			}
 		},
 		"components-skeleton": {
@@ -1565,26 +8543,87 @@
 			"path": "./src/components/Skeleton/tests/Skeleton.stories.tsx",
 			"stories": [
 				{
+					"id": "components-skeleton--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"text\">\n            <Skeleton />\n        </Example.Item>\n\n        <Example.Item title=\"view, rectangle\">\n            <Skeleton width=\"100px\" height=\"100px\" />\n        </Example.Item>\n\n        <Example.Item title=\"view, circle\">\n            <Skeleton width=\"100px\" height=\"100px\" borderRadius=\"circular\" />\n        </Example.Item>\n\n        <Example.Item title=\"view, rectangle, responsive\">\n            <Skeleton width={{ s: \"100px\", m: \"200px\" }} height={{ s: \"100px\", m: \"200px\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-skeleton--radius",
 					"name": "radius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius=small\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"small\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=medium\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"medium\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=large\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"large\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=circular\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"circular\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-skeleton--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Skeleton className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Skeleton } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Skeleton/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Skeleton",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Skeleton/Skeleton.tsx",
-				"actualName": "Skeleton",
+				"methods": [],
+				"props": {
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width style, literal string value or a base unit token number multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Radius>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Skeleton/Skeleton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Skeleton/Skeleton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1594,66 +8633,421 @@
 			"path": "./src/components/Slider/tests/Slider.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "components-slider--base",
+					"name": "name, minName, maxName, range",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"single, name\">\n            <Slider name=\"slider-single\" defaultValue={30} />\n        </Example.Item>\n        <Example.Item title=\"range, name\">\n            <Slider range name=\"slider-range\" defaultMinValue={30} defaultMaxValue={85} />\n        </Example.Item>\n        <Example.Item title=\"range, minName, maxName\">\n            <Slider\n                range\n                minName=\"slider-min\"\n                maxName=\"slider-max\"\n                defaultMinValue={30}\n                defaultMaxValue={85}\n            />\n        </Example.Item>\n        <div style={{ height: 2000 }} />\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--orientation",
 					"name": "orientation",
 					"snippet": "const orientation = () => (\n    <Example>\n        <Example.Item title=\"orientation: vertical\">\n            <View height=\"200px\">\n                <Slider\n                    range\n                    name=\"slider\"\n                    defaultMinValue={30}\n                    defaultMaxValue={85}\n                    orientation=\"vertical\"\n                />\n            </View>\n        </Example.Item>\n        <View height=\"2000px\" />\n    </Example>\n);"
 				},
 				{
-					"name": "minMax",
+					"id": "components-slider--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <Example>\n        <Example.Item title=\"min, max\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={60} />\n        </Example.Item>\n        <Example.Item title=\"min, max, value < min\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={30} />\n        </Example.Item>\n        <Example.Item title=\"min, max, value > max\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={80} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--step",
 					"name": "step",
 					"snippet": "const step = () => (\n    <Example>\n        <Example.Item title=\"step: 5\">\n            <Slider name=\"slider\" defaultValue={30} step={5} />\n        </Example.Item>\n\n        <Example.Item title=\"step: 5, defaultValue: 31, rounded down to 30\">\n            <Slider name=\"slider\" defaultValue={31} step={5} />\n        </Example.Item>\n\n        <Example.Item title=\"step: 0.01, float\">\n            <Slider name=\"slider\" defaultValue={30} step={0.01} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <Slider name=\"slider\" defaultValue={30} disabled />\n        </Example.Item>\n\n        <Example.Item title=\"disabled, range\">\n            <Slider name=\"slider\" range defaultMinValue={30} defaultMaxValue={80} disabled />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--render-value",
 					"name": "renderValue",
 					"snippet": "const renderValue = () => (\n    <Example>\n        <Example.Item title=\"renderValue: $\">\n            <Slider name=\"name\" defaultValue={50} renderValue={(args) => `$${args.value}`} />\n        </Example.Item>\n        <Example.Item title=\"renderValue: false\">\n            <Slider name=\"name\" defaultValue={50} renderValue={false} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-slider--default-value",
+					"name": "defaultValue, onChange, onChangeCommit",
 					"snippet": "const defaultValue = () => <View paddingTop={10}>\n    <Slider name=\"test-name\" defaultValue={50} onChange={fn()} onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "value",
+					"id": "components-slider--value",
+					"name": "value, onChange, onChangeCommit",
 					"snippet": "const value = () => <View paddingTop={10}>\n    <Slider name=\"test-name\" value={50} onChange={fn()} onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "rangeDefaultValue",
+					"id": "components-slider--range-default-value",
+					"name": "range, defaultValue, onChange, onChangeCommit",
 					"snippet": "const rangeDefaultValue = () => <View paddingTop={10}>\n    <Slider\n        range\n        name=\"test-name\"\n        defaultMinValue={50}\n        defaultMaxValue={70}\n        onChange={fn()}\n        onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "rangeValue",
+					"id": "components-slider--range-value",
+					"name": "range, value, onChange, onChangeCommit, minName, maxName",
 					"snippet": "const rangeValue = () => <View paddingTop={10}>\n    <Slider\n        range\n        minName=\"test-name-min\"\n        maxName=\"test-name-max\"\n        minValue={50}\n        maxValue={70}\n        onChange={fn()}\n        onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "className",
+					"id": "components-slider--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Slider name=\"name\" className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				},
 				{
-					"name": "testForm",
+					"id": "components-slider--test-form",
+					"name": "test: form onChange",
 					"snippet": "const testForm = (args) => {\n    const formRef = React.useRef<HTMLFormElement>(null);\n    const [data, setData] = React.useState<[string, FormDataEntryValue][]>([]);\n\n    const handleChange = (e: React.FormEvent<HTMLFormElement>) => {\n        const formData = new FormData(e.currentTarget);\n        const nextState = [...formData.entries()];\n\n        args.handleFormChange({ formData: nextState });\n        setData(nextState);\n    };\n\n    return (\n        <View paddingTop={10} gap={4}>\n            <form onChange={handleChange} ref={formRef}>\n                <Slider\n                    range\n                    minName=\"slider-min\"\n                    maxName=\"slider-max\"\n                    defaultMinValue={30}\n                    defaultMaxValue={50}\n                />\n            </form>\n\n            {data.map((v) => v.join(\": \")).join(\", \")}\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testSwipe",
+					"id": "components-slider--test-swipe",
+					"name": "test: prevents parent swipe",
 					"snippet": "const testSwipe = () => {\n    const toggle = useToggle(true);\n\n    return (\n        <Modal active={toggle.active} onClose={toggle.deactivate} position=\"end\">\n            <View gap={4}>\n                <Modal.Title>Modal</Modal.Title>\n                <Slider name=\"slider\" defaultValue={30} />\n            </View>\n        </Modal>\n    );\n};"
 				}
 			],
 			"import": "import { Example, Modal, Slider, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Slider/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Slider",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Slider/Slider.tsx",
-				"actualName": "Slider",
+				"methods": [],
+				"props": {
+					"step": {
+						"defaultValue": null,
+						"description": "Step of the slider",
+						"name": "step",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the slider user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum value of the slider",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum value of the slider",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"orientation": {
+						"defaultValue": null,
+						"description": "Orientation of the slider",
+						"name": "orientation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"vertical\" | \"horizontal\"",
+							"value": [{ "value": "\"vertical\"" }, { "value": "\"horizontal\"" }]
+						}
+					},
+					"renderValue": {
+						"defaultValue": null,
+						"description": "Render a custom value in the thumb tooltip",
+						"name": "renderValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | ((args: { value: number; }) => string)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the slider, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the slider, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"range": {
+						"defaultValue": null,
+						"description": "Enables range slider with two thumbs",
+						"name": "range",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the slider input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"minName": {
+						"defaultValue": null,
+						"description": "Name of the slider min value input element, overrides the name",
+						"name": "minName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"maxName": {
+						"defaultValue": null,
+						"description": "Name of the slider max value input element, overrides the name",
+						"name": "maxName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the slider value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: SingleChangeArgs) => void) | ((args: RangeChangeArgs) => void) | ((args: RangeChangeArgs) => void)"
+						}
+					},
+					"onChangeCommit": {
+						"defaultValue": null,
+						"description": "Callback when the user commits the change by releasing the thumb\nCallback when the user commits the change by releasing the thumbs",
+						"name": "onChangeCommit",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: SingleChangeArgs) => void) | ((args: RangeChangeArgs) => void) | ((args: RangeChangeArgs) => void)"
+						}
+					},
+					"minValue": {
+						"defaultValue": null,
+						"description": "Minimum value of the slider",
+						"name": "minValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"maxValue": {
+						"defaultValue": null,
+						"description": "Maximum value of the slider",
+						"name": "maxValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultMinValue": {
+						"defaultValue": null,
+						"description": "Default minimum value of the slider, enables uncontrolled mode",
+						"name": "defaultMinValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultMaxValue": {
+						"defaultValue": null,
+						"description": "Default maximum value of the slider, enables uncontrolled mode",
+						"name": "defaultMaxValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1663,35 +9057,137 @@
 			"path": "./src/components/Stepper/tests/Stepper.stories.tsx",
 			"stories": [
 				{
+					"id": "components-stepper--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example>\n        <Example.Item title=\"direction: row\">\n            <Stepper activeId=\"1\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <Stepper activeId=\"1\" direction=\"column\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-stepper--label-display",
 					"name": "labelDisplay",
 					"snippet": "const labelDisplay = () => (\n    <Example>\n        <Example.Item title=\"direction: row, labels hidden\">\n            <Stepper activeId=\"1\" labelDisplay=\"hidden\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: column, labels hiden\">\n            <Stepper activeId=\"1\" direction=\"column\" labelDisplay=\"hidden\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: row, labels hidden on s\">\n            <Stepper activeId=\"1\" labelDisplay={{ s: \"hidden\", m: \"inline\" }}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-stepper--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 6, direction: row\">\n            <Stepper activeId=\"1\" gap={6}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"gap: 6, direction: column\">\n            <Stepper activeId=\"1\" direction=\"column\" gap={6}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap\", \"[s] 2\", \"[m+] 5\"]}>\n            <Stepper activeId=\"1\" gap={{ s: 2, m: 5 }}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-stepper--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Stepper className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Stepper.Item attributes={{ id: \"test-item-id\" }} className=\"test-item-classname\" />\n        </Stepper>\n    </div>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-stepper--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"multiline subtitle\",\n                \"should wrap the text correctly\",\n                \"should display the connector correctly\",\n            ]}\n        >\n            <Demo\n                activeId={0}\n                subtitle=\"It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, Placeholder, Stepper, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Stepper/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Stepper",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Stepper/Stepper.tsx",
-				"actualName": "Stepper",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"activeId": {
+						"defaultValue": null,
+						"description": "Id of the item to display as active",
+						"name": "activeId",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string | number" }
+					},
+					"labelDisplay": {
+						"defaultValue": null,
+						"description": "Display variant for the item label",
+						"name": "labelDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"hidden\" | \"inline\">" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Direction of the stepper",
+						"name": "direction",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between items (default: 3)",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
+				"exportName": "Stepper"
 			}
 		},
 		"components-switch": {
@@ -1700,38 +9196,236 @@
 			"path": "./src/components/Switch/tests/Switch.stories.tsx",
 			"stories": [
 				{
-					"name": "size",
+					"id": "components-switch--size",
+					"name": "Size",
 					"snippet": "const size = () => (\n\t<Example>\n\t\t<Example.Item title=\"size: medium\">\n\t\t\t<Switch name=\"active\" size=\"medium\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: small\">\n\t\t\t<Switch name=\"active\" size=\"small\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: large\">\n\t\t\t<Switch name=\"active\" size=\"large\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: responsive, s: small, m: large\">\n\t\t\t<Switch\n\t\t\t\tname=\"active\"\n\t\t\t\tsize={{ s: \"small\", m: \"large\" }}\n\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t/>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "label",
+					"id": "components-switch--label",
+					"name": "Label",
 					"snippet": "const label = () => (\n\t<Example>\n\t\t<Example.Item title=\"size: medium\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch reversed name=\"active\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: small\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" size=\"small\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch\n\t\t\t\t\treversed\n\t\t\t\t\tname=\"active\"\n\t\t\t\t\tsize=\"small\"\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t\t>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\n\t\t<Example.Item title=\"size: large\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" size=\"large\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch\n\t\t\t\t\treversed\n\t\t\t\t\tname=\"active\"\n\t\t\t\t\tsize=\"large\"\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t\t>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-switch--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Switch name=\"test-name\" defaultChecked onChange={fn()}>Label\n            </Switch>;"
 				},
 				{
-					"name": "checked",
+					"id": "components-switch--checked",
+					"name": "checked, uncontrolled",
 					"snippet": "const checked = () => <Switch name=\"test-name\" checked onChange={fn()}>Label\n            </Switch>;"
 				},
 				{
+					"id": "components-switch--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, unselected\">\n            <Switch name=\"active\" disabled inputAttributes={{ \"aria-label\": \"test switch\" }} />\n        </Example.Item>\n        <Example.Item title=\"disabled, selected\">\n            <Switch\n                name=\"active\"\n                disabled\n                defaultChecked\n                inputAttributes={{ \"aria-label\": \"test switch\" }}\n            />\n        </Example.Item>\n        <Example.Item title=\"disabled, with label\">\n            <Switch name=\"active\" disabled>\n                Switch\n            </Switch>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-switch--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Switch\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ \"aria-label\": \"test select\", id: \"test-input-id\" }}\n            name=\"name\"\n        >\n            Label\n        </Switch>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Switch, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Switch/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Switch",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Switch/Switch.tsx",
-				"actualName": "Switch",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the switch",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the switch input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the switch user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"reversed": {
+						"defaultValue": null,
+						"description": "Reverse the children position",
+						"name": "reversed",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the switch value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the switch is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the switch is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default value of the switch, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Value of the switch, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1741,51 +9435,112 @@
 			"path": "./src/components/Table/tests/Table.stories.tsx",
 			"stories": [
 				{
-					"name": "layout",
+					"id": "components-table--layout",
+					"name": "base",
 					"snippet": "const layout = () => (\n    <Example>\n        <Example.Item title=\"base\">\n            <Table>\n                <Table.Head>\n                    <Table.Row>\n                        <Table.Heading>Column 1</Table.Heading>\n                        <Table.Heading>Column 2</Table.Heading>\n                    </Table.Row>\n                </Table.Head>\n                <Table.Body>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell>Cell 2</Table.Cell>\n                    </Table.Row>\n                </Table.Body>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"colspan: 2 for col 2, rowspan: 2 for cell 3\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading colSpan={2}>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                    <Table.Cell rowSpan={2}>Cell 3</Table.Cell>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"align: center for heading 1, align: end for heading 2\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading align=\"center\">Column 1</Table.Heading>\n                    <Table.Heading align=\"end\">Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"valign: center for cell 2, valign: end for cell 3\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>\n                        <View height={15} backgroundColor=\"neutral-faded\" />\n                    </Table.Cell>\n                    <Table.Cell verticalAlign=\"center\">Cell 2</Table.Cell>\n                    <Table.Cell verticalAlign=\"end\">Cell 3</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"width: 40%, minWidth: 200px for col 1\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"40%\" minWidth=\"200px\">\n                        Column 1\n                    </Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-table--border",
 					"name": "border",
 					"snippet": "const border = () => (\n    <Example>\n        <Example.Item title=\"border: true\">\n            <Table border>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"columnBorder: true\">\n            <Table columnBorder>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"columnBorder: true, border: true\">\n            <Table columnBorder border>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-table--rows",
 					"name": "rows",
 					"snippet": "const rows = () => (\n    <Example>\n        <Example.Item title=\"highlighted for row 2\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row highlighted>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"clickable row 2, focus ring\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row onClick={() => {}}>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-table--render",
+					"name": "rendering",
 					"snippet": "const render = () => (\n    <Table>\n        <Table.Head>\n            <Table.Row>\n                <Table.Heading>Heading</Table.Heading>\n                <Table.Heading>Heading</Table.Heading>\n            </Table.Row>\n        </Table.Head>\n        <Table.Body>\n            <Table.Row>\n                <Table.Cell>Content</Table.Cell>\n                <Table.Cell>Content</Table.Cell>\n            </Table.Row>\n        </Table.Body>\n    </Table>\n);"
 				},
 				{
-					"name": "tbody",
+					"id": "components-table--tbody",
+					"name": "tbody rendering",
 					"snippet": "const tbody = () => (\n    <Table>\n        <Table.Row>\n            <Table.Heading>Heading</Table.Heading>\n            <Table.Heading>Heading</Table.Heading>\n        </Table.Row>\n    </Table>\n);"
 				},
 				{
-					"name": "tabIndex",
+					"id": "components-table--tab-index",
+					"name": "adds tabIndex for clickable rows",
 					"snippet": "const tabIndex = () => (\n    <Table>\n        <Table.Row>\n            <Table.Cell />\n        </Table.Row>\n        <Table.Row onClick={() => {}}>\n            <Table.Cell />\n        </Table.Row>\n        <Table.Row attributes={{ onClick: () => {} }}>\n            <Table.Cell />\n        </Table.Row>\n    </Table>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-table--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Table className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Table.Row attributes={{ id: \"test-row-id\" }}>\n                <Table.Cell attributes={{ id: \"test-cell-id\" }}></Table.Cell>\n            </Table.Row>\n        </Table>\n    </div>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-table--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"scroll fade\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"500px\">Column 1</Table.Heading>\n                    <Table.Heading width=\"500px\">Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"card with highlighted heading\">\n            <Card elevated padding={0}>\n                <Table>\n                    <Table.Row highlighted>\n                        <Table.Heading width=\"50%\" minWidth=\"200px\">\n                            Column 1\n                        </Table.Heading>\n                        <Table.Heading colSpan={2} align=\"end\">\n                            Column 2\n                        </Table.Heading>\n                    </Table.Row>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell align=\"center\">Cell 2</Table.Cell>\n                        <Table.Cell align=\"end\">Cell 3</Table.Cell>\n                    </Table.Row>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell align=\"center\">Cell 2</Table.Cell>\n                        <Table.Cell align=\"end\">Cell 3</Table.Cell>\n                    </Table.Row>\n                </Table>\n            </Card>\n        </Example.Item>\n        <Example.Item title=\"width: auto, nowrap\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"50%\">Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                    <Table.Heading>Column 3</Table.Heading>\n                    <Table.Heading width=\"auto\">Long heading title</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                    <Table.Cell>Cell 3</Table.Cell>\n                    <Table.Cell>Cell 4</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "examples",
+					"id": "components-table--examples",
+					"name": "test: selectable",
 					"snippet": "const examples = () => (\n    <Example>\n        <Example.Item title=\"selectable\">\n            <SelectionDemo />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Card, Checkbox, Example, Table, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Table/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Table",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Table/Table.tsx",
-				"actualName": "Table",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"border": {
+						"defaultValue": null,
+						"description": "Add border around the table",
+						"name": "border",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"columnBorder": {
+						"defaultValue": null,
+						"description": "Add border between the table columns",
+						"name": "columnBorder",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
+				"exportName": "Table"
 			}
 		},
 		"components-tabs": {
@@ -1794,71 +9549,196 @@
 			"path": "./src/components/Tabs/tests/Tabs.stories.tsx",
 			"stories": [
 				{
+					"id": "components-tabs--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Tabs>\n        <Tabs.List>\n            <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n            <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n        </Tabs.List>\n\n        <Tabs.Panel value=\"1\">\n            <View padding={4}>Content 1</View>\n        </Tabs.Panel>\n        <Tabs.Panel value=\"2\">\n            <View padding={4}>Content 2</View>\n        </Tabs.Panel>\n    </Tabs>\n);"
 				},
 				{
+					"id": "components-tabs--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Tabs defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills\">\n            <Tabs variant=\"pills\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills-elevated\">\n            <Tabs variant=\"pills-elevated\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: borderless\">\n            <Tabs variant=\"borderless\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"variant: default, size: large\">\n            <Tabs size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills, size: large\">\n            <Tabs variant=\"pills\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills-elevated, size: large\">\n            <Tabs variant=\"pills-elevated\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: borderless, size: large\">\n            <Tabs variant=\"borderless\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example>\n        <Example.Item title=\"direction: column, variant: underline\">\n            <Tabs direction=\"column\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: pills\">\n            <Tabs direction=\"column\" variant=\"pills\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: pills-elevated\">\n            <Tabs direction=\"column\" variant=\"pills-elevated\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: borderless\">\n            <Tabs direction=\"column\" variant=\"borderless\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Tabs>\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"1\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"icon only\">\n            <Tabs variant=\"pills-elevated\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap} attributes={{ \"aria-label\": \"Tab 1\" }} />\n                    <Tabs.Item value=\"1\" icon={IconZap} attributes={{ \"aria-label\": \"Tab 2\" }} />\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "equalWidth",
+					"id": "components-tabs--equal-width",
+					"name": "itemWidth",
 					"snippet": "const equalWidth = () => (\n    <Example>\n        <Example.Item title=\"equal width items\">\n            <Tabs onChange={console.log} itemWidth=\"equal\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"1\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                    <Tabs.Item value=\"2\" icon={IconZap}>\n                        Very long item 3\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--href",
 					"name": "href",
 					"snippet": "const href = () => (\n    <Example>\n        <Example.Item title=\"href, no onChange\">\n            <Tabs value=\"2\">\n                <Tabs.List>\n                    <Tabs.Item value=\"1\" href=\"#item-1\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"2\" href=\"#item-2\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                    <Tabs.Item value=\"3\" href=\"#item-3\" icon={IconZap}>\n                        Very long item 3\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "disabled",
+					"id": "components-tabs--disabled",
+					"name": "item, disabled",
 					"snippet": "const disabled = () => {\n    return (\n        <Example>\n            <Example.Item title=\"disabled\">\n                <Tabs defaultValue=\"1\">\n                    <Tabs.List>\n                        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"2\" disabled icon={IconZap}>\n                            Item 2\n                        </Tabs.Item>\n                        <Tabs.Item value=\"3\">Item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"1\">\n                        <View padding={4}>Content 1</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <View padding={4}>Content 2</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"3\">\n                        <View padding={4}>Content 3</View>\n                    </Tabs.Panel>\n                </Tabs>\n            </Example.Item>\n\n            <Example.Item title=\"disabled, href\">\n                <Tabs defaultValue=\"1\">\n                    <Tabs.List>\n                        <Tabs.Item href=\"#item1\" value=\"1\">\n                            Item 1\n                        </Tabs.Item>\n                        <Tabs.Item href=\"#item2\" value=\"2\" disabled icon={IconZap}>\n                            Item 2\n                        </Tabs.Item>\n                        <Tabs.Item href=\"#item3\" value=\"3\">\n                            Item 3\n                        </Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"1\">\n                        <View padding={4}>Content 1</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <View padding={4}>Content 2</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"3\">\n                        <View padding={4}>Content 3</View>\n                    </Tabs.Panel>\n                </Tabs>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-tabs--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <Tabs defaultValue=\"2\" onChange={fn()}>\n    <Tabs.List>\n        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n        <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n    </Tabs.List>\n    <Tabs.Panel value=\"1\">Content 1</Tabs.Panel>\n    <Tabs.Panel value=\"2\">Content 2</Tabs.Panel>\n</Tabs>;"
 				},
 				{
-					"name": "value",
+					"id": "components-tabs--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <Tabs value=\"2\" onChange={fn()}>\n    <Tabs.List>\n        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n        <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n    </Tabs.List>\n    <Tabs.Panel value=\"1\">Content 1</Tabs.Panel>\n    <Tabs.Panel value=\"2\">Content 2</Tabs.Panel>\n</Tabs>;"
 				},
 				{
-					"name": "className",
+					"id": "components-tabs--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Tabs>\n            <Tabs.List attributes={{ id: \"test-list-id\" }} className=\"test-list-classname\">\n                <Tabs.Item attributes={{ id: \"test-item-id\" }} value=\"1\">\n                    Item\n                </Tabs.Item>\n            </Tabs.List>\n\n            <Tabs.Panel\n                attributes={{ \"data-testid\": \"test-panel-id\" }}\n                className=\"test-panel-classname\"\n                value=\"1\"\n            />\n        </Tabs>\n    </div>\n);"
 				},
 				{
-					"name": "testFocusableContent",
+					"id": "components-tabs--test-focusable-content",
+					"name": "test: focusable content",
 					"snippet": "const testFocusableContent = () => (\n    <Example>\n        <Example.Item title=\"panels without focusable content\">\n            <Tabs>\n                <View gap={4}>\n                    <Tabs.List>\n                        <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                        <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"0\">Tab 1</Tabs.Panel>\n                    <Tabs.Panel value=\"1\">Tab 2</Tabs.Panel>\n                    <Tabs.Panel value=\"2\">Tab 3</Tabs.Panel>\n                </View>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"panels with focusable content\">\n            <Tabs>\n                <View gap={4}>\n                    <Tabs.List>\n                        <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                        <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"0\">\n                        <Button onClick={() => {}}>Tab 1 action</Button>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"1\">\n                        <Button onClick={() => {}}>Tab 2 action</Button>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <Button onClick={() => {}}>Tab 3 action</Button>\n                    </Tabs.Panel>\n                </View>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "components-tabs--test-composition",
+					"name": "test: composition",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item title=\"Viewport overflow\">\n            <Tabs>\n                <Tabs.List>\n                    {[...Array(8)].map((_, i) => (\n                        <Tabs.Item value={`${i}`} key={i} icon={IconZap}>\n                            Very long item {i}\n                        </Tabs.Item>\n                    ))}\n                </Tabs.List>\n\n                {[...Array(8)].map((_, i) => (\n                    <Tabs.Panel value={`${i}`} key={i}>\n                        Tab {i}\n                    </Tabs.Panel>\n                ))}\n            </Tabs>\n        </Example.Item>\n        <Example.Item>\n            <Tabs onChange={console.log} variant=\"pills-elevated\" name=\"hey\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">\n                        <View borderColor=\"neutral-faded\" padding={5}>\n                            Item 3\n                        </View>\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"Custom non-interactive list children\">\n            <Tabs direction=\"column\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <View height={6} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testEdgeCaseDom",
+					"id": "components-tabs--test-edge-case-dom",
+					"name": "test: scroll subscription",
 					"snippet": "const testEdgeCaseDom = () => {\n    const [activeItem, setActiveItem] = React.useState(\"1\");\n    const sectionsRef = React.useRef(null);\n\n    return (\n        <Example>\n            <Example.Item title=\"active item changes on scroll\">\n                <View justify=\"center\" align=\"center\" padding={10}>\n                    <View width={60} gap={2}>\n                        <Tabs value={activeItem} onChange={(args) => setActiveItem(args.value)}>\n                            <Tabs.List>\n                                <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                                <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n                                <Tabs.Item value=\"3\">Item 3</Tabs.Item>\n                                <Tabs.Item value=\"4\">Item 4</Tabs.Item>\n                            </Tabs.List>\n                        </Tabs>\n\n                        <ScrollArea\n                            attributes={{ ref: sectionsRef }}\n                            height={70}\n                            onScroll={(args) => {\n                                setActiveItem(Math.min(4, Math.floor(args.y * 10) + 1).toString());\n                            }}\n                        >\n                            <View gap={4}>\n                                <View gap={2}>\n                                    <Text>Section 1</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View grow height=\"100px\" backgroundColor=\"neutral-faded\" key={i} />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 2</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 3</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 4</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n                            </View>\n                        </ScrollArea>\n                    </View>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Example, ScrollArea, Tabs, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Tabs/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Tabs",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Tabs/Tabs.tsx",
-				"actualName": "Tabs",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Direction of the tab buttons",
+						"name": "direction",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"itemWidth": {
+						"defaultValue": null,
+						"description": "Equal width for the tab buttons",
+						"name": "itemWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"equal\"", "value": [{ "value": "\"equal\"" }] }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Render variant for component",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"bordered\" | \"borderless\" | \"pills\" | \"pills-elevated\"",
+							"value": [
+								{ "value": "\"bordered\"" },
+								{ "value": "\"borderless\"" },
+								{ "value": "\"pills\"" },
+								{ "value": "\"pills-elevated\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"large\" | \"medium\"",
+							"value": [{ "value": "\"large\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the tab buttons group when used as a form control",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the active tab value changes",
+						"name": "onChange",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((args: { value: string; name?: string; }) => void)" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the active tab, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the active tab, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "Tabs"
 			}
 		},
 		"components-textarea": {
@@ -1867,71 +9747,315 @@
 			"path": "./src/components/TextArea/tests/TextArea.stories.tsx",
 			"stories": [
 				{
-					"name": "variants",
+					"id": "components-textarea--variants",
+					"name": "variant",
 					"snippet": "const variants = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <TextArea variant=\"faded\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless\">\n            <TextArea variant=\"headless\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: medium\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"medium\" />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"large\" />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"xlarge\" />\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] large\", \"[m+] medium\"]}>\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size={{ s: \"xlarge\", m: \"medium\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--resize",
 					"name": "resize",
 					"snippet": "const resize = () => (\n    <Example>\n        <Example.Item title=\"resize: none\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" resize=\"none\" />\n        </Example.Item>\n        <Example.Item title=\"resize: auto\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" resize=\"auto\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-textarea--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" hasError />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner\">\n            <View gap={2}>\n                <Text variant=\"featured-2\">What problem are you trying to solve?</Text>\n                <TextArea.Aligner>\n                    <TextArea\n                        variant=\"headless\"\n                        placeholder=\"Try something like 'I have a job'\"\n                        name=\"description\"\n                    />\n                </TextArea.Aligner>\n                <View.Item>\n                    <Button>Next</Button>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-textarea--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"long value without breaks\">\n            <TextArea\n                name=\"hey\"\n                defaultValue={`<div style=\"position:relative;width:100%;padding-top:calc(150% + 72px)\">\n<iframe src=\"nskjdfdsdkjfsjkdfhbsjlhdfbsjlhfbs;jhbsdljfhsbljhfsbljhfbsjlfdhbsljhfbsdljhfbsljhfbslufbhsdlfds\" />\n</div>`}\n                resize=\"auto\"\n                placeholder=\"Placeholder\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-textarea--render",
+					"name": "base",
 					"snippet": "const render = () => <TextArea name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-textarea--placeholder",
 					"name": "placeholder",
 					"snippet": "const placeholder = () => (\n    <TextArea\n        name=\"test-name\"\n        placeholder=\"Placeholder\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-textarea--id",
 					"name": "id",
 					"snippet": "const id = () => (\n    <TextArea name=\"test-name\" id=\"test-id\" inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
+					"id": "components-textarea--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <TextArea name=\"test-name\" disabled inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-textarea--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <TextArea\n    name=\"test-name\"\n    defaultValue=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-textarea--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <TextArea\n    name=\"test-name\"\n    value=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-textarea--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <TextArea\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-textarea--form-control",
+					"name": "test: form control",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"with helper\">\n            <FormControl>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextArea name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n        <Example.Item title=\"with error\">\n            <FormControl hasError>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextArea name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, FormControl, Text, TextArea, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/TextArea/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "TextArea",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/TextArea/TextArea.tsx",
-				"actualName": "TextArea",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text area",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text area input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text area user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text area value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLTextAreaElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text area is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLTextAreaElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text area is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLTextAreaElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"textarea\">" }
+					},
+					"resize": {
+						"defaultValue": null,
+						"description": "Enable or disable the text area resizing, supports auto-sizing",
+						"name": "resize",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"none\" | \"auto\"",
+							"value": [{ "value": "\"none\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "TextArea"
 			}
 		},
 		"components-textfield": {
@@ -1940,71 +10064,445 @@
 			"path": "./src/components/TextField/tests/TextField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-textfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <TextField variant=\"faded\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless\">\n            <TextField variant=\"headless\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded\">\n            <TextField\n                rounded\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                icon={IconZap}\n                prefix=\"+31\"\n                endSlot={<Button rounded size=\"small\" icon={IconZap} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"rounded, variant: faded\">\n            <View direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <TextField\n                        rounded\n                        variant=\"faded\"\n                        name=\"Name\"\n                        placeholder=\"Enter your name\"\n                        startSlot={\n                            <Badge rounded size=\"small\">\n                                Hello\n                            </Badge>\n                        }\n                    />\n                </View.Item>\n                <Button rounded>Submit</Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-textfield--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" hasError />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "attachments",
+					"id": "components-textfield--attachments",
+					"name": "icon, endIcon, suffix, prefix, startSlot, endSlot, startSlotPadding, endSlotPadding",
 					"snippet": "const attachments = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" value=\"Reshaped\" icon={IconZap} />\n        </Example.Item>\n        <Example.Item title=\"endIcon\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" value=\"Reshaped\" endIcon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title={[\"startSlot\", \"vertical and horizontal padding aligned\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title={[\"endSlot\", \"vertical and horizontal padding aligned\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                endSlot={\n                    <Button\n                        icon={IconZap}\n                        size=\"small\"\n                        onClick={() => {}}\n                        attributes={{ \"aria-label\": \"Action\" }}\n                    />\n                }\n            />\n        </Example.Item>\n\n        <Example.Item title=\"paddingSlotStart=4, paddingSlotEnd=2\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlotPadding={4}\n                endSlotPadding={2}\n                startSlot={<Placeholder h={20} />}\n                endSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"with all affixes\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                endIcon={IconZap}\n                icon={IconZap}\n                prefix=\"Estimated value\"\n                suffix=\"m2\"\n                startSlot={<Placeholder h={20} />}\n                endSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"multiline wrap\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlot={[...Array(10).keys()].map((i) => (\n                    <Badge size=\"small\" key={i}>\n                        Item {i + 1}\n                    </Badge>\n                ))}\n                multiline\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"small\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"medium\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"large\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"xlarge\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] xlarge\", \"[m+] medium\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                size={{ s: \"xlarge\", m: \"medium\" }}\n                icon={IconZap}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner\">\n            <View gap={2}>\n                <Text variant=\"featured-2\">What problem are you trying to solve?</Text>\n                <TextField.Aligner>\n                    <TextField\n                        variant=\"headless\"\n                        placeholder=\"Try something like 'I have a job'\"\n                        name=\"description\"\n                    />\n                </TextField.Aligner>\n                <View.Item>\n                    <Button>Next</Button>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-textfield--render",
+					"name": "base",
 					"snippet": "const render = () => <TextField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-textfield--placeholder",
 					"name": "placeholder",
 					"snippet": "const placeholder = () => (\n    <TextField\n        name=\"test-name\"\n        placeholder=\"Placeholder\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-textfield--id",
 					"name": "id",
 					"snippet": "const id = () => (\n    <TextField name=\"test-name\" id=\"test-id\" inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
+					"id": "components-textfield--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <TextField name=\"test-name\" disabled inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-textfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <TextField\n    name=\"test-name\"\n    defaultValue=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-textfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <TextField\n    name=\"test-name\"\n    value=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-textfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <TextField\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-textfield--form-control",
+					"name": "test: form control",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"with helper\">\n            <FormControl>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextField name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n        <Example.Item title=\"with error\">\n            <FormControl hasError>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextField name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Badge, Button, Example, FormControl, Placeholder, Text, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/TextField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "TextField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/TextField/TextField.tsx",
-				"actualName": "TextField",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"multiline": {
+						"defaultValue": null,
+						"description": "Enable multiline text field wrapping",
+						"name": "multiline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to be fully rounded",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content after the text field value",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text field value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the text field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the text field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "TextField"
 			}
 		},
 		"components-timeline": {
@@ -2013,27 +10511,71 @@
 			"path": "./src/components/Timeline/tests/Timeline.stories.tsx",
 			"stories": [
 				{
+					"id": "components-timeline--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"children passed directly\">\n            <Timeline>\n                <Placeholder />\n                <Placeholder />\n                <Placeholder />\n            </Timeline>\n        </Example.Item>\n        <Example.Item title=\"children wrapped with Timeline.Item\">\n            <Timeline>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "marker",
+					"id": "components-timeline--marker",
+					"name": "markerSlot",
 					"snippet": "const marker = () => (\n    <Example>\n        <Example.Item title=\"slot\">\n            <Timeline>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n\n        <Example.Item title=\"null marker\">\n            <Timeline>\n                <Timeline.Item markerSlot={null}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={null}>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-timeline--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Timeline className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Timeline.Item className=\"test-item-classname\" attributes={{ id: \"test-item-id\" }}>\n                Content\n            </Timeline.Item>\n            <Timeline.Item>Content</Timeline.Item>\n        </Timeline>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Placeholder, Timeline } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Timeline/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Timeline",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Timeline/Timeline.tsx",
-				"actualName": "Timeline",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"ul\">" }
+					}
+				},
+				"exportName": "Timeline"
 			}
 		},
 		"components-toast": {
@@ -2041,32 +10583,54 @@
 			"name": "Toast",
 			"path": "./src/components/Toast/tests/Toast.stories.tsx",
 			"stories": [
-				{ "name": "size", "snippet": "const size = () => <Size />;" },
 				{
+					"id": "components-toast--size",
+					"name": "size",
+					"snippet": "const size = () => <Size />;"
+				},
+				{
+					"id": "components-toast--position",
 					"name": "position",
 					"snippet": "const position = () => <Position />;"
 				},
-				{ "name": "color", "snippet": "const color = () => <Color />;" },
-				{ "name": "timeout", "snippet": "const timeout = () => <Timeout />;" },
 				{
-					"name": "regionOptions",
+					"id": "components-toast--color",
+					"name": "color",
+					"snippet": "const color = () => <Color />;"
+				},
+				{
+					"id": "components-toast--timeout",
+					"name": "timeout",
+					"snippet": "const timeout = () => <Timeout />;"
+				},
+				{
+					"id": "components-toast--region-options",
+					"name": "expanded",
 					"snippet": "const regionOptions = () => <Expanded />;"
 				},
-				{ "name": "slots", "snippet": "const slots = () => <Slots />;" },
 				{
+					"id": "components-toast--slots",
+					"name": "slots",
+					"snippet": "const slots = () => <Slots />;"
+				},
+				{
+					"id": "components-toast--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const toast = useToast();\n\n    return (\n        <Button\n            onClick={() => {\n                const id = toast.show({\n                    title: \"Title\",\n                    text: \"Text\",\n                    children: \"Children\",\n                    startSlot: \"Slot\",\n                    actionsSlot: (\n                        <Button attributes={{ \"data-testid\": \"trigger-id\" }} onClick={() => toast.hide(id)}>\n                            Trigger\n                        </Button>\n                    ),\n                });\n            }}\n        >\n            Show toast\n        </Button>\n    );\n};"
 				},
 				{
-					"name": "nested",
+					"id": "components-toast--nested",
+					"name": "ToastProvider",
 					"snippet": "const nested = () => {\n    return (\n        <div data-testid=\"test-container-id\">\n            <ToastProvider>\n                <NestedDemo />\n            </ToastProvider>\n        </div>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-toast--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => {\n    const toast = useToast();\n\n    return (\n        <Button\n            onClick={() => {\n                const id = toast.show({\n                    text: \"Content\",\n                    attributes: { \"data-testid\": \"test-id\" },\n                    className: \"test-classname\",\n                });\n            }}\n        >\n            Show toast\n        </Button>\n    );\n};"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-toast--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"Multiline, should support dynamic height\">\n            <Multiline />\n        </Example.Item>\n        <Example.Item title=\"Nested ToastProvider\">\n            <ToastProvider>\n                <Nested />\n            </ToastProvider>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
@@ -2083,30 +10647,601 @@
 			"path": "./src/components/ToggleButton/tests/ToggleButton.stories.tsx",
 			"stories": [
 				{
+					"id": "components-togglebutton--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"outline\">\n            <ToggleButton>Button</ToggleButton>\n        </Example.Item>\n        <Example.Item title=\"ghost\">\n            <ToggleButton variant=\"ghost\">Button</ToggleButton>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-togglebutton--selected-color",
 					"name": "selectedColor",
 					"snippet": "const selectedColor = () => (\n    <Example>\n        <Example.Item title=\"selectedColor: primary\">\n            <ToggleButton selectedColor=\"primary\" defaultChecked>\n                Button\n            </ToggleButton>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onChange",
+					"id": "components-togglebutton--on-change",
+					"name": "checked, defaultChecked, onChange",
 					"snippet": "const onChange = () => <Example>\n    <Example.Item title=\"defaultChecked, onChange\">\n        <ToggleButton defaultChecked onChange={fn()} value=\"1\">Button\n                                </ToggleButton>\n    </Example.Item>\n    <Example.Item title=\"checked, onChange\">\n        <ToggleButton checked onChange={fn()} value=\"2\">Button\n                                </ToggleButton>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-togglebutton--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <ToggleButton onClick={fn()}>Button</ToggleButton>;"
 				}
 			],
 			"import": "import { Example, ToggleButton } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ToggleButton/ToggleButton.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "ToggleButton",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ToggleButton/ToggleButton.tsx",
-				"actualName": "ToggleButton",
+				"methods": [],
+				"props": {
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loading": {
+						"defaultValue": null,
+						"description": "Show loading state",
+						"name": "loading",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loadingAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the loading indicator",
+						"name": "loadingAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Make the component take the full width of the parent element",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"ghost\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"ghost\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"selectedColor": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme when selected",
+						"name": "selectedColor",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the toggle button, enables controlled mode for the ToggleButtonGroup",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the toggle button value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { checked: boolean; value: string; event: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>; }) => void)"
+						}
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default value of the toggle button, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Value of the toggle button, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2116,34 +11251,194 @@
 			"path": "./src/components/ToggleButtonGroup/tests/ToggleButtonGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "single",
+					"id": "components-togglebuttongroup--single",
+					"name": "checked, defaultChecked, onChange",
 					"snippet": "const single = () => <Example>\n    <Example.Item title=\"single, uncontrolled, onChange\">\n        <ToggleButtonGroup onChange={fn()}>\n            <ToggleButton value=\"1\" onChange={fn()}>Button\n                                    </ToggleButton>\n            <ToggleButton value=\"2\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n    <Example.Item title=\"single, controlled, onChange\">\n        <ToggleButtonGroup onChange={fn()} value={[]}>\n            <ToggleButton value=\"3\" onChange={fn()}>Button\n                                    </ToggleButton>\n            <ToggleButton value=\"4\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "multiple",
+					"id": "components-togglebuttongroup--multiple",
+					"name": "selectionMode, checked, defaultChecked, onChange",
 					"snippet": "const multiple = () => <Example>\n    <Example.Item title=\"multiple, uncontrolled, onChange\">\n        <ToggleButtonGroup onChange={fn()} selectionMode=\"multiple\">\n            <ToggleButton value=\"1\">Button</ToggleButton>\n            <ToggleButton value=\"2\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n    <Example.Item title=\"multiple, controlled, onChange\">\n        <ToggleButtonGroup onChange={fn()} value={[]} selectionMode=\"multiple\">\n            <ToggleButton value=\"3\">Button</ToggleButton>\n            <ToggleButton value=\"4\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "selectedColor",
+					"id": "components-togglebuttongroup--selected-color",
+					"name": "color,selectedColor",
 					"snippet": "const selectedColor = () => (\n    <Example>\n        <Example.Item title=\"selectedColor: primary\">\n            <ToggleButtonGroup selectedColor=\"primary\" defaultValue={[\"2\"]}>\n                <ToggleButton value=\"1\">Button</ToggleButton>\n                <ToggleButton value=\"2\">Button</ToggleButton>\n                <ToggleButton value=\"3\">Button</ToggleButton>\n            </ToggleButtonGroup>\n        </Example.Item>\n        <Example.Item title=\"color: primary, selectedColor: critical\">\n            <ToggleButtonGroup color=\"primary\" selectedColor=\"critical\" defaultValue={[\"2\"]}>\n                <ToggleButton value=\"1\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n                <ToggleButton value=\"2\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n                <ToggleButton value=\"3\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n            </ToggleButtonGroup>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-togglebuttongroup--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ToggleButtonGroup className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <ToggleButton>Button 1</ToggleButton>\n            <ToggleButton>Button 1</ToggleButton>\n        </ToggleButtonGroup>\n    </div>\n);"
 				},
 				{
-					"name": "testIcon",
+					"id": "components-togglebuttongroup--test-icon",
+					"name": "test: icon only",
 					"snippet": "const testIcon = () => (\n    <Example>\n        <Example.Item title=\"icon only\">\n            <ToggleButtonGroup selectedColor=\"primary\">\n                <ToggleButton value=\"1\" icon={IconPlus} />\n                <ToggleButton value=\"2\" icon={IconMinus} />\n                <ToggleButton value=\"3\" icon={IconCheckmark} />\n            </ToggleButtonGroup>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, ToggleButton, ToggleButtonGroup } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ToggleButtonGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ToggleButtonGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx",
-				"actualName": "ToggleButtonGroup",
+				"methods": [],
+				"props": {
+					"selectionMode": {
+						"defaultValue": { "value": "\"single\"" },
+						"description": "Selection mode for the toggle button group",
+						"name": "selectionMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"single\" | \"multiple\"",
+							"value": [{ "value": "\"single\"" }, { "value": "\"multiple\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme applied to each button",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"selectedColor": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme for the selected button",
+						"name": "selectedColor",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the toggle button group value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { value: string[]; event: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>; }) => void)"
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting child Button components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Selected values in the group, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default selected values in the group, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2153,30 +11448,269 @@
 			"path": "./src/components/Tooltip/tests/Tooltip.stories.tsx",
 			"stories": [
 				{
+					"id": "components-tooltip--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: bottom-start\">\n            <View direction=\"row\" gap={2}>\n                <Demo position=\"bottom-start\" text=\"Tooltip 1\" />\n                <Demo position=\"bottom-start\" text=\"Tooltip 2\" />\n                <Demo position=\"bottom-start\" text=\"Tooltip 3\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: bottom\">\n            <Demo position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"position: bottom-end\">\n            <Demo position=\"bottom-end\" />\n        </Example.Item>\n        <Example.Item title=\"position: top-start\">\n            <Demo position=\"top-start\" />\n        </Example.Item>\n        <Example.Item title=\"position: top\">\n            <Demo position=\"top\" />\n        </Example.Item>\n        <Example.Item title=\"position: top-end\">\n            <Demo position=\"top-end\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: start\">\n            <View align=\"end\">\n                <Demo position=\"start\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: start-top\">\n            <View align=\"end\">\n                <Demo position=\"start-top\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: start-bottom\">\n            <View align=\"end\">\n                <Demo position=\"start-bottom\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <Demo position=\"end\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: end-top\">\n            <Demo position=\"end-top\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: end-bottom\">\n            <Demo position=\"end-bottom\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tooltip--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: inverted\">\n            <Demo color=\"inverted\" position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"color: dark\">\n            <Demo color=\"dark\" position=\"bottom\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-tooltip--default-active",
+					"name": "uncontrolled",
 					"snippet": "const defaultActive = () => <Tooltip text=\"Content\" onOpen={fn()} onClose={fn()}>\n    {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n</Tooltip>;"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-tooltip--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"responsive visibility\">\n            <DemoResponsive text=\"Responsive\" />\n        </Example.Item>\n\n        <Example.Item title=\"without text\">\n            <Tooltip>{() => <Button>Button</Button>}</Tooltip>\n        </Example.Item>\n\n        <Example.Item title=\"tooltip with popover\">\n            <Tooltip text=\"Tooltip\" position=\"top\">\n                {(attributes) => (\n                    <Popover position=\"bottom\">\n                        <Popover.Trigger>\n                            {(popoverAttributes) => (\n                                <Button attributes={{ ...attributes, ...popoverAttributes }}>Action</Button>\n                            )}\n                        </Popover.Trigger>\n                        <Popover.Content>Popover</Popover.Content>\n                    </Popover>\n                )}\n            </Tooltip>\n        </Example.Item>\n\n        <Example.Item title=\"nested popovers inside a tooltip\">\n            <View direction=\"row\" gap={2}>\n                <Tooltip position=\"top\" text=\"Hello\">\n                    {(tooltipAttributes) => (\n                        <Popover position=\"bottom\" width=\"300px\">\n                            <Popover.Trigger>\n                                {(attributes) => (\n                                    <Button attributes={{ ...tooltipAttributes, ...attributes }}>\n                                        Tooltip with popover\n                                    </Button>\n                                )}\n                            </Popover.Trigger>\n                            <Popover.Content>\n                                <View gap={2} align=\"center\" direction=\"row\" justify=\"space-between\">\n                                    Popover content\n                                    <Popover position=\"bottom\" width=\"300px\">\n                                        <Popover.Trigger>\n                                            {(attributes) => <Button attributes={attributes}>Open</Button>}\n                                        </Popover.Trigger>\n                                        <Popover.Content>\n                                            <Popover.Dismissible align=\"center\" closeAriaLabel=\"Close\">\n                                                Another popover content\n                                            </Popover.Dismissible>\n                                        </Popover.Content>\n                                    </Popover>\n                                </View>\n                            </Popover.Content>\n                        </Popover>\n                    )}\n                </Tooltip>\n                <Tooltip position=\"top\" text=\"Hello\">\n                    {(tooltipAttributes) => <Button attributes={tooltipAttributes}>Just a tooltip</Button>}\n                </Tooltip>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, Popover, Tooltip, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Tooltip/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Tooltip",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Tooltip/Tooltip.tsx",
-				"actualName": "Tooltip",
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the flyout content interactivity",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"contentAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the content element",
+						"name": "contentAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"contentClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the content element",
+						"name": "contentClassName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "(attributes: TriggerAttributes) => ReactNode" }
+					},
+					"text": {
+						"defaultValue": null,
+						"description": "Text content for the tooltip",
+						"name": "text",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"inverted\"" },
+						"description": "Color of the tooltip",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"dark\" | \"inverted\"",
+							"value": [{ "value": "\"dark\"" }, { "value": "\"inverted\"" }]
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2186,51 +11720,191 @@
 			"path": "./src/components/Accordion/tests/Accordion.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-accordion--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Accordion defaultActive>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--icon-size",
 					"name": "iconSize",
 					"snippet": "const iconSize = () => (\n    <Accordion iconSize={6}>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--icon-position",
 					"name": "iconPosition",
 					"snippet": "const iconPosition = () => (\n    <Accordion iconPosition=\"start\">\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Accordion defaultActive gap={4}>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <Placeholder />\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--on-toggle",
 					"name": "onToggle",
 					"snippet": "const onToggle = () => <Accordion onToggle={fn()}>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
+					"id": "utility-components-accordion--active",
 					"name": "active",
 					"snippet": "const active = () => <Accordion onToggle={fn()} active>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
+					"id": "utility-components-accordion--default-active",
 					"name": "defaultActive",
 					"snippet": "const defaultActive = () => <Accordion onToggle={fn()} defaultActive>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
-					"name": "renderProps",
+					"id": "utility-components-accordion--render-props",
+					"name": "children: render props",
 					"snippet": "const renderProps = () => <Accordion onToggle={fn()}>\n    <Accordion.Trigger>\n        {(attributes, { active }) => (\n            <Button attributes={{ ...attributes, \"data-active\": active }}>Trigger</Button>\n        )}\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-accordion--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Accordion className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Accordion.Trigger>\n                <Placeholder>Trigger</Placeholder>\n            </Accordion.Trigger>\n            <Accordion.Content>\n                <View paddingTop={2}>\n                    <Placeholder />\n                </View>\n            </Accordion.Content>\n        </Accordion>\n    </div>\n);"
 				}
 			],
 			"import": "import { Accordion, Button, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Accordion/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Accordion",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Accordion/Accordion.tsx",
-				"actualName": "Accordion",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"iconSize": {
+						"defaultValue": null,
+						"description": "Expand / collapse icon size in units",
+						"name": "iconSize",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"iconPosition": {
+						"defaultValue": null,
+						"description": "Position of the expand / collapse icon",
+						"name": "iconPosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"start\" | \"end\"",
+							"value": [{ "value": "\"start\"" }, { "value": "\"end\"" }]
+						}
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between the trigger and the content",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the trigger and the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onToggle": {
+						"defaultValue": null,
+						"description": "Callback when the accordion is expanded or collapsed",
+						"name": "onToggle",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((active: boolean) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control whether the accordion is expanded or collapsed, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control whether the accordion is expanded or collapsed by default, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Accordion"
 			}
 		},
 		"utility-components-actionable": {
@@ -2239,54 +11913,456 @@
 			"path": "./src/components/Actionable/tests/Actionable.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "utility-components-actionable--base",
+					"name": "href, onClick",
 					"snippet": "const base = () => <Example>\n    <Example.Item title=\"span\">\n        <Actionable>Span</Actionable>\n    </Example.Item>\n    <Example.Item title=\"onClick\">\n        <Actionable onClick={fn()}>Button</Actionable>\n    </Example.Item>\n    <Example.Item title=\"href\">\n        <Actionable href=\"https://reshaped.so\" attributes={{ target: \"_blank\" }}>Link\n                            </Actionable>\n    </Example.Item>\n    <Example.Item title=\"attributes.href\">\n        <Actionable attributes={{ href: \"https://reshaped.so\" }}>Link with attributes</Actionable>\n    </Example.Item>\n    <Example.Item title=\"href, onClick\">\n        <Actionable\n            onClick={(e) => {\n                e.preventDefault();\n                args.handleSecondClick(e);\n            }}\n            href=\"https://reshaped.so\">Link with onClick\n                            </Actionable>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "utility-components-actionable--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, button\">\n            <Actionable disabled onClick={() => {}}>\n                Button\n            </Actionable>\n        </Example.Item>\n        <Example.Item title=\"disabled, link\">\n            <Actionable disabled href=\"https://reshaped.so\">\n                Link\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--full-width",
 					"name": "fullWidth",
 					"snippet": "const fullWidth = () => (\n    <Example>\n        <Example.Item title=\"fullWidth\">\n            <Actionable fullWidth href=\"https://reshaped.so\">\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--inset-focus",
 					"name": "insetFocus",
 					"snippet": "const insetFocus = () => (\n    <Example>\n        <Example.Item title=\"insetFocus\">\n            <Actionable insetFocus onClick={() => {}}>\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--disable-focus-ring",
 					"name": "disableFocusRing",
 					"snippet": "const disableFocusRing = () => (\n    <Example>\n        <Example.Item title=\"disableFocusRing\">\n            <Actionable disableFocusRing onClick={() => {}}>\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--border-radius",
 					"name": "borderRadius",
 					"snippet": "const borderRadius = () => (\n    <Example>\n        <Example.Item title=\"borderRadius: inherit\">\n            <Actionable borderRadius=\"inherit\" onClick={() => {}}>\n                <View borderRadius=\"large\">Actionable</View>\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--type",
 					"name": "type",
 					"snippet": "const type = (args) => (\n    <Example>\n        <Example.Item title=\"type: submit\">\n            <form\n                onSubmit={(e) => {\n                    e.preventDefault();\n                    args.handleSubmit();\n                }}\n            >\n                <Actionable onClick={() => {}} type=\"submit\">\n                    Submit\n                </Actionable>\n            </form>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "as",
+					"id": "utility-components-actionable--as",
+					"name": "as, render",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"as: span\">\n            <Actionable onClick={() => {}} as=\"span\">\n                Trigger\n            </Actionable>\n        </Example.Item>\n        <Example.Item title=\"render, disabled\">\n            <Actionable disabled onClick={() => {}} render={(props) => <section {...props} />}>\n                Trigger\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--stop-propagation",
 					"name": "stopPropagation",
 					"snippet": "const stopPropagation = () => <div onClick={fn()}>\n    <Actionable stopPropagation onClick={() => {}}>Trigger\n                    </Actionable>\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-actionable--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Actionable className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Actionable>\n    </div>\n);"
 				}
 			],
 			"import": "import { Actionable, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Actionable/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Actionable",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Actionable/Actionable.tsx",
-				"actualName": "Actionable",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"touchHitbox": {
+						"defaultValue": null,
+						"description": "Enable a minimum required touch hitbox",
+						"name": "touchHitbox",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Take up the full width of its parent",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"insetFocus": {
+						"defaultValue": null,
+						"description": "Enable a focus ring inside the element bounds",
+						"name": "insetFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableFocusRing": {
+						"defaultValue": null,
+						"description": "Don't show a focus ring on focus, can be used when it is within a container with a focus ring",
+						"name": "disableFocusRing",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Apply the focus ring to the child and rely on its border radius",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"inherit\"", "value": [{ "value": "\"inherit\"" }] }
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2296,30 +12372,149 @@
 			"path": "./src/components/Container/tests/Container.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-container--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: default\">\n            <Container>\n                <Placeholder />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"padding: 0\">\n            <Container padding={0}>\n                <Placeholder />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "utility-components-container--size",
+					"name": "width, height, maxHeight",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"width: 200px, height: 200px\">\n            <Container width=\"200px\" height=\"200px\">\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width: 200px, height: 200px, maxHeight: 100px\">\n            <Container width=\"200px\" height=\"200px\" maxHeight=\"100px\">\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width, height: [s] 100px, [m+] 200px\">\n            <Container width={{ s: \"100px\", m: \"200px\" }} height={{ s: \"100px\", m: \"200px\" }}>\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width, height: [s] 100px, [m+] 200px, maxHeight: [s] 50px, [m+]: 100px\">\n            <Container\n                width={{ s: \"100px\", m: \"200px\" }}\n                height={{ s: \"100px\", m: \"200px\" }}\n                maxHeight={{ s: \"50px\", m: \"100px\" }}\n            >\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "flex",
+					"id": "utility-components-container--flex",
+					"name": "align, justify",
 					"snippet": "const flex = () => (\n    <Example>\n        <Example.Item title=\"align: center, justify: center\">\n            <Container align=\"center\" justify=\"center\" height=\"200px\">\n                <Placeholder />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-container--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Container className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </Container>\n    </div>\n);"
 				}
 			],
 			"import": "import { Container, Example, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Container/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Container",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Container/Container.tsx",
-				"actualName": "Container",
+				"methods": [],
+				"props": {
+					"align": {
+						"defaultValue": null,
+						"description": "Flex align-items for the content",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Flex justify-content for the content",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier\nComponent height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" },
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height style, literal string value or a base unit token number multiplier\nComponent max height, literal css value or unit token multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" },
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Component inline padding",
+						"name": "padding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Component width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2329,34 +12524,157 @@
 			"path": "./src/components/Dismissible/tests/Dismissible.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-dismissible--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Dismissible closeAriaLabel=\"Close banner\" onClose={() => {}}>\n                <Placeholder />\n            </Dismissible>\n        </Example.Item>\n        <Example.Item title=\"variant: media\">\n            <View width=\"300px\">\n                <Dismissible variant=\"media\" closeAriaLabel=\"Close banner\" onClose={() => {}}>\n                    <View aspectRatio={16 / 9}>\n                        <Image\n                            height=\"100%\"\n                            src=\"https://images.unsplash.com/photo-1607030529528-ca6923e27f77?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1867&q=80)\"\n                        />\n                    </View>\n                </Dismissible>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-dismissible--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: center\">\n            <Dismissible align=\"center\" closeAriaLabel=\"Close\" onClose={() => {}}>\n                <Placeholder />\n            </Dismissible>\n        </Example.Item>\n\n        <Example.Item title=\"align: center, variant: media\">\n            <Dismissible align=\"center\" closeAriaLabel=\"Close\" variant=\"media\" onClose={() => {}}>\n                <View aspectRatio={16 / 9}>\n                    <Image\n                        height=\"100%\"\n                        src=\"https://images.unsplash.com/photo-1607030529528-ca6923e27f77?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1867&q=80)\"\n                    />\n                </View>\n            </Dismissible>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-dismissible--hide-close-button",
 					"name": "hideCloseButton",
 					"snippet": "const hideCloseButton = () => (\n    <Example>\n        <Example.Item title=\"hide close button\">\n            <div id=\"root\">\n                <Dismissible hideCloseButton>\n                    <Placeholder />\n                </Dismissible>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "closeAriaLabel",
+					"id": "utility-components-dismissible--close-aria-label",
+					"name": "onClose, closeAriaLabel",
 					"snippet": "const closeAriaLabel = () => <Dismissible closeAriaLabel=\"Close\" onClose={fn()}>\n    <Placeholder />\n</Dismissible>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-dismissible--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Dismissible\n            closeAriaLabel=\"Close\"\n            onClose={() => {}}\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n        >\n            <Placeholder />\n        </Dismissible>\n    </div>\n);"
 				}
 			],
 			"import": "import { Dismissible, Example, Image, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Dismissible/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Dismissible",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Dismissible/Dismissible.tsx",
-				"actualName": "Dismissible",
+				"methods": [],
+				"props": {
+					"hideCloseButton": {
+						"defaultValue": null,
+						"description": "Hide the close button\nShow the close button",
+						"name": "hideCloseButton",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"closeAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the close button",
+						"name": "closeAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"media\"", "value": [{ "value": "\"media\"" }] }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Close button alignment",
+						"name": "align",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"center\"",
+							"value": [{ "value": "\"top\"" }, { "value": "\"center\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is dismissed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2366,135 +12684,577 @@
 			"path": "./src/components/Flyout/tests/Flyout.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-flyout--position",
 					"name": "position",
 					"snippet": "const position = () => {\n    return (\n        <View gap={4} padding={50} align=\"center\" justify=\"center\" height=\"100vh\" width=\"120%\">\n            <View gap={4} direction=\"row\">\n                <Demo position=\"top-start\" defaultActive />\n                <Demo position=\"top\" />\n                <Demo position=\"top-end\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"end-top\" />\n                <Demo position=\"end\" />\n                <Demo position=\"end-bottom\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"start-top\" />\n                <Demo position=\"start\" />\n                <Demo position=\"start-bottom\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"bottom-start\" />\n                <Demo position=\"bottom\" />\n                <Demo position=\"bottom-end\" />\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "defaultActive",
+					"id": "utility-components-flyout--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <Flyout onOpen={fn()} onClose={fn()} defaultActive>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "active",
+					"id": "utility-components-flyout--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <Flyout onOpen={fn()} onClose={fn()} active>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "utility-components-flyout--active-false",
+					"name": "active: false, controlled",
 					"snippet": "const activeFalse = () => <Flyout onOpen={fn()} onClose={fn()} active={false}>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "modes",
+					"id": "utility-components-flyout--modes",
+					"name": "triggerType, trapFocusMode",
 					"snippet": "const modes = () => {\n    return (\n        <Example>\n            <Example.Item title=\"triggerType: click\">\n                <View direction=\"row\" gap={4}>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"dialog\" text=\"dialog\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"action-menu\" text=\"action-menu\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"action-bar\" text=\"action-bar\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"content-menu\" text=\"content-menu\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode={false} text=\"false\">\n                        {modeContent}\n                    </Demo>\n                </View>\n            </Example.Item>\n\n            <Example.Item title=\"triggerType: hover\">\n                <View direction=\"row\" gap={4}>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"dialog\" triggerType=\"hover\" text=\"dialog\">\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"action-menu\"\n                        triggerType=\"hover\"\n                        text=\"action-menu\"\n                    >\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"action-bar\"\n                        triggerType=\"hover\"\n                        text=\"action-bar\"\n                    >\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"content-menu\"\n                        triggerType=\"hover\"\n                        text=\"content-menu\"\n                    >\n                        {modeContent}\n                    </Demo>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "positionFallbacks",
+					"id": "utility-components-flyout--position-fallbacks",
+					"name": "fallbackPositions",
 					"snippet": "const positionFallbacks = () => {\n    return (\n        <Example>\n            <Example.Item title=\"position: top, default fallbacks\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" />\n                </View>\n            </Example.Item>\n            <Example.Item title=\"position: top, fallbackPositions: [start]\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" fallbackPositions={[\"start\"]} contentHeight={200} defaultActive />\n                </View>\n            </Example.Item>\n            <Example.Item title=\"position: top, fallbackPositions: false\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" fallbackPositions={false} contentHeight={400} />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--fallback-adjust-layout",
 					"name": "fallbackAdjustLayout",
 					"snippet": "const fallbackAdjustLayout = () => {\n    return (\n        <Demo\n            contentHeight={false}\n            position=\"bottom-start\"\n            width=\"200px\"\n            fallbackAdjustLayout\n            defaultActive\n        >\n            <div style={{ height: \"600px\" }}>Content</div>\n        </Demo>\n    );\n};"
 				},
 				{
-					"name": "fallbackAdjustLayoutShift",
+					"id": "utility-components-flyout--fallback-adjust-layout-shift",
+					"name": "fallbackAdjustLayout, shift",
 					"snippet": "const fallbackAdjustLayoutShift = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={10}>\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    attributes={{ ref: containerRef }}\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls containerRef={containerRef} />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <FallbackAdjustLayoutControls />\n            <div style={{ height: \"100vh\", width: \"250%\" }} />\n        </View>\n    );\n};"
 				},
 				{
-					"name": "fallbackAdjustLayoutSize",
+					"id": "utility-components-flyout--fallback-adjust-layout-size",
+					"name": "fallbackAdjustLayout, size",
 					"snippet": "const fallbackAdjustLayoutSize = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={10}>\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls large />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    attributes={{ ref: containerRef }}\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls containerRef={containerRef} large />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <FallbackAdjustLayoutControls large />\n            <div style={{ height: \"100vh\", width: \"250%\" }} />\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--origin-coordinates",
 					"name": "originCoordinates",
 					"snippet": "const originCoordinates = () => {\n    return (\n        <View gap={4} direction=\"row\">\n            <Demo position=\"bottom-start\" originCoordinates={{ x: 150, y: 150 }} defaultActive />\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--width",
 					"name": "width",
 					"snippet": "const width = () => (\n    <Example>\n        <Example.Item title=\"width: 300px\">\n            <Demo width=\"300px\" position=\"bottom\" />\n        </Example.Item>\n\n        <Example.Item title=\"width: trigger\">\n            <Demo width=\"trigger\" contentWidth={false} defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-flyout--content-gap",
 					"name": "contentGap",
 					"snippet": "const contentGap = () => <Demo contentGap={10} defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--content-shift",
 					"name": "contentShift",
 					"snippet": "const contentShift = () => <Demo contentShift={10} defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-content-hover",
 					"name": "disableContentHover",
 					"snippet": "const disableContentHover = () => <Demo triggerType=\"hover\" disableContentHover />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-close-on-outside-click",
 					"name": "disableCloseOnOutsideClick",
 					"snippet": "const disableCloseOnOutsideClick = () => <Demo disableCloseOnOutsideClick />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-hide-animation",
 					"name": "disableHideAnimation",
 					"snippet": "const disableHideAnimation = () => <Demo disableHideAnimation defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Flyout disabled>\n        <Flyout.Trigger>\n            {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n        </Flyout.Trigger>\n        <Flyout.Content>\n            <Content />\n        </Flyout.Content>\n    </Flyout>\n);"
 				},
 				{
+					"id": "utility-components-flyout--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const portalRef = React.useRef<HTMLDivElement>(null);\n    const portalRef2 = React.useRef<HTMLDivElement>(null);\n    const portalRef3 = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={4} direction=\"row\">\n            <View\n                grow\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef, \"data-testid\": \"container\" }}\n                justify=\"end\"\n                align=\"start\"\n                padding={4}\n            >\n                <Demo containerRef={portalRef} position=\"bottom-start\" defaultActive />\n            </View>\n            <View\n                grow\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef2 }}\n                justify=\"start\"\n                align=\"end\"\n                padding={4}\n            >\n                <Demo containerRef={portalRef2} position=\"top-end\" />\n            </View>\n            <View\n                width={50}\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef3 }}\n                padding={4}\n                overflow=\"auto\"\n            >\n                <View height={120} width=\"120%\" justify=\"center\" align=\"center\">\n                    <Demo containerRef={portalRef3} position=\"bottom-end\" />\n                </View>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--initial-focus-ref",
 					"name": "initialFocusRef",
 					"snippet": "const initialFocusRef = () => {\n    const initialFocusRef = React.useRef<HTMLInputElement>(null);\n\n    return (\n        <Demo initialFocusRef={initialFocusRef}>\n            <View gap={4}>\n                <Button onClick={() => {}}>Action 1</Button>\n                <TextField name=\"foo\" inputAttributes={{ ref: initialFocusRef }} />\n            </View>\n        </Demo>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--instance-ref",
 					"name": "instanceRef",
 					"snippet": "const instanceRef = () => {\n    const flyoutRef = React.useRef<FlyoutInstance>(null);\n\n    return (\n        <View direction=\"row\" gap={4}>\n            <Demo\n                instanceRef={flyoutRef}\n                disableCloseOnOutsideClick\n                onOpen={fn()}\n                onClose={fn()} />\n            <Button onClick={() => flyoutRef.current?.open()}>Open</Button>\n            <Button onClick={() => flyoutRef.current?.close()}>Close</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "contentAttributes",
+					"id": "utility-components-flyout--content-attributes",
+					"name": "content: className, attributes",
 					"snippet": "const contentAttributes = () => {\n    return (\n        <Flyout position=\"bottom\" defaultActive>\n            <Flyout.Trigger>\n                {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n            </Flyout.Trigger>\n            <Flyout.Content attributes={{ \"data-testid\": \"test-id\" }} className=\"test-classname\">\n                <Content />\n            </Flyout.Content>\n        </Flyout>\n    );\n};"
 				},
 				{
-					"name": "testShadowDom",
+					"id": "utility-components-flyout--test-shadow-dom",
+					"name": "test: shadow dom",
 					"snippet": "const testShadowDom = () => <custom-element-flyout />;"
 				},
 				{
-					"name": "testInsideFixed",
+					"id": "utility-components-flyout--test-inside-fixed",
+					"name": "test: inside position fixed",
 					"snippet": "const testInsideFixed = () => (\n    <React.Fragment>\n        <View\n            position=\"fixed\"\n            insetBottom={2}\n            insetStart={2}\n            insetEnd={2}\n            backgroundColor=\"elevation-overlay\"\n            borderColor=\"neutral-faded\"\n            borderRadius=\"small\"\n            padding={4}\n            zIndex={10}\n            attributes={{ \"data-testid\": \"container\" }}\n            height={20}\n        >\n            <Demo defaultActive position=\"top-start\" />\n        </View>\n        <View paddingTop={18} gap={4}>\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n        </View>\n    </React.Fragment>\n);"
 				},
 				{
-					"name": "testInsideSticky",
+					"id": "utility-components-flyout--test-inside-sticky",
+					"name": "test: inside position sticky",
 					"snippet": "const testInsideSticky = () => (\n    <React.Fragment>\n        <View\n            position=\"sticky\"\n            insetTop={4}\n            insetStart={0}\n            insetEnd={0}\n            backgroundColor=\"elevation-overlay\"\n            borderColor=\"neutral-faded\"\n            borderRadius=\"small\"\n            padding={4}\n            zIndex={10}\n            attributes={{ \"data-testid\": \"container\" }}\n        >\n            <Demo defaultActive />\n        </View>\n        <View gap={4} paddingTop={2}>\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n        </View>\n    </React.Fragment>\n);"
 				},
 				{
-					"name": "testInsideScrollable",
+					"id": "utility-components-flyout--test-inside-scrollable",
+					"name": "test: inside scrollable",
 					"snippet": "const testInsideScrollable = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View padding={20}>\n            <View height={30} overflow=\"auto\" backgroundColor=\"neutral-faded\" borderRadius=\"small\">\n                <View height={50} attributes={{ ref: containerRef }} padding={20} paddingBottom={30}>\n                    <Demo position=\"bottom\" />\n                </View>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testInsideModal",
+					"id": "utility-components-flyout--test-inside-modal",
+					"name": "test: inside modal",
 					"snippet": "const testInsideModal = () => {\n    return (\n        <Modal active position=\"end\">\n            <View gap={4} align=\"start\">\n                <Modal.Title>Title</Modal.Title>\n                <Demo position=\"bottom-start\" />\n                <View height={300} width={25} backgroundColor=\"neutral-faded\" />\n                <Demo position=\"start\" />\n                <View height={300} width={25} backgroundColor=\"neutral-faded\" />\n                <Demo position=\"bottom-start\" />\n            </View>\n        </Modal>\n    );\n};"
 				},
 				{
-					"name": "testDynamicBounds",
+					"id": "utility-components-flyout--test-dynamic-bounds",
+					"name": "test: auto position update",
 					"snippet": "const testDynamicBounds = () => {\n    const [left, setLeft] = React.useState(50);\n    const [top, setTop] = React.useState(50);\n    const [size, setSize] = React.useState<\"medium\" | \"large\">(\"medium\");\n    const flyoutRef = React.useRef<FlyoutInstance>(null);\n\n    React.useEffect(() => {\n        flyoutRef.current?.updatePosition();\n    }, [left, top]);\n\n    return (\n        <View gap={4}>\n            <View direction=\"row\" gap={2}>\n                <Button onClick={() => setLeft((prev) => prev - 10)}>Left</Button>\n                <Button onClick={() => setLeft((prev) => prev + 10)}>Right</Button>\n                <Button onClick={() => setTop((prev) => prev - 10)}>Up</Button>\n                <Button onClick={() => setTop((prev) => prev + 10)}>Down</Button>\n                <Button\n                    onClick={() => {\n                        setLeft(50);\n                        setTop(50);\n                    }}\n                >\n                    Center\n                </Button>\n                <Button onClick={() => setSize(\"large\")}>Large button</Button>\n                <Button onClick={() => setSize(\"medium\")}>Small button</Button>\n            </View>\n            <View height={100}>\n                <Flyout\n                    position=\"bottom\"\n                    instanceRef={flyoutRef}\n                    disableCloseOnOutsideClick\n                    defaultActive\n                >\n                    <Flyout.Trigger>\n                        {(attributes) => (\n                            <div style={{ position: \"absolute\", left: `${left}%`, top: `${top}%` }}>\n                                <Button color=\"primary\" attributes={attributes} size={size}>\n                                    Open\n                                </Button>\n                            </div>\n                        )}\n                    </Flyout.Trigger>\n                    <Flyout.Content>\n                        <Content />\n                    </Flyout.Content>\n                </Flyout>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testScopedTheming",
+					"id": "utility-components-flyout--test-scoped-theming",
+					"name": "test: content uses scope theme",
 					"snippet": "const testScopedTheming = () => (\n    <View gap={3} align=\"start\">\n        <Button color=\"primary\">Slate button</Button>\n        <Theme name=\"reshaped\">\n            <Flyout triggerType=\"click\" active position=\"bottom-start\">\n                <Flyout.Trigger>\n                    {(attributes) => (\n                        <Button color=\"primary\" attributes={attributes}>\n                            Reshaped button\n                        </Button>\n                    )}\n                </Flyout.Trigger>\n                <Flyout.Content>\n                    <Content>\n                        <View gap={1}>\n                            <View.Item>Portal content, rendered in body</View.Item>\n                            <Button color=\"primary\">Reshaped button</Button>\n                        </View>\n                    </Content>\n                </Flyout.Content>\n            </Flyout>\n        </Theme>\n    </View>\n);"
 				},
 				{
-					"name": "testWithoutFocusable",
+					"id": "utility-components-flyout--test-without-focusable",
+					"name": "test: without focusable content",
 					"snippet": "const testWithoutFocusable = () => <Demo position=\"bottom-start\" />;"
 				},
 				{
-					"name": "testChangeSize",
+					"id": "utility-components-flyout--test-change-size",
+					"name": "test: size updates",
 					"snippet": "const testChangeSize = () => {\n    const [position, setPosition] = React.useState<FlyoutProps[\"position\"]>(\"bottom-start\");\n    const [updatedHeight, setUpdatedHeight] = React.useState(false);\n\n    return (\n        <>\n            <View direction=\"row\" gap={4} align=\"center\">\n                <Select\n                    name=\"position\"\n                    options={[\n                        \"bottom-start\",\n                        \"bottom\",\n                        \"bottom-end\",\n                        \"top-start\",\n                        \"top\",\n                        \"top-end\",\n                        \"start-top\",\n                        \"start\",\n                        \"start-bottom\",\n                        \"end-top\",\n                        \"end\",\n                        \"end-bottom\",\n                    ].map((p) => ({ label: p, value: p }))}\n                    onChange={(args) => setPosition(args.value as FlyoutProps[\"position\"])}\n                    value={position}\n                />\n                <Switch name=\"height\" onChange={(args) => setUpdatedHeight(args.checked)}>\n                    Change height\n                </Switch>\n            </View>\n            <div\n                style={{\n                    position: \"fixed\",\n                    top: \"50%\",\n                    left: \"50%\",\n                    transform: \"translate(-50%, -50%)\",\n                }}\n            >\n                <Demo position={position} disableCloseOnOutsideClick active contentHeight={false}>\n                    <View\n                        backgroundColor=\"neutral-faded\"\n                        borderRadius=\"small\"\n                        height={updatedHeight ? 50 : 25}\n                        attributes={{ style: { transition: \"0.2s ease-in-out\" } }}\n                    />\n                </Demo>\n            </div>\n        </>\n    );\n};"
 				}
 			],
 			"import": "import {\n    Button,\n    Example,\n    Flyout,\n    Modal,\n    Reshaped,\n    Select,\n    Switch,\n    TextField,\n    Theme,\n    View,\n} from \"reshaped\";\nimport React from \"react\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Flyout/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Flyout",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Flyout/Flyout.tsx",
-				"actualName": "Flyout",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"groupTimeouts": {
+						"defaultValue": null,
+						"description": "Removes the content display delay if another flyout is already active",
+						"name": "groupTimeouts",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | TrapMode" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the flyout content interactivity",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Automatically focus the first focusable element in the content, when false the content container will be focused instead",
+						"name": "autoFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the content element",
+						"name": "contentClassName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"contentAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the content element",
+						"name": "contentAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Flyout"
 			}
 		},
 		"utility-components-formcontrol": {
@@ -2503,43 +13263,147 @@
 			"path": "./src/components/FormControl/tests/FormControl.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-formcontrol--status",
 					"name": "status",
 					"snippet": "const status = () => (\n    <Example>\n        <Example.Item title=\"status: default\">\n            <FormControl>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"status: error\">\n            <FormControl hasError>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: medium\">\n            <FormControl size=\"medium\">\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <FormControl size=\"large\">\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" size=\"large\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <FormControl disabled>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--required",
 					"name": "required",
 					"snippet": "const required = () => (\n    <Example>\n        <Example.Item title=\"required\">\n            <FormControl required>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "utility-components-formcontrol--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"horizontal\">\n            <FormControl>\n                <View direction=\"row\" gap={10} align=\"center\">\n                    <View width=\"100px\">\n                        <FormControl.Label>Label</FormControl.Label>\n                    </View>\n                    <View.Item grow>\n                        <TextField name=\"name\" placeholder=\"Enter value\" />\n                    </View.Item>\n                </View>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-formcontrol--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <FormControl id=\"test-id\" hasError>\n        <FormControl.Label>Label</FormControl.Label>\n        <TextField name=\"name\" />\n        <FormControl.Helper>Caption</FormControl.Helper>\n        <FormControl.Error>Error</FormControl.Error>\n    </FormControl>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--group",
 					"name": "group",
 					"snippet": "const group = () => (\n    <FormControl group>\n        <FormControl.Label>Label</FormControl.Label>\n        <RadioGroup name=\"name\">\n            <View gap={2}>\n                <Radio value=\"1\">One</Radio>\n                <Radio value=\"2\">Two</Radio>\n            </View>\n        </RadioGroup>\n    </FormControl>\n);"
 				}
 			],
 			"import": "import { Example, FormControl, Radio, RadioGroup, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/FormControl/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "FormControl",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/FormControl/FormControl.tsx",
-				"actualName": "FormControl",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size, to be used together with the other form component sizes",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"large\" | \"medium\"",
+							"value": [{ "value": "\"large\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"required": {
+						"defaultValue": null,
+						"description": "Change component to show a required indicator",
+						"name": "required",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Apply disabled styles",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"group": {
+						"defaultValue": null,
+						"description": "Apply semantic html markup when used for displaying multiple form fields together with a single label",
+						"name": "group",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Custom id for the form control",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "FormControl"
 			}
 		},
 		"utility-components-grid": {
@@ -2548,43 +13412,421 @@
 			"path": "./src/components/Grid/tests/Grid.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "utility-components-grid--base",
+					"name": "gap, columnGap, rowGap, align, justify, maxWidth, width, height",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"gap: 2\">\n            <Grid gap={2} columns={2}>\n                {[1, 2].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"columnGap: 2, rowGap: 4\">\n            <Grid columnGap={2} rowGap={4} columns={2}>\n                {[1, 2, 3, 4].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"align: center\">\n            <Grid gap={2} columns={2} align=\"center\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={8}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"justify: center\">\n            <Grid gap={2} columns=\"200px 200px\" justify=\"center\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"maxWidth: 400px\">\n            <Grid gap={2} columns=\"200px 200px\" maxWidth=\"400px\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"width: 400px, height: 200px\">\n            <Grid gap={2} columns={2} width=\"400px\" height=\"200px\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "layout",
+					"id": "utility-components-grid--layout",
+					"name": "rows, columns",
 					"snippet": "const layout = () => (\n    <Example>\n        <Example.Item title=\"simple: 2 rows, 3 columns\">\n            <Grid gap={4} columns={3} rows={2}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"columns template, 1fr 2fr 1fr\">\n            <Grid gap={4} columns=\"1fr 2fr 1fr\" rows={2}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"rows template, 1fr 2fr\">\n            <Grid gap={4} columns={3} rows=\"1fr 2fr\">\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"responsive\">\n            <Grid gap={4} columns={{ s: 3, m: \"1fr 2fr 1fr\" }} rows={{ s: 2, m: \"1fr 2fr\" }}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemLayout",
+					"id": "utility-components-grid--item-layout",
+					"name": "colStart, colEnd, rowStart, rowEnd",
 					"snippet": "const itemLayout = () => (\n    <Example>\n        <Example.Item title=\"column, start 1, end 3\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item colStart={1} colEnd={3}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"column, start 1, span 2\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item colStart={1} colSpan={2}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"row, start 1, end 3\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowEnd={3}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"row, start 1, span 2\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowSpan={2}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"responsive\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowSpan={{ s: 1, m: 2 }} colStart={1} colSpan={{ s: 1, m: 2 }}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-grid--areas",
 					"name": "areas",
 					"snippet": "const areas = () => (\n    <Example>\n        <Example.Item title=\"simple: 2 rows, 3 columns\">\n            <Grid gap={4} rows={2} areas={[\"a .\", \"a b\"]}>\n                {[\"a\", \"b\"].map((area) => (\n                    <Grid.Item area={area} key={area}>\n                        <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                            {area}\n                        </View>\n                    </Grid.Item>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "auto",
+					"id": "utility-components-grid--auto",
+					"name": "autoFlow, autoColumns, autoRows",
 					"snippet": "const auto = () => (\n    <Example>\n        <Example.Item title=\"auto flow: column\">\n            <Grid gap={4} autoFlow=\"column\" rows={2} columns={2}>\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"auto rows\">\n            <Grid gap={4} autoRows=\"100px\" columns={2}>\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"auto columns\">\n            <Grid gap={4} autoColumns=\"100px\" autoFlow=\"column\">\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-grid--as",
 					"name": "as",
 					"snippet": "const as = () => (\n    <Grid as=\"ul\">\n        <Grid.Item as=\"li\">Content</Grid.Item>\n    </Grid>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-grid--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Grid className=\"test-class\" attributes={{ id: \"test-id\" }}>\n            <Grid.Item className=\"test-item-class\" attributes={{ id: \"test-item-id\" }}>\n                Content\n            </Grid.Item>\n        </Grid>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Grid, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Grid/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Grid",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Grid/Grid.tsx",
-				"actualName": "Grid",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between grid items",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"columnGap": {
+						"defaultValue": null,
+						"description": "Horizontal gap between grid items",
+						"name": "columnGap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"rowGap": {
+						"defaultValue": null,
+						"description": "Vertical gap between grid items",
+						"name": "rowGap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Align grid items vertically",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Justify grid items horizontally",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"rows": {
+						"defaultValue": null,
+						"description": "Grid template rows",
+						"name": "rows",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<number | \"inherit\" | \"none\" | \"auto\" | (string & {}) | \"-moz-initial\" | \"initial\" | \"revert\" | \"revert-layer\" | \"unset\" | \"max-content\" | \"min-content\" | \"subgrid\">"
+						}
+					},
+					"columns": {
+						"defaultValue": null,
+						"description": "Grid template columns",
+						"name": "columns",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<number | \"inherit\" | \"none\" | \"auto\" | (string & {}) | \"-moz-initial\" | \"initial\" | \"revert\" | \"revert-layer\" | \"unset\" | \"max-content\" | \"min-content\" | \"subgrid\">"
+						}
+					},
+					"areas": {
+						"defaultValue": null,
+						"description": "Grid areas for template syntax",
+						"name": "areas",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string[]>" }
+					},
+					"autoFlow": {
+						"defaultValue": null,
+						"description": "Grid auto flow",
+						"name": "autoFlow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoFlow>" }
+					},
+					"autoColumns": {
+						"defaultValue": null,
+						"description": "Grid auto columns",
+						"name": "autoColumns",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoColumns<0 | (string & {})>>" }
+					},
+					"autoRows": {
+						"defaultValue": null,
+						"description": "Grid auto rows",
+						"name": "autoRows",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoRows<0 | (string & {})>>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Maximum width of the grid container, literal css value or unit token multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width of the grid container, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height of the grid container, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Custom root element html tag",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					}
+				},
+				"exportName": "Grid"
 			}
 		},
 		"utility-components-hidden": {
@@ -2593,22 +13835,261 @@
 			"path": "./src/components/Hidden/tests/Hidden.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-hidden--visibility",
 					"name": "visibility",
 					"snippet": "const visibility = () => (\n    <Example>\n        <Example.Item title=\"hide: always\">\n            <Hidden hide={true}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on s\">\n            <Hidden hide={{ s: false, m: true }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on l/xl\">\n            <Hidden hide={{ s: true, l: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on m/l/xl\">\n            <Hidden hide={{ s: true, m: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on m\">\n            <Hidden hide={{ s: true, m: false, l: true }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on s/xl\">\n            <Hidden hide={{ s: false, m: true, xl: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"hide: always, visibility\">\n            <Hidden hide visibility>\n                Content\n            </Hidden>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-hidden--as",
 					"name": "as",
 					"snippet": "const as = () => <Hidden as=\"span\">Content</Hidden>;"
 				}
 			],
 			"import": "import { Example, Hidden } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Hidden/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Hidden",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Hidden/Hidden.tsx",
-				"actualName": "Hidden",
+				"methods": [],
+				"props": {
+					"hide": {
+						"defaultValue": null,
+						"description": "Pick at which viewport sizes to hide the children",
+						"name": "hide",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"visibility": {
+						"defaultValue": null,
+						"description": "Use visibility hidden instead of display none",
+						"name": "visibility",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Custom root element html tag",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2618,22 +14099,39 @@
 			"path": "./src/components/HiddenVisually/tests/HiddenVisually.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-hiddenvisually--visibility",
 					"name": "visibility",
 					"snippet": "const visibility = () => (\n    <Example>\n        <Example.Item title=\"pronounced by screen readers\">\n            <HiddenVisually>Screen-reader only</HiddenVisually>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-hiddenvisually--children",
 					"name": "children",
 					"snippet": "const children = () => <HiddenVisually>Content</HiddenVisually>;"
 				}
 			],
 			"import": "import { Example, HiddenVisually } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/HiddenVisually/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "HiddenVisually",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/HiddenVisually/HiddenVisually.tsx",
-				"actualName": "HiddenVisually",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/HiddenVisually/HiddenVisually.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2643,34 +14141,115 @@
 			"path": "./src/components/Icon/tests/Icon.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-icon--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: 4\">\n            <Icon svg={IconZap} size={4} />\n        </Example.Item>\n        <Example.Item title=\"size: 8\">\n            <Icon svg={IconZap} size={8} />\n        </Example.Item>\n        <Example.Item title=\"size: 100%\">\n            <View width={25} height={25}>\n                <Icon svg={IconZap} size=\"100%\" />\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive size\", \"[s] 5\", \"[m]: 10\"]}>\n            <Icon svg={IconZap} size={{ s: 5, m: 10 }} />\n        </Example.Item>\n        <Example.Item title=\"size: inherit from font\">\n            <Text variant=\"title-6\">\n                <View direction=\"row\" align=\"center\" gap={2}>\n                    <Icon svg={IconZap} />\n                    <View.Item>Reshaped</View.Item>\n                </View>\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-icon--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <Icon svg={IconZap} color=\"neutral\" />\n        </Example.Item>\n        <Example.Item title=\"color: neutral-faded\">\n            <Icon svg={IconZap} color=\"neutral-faded\" />\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <Icon svg={IconZap} color=\"primary\" />\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Icon svg={IconZap} color=\"critical\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Icon svg={IconZap} color=\"positive\" />\n        </Example.Item>\n        <Example.Item title=\"color: disabled\">\n            <Icon svg={IconZap} color=\"disabled\" />\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <div style={{ color: \"tomato\" }}>\n                <Icon svg={IconZap} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "autoWidth",
+					"id": "utility-components-icon--auto-width",
+					"name": "autoWidth, blank",
 					"snippet": "const autoWidth = () => (\n    <Example>\n        <Example.Item title=\"square boundaries\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={IconMic} size={10} />\n            </div>\n        </Example.Item>\n        <Example.Item title=\"auto width boundaries\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={IconMic} size={10} autoWidth />\n            </div>\n        </Example.Item>\n        <Example.Item title=\"blank\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={null} size={10} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-icon--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Icon svg={IconZap} className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				},
 				{
-					"name": "render",
+					"id": "utility-components-icon--render",
+					"name": "test: hidden from sr",
 					"snippet": "const render = () => (\n    <div data-testid=\"root\">\n        <Icon svg={IconZap} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Icon, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Icon/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Icon",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Icon/Icon.tsx",
-				"actualName": "Icon",
+				"methods": [],
+				"props": {
+					"svg": {
+						"defaultValue": null,
+						"description": "Icon svg component or node",
+						"name": "svg",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Icon size, literal css value or unit token multiplier",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Icon color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"warning\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"autoWidth": {
+						"defaultValue": null,
+						"description": "Use the width of the svg asset instead of providing a square bounding box",
+						"name": "autoWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2680,54 +14259,230 @@
 			"path": "./src/components/Image/tests/Image.stories.tsx",
 			"stories": [
 				{
-					"name": "src",
+					"id": "utility-components-image--src",
+					"name": "src, alt",
 					"snippet": "const src = () => (\n    <Example>\n        <Example.Item title=\"src, alt\">\n            <Image src={imgUrl} alt=\"Image alt\" />\n        </Example.Item>\n\n        <Example.Item title=\"src\">\n            <Image src={imgUrl} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "utility-components-image--size",
+					"name": "width, height, maxWidth, aspectRatio",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"width: 200px\">\n            <Image src={imgUrl} width=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"height: 200px\">\n            <Image src={imgUrl} height=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"maxWidth: 200px\">\n            <Image src={imgUrl} maxWidth=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"aspectRatio: 1/1\">\n            <Image src={imgUrl} aspectRatio={1 / 1} width=\"300px\" />\n        </Example.Item>\n        <Example.Item title={[\"responsive width\", \"[s] 200px\", \"[m+] 300px\"]}>\n            <Image src={imgUrl} width={{ s: \"200px\", m: \"300px\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "radius",
+					"id": "utility-components-image--radius",
+					"name": "borderRadius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius: small\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"small\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"radius: medium\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"medium\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"radius: large\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--display-mode",
 					"name": "displayMode",
 					"snippet": "const displayMode = () => (\n    <Example>\n        <Example.Item title=\"mode: cover\">\n            <Image src={imgUrl} height=\"200px\" width=\"100%\" displayMode=\"cover\" />\n        </Example.Item>\n        <Example.Item title=\"mode: contain\">\n            <Image src={imgUrl} height=\"200px\" width=\"100%\" displayMode=\"contain\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--on-load",
 					"name": "onLoad",
 					"snippet": "const onLoad = () => <Image src={imgUrl} alt=\"photo\" onLoad={fn()} />;"
 				},
 				{
+					"id": "utility-components-image--on-error",
 					"name": "onError",
 					"snippet": "const onError = () => <Image src=\"/invalid.png\" alt=\"photo\" onError={fn()} />;"
 				},
 				{
+					"id": "utility-components-image--fallback",
 					"name": "fallback",
 					"snippet": "const fallback = () => (\n    <Example>\n        <Example.Item title=\"fallback, background, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"fallback, image, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback={imgUrl} />\n                </View>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"fallback, icon, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback={<Icon svg={IconZap} size={10} />} />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"fallback, icon, no url\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image fallback={<Icon svg={IconZap} size={10} />} />\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--render-image",
 					"name": "renderImage",
 					"snippet": "const renderImage = () => (\n    <Example>\n        <Example.Item title=\"renderImage\">\n            <Image\n                src={imgUrl}\n                alt=\"Amsterdam canal\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image\" />}\n            />\n        </Example.Item>\n        <Example.Item title=\"renderImage, fallback\">\n            <Image\n                src=\"error\"\n                fallback={imgUrl}\n                alt=\"Amsterdam canal 2\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image-fallback\" />}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "imageAttributes",
+					"id": "utility-components-image--image-attributes",
+					"name": "className, attributes,imageAttributes",
 					"snippet": "const imageAttributes = () => (\n    <div data-testid=\"root\">\n        <Image\n            src={imgUrl}\n            alt=\"photo\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            imageAttributes={{ \"data-testid\": \"test-img-id\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "ratio",
+					"id": "utility-components-image--ratio",
+					"name": "test: aspectRatio",
 					"snippet": "const ratio = () => (\n    <Example>\n        <Example.Item title=\"ratio: 16/9\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"ratio: 16/9, displayMode: contain\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} displayMode=\"contain\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Icon, Image, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Image/Image.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Image",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Image/Image.tsx",
-				"actualName": "Image",
+				"methods": [],
+				"props": {
+					"src": {
+						"defaultValue": null,
+						"description": "Image URL",
+						"name": "src",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"alt": {
+						"defaultValue": null,
+						"description": "Image alt text",
+						"name": "alt",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Image width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Image height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Image max width, literal css value or unit token multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"aspectRatio": {
+						"defaultValue": null,
+						"description": "Image aspect ratio, width / height",
+						"name": "aspectRatio",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Image border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"large\" | \"medium\"",
+							"value": [
+								{ "value": "\"small\"" },
+								{ "value": "\"large\"" },
+								{ "value": "\"medium\"" }
+							]
+						}
+					},
+					"displayMode": {
+						"defaultValue": null,
+						"description": "Image display mode for controlling how it fits into the provided boundaries",
+						"name": "displayMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"cover\" | \"contain\"",
+							"value": [{ "value": "\"cover\"" }, { "value": "\"contain\"" }]
+						}
+					},
+					"onLoad": {
+						"defaultValue": null,
+						"description": "Image on load event",
+						"name": "onLoad",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: SyntheticEvent<Element, Event>) => void)" }
+					},
+					"onError": {
+						"defaultValue": null,
+						"description": "Image on error event",
+						"name": "onError",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: SyntheticEvent<Element, Event>) => void)" }
+					},
+					"fallback": {
+						"defaultValue": null,
+						"description": "Image fallback content if the image fails to load or was not provided",
+						"name": "fallback",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"renderImage": {
+						"defaultValue": null,
+						"description": "Image render function, can be used for integrating with Image component in 3rd party frameworks",
+						"name": "renderImage",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Omit<Attributes<\"img\">, \"src\" | \"alt\"> & { src: string; alt: string; }) => ReactNode)"
+						}
+					},
+					"imageAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the image element",
+						"name": "imageAttributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"img\">" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(Attributes<\"div\"> & Attributes<\"img\">)" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2737,46 +14492,229 @@
 			"path": "./src/components/Overlay/tests/Overlay.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-overlay--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate}>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--transparent",
 					"name": "transparent",
 					"snippet": "const transparent = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate} transparent>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--blurred",
 					"name": "blurred",
 					"snippet": "const blurred = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate} blurred>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "renderProps",
+					"id": "utility-components-overlay--render-props",
+					"name": "children, render props",
 					"snippet": "const renderProps = () => (\n    <Overlay active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        {(args) => (args.active ? \"Opened\" : \"Closed\")}\n    </Overlay>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "utility-components-overlay--handlers",
+					"name": "onOpen, onClose, onAfterOpen, onAfterClose",
 					"snippet": "const handlers = () => {\n    const overlayToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => overlayToggle.toggle()}>Open overlay</Button>\n            <Overlay\n                active={overlayToggle.active}\n                onClose={(closeArgs) => {\n                    overlayToggle.deactivate();\n                    args.handleClose(closeArgs);\n                }}\n                onOpen={fn()}\n                onAfterOpen={fn()}\n                onAfterClose={fn()}>Content\n                                </Overlay>\n        </>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--disable-close-on-click",
 					"name": "disableCloseOnClick",
 					"snippet": "const disableCloseOnClick = (args) => (\n    <Overlay\n        active\n        disableCloseOnClick\n        onClose={(closeArgs) => {\n            args.handleClose(closeArgs);\n        }}\n    >\n        Content\n    </Overlay>\n);"
 				},
 				{
+					"id": "utility-components-overlay--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <>\n            <div ref={containerRef} data-testid=\"test-id\" style={{ height: 200 }} />\n            <Overlay active containerRef={containerRef}>\n                Content\n            </Overlay>\n        </>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-overlay--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <Overlay active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        Content\n    </Overlay>\n);"
 				}
 			],
 			"import": "import { Button, Example, Overlay } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Overlay/index.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Overlay",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Overlay/Overlay.tsx",
-				"actualName": "Overlay",
+				"methods": [],
+				"props": {
+					"transparent": {
+						"defaultValue": null,
+						"description": "Make the overlay transparent",
+						"name": "transparent",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number | boolean" }
+					},
+					"blurred": {
+						"defaultValue": null,
+						"description": "Make the overlay blurred",
+						"name": "blurred",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Control the overflow of the component content",
+						"name": "overflow",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"auto\"",
+							"value": [{ "value": "\"hidden\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, render function receives the state of the component as an argument",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode | ((props: { active: boolean; }) => ReactNode)" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the visibility of the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason: CloseReason; }) => void)" }
+					},
+					"onAfterClose": {
+						"defaultValue": null,
+						"description": "Callback after the component close transition is complete",
+						"name": "onAfterClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the component is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onAfterOpen": {
+						"defaultValue": null,
+						"description": "Callback after the component open transition is complete",
+						"name": "onAfterOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"disableCloseOnClick": {
+						"defaultValue": null,
+						"description": "Disable closing the component on outside click",
+						"name": "disableCloseOnClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": null,
+						"description": "Element to render the component in",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2786,42 +14724,213 @@
 			"path": "./src/components/Reshaped/tests/Reshaped.stories.tsx",
 			"stories": [
 				{
-					"name": "rtl",
+					"id": "utility-components-reshaped--rtl",
+					"name": "defaultRTL",
 					"snippet": "const rtl = () => (\n    <Reshaped defaultRTL theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				},
 				{
-					"name": "controlledMode",
+					"id": "utility-components-reshaped--controlled-mode",
+					"name": "colorMode, controlled",
 					"snippet": "const controlledMode = () => {\n    const [mode, setMode] = useState<G.ColorMode>(\"dark\");\n\n    return (\n        <Reshaped theme=\"reshaped\" colorMode={mode}>\n            <Button\n                onClick={() => {\n                    setMode(mode === \"dark\" ? \"light\" : \"dark\");\n                }}\n            >\n                Toggle color mode\n            </Button>\n        </Reshaped>\n    );\n};"
 				},
 				{
-					"name": "lightMode",
+					"id": "utility-components-reshaped--light-mode",
+					"name": "defaultColorMode=light",
 					"snippet": "const lightMode = () => <Reshaped theme=\"reshaped\">Hello</Reshaped>;"
 				},
 				{
-					"name": "darkMode",
+					"id": "utility-components-reshaped--dark-mode",
+					"name": "defaultColorMode=dark",
 					"snippet": "const darkMode = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				},
 				{
+					"id": "utility-components-reshaped--scoped",
 					"name": "scoped",
 					"snippet": "const scoped = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\" scoped>\n        Hello\n    </Reshaped>\n);"
 				},
 				{
-					"name": "testScoped",
+					"id": "utility-components-reshaped--test-scoped",
+					"name": "test: scoped switch",
 					"snippet": "const testScoped = () => (\n    <Reshaped theme=\"reshaped\">\n        <Reshaped theme=\"slate\" scoped>\n            <ScopedComponent />\n        </Reshaped>\n    </Reshaped>\n);"
 				},
 				{
-					"name": "keyboardMode",
+					"id": "utility-components-reshaped--keyboard-mode",
+					"name": "test: keyboard mode",
 					"snippet": "const keyboardMode = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				}
 			],
 			"import": "import { Button, Reshaped } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Reshaped/Reshaped.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Reshaped",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Reshaped/Reshaped.tsx",
-				"actualName": "Reshaped",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"theme": {
+						"defaultValue": null,
+						"description": "Theme of the application, enables controlled mode",
+						"name": "theme",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NonNullable<Theme>" }
+					},
+					"defaultTheme": {
+						"defaultValue": null,
+						"description": "Default theme of the application, enables uncontrolled mode",
+						"name": "defaultTheme",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NonNullable<Theme>" }
+					},
+					"defaultRTL": {
+						"defaultValue": null,
+						"description": "Default content direction of the application",
+						"name": "defaultRTL",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode of the application, enables controlled mode",
+						"name": "colorMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode",
+							"value": [{ "value": "\"light\"" }, { "value": "\"dark\"" }]
+						}
+					},
+					"defaultColorMode": {
+						"defaultValue": null,
+						"description": "Default color mode of the application, enables uncontrolled mode",
+						"name": "defaultColorMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode",
+							"value": [{ "value": "\"light\"" }, { "value": "\"dark\"" }]
+						}
+					},
+					"defaultViewport": {
+						"defaultValue": null,
+						"description": "Default viewport size of the application",
+						"name": "defaultViewport",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Viewport",
+							"value": [
+								{ "value": "\"s\"" },
+								{ "value": "\"m\"" },
+								{ "value": "\"l\"" },
+								{ "value": "\"xl\"" }
+							]
+						}
+					},
+					"toastOptions": {
+						"defaultValue": null,
+						"description": "Global options for the ToastProvider",
+						"name": "toastOptions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "Partial<Record<Position, { width?: string; expanded?: boolean; }>> | undefined"
+						}
+					},
+					"scoped": {
+						"defaultValue": null,
+						"description": "Enable scoped mode for applications not using Reshaped provider at the application root",
+						"name": "scoped",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2831,42 +14940,150 @@
 			"path": "./src/components/ScrollArea/tests/ScrollArea.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-scrollarea--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"vertical scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"horizontal scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\" height=\"100px\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"horizontal and vertical scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-scrollarea--scrollbar-display",
 					"name": "scrollbarDisplay",
 					"snippet": "const scrollbarDisplay = () => (\n    <Example>\n        <Example.Item title=\"scrollbarDisplay: hover\">\n            <ScrollArea height=\"100px\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"scrollbarDisplay: hidden\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"hidden\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"scrollbarDisplay: visible\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "height",
+					"id": "utility-components-scrollarea--height",
+					"name": "height, maxHeight",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"height: 80px\">\n            <ScrollArea height=\"80px\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"responsive height: s 80px, m: 120px\">\n            <ScrollArea height={{ s: \"80px\", m: \"120px\" }}>\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"maxHeight: 80px\">\n            <ScrollArea maxHeight=\"80px\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"responsive max height: s 80px, m: 200px\">\n            <ScrollArea maxHeight={{ s: \"80px\", m: \"200px\" }}>\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onScroll",
+					"id": "utility-components-scrollarea--on-scroll",
+					"name": "ref, onScroll",
 					"snippet": "const onScroll = () => {\n    const ref = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={4}>\n            <View.Item>\n                <Button onClick={() => ref.current?.scrollBy({ top: 50, left: 50 })}>Scroll</Button>\n            </View.Item>\n            <ScrollArea height=\"100px\" ref={ref} scrollbarDisplay=\"visible\" onScroll={fn()}>\n                <View backgroundColor=\"neutral-faded\" padding={4} width=\"1000px\" height=\"200px\">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                                            has been the industry's standard dummy text ever since the 1500s, when an unknown\n                                            printer took a galley of type and scrambled it to make a type specimen book. It has\n                                            survived not only five centuries, but also the leap into electronic typesetting,\n                                            remaining essentially unchanged. It was popularised in the 1960s with the release of\n                                            Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                                            publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                                        </View>\n            </ScrollArea>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-scrollarea--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ScrollArea className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </ScrollArea>\n    </div>\n);"
 				},
 				{
-					"name": "testNested",
+					"id": "utility-components-scrollarea--test-nested",
+					"name": "test: nested",
 					"snippet": "const testNested = () => (\n    <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n        <View padding={4} paddingInline={16}>\n            <ScrollArea height=\"200px\" scrollbarDisplay=\"visible\">\n                {Array(20)\n                    .fill(\"\")\n                    .map((_, index) => {\n                        return <div key={index}>Item {index + 1}</div>;\n                    })}\n            </ScrollArea>\n        </View>\n    </ScrollArea>\n);"
 				},
 				{
-					"name": "testDynamicHeight",
+					"id": "utility-components-scrollarea--test-dynamic-height",
+					"name": "test: dynamic height change",
 					"snippet": "const testDynamicHeight = () => {\n    const [count, setCount] = React.useState(10);\n\n    return (\n        <View gap={4}>\n            <View.Item>\n                <Button onClick={() => setCount((prev) => prev + 10)}>Add more items</Button>\n            </View.Item>\n\n            <ScrollArea height=\"200px\" scrollbarDisplay=\"visible\">\n                <View gap={2}>\n                    {new Array(count).fill(\"\").map((_, i) => (\n                        <View.Item key={i}>Item {i + 1}</View.Item>\n                    ))}\n                </View>\n            </ScrollArea>\n        </View>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Example, ScrollArea, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ScrollArea/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ScrollArea",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ScrollArea/ScrollArea.tsx",
-				"actualName": "ScrollArea",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"scrollbarDisplay": {
+						"defaultValue": null,
+						"description": "Scrollbar visibility behavior based on the user interaction",
+						"name": "scrollbarDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"hover\" | \"visible\"",
+							"value": [
+								{ "value": "\"hidden\"" },
+								{ "value": "\"hover\"" },
+								{ "value": "\"visible\"" }
+							]
+						}
+					},
+					"onScroll": {
+						"defaultValue": null,
+						"description": "Callback when the scroll area is scrolled",
+						"name": "onScroll",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: Coordinates) => void)" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height of the scroll area, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height of the scroll area, literal css value or unit token multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2876,54 +15093,387 @@
 			"path": "./src/components/Text/tests/Text.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-text--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: title-1\">\n            <Text variant=\"title-1\">Title 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-2\">\n            <Text variant=\"title-2\">Title 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-3\">\n            <Text variant=\"title-3\">Title 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-4\">\n            <Text variant=\"title-4\">Title 4</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-5\">\n            <Text variant=\"title-5\">Title 5</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-6\">\n            <Text variant=\"title-6\">Title 6</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-1\">\n            <Text variant=\"featured-1\">Featured 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-2\">\n            <Text variant=\"featured-2\">Featured 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-3\">\n            <Text variant=\"featured-3\">Featured 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-1\">\n            <Text variant=\"body-1\">Body 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-2\">\n            <Text variant=\"body-2\">Body 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-3\">\n            <Text variant=\"body-3\">Body 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: caption-1\">\n            <Text variant=\"caption-1\">Caption 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: caption-2\">\n            <Text variant=\"caption-2\">Caption 2</Text>\n        </Example.Item>\n        <Example.Item title={[\"responsive variant\", \"[s] body-3\", \"[m+] title-4\"]}>\n            <Text variant={{ s: \"body-3\", m: \"title-4\" }}>Responsive</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--weight",
 					"name": "weight",
 					"snippet": "const weight = () => (\n    <Example>\n        <Example.Item title=\"weight: regular\">\n            <Text weight=\"regular\">Regular</Text>\n        </Example.Item>\n        <Example.Item title=\"weight: medium\">\n            <Text weight=\"medium\">Medium</Text>\n        </Example.Item>\n        <Example.Item title=\"weight: bold\">\n            <Text weight=\"bold\">Bold</Text>\n        </Example.Item>\n        <Example.Item title={[\"responsive\", \"[s] weight: regular\", \"[m+] bold\"]}>\n            <Text weight={{ s: \"regular\", m: \"bold\" }}>Responsive</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: inherit\">\n            <Text>Neutral</Text>\n        </Example.Item>\n        <Example.Item title=\"color: neutral-faded\">\n            <Text color=\"neutral-faded\">Faded</Text>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Text color=\"positive\">Positive</Text>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <Text color=\"warning\">Warning</Text>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Text color=\"critical\">Critical</Text>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <Text color=\"primary\">Primary</Text>\n        </Example.Item>\n        <Example.Item title=\"color: disabled\">\n            <Text color=\"disabled\" attributes={{ \"aria-disabled\": true }}>\n                Disabled\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--decoration",
 					"name": "decoration",
 					"snippet": "const decoration = () => (\n    <Example>\n        <Example.Item title=\"decoration: line-through\">\n            <Text decoration=\"line-through\">Line through</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--wrap",
 					"name": "wrap",
 					"snippet": "const wrap = () => (\n    <Example>\n        <Example.Item title=\"wrap: balance\">\n            <Text wrap=\"balance\" variant=\"title-3\">\n                The design system you want to build\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "mono",
+					"id": "utility-components-text--mono",
+					"name": "monospace",
 					"snippet": "const mono = () => (\n    <Example>\n        <Example.Item title=\"monospace\">\n            <Text monospace>Content</Text>\n        </Example.Item>\n        <Example.Item title=\"monospace, variant, weight\">\n            <Text monospace variant=\"title-1\" weight=\"regular\">\n                Content\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--max-lines",
 					"name": "maxLines",
 					"snippet": "const maxLines = () => (\n    <Example>\n        <Example.Item title=\"maxLines: 2\">\n            <Text maxLines={2}>\n                There are many variations of passages of Lorem Ipsum available, but the majority have\n                suffered alteration in some form, by injected humour, or randomised words which don't look\n                even slightly believable. If you are going to use a passage of Lorem Ipsum, you need to be\n                sure there isn't anything embarrassing hidden in the middle of text. All the Lorem Ipsum\n                generators on the Internet tend to repeat predefined chunks as necessary, making this the\n                first true generator on the Internet. It uses a dictionary of over 200 Latin words,\n                combined with a handful of model sentence structures, to generate Lorem Ipsum which looks\n                reasonable. The generated Lorem Ipsum is therefore always free from repetition, injected\n                humour, or non-characteristic words etc.\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: start\">\n            <Text align=\"start\">Text content</Text>\n        </Example.Item>\n        <Example.Item title=\"align: center\">\n            <Text align=\"center\">Text content</Text>\n        </Example.Item>\n        <Example.Item title=\"align: end\">\n            <Text align=\"end\">Text content</Text>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive alignment\", \"[s]: center\", \"[m+] start\"]}>\n            <Text align={{ s: \"center\", m: \"start\" }}>Text content</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "asProp",
+					"id": "utility-components-text--as-prop",
+					"name": "as",
 					"snippet": "const asProp = () => (\n    <>\n        <Text as=\"h1\">Content</Text>\n        <Text variant=\"title-3\">Content</Text>\n        <Text variant={{ s: \"title-3\", m: \"title-4\" }}>Content</Text>\n    </>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-text--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Text className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Text>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Text/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Text",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Text/Text.tsx",
-				"actualName": "Text",
+				"methods": [],
+				"props": {
+					"variant": {
+						"defaultValue": null,
+						"description": "Text render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Variant>" }
+					},
+					"weight": {
+						"defaultValue": null,
+						"description": "Text font weight",
+						"name": "weight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"medium\" | \"bold\" | \"regular\">" }
+					},
+					"monospace": {
+						"defaultValue": null,
+						"description": "Render monospace font",
+						"name": "monospace",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Text color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"warning\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Text alignment",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"center\" | \"start\" | \"end\">" }
+					},
+					"wrap": {
+						"defaultValue": null,
+						"description": "CSS wrapping style",
+						"name": "wrap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"balance\"", "value": [{ "value": "\"balance\"" }] }
+					},
+					"decoration": {
+						"defaultValue": null,
+						"description": "CSS text decoration style",
+						"name": "decoration",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"line-through\"",
+							"value": [{ "value": "\"line-through\"" }]
+						}
+					},
+					"maxLines": {
+						"defaultValue": null,
+						"description": "Maximum number of lines to render, used for text truncation",
+						"name": "maxLines",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different html tag",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2933,46 +15483,114 @@
 			"path": "./src/components/Theme/tests/Theme.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-theme--scoped",
 					"name": "scoped",
 					"snippet": "const scoped = () => (\n    <Example>\n        <Example.Item title=\"scoped, single\">\n            <Theme name=\"reshaped\">\n                <Card attributes={{ \"data-testid\": \"test-id\" }}>\n                    <Button color=\"primary\">Action</Button>\n                </Card>\n            </Theme>\n        </Example.Item>\n\n        <Example.Item title=\"scoped, multiple\">\n            <Theme name={[\"reshaped\", \"figma\"]}>\n                <Card attributes={{ \"data-testid\": \"test-id-multi\" }}>\n                    <View direction=\"row\" gap={4}>\n                        <Button color=\"primary\">Action</Button>\n\n                        <Popover>\n                            <Popover.Trigger>\n                                {(attributes) => <Button attributes={attributes}>Popover</Button>}\n                            </Popover.Trigger>\n                            <Popover.Content>Content</Popover.Content>\n                        </Popover>\n                    </View>\n                </Card>\n            </Theme>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-theme--light",
 					"name": "light",
 					"snippet": "const light = () => (\n    <Theme name=\"reshaped\" colorMode=\"light\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--dark",
 					"name": "dark",
 					"snippet": "const dark = () => (\n    <Theme name=\"reshaped\" colorMode=\"dark\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--inherited",
 					"name": "inherited",
 					"snippet": "const inherited = () => (\n    <Theme name=\"reshaped\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--inverted",
 					"name": "inverted",
 					"snippet": "const inverted = () => (\n    <Theme name=\"reshaped\" colorMode=\"inverted\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--controlled",
 					"name": "controlled",
 					"snippet": "const controlled = () => {\n    const Internal = () => {\n        const { setTheme, theme } = useTheme();\n\n        return (\n            <Button color=\"primary\" onClick={() => setTheme(\"slate\")}>\n                Switch to slate\n            </Button>\n        );\n    };\n\n    return (\n        <div data-testid=\"root\">\n            <Theme name=\"reshaped\">\n                <Internal />\n            </Theme>\n        </div>\n    );\n};"
 				},
 				{
+					"id": "utility-components-theme--uncontrolled",
 					"name": "uncontrolled",
 					"snippet": "const uncontrolled = () => {\n    const Internal = () => {\n        const { setTheme } = useTheme();\n\n        return (\n            <Button color=\"primary\" onClick={() => setTheme(\"slate\")}>\n                Switch to slate\n            </Button>\n        );\n    };\n\n    return (\n        <div data-testid=\"root\">\n            <Theme defaultName=\"reshaped\">\n                <Internal />\n            </Theme>\n        </div>\n    );\n};"
 				},
 				{
-					"name": "disabledTransition",
+					"id": "utility-components-theme--disabled-transition",
+					"name": "disabled transitions",
 					"snippet": "const disabledTransition = () => {\n    const { invertColorMode } = useTheme();\n\n    return (\n        <Example>\n            <Example.Item title=\"should have no transitions while switching color mode\">\n                <View gap={3}>\n                    <Button onClick={invertColorMode}>Invert mode</Button>\n\n                    <MenuItem selected>Test transition</MenuItem>\n\n                    <Card>Default card</Card>\n\n                    <Theme colorMode=\"inverted\">\n                        <Card>Inverted card</Card>\n                    </Theme>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Card, Example, MenuItem, Popover, Theme, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Theme/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Theme",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Theme/Theme.tsx",
-				"actualName": "Theme",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the theme to use, enables controlled mode",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"defaultName": {
+						"defaultValue": null,
+						"description": "Default name of the theme to use, enables uncontrolled mode",
+						"name": "defaultName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode to use",
+						"name": "colorMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode | \"inverted\"",
+							"value": [
+								{ "value": "\"light\"" },
+								{ "value": "\"dark\"" },
+								{ "value": "\"inverted\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2982,147 +15600,880 @@
 			"path": "./src/components/View/tests/View.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-view--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example title=\"Border is used to highlight the padding value\">\n        <Example.Item title=\"padding: 4\">\n            <View padding={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <View padding={6} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: 0\">\n            <View padding={0} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: vertical 2, horizontal 4\">\n            <View paddingInline={4} paddingBlock={2} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingTop: 4\">\n            <View paddingTop={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingBottom: 4\">\n            <View paddingBottom={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingStart: 4\">\n            <View paddingStart={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingEnd: 4\">\n            <View paddingEnd={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive padding:\",\n                \"[s] vertical 2, horizontal 4\",\n                \"[m+] vertical 4, horizontal 8\",\n            ]}\n        >\n            <View paddingInline={{ s: 4, m: 8 }} paddingBlock={{ s: 2, m: 4 }} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"responsive padding:\", \"[s] top 2, bottom 4\", \"[m+] top 4, bottom 0, start: 8\"]}\n        >\n            <View\n                paddingTop={{ s: 2, m: 4 }}\n                paddingBottom={{ s: 4, m: 0 }}\n                paddingStart={{ s: 0, m: 8 }}\n                borderColor=\"neutral\"\n            >\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"nested padding, child view should have no horizontal padding\">\n            <View paddingStart={4} borderColor=\"neutral\">\n                <View borderColor=\"primary\" paddingBlock={4}>\n                    <Placeholder />\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example title=\"Item 1 is another component, Item 2 is View.Item, Item 3 is text\">\n        <Example.Item title=\"direction: column as default\">\n            <View gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <View gap={3} direction=\"column\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column-reverse\">\n            <View gap={3} direction=\"column-reverse\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row\">\n            <View gap={3} direction=\"row\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row-reverse\">\n            <View gap={3} direction=\"row-reverse\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"responsive direction\", \"[s] column-reverse\", \"[m] row-reverse\", \"[l+] row\"]}\n        >\n            <View direction={{ s: \"column-reverse\", m: \"row-reverse\", l: \"row\" }} gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 4, direction: row\">\n            <View direction=\"row\" gap={4} divided>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n                <Placeholder>Item 3</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 0, direction: row\">\n            <View direction=\"row\" gap={0}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap, direction: row\", \"[s] 4\", \"[m+] 8\"]}>\n            <View direction=\"row\" gap={{ s: 4, m: 8 }}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 4, direction: column\">\n            <View gap={4}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 0, direction: column\">\n            <View gap={0}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap, direction: column\", \"[s] 4\", \"[m+] 8\"]}>\n            <View gap={{ s: 4, m: 8 }}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--divided",
 					"name": "divided",
 					"snippet": "const divided = () => (\n    <Example>\n        <Example.Item title=\"direction: row\">\n            <View divided direction=\"row\" gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <View divided gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive divided\", \"[s] direction: row\", \"[m+] direction: column\"]}>\n            <View divided direction={{ s: \"row\", m: \"column\" }} gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row, columns\">\n            <View divided gap={3} direction=\"row\">\n                <View.Item columns={2}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={8}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={2}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"with React.Fragment\">\n            <View direction=\"row\" gap={4} divided>\n                <Placeholder>Item 1</Placeholder>\n                <>\n                    <Placeholder>Item 2</Placeholder>\n                    <Placeholder>Item 3</Placeholder>\n                </>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example title=\"Removes side borders and border radius when applied\">\n        <Example.Item title=\"bleed: 4\">\n            <View bleed={4} padding={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive bleed\", \"[s] 4\", \"[m+] 0\"]}>\n            <View bleed={{ s: 4, m: 0 }} padding={4} borderRadius=\"small\" borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--wrap",
 					"name": "wrap",
 					"snippet": "const wrap = () => (\n    <Example>\n        <Example.Item title=\"wrap: false\">\n            <View direction=\"row\" wrap={false} gap={3}>\n                <Placeholder w={600} h={100} />\n                <Placeholder w={600} h={100} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: start, direction: row\">\n            <View align=\"start\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: center, direction: row\">\n            <View align=\"center\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: end, direction: row\">\n            <View align=\"end\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"align: stretch, direction: row\",\n                \"2nd item is stretched based on the 1st item height\",\n            ]}\n        >\n            <View align=\"stretch\" direction=\"row\" gap={3}>\n                <Placeholder h={100} />\n                <Placeholder h=\"auto\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: baseline, direction: row\">\n            <View align=\"baseline\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Text variant=\"title-6\">Content</Text>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"align: start, direction: column\">\n            <View align=\"start\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: center, direction: column\">\n            <View align=\"center\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: end, direction: row\">\n            <View align=\"end\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"align: stretch, direction: column\",\n                \"1st item uses its own width, 2nd item is stretched to full width\",\n            ]}\n        >\n            <View align=\"stretch\" direction=\"column\" gap={3}>\n                <Placeholder w={100} />\n                <Placeholder w=\"auto\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--justify",
 					"name": "justify",
 					"snippet": "const justify = () => (\n    <Example>\n        <Example.Item title=\"justify: start, direction: row\">\n            <View justify=\"start\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: center, direction: row\">\n            <View justify=\"center\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: end, direction: row\">\n            <View justify=\"end\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: space-between, direction: row\">\n            <View justify=\"space-between\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"justify: start, direction: column, height: 200px\">\n            <View height=\"200px\" justify=\"start\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: center, direction: column, height: 200px\">\n            <View height=\"200px\" justify=\"center\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: end, direction: column, height: 200px\">\n            <View justify=\"end\" height=\"200px\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: space-between, direction: column, height: 200px\">\n            <View justify=\"space-between\" height=\"200px\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--text-align",
 					"name": "textAlign",
 					"snippet": "const textAlign = () => (\n    <Example>\n        <Example.Item title=\"textAlign: start\">\n            <View textAlign=\"start\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: center\">\n            <View textAlign=\"center\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: end\">\n            <View textAlign=\"end\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: [s] start, [m+] end\">\n            <View textAlign={{ s: \"start\", m: \"end\" }}>Content</View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"height: 100px, width: 100px\">\n            <View backgroundColor=\"neutral-faded\" height=\"100px\" width=\"100px\" />\n        </Example.Item>\n        <Example.Item title=\"height: 25, width: 25\">\n            <View backgroundColor=\"neutral-faded\" height={25} width={25} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive height and width\",\n                \"[s] height: 25, width: 25\",\n                \"[m+] height: 200px, width: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                height={{ s: 25, m: \"200px\" }}\n                width={{ s: 25, m: \"200px\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "ratio",
+					"id": "utility-components-view--ratio",
+					"name": "aspectRatio",
 					"snippet": "const ratio = () => (\n    <Example>\n        <Example.Item title=\"ratio: 16 / 9\">\n            <View backgroundColor=\"neutral-faded\" aspectRatio={16 / 9} width=\"200px\" />\n        </Example.Item>\n        <Example.Item title={[\"responsive ratio\", \"[s] 1/1\", \"[m+] 16/9\"]}>\n            <View backgroundColor=\"neutral-faded\" aspectRatio={{ s: 1, m: 16 / 9 }} width=\"200px\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "maxSize",
+					"id": "utility-components-view--max-size",
+					"name": "width, height, maxWidth, maxHeight",
 					"snippet": "const maxSize = () => (\n    <Example>\n        <Example.Item title=\"maxHeight: 150px, maxWidth: 150px, height: 300px\">\n            <View backgroundColor=\"neutral-faded\" maxHeight=\"150px\" maxWidth=\"150px\" height=\"300px\" />\n        </Example.Item>\n        <Example.Item title=\"maxHeight: 25, maxWidth: 25, height: 50\">\n            <View backgroundColor=\"neutral-faded\" maxHeight={25} maxWidth={25} height={50} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive maxHeight and maxWidth, height: 300\",\n                \"[s] maxHeight: 25, maxWidth: 25\",\n                \"[m+] maxHeight: 200px, maxWidth: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                maxHeight={{ s: 25, m: \"200px\" }}\n                maxWidth={{ s: 25, m: \"200px\" }}\n                height=\"300px\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "minSize",
+					"id": "utility-components-view--min-size",
+					"name": "width, height, minWidth, minHeight",
 					"snippet": "const minSize = () => (\n    <Example>\n        <Example.Item title=\"minHeight: 150px, minWidth: 150px, height: 50px, width: 50px\">\n            <View\n                backgroundColor=\"neutral-faded\"\n                minHeight=\"150px\"\n                minWidth=\"150px\"\n                height=\"50px\"\n                width=\"50px\"\n            />\n        </Example.Item>\n        <Example.Item title=\"minHeight: 25, minWidth: 25, height: 5, width: 5\">\n            <View backgroundColor=\"neutral-faded\" minHeight={25} minWidth={25} height={5} width={5} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive minHeight and minWidth, height: 50px, width: 50px\",\n                \"[s] minHeight: 25, minWidth: 25\",\n                \"[m+] minHeight: 200px, minWidth: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                minHeight={{ s: 25, m: \"200px\" }}\n                minWidth={{ s: 25, m: \"200px\" }}\n                height=\"50px\"\n                width=\"50px\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "background",
+					"id": "utility-components-view--background",
+					"name": "backgroundColor",
 					"snippet": "const background = () => (\n    <Example title=\"border is used to highlight the backround value when it's similar to the page background, text color changes based on the background\">\n        <Example.Item title=\"bg: page\">\n            <View backgroundColor=\"page\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: page-faded\">\n            <View backgroundColor=\"page-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: disabled\">\n            <View backgroundColor=\"disabled\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: disabled-faded\">\n            <View backgroundColor=\"disabled-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-base\">\n            <View backgroundColor=\"elevation-base\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-raised\">\n            <View backgroundColor=\"elevation-raised\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-overlay\">\n            <View backgroundColor=\"elevation-overlay\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: neutral\">\n            <View backgroundColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: neutral-faded\">\n            <View backgroundColor=\"neutral-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: primary\">\n            <View backgroundColor=\"primary\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: primary-faded\">\n            <View backgroundColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: critical\">\n            <View backgroundColor=\"critical\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: critical-faded\">\n            <View backgroundColor=\"critical-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: warning\">\n            <View backgroundColor=\"warning\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: warning-faded\">\n            <View backgroundColor=\"warning-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: positive\">\n            <View backgroundColor=\"positive\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: positive-faded\">\n            <View backgroundColor=\"positive-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--border-color",
 					"name": "borderColor",
 					"snippet": "const borderColor = () => (\n    <Example>\n        <Example.Item title=\"border: neutral\">\n            <View borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: neutral-faded\">\n            <View borderColor=\"neutral-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: primary\">\n            <View borderColor=\"primary\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: primary-faded\">\n            <View borderColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: critical\">\n            <View borderColor=\"critical\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: critical-faded\">\n            <View borderColor=\"critical-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: warning\">\n            <View borderColor=\"warning\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: warning-faded\">\n            <View borderColor=\"warning-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: positive\">\n            <View borderColor=\"positive\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: positive-faded\">\n            <View borderColor=\"positive-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: transparent, background: primary-faded\">\n            <View borderColor=\"transparent\" backgroundColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive\", \"[s] primary\", \"[m+] neutral\"]}>\n            <View borderColor={{ s: \"primary\", m: \"neutral\" }} padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--border",
 					"name": "border",
 					"snippet": "const border = () => (\n    <Example>\n        <Example.Item title=\"border: true\">\n            <View border borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderTop: true\">\n            <View borderTop borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderBottom: true\">\n            <View borderBottom borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderStart: true\">\n            <View borderStart borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderEnd: true\">\n            <View borderEnd borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderInline: true\">\n            <View borderInline borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderBlock: true\">\n            <View borderBlock borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderTop: true, borderStart: true, \">\n            <View borderColor=\"neutral\" borderTop borderStart padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"responsive\",\n                \"[s] borderTop: true, borderStart: true\",\n                \"[m+] borderBottom: true, borderEnd: true\",\n            ]}\n        >\n            <View\n                borderColor=\"neutral\"\n                borderTop={{ s: true, m: false }}\n                borderStart={{ s: true, m: false }}\n                borderBottom={{ s: false, m: true }}\n                borderEnd={{ s: false, m: true }}\n                padding={4}\n            >\n                Content\n            </View>\n        </Example.Item>\n\n        <div style={{ height: 100 }} />\n    </Example>\n);"
 				},
 				{
-					"name": "radius",
+					"id": "utility-components-view--radius",
+					"name": "borderRadius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius: small\">\n            <View borderRadius=\"small\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: medium\">\n            <View borderRadius=\"medium\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: large\">\n            <View borderRadius=\"large\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: circular\">\n            <View borderRadius=\"circular\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--shadow",
 					"name": "shadow",
 					"snippet": "const shadow = () => (\n    <Example>\n        <Example.Item title=\"shadow: raised, radius: medium\">\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                shadow=\"raised\"\n                borderRadius=\"medium\"\n                backgroundColor=\"elevation-raised\"\n            />\n        </Example.Item>\n        <Example.Item title=\"shadow: overlay, radius: medium\">\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                shadow=\"overlay\"\n                borderRadius=\"medium\"\n                backgroundColor=\"elevation-overlay\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--overflow",
 					"name": "overflow",
 					"snippet": "const overflow = () => (\n    <Example>\n        <Example.Item\n            title={[\"overflow: hidden, radius: medium\", \"child background should have radius\"]}\n        >\n            <View height=\"100px\" width=\"100px\" shadow=\"raised\" borderRadius=\"medium\" overflow=\"hidden\">\n                <View backgroundColor=\"primary\" height=\"100%\" width=\"100%\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positioning",
+					"id": "utility-components-view--positioning",
+					"name": "position",
 					"snippet": "const positioning = () => (\n    <Example>\n        <Example.Item title=\"position: relative + absolute\">\n            <View borderColor=\"neutral\" position=\"relative\">\n                <Placeholder />\n                <View\n                    position=\"absolute\"\n                    insetTop={0}\n                    insetEnd={0}\n                    backgroundColor=\"critical\"\n                    zIndex={5}\n                    height={10}\n                    width={10}\n                />\n                <View\n                    position=\"absolute\"\n                    insetTop={0}\n                    insetEnd={0}\n                    backgroundColor=\"primary\"\n                    height={15}\n                    width={15}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: sticky\">\n            <div style={{ overflow: \"auto\", height: 100 }} tabIndex={0}>\n                <View position=\"sticky\" borderColor=\"primary\" insetTop={0}>\n                    Content\n                </View>\n                <Placeholder h={1000} />\n            </div>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive\", \"[s] position: absolute\", \"[m+]: position: relative\"]}>\n            <div style={{ overflow: \"auto\", height: 100, position: \"relative\" }} tabIndex={0}>\n                <View position={{ s: \"absolute\", m: \"relative\" }} borderColor=\"primary\" insetTop={0}>\n                    Content\n                </View>\n                <Placeholder h={1000} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--inset",
 					"name": "inset",
 					"snippet": "const inset = () => (\n    <Example>\n        <Example.Item title=\"inset: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" inset={4} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetTop: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" insetTop={4} height={10} width={10} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetStart: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetStart={4}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetEnd: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" insetEnd={4} height={10} width={10} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetBottom: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetBottom={4}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"responsive, [s] insetBottom: 4 [m+] insetEnd: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetBottom={{ s: 4, m: \"auto\" }}\n                    insetEnd={{ s: \"auto\", m: 4 }}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--animated",
 					"name": "animated",
 					"snippet": "const animated = () => {\n    const [background, setBackground] = React.useState<ViewProps[\"backgroundColor\"]>(\"neutral\");\n\n    return (\n        <View gap={3} align=\"start\">\n            <Button\n                onClick={() => setBackground((prev) => (prev === \"neutral\" ? \"primary\" : \"neutral\"))}\n            >\n                Change background\n            </Button>\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                backgroundColor={background}\n                align=\"center\"\n                justify=\"center\"\n                animated\n            >\n                Content\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "itemGapBefore",
+					"id": "utility-components-view--item-gap-before",
+					"name": "item, gapBefore",
 					"snippet": "const itemGapBefore = () => (\n    <Example>\n        <Example.Item title={[\"gap: 4, 3rd item gapBefore: 10, direction: row\", \"increased gap\"]}>\n            <View direction=\"row\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={10}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 4, direction: row\", \"reduced gap\"]}>\n            <View direction=\"row\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={4}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 0, direction: row\", \"removed gap\"]}>\n            <View direction=\"row\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={0}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"gap: 4, direction: row, 2nd item gap: auto\">\n            <View direction=\"row\" gap={4}>\n                <Placeholder w={200} />\n                <View.Item gapBefore=\"auto\">\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"gap: 4, 3rd item gapBefore: 10, direction: column\", \"increased gap\"]}>\n            <View direction=\"column\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={10}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 4, direction: column\", \"reduced gap\"]}>\n            <View direction=\"column\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={4}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 0, direction: column\", \"removed gap\"]}>\n            <View direction=\"column\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={0}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"gap: 4, direction: column, height: 200px, 2nd item gap: auto\">\n            <View height=\"200px\" gap={4}>\n                <Placeholder />\n                <View.Item gapBefore=\"auto\">\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"responsive item gap\",\n                \"gap: 4, direction: row\",\n                \"[s] 3rd item gapBefore: 10\",\n                \"[m+] 3rd item gapBefore: 0\",\n            ]}\n        >\n            <View direction=\"row\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={{ s: 10, m: 0 }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemGrow",
+					"id": "utility-components-view--item-grow",
+					"name": "item, grow",
 					"snippet": "const itemGrow = () => (\n    <Example>\n        <Example.Item title=\"direction: row, 2nd item grow\">\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column, height: 200px, 2nd item grow\">\n            <View direction=\"column\" gap={3} height=\"200px\">\n                <Placeholder />\n                <View.Item grow>\n                    <Placeholder h=\"100%\" />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row, 2nd item grow, applied to View\">\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View grow>\n                    <Placeholder />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive item grow, direction: row\",\n                \"[s] 2nd item grow\",\n                \"[m+] 2nd item doesn't grow\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View.Item grow={{ s: true, m: false }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive item grow, direction: column, height: 200px\",\n                \"[s] 2nd item grow\",\n                \"[m+] 2nd item doesn't grow\",\n            ]}\n        >\n            <View direction=\"column\" gap={3} height=\"200px\">\n                <Placeholder />\n                <View.Item grow={{ s: true, m: false }}>\n                    <Placeholder h=\"100%\" />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemColumns",
+					"id": "utility-components-view--item-columns",
+					"name": "item, columns",
 					"snippet": "const itemColumns = () => (\n    <Example>\n        <Example.Item title=\"columns 6, 6, gap: 0\">\n            <View direction=\"row\">\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 3, 9, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={3}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, 9, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive columns\", \"[s] columns 6, 6, 12, gap: 4\", \"[m+]: 4, 4, 4\"]}>\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={{ s: 6, m: 4 }}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 6, m: 4 }}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 12, m: 4 }}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, 9, gap: 4, 2nd item gapBefore: 20\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6} gapBefore={20}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemOrder",
+					"id": "utility-components-view--item-order",
+					"name": "item, order",
 					"snippet": "const itemOrder = () => (\n    <Example>\n        <Example.Item title=\"order: 1 3 2\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={4}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={4} order={1}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={4}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive order\", \"[s] 1 2 3\", \"[m+] 1 3 2\"]}>\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={4}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={4} order={{ s: 0, m: 1 }}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={4}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive order\",\n                \"[s]: 1 3 2, 2 is full width on second row\",\n                \"[m+]: 1 2 3, 2 has grow in the center of the first row\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <View.Item columns={{ s: 6, m: \"auto\" }}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item\n                    grow={{ s: false, m: true }}\n                    order={{ s: 1, m: 0 }}\n                    columns={{ s: 12, m: \"auto\" }}\n                >\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 6, m: \"auto\" }}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "hiddenItem",
+					"id": "utility-components-view--hidden-item",
+					"name": "composition, Hidden item",
 					"snippet": "const hiddenItem = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"[s] 2nd item: visible, grow, 3rd item: !grow\",\n                \"[m+] 2nd item: hidden, 2nd item divider: hidden, 3rd item: grow\",\n            ]}\n        >\n            <View direction=\"row\" divided gap={3}>\n                <Placeholder />\n                <Hidden hide={{ s: false, m: true }}>\n                    <View.Item grow key=\"3\">\n                        <Placeholder />\n                    </View.Item>\n                </Hidden>\n                <View.Item grow={{ s: false, m: true }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"[s] 2nd item: visible, grow, 3rd item: !grow\",\n                \"[m+] 2nd item: hidden, 2nd item: grow doesn't push 3rd item, 3rd item: grow\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Placeholder />\n                <Hidden hide={{ s: false, m: true }}>\n                    <View.Item grow>\n                        <Placeholder />\n                    </View.Item>\n                </Hidden>\n                <View.Item grow={{ s: false, m: true }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "keys",
+					"id": "utility-components-view--keys",
+					"name": "item, key",
 					"snippet": "const keys = () => {\n    const toggle = useToggle();\n\n    return (\n        <View gap={2}>\n            <Button onClick={() => toggle.toggle()}>Toggle</Button>\n            <View.Item>Item 1</View.Item>\n            {toggle.active && <KeyItem>Item 2</KeyItem>}\n            <KeyItem>Item 3</KeyItem>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "nestedGaps",
+					"id": "utility-components-view--nested-gaps",
+					"name": "composition, nested gap",
 					"snippet": "const nestedGaps = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"direction: column, gap: 10\",\n                \"Child 1: direction: column, gap: 2\",\n                \"Child 2: direction column, gap: 6\",\n                \"Child 3: gapBefore: 0\",\n                \"Child 3 view: direction: row, gap: 2\",\n            ]}\n        >\n            <View gap={10}>\n                <View gap={2}>\n                    <Placeholder>Child 1</Placeholder>\n                    <Placeholder>Child 1</Placeholder>\n                </View>\n\n                <View gap={6}>\n                    <Placeholder>Child 2</Placeholder>\n                    <Placeholder>Child 2</Placeholder>\n                </View>\n\n                <View.Item gapBefore={0}>\n                    <View direction=\"row\" gap={2}>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "utility-components-view--test-composition",
+					"name": "composition, edge cases",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item>\n            <View direction=\"row\" align=\"center\" gap={4} padding={4}>\n                <View width=\"80px\" height=\"60px\" backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n\n                <View direction=\"row\" align=\"center\" gap={1} grow>\n                    <View.Item shrink>\n                        <Text>Text (like Jeff's Puzzles)</Text>\n                    </View.Item>\n\n                    <View minWidth=\"auto\" grow>\n                        <Button size=\"small\" color=\"neutral\" icon={IconPlus} />\n                    </View>\n                </View>\n\n                <Button color=\"primary\" rounded>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"View.Item, MenuItem, Aspect ratio\",\n                \"ratio should increase height on viewport change\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <View.Item>\n                    <Placeholder />\n                </View.Item>\n                <MenuItem selected roundedCorners>\n                    Menu\n                </MenuItem>\n                <View.Item grow>\n                    <View aspectRatio={16 / 9}>\n                        <Placeholder h=\"100%\" />\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"Scrollable tabs inside View.Item with grow\">\n            <View direction=\"row\" align=\"center\" gap={3}>\n                <Placeholder />\n                <View.Item grow>\n                    <View padding={0} align=\"center\">\n                        <Tabs variant=\"pills\">\n                            <Tabs.List>\n                                <Tabs.Item value=\"1\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"2\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"3\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"4\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"5\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"6\">Very long item</Tabs.Item>\n                            </Tabs.List>\n                            {[1, 2, 3, 5, 6].map((i) => (\n                                <Tabs.Panel key={i} value={i.toString()} />\n                            ))}\n                        </Tabs>\n                    </View>\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"2nd item has grow, Avatar stays circle\">\n            <View direction=\"row\" gap={3}>\n                <Avatar initials=\"DB\" />\n                <View.Item grow>\n                    Veggies sunt bona vobis, proinde vos postulo esse magis grape pea sprouts horseradish\n                    courgette maize spinach prairie turnip jícama coriander quandong gourd broccoli seakale\n                    gumbo. Parsley corn lentil zucchini radicchio maize burdock avocado sea lettuce.\n                    Garbanzo tigernut earthnut pea fennel.\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"item gapBefore from parent doesn't affect the child view\",\n                \"columns should take full width\",\n            ]}\n        >\n            <View>\n                <View.Item gapBefore={20}>\n                    <View direction=\"row\" gap={4}>\n                        <View.Item columns={6}>\n                            <Placeholder />\n                        </View.Item>\n                        <View.Item columns={6}>\n                            <Placeholder />\n                        </View.Item>\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"View becomes flexbox if there is a child with grow\">\n            <View height=\"300px\" borderColor=\"neutral-faded\">\n                <View height=\"50px\" />\n                <View grow backgroundColor=\"neutral-faded\" padding={4}>\n                    Grow\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "asProp",
+					"id": "utility-components-view--as-prop",
+					"name": "as",
 					"snippet": "const asProp = () => (\n    <View as=\"ul\">\n        <View.Item as=\"li\">Content</View.Item>\n    </View>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-view--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <View className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </View>\n    </div>\n);"
 				},
 				{
-					"name": "itemClassName",
+					"id": "utility-components-view--item-class-name",
+					"name": "item className, attributes",
 					"snippet": "const itemClassName = () => (\n    <div data-testid=\"root\">\n        <View.Item className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </View.Item>\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Button, Example, Hidden, MenuItem, Placeholder, Tabs, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/View/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "View",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/View/View.tsx",
-				"actualName": "View",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"divided": {
+						"defaultValue": null,
+						"description": "Render a divider between each child",
+						"name": "divided",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Flex direction for the content",
+						"name": "direction",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Direction>" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between children, base unit token number multiplier",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"wrap": {
+						"defaultValue": null,
+						"description": "Flex wrap for the content",
+						"name": "wrap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Flex align-items for the content",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Flex justify-content for the content",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width style, literal string value or a base unit token number multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"aspectRatio": {
+						"defaultValue": null,
+						"description": "Aspect ratio style, represented as width / height",
+						"name": "aspectRatio",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height style, literal string value or a base unit token number multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Maximum width style, literal string value or a base unit token number multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"minHeight": {
+						"defaultValue": null,
+						"description": "Minimum height style, literal string value or a base unit token number multiplier",
+						"name": "minHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"minWidth": {
+						"defaultValue": null,
+						"description": "Minimum width style, literal string value or a base unit token number multiplier",
+						"name": "minWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Padding style for all sides, base unit token number multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingTop": {
+						"defaultValue": null,
+						"description": "Padding top, base unit token number multiplier",
+						"name": "paddingTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingBottom": {
+						"defaultValue": null,
+						"description": "Padding bottom, base unit token number multiplier",
+						"name": "paddingBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingStart": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "paddingStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingEnd": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "paddingEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingInline": {
+						"defaultValue": null,
+						"description": "Padding inline, base unit token number multiplier",
+						"name": "paddingInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingBlock": {
+						"defaultValue": null,
+						"description": "Padding block, base unit token number multiplier",
+						"name": "paddingBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margin and remove side borders, base unit token number multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"textAlign": {
+						"defaultValue": null,
+						"description": "Text align for the content",
+						"name": "textAlign",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<TextAlign>" }
+					},
+					"backgroundColor": {
+						"defaultValue": null,
+						"description": "Background color, based on the color tokens",
+						"name": "backgroundColor",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"critical-faded\" | \"warning\" | \"warning-faded\" | \"positive-faded\" | \"primary-faded\" | \"elevation-base\" | \"elevation-raised\" | \"elevation-overlay\" | \"page\" | \"page-faded\" | \"disabled-faded\" | \"brand\" | \"white\" | \"black\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"critical-faded\"" },
+								{ "value": "\"warning\"" },
+								{ "value": "\"warning-faded\"" },
+								{ "value": "\"positive-faded\"" },
+								{ "value": "\"primary-faded\"" },
+								{ "value": "\"elevation-base\"" },
+								{ "value": "\"elevation-raised\"" },
+								{ "value": "\"elevation-overlay\"" },
+								{ "value": "\"page\"" },
+								{ "value": "\"page-faded\"" },
+								{ "value": "\"disabled-faded\"" },
+								{ "value": "\"brand\"" },
+								{ "value": "\"white\"" },
+								{ "value": "\"black\"" }
+							]
+						}
+					},
+					"borderColor": {
+						"defaultValue": null,
+						"description": "Border color, based on the color tokens",
+						"name": "borderColor",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<BorderColor>" }
+					},
+					"border": {
+						"defaultValue": null,
+						"description": "Add border to all sides",
+						"name": "border",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderTop": {
+						"defaultValue": null,
+						"description": "Add border to the top side",
+						"name": "borderTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderBottom": {
+						"defaultValue": null,
+						"description": "Add border to the bottom side",
+						"name": "borderBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderStart": {
+						"defaultValue": null,
+						"description": "Add border to the inline start side",
+						"name": "borderStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderEnd": {
+						"defaultValue": null,
+						"description": "Add border to the inline end side",
+						"name": "borderEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderInline": {
+						"defaultValue": null,
+						"description": "Add border to the inline direction",
+						"name": "borderInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderBlock": {
+						"defaultValue": null,
+						"description": "Add border to the block direction",
+						"name": "borderBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Radius>" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Position style",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Position>" }
+					},
+					"inset": {
+						"defaultValue": null,
+						"description": "Inset style, base unit token number multiplier when used as a number",
+						"name": "inset",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetStart": {
+						"defaultValue": null,
+						"description": "Inset start, base unit token number multiplier when used as a number",
+						"name": "insetStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetEnd": {
+						"defaultValue": null,
+						"description": "Inset end, base unit token number multiplier when used as a number",
+						"name": "insetEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetTop": {
+						"defaultValue": null,
+						"description": "Inset top, base unit token number multiplier when used as a number",
+						"name": "insetTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetBottom": {
+						"defaultValue": null,
+						"description": "Inset bottom, base unit token number multiplier when used as a number",
+						"name": "insetBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"zIndex": {
+						"defaultValue": null,
+						"description": "z-index style",
+						"name": "zIndex",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"shadow": {
+						"defaultValue": null,
+						"description": "Shadow style, based on the shadow tokens",
+						"name": "shadow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Overflow style",
+						"name": "overflow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"auto\"",
+							"value": [{ "value": "\"hidden\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"animated": {
+						"defaultValue": null,
+						"description": "Add transition for the properties",
+						"name": "animated",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					},
+					"grow": {
+						"defaultValue": null,
+						"description": "Apply flex-grow, using it on View.Item applies additional styles on the parent View",
+						"name": "grow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"shrink": {
+						"defaultValue": null,
+						"description": "Apply flex-shrink",
+						"name": "shrink",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "View"
 			}
 		},
 		"hooks-useelementid": {
@@ -3131,7 +16482,8 @@
 			"path": "./src/hooks/tests/useElementId.stories.tsx",
 			"stories": [
 				{
-					"name": "id",
+					"id": "hooks-useelementid--id",
+					"name": "passed id",
 					"snippet": "const id = () => {\n    return <Component id=\"hey\" />;\n};"
 				}
 			],
@@ -3148,6 +16500,7 @@
 			"path": "./src/hooks/tests/useHandlerRef.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usehandlerref--base",
 					"name": "base",
 					"snippet": "const base = (args) => {\n    const [count, setCount] = React.useState(0);\n\n    // Creating a new handler on each render\n    const handleEffect = () => {\n        args.handleEffect(0);\n    };\n\n    return (\n        <View gap={4}>\n            <Button onClick={() => setCount((prev) => prev + 1)}>Increase count</Button>\n            <Component onEffect={handleEffect} count={count} />\n        </View>\n    );\n};"
 				}
@@ -3165,43 +16518,53 @@
 			"path": "./src/hooks/tests/useHotkeys.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usehotkeys--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const { checkHotkeyState } = useHotkeys({\n        \"shift + b + n\": () => console.log(\"pressed\"),\n        \"c + v\": () => console.log(\"c + v\"),\n        \"Meta + k\": () => console.log(\"meta + k\"),\n        \"Meta + f\": () => console.log(\"meta + f\"),\n        \"Meta + v\": () => console.log(\"meta + v\"),\n        \"Meta + b\": () => console.log(\"meta + b\"),\n        \"control + enter\": () => console.log(\"control + enter\"),\n        \"meta + enter\": () => console.log(\"meta + enter\"),\n        \"mod + enter\": () => console.log(\"mod + enter\"),\n        \"mod + ArrowRight\": () => console.log(\"right\"),\n        \"mod + ArrowUp\": () => console.log(\"top\"),\n        \"shift + ArrowRight\": () => console.log(\"right\"),\n        \"shift + ArrowUp\": () => console.log(\"top\"),\n        \"alt+shift+n\": () => console.log(\"alt+shift+n\"),\n        \"shift+alt+n\": () => console.log(\"shift+alt+n\"),\n        \"alt+shiftLeft+n\": () => console.log(\"alt+shiftLeft+n\"),\n    });\n    const active = checkHotkeyState(\"shift + b + n\");\n    const shiftActive = checkHotkeyState(\"shift\");\n    const bActive = checkHotkeyState(\"b\");\n    const nActive = checkHotkeyState(\"n\");\n\n    return (\n        <View\n            animated\n            gap={2}\n            direction=\"row\"\n            backgroundColor={active ? \"positive-faded\" : undefined}\n            padding={2}\n            borderRadius=\"small\"\n        >\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={shiftActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={shiftActive ? undefined : \"raised\"}\n            >\n                Shift\n            </View>\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={bActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={bActive ? undefined : \"raised\"}\n            >\n                b\n            </View>\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={nActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={nActive ? undefined : \"raised\"}\n            >\n                n\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "singleKey",
+					"id": "hooks-usehotkeys--single-key",
+					"name": "single key",
 					"snippet": "const singleKey = (args) => <Component hotkeys={{ a: args.handleHotkey }} />;"
 				},
 				{
-					"name": "modKey",
+					"id": "hooks-usehotkeys--mod-key",
+					"name": "mod key",
 					"snippet": "const modKey = (args) => <Component hotkeys={{ mod: args.handleHotkey }} />;"
 				},
 				{
-					"name": "modKeyHold",
+					"id": "hooks-usehotkeys--mod-key-hold",
+					"name": "mod key on hold",
 					"snippet": "const modKeyHold = (args) => <Component hotkeys={{ \"Meta + b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyList",
+					"id": "hooks-usehotkeys--key-list",
+					"name": "key list",
 					"snippet": "const keyList = (args) => <Component hotkeys={{ \"a,b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombination",
+					"id": "hooks-usehotkeys--key-combination",
+					"name": "key combination",
 					"snippet": "const keyCombination = (args) => <Component hotkeys={{ \"a+b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationFormat",
+					"id": "hooks-usehotkeys--key-combination-format",
+					"name": "key combination without formatting",
 					"snippet": "const keyCombinationFormat = (args) => <Component hotkeys={{ \"A  + b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationOrder",
+					"id": "hooks-usehotkeys--key-combination-order",
+					"name": "key combination without order",
 					"snippet": "const keyCombinationOrder = (args) => <Component hotkeys={{ \"b+a\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationMoreThanRequired",
+					"id": "hooks-usehotkeys--key-combination-more-than-required",
+					"name": "key combination, more keys pressed",
 					"snippet": "const keyCombinationMoreThanRequired = (args) => <Component hotkeys={{ \"z + x\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "optionModified",
+					"id": "hooks-usehotkeys--option-modified",
+					"name": "modified with alt/option",
 					"snippet": "const optionModified = (args) => (\n    <Component hotkeys={{ \"alt+n\": args.handleHotkeyModified, \"alt+shift\": args.handleHotkey }} />\n);"
 				}
 			],
@@ -3218,22 +16581,27 @@
 			"path": "./src/hooks/tests/useKeyboardArrowNavigation.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usekeyboardarrownavigation--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "horizontal",
+					"id": "hooks-usekeyboardarrownavigation--horizontal",
+					"name": "orientation: horizontal",
 					"snippet": "const horizontal = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, orientation: \"horizontal\" });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "vertical",
+					"id": "hooks-usekeyboardarrownavigation--vertical",
+					"name": "orientation: vertical",
 					"snippet": "const vertical = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, orientation: \"vertical\" });\n\n    return (\n        <View gap={2} direction=\"column\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-usekeyboardarrownavigation--circular",
 					"name": "circular",
 					"snippet": "const circular = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, circular: true });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-usekeyboardarrownavigation--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, disabled: true });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				}
@@ -3249,7 +16617,13 @@
 			"id": "hooks-usekeyboardmode",
 			"name": "useKeyboardMode",
 			"path": "./src/hooks/tests/useKeyboardMode.stories.tsx",
-			"stories": [{ "name": "base", "snippet": "const base = () => <Component />;" }],
+			"stories": [
+				{
+					"id": "hooks-usekeyboardmode--base",
+					"name": "base",
+					"snippet": "const base = () => <Component />;"
+				}
+			],
 			"import": "import { Button, View } from \"reshaped\";",
 			"jsDocTags": {},
 			"error": {
@@ -3263,19 +16637,23 @@
 			"path": "./src/hooks/tests/useOnClickOutside.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-useonclickoutside--base",
 					"name": "base",
 					"snippet": "const base = (args) => {\n    const ref = React.useRef(null);\n    const [target, setTarget] = React.useState<\"inside\" | \"outside\" | null>(null);\n\n    useOnClickOutside([ref], () => {\n        args.handleOutsideClick();\n        setTarget(\"outside\");\n    });\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }} onClick={() => setTarget(\"inside\")}>\n                Trigger\n            </Button>\n            {target && `Clicked ${target}`}\n        </View>\n    );\n};"
 				},
 				{
-					"name": "refs",
+					"id": "hooks-useonclickoutside--refs",
+					"name": "multiple refs",
 					"snippet": "const refs = (args) => {\n    const ref = React.useRef(null);\n    const ref2 = React.useRef(null);\n\n    useOnClickOutside([ref, ref2], () => {\n        args.handleOutsideClick();\n    });\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }}>Trigger</Button>\n            <Button attributes={{ ref: ref2 }}>Trigger 2</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-useonclickoutside--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = (args) => {\n    const ref = React.useRef(null);\n\n    useOnClickOutside(\n        [ref],\n        () => {\n            args.handleOutsideClick();\n        },\n        {\n            disabled: true,\n        }\n    );\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }}>Trigger</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "deps",
+					"id": "hooks-useonclickoutside--deps",
+					"name": "test: handler uses latest state",
 					"snippet": "const deps = (args) => {\n    const ref = React.useRef(null);\n    const [count, setCount] = React.useState(0);\n\n    useOnClickOutside([ref], () => {\n        args.handleOutsideClick({ count });\n    });\n\n    return (\n        <Button attributes={{ ref }} onClick={() => setCount((prev) => prev + 1)}>\n            Trigger\n        </Button>\n    );\n};"
 				}
 			],
@@ -3290,7 +16668,13 @@
 			"id": "hooks-usertl",
 			"name": "useRTL",
 			"path": "./src/hooks/tests/useRTL.stories.tsx",
-			"stories": [{ "name": "setRTL", "snippet": "const setRTL = () => <Component />;" }],
+			"stories": [
+				{
+					"id": "hooks-usertl--set-rtl",
+					"name": "setRTL",
+					"snippet": "const setRTL = () => <Component />;"
+				}
+			],
 			"import": "",
 			"jsDocTags": {},
 			"error": {
@@ -3304,10 +16688,12 @@
 			"path": "./src/hooks/tests/useResponsiveClientValue.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-useresponsiveclientvalue--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const value = useResponsiveClientValue<ViewProps[\"backgroundColor\"]>({\n        s: \"neutral\",\n        m: \"critical\",\n        l: \"positive\",\n    });\n\n    return <View width={25} height={25} backgroundColor={value} />;\n};"
 				},
 				{
+					"id": "hooks-useresponsiveclientvalue--boolean",
 					"name": "boolean",
 					"snippet": "const boolean = () => {\n    const value = useResponsiveClientValue<boolean>({\n        s: true,\n        l: false,\n    });\n\n    return <div>{value?.toString()}</div>;\n};"
 				}
@@ -3325,19 +16711,23 @@
 			"path": "./src/hooks/tests/useScrollLock.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usescrolllock--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock();\n\n    return (\n        <React.Fragment>\n            <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n            <div style={{ height: \"150vh\" }} />\n        </React.Fragment>\n    );\n};"
 				},
 				{
-					"name": "origin",
+					"id": "hooks-usescrolllock--origin",
+					"name": "originRef",
 					"snippet": "const origin = () => {\n    const originRef = React.useRef<HTMLDivElement>(null);\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock({ originRef });\n\n    return (\n        <View overflow=\"auto\" height={25} attributes={{ ref: originRef, \"data-testid\": \"root\" }}>\n            <View height={50} padding={4} backgroundColor=\"neutral-faded\" borderRadius=\"medium\">\n                <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "container",
+					"id": "hooks-usescrolllock--container",
+					"name": "containerRef",
 					"snippet": "const container = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock({ containerRef });\n\n    return (\n        <View height={25} attributes={{ ref: containerRef, \"data-testid\": \"root\" }}>\n            <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testContainerAsync",
+					"id": "hooks-usescrolllock--test-container-async",
+					"name": "test: containerRef locked count",
 					"snippet": "const testContainerAsync = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const globalLock = useScrollLock();\n    const scopedLock = useScrollLock({ containerRef });\n\n    return (\n        <Example>\n            <Example.Item title=\"calling regular lock and lock with a container only requires a single unlock to remove overflow\">\n                <View attributes={{ ref: containerRef }} gap={4} direction=\"row\">\n                    <Button\n                        onClick={globalLock.scrollLocked ? globalLock.unlockScroll : globalLock.lockScroll}\n                    >\n                        Toggle\n                    </Button>\n                    <Button\n                        onClick={scopedLock.scrollLocked ? scopedLock.unlockScroll : scopedLock.lockScroll}\n                    >\n                        Toggle\n                    </Button>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
@@ -3354,14 +16744,17 @@
 			"path": "./src/hooks/tests/useToggle.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usetoggle--toggle",
 					"name": "toggle",
 					"snippet": "const toggle = () => {\n    const { toggle, active } = useToggle();\n\n    return (\n        <Button onClick={() => toggle()} attributes={{ \"data-active\": active }}>\n            {active ? \"Deactivate\" : \"Activate\"}\n        </Button>\n    );\n};"
 				},
 				{
+					"id": "hooks-usetoggle--activate",
 					"name": "activate",
 					"snippet": "const activate = () => {\n    const { activate, active } = useToggle();\n\n    return (\n        <React.Fragment>\n            <Button onClick={activate} attributes={{ \"data-active\": active }}>\n                Activate\n            </Button>\n        </React.Fragment>\n    );\n};"
 				},
 				{
+					"id": "hooks-usetoggle--deactivate",
 					"name": "deactivate",
 					"snippet": "const deactivate = () => {\n    const { deactivate, active } = useToggle(true);\n\n    return (\n        <Button onClick={deactivate} attributes={{ \"data-active\": active }}>\n            Deactivate\n        </Button>\n    );\n};"
 				}
@@ -3379,39 +16772,48 @@
 			"path": "./src/utilities/a11y/tests/TrapFocus.stories.tsx",
 			"stories": [
 				{
-					"name": "modeDialog",
+					"id": "utilities-trapfocus--mode-dialog",
+					"name": "mode: dialog",
 					"snippet": "const modeDialog = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, { mode: \"dialog\" });\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\"mode: dialog\", \"tab navigation, always stays inside until released\"]}\n            >\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View.Item>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeActionMenu",
+					"id": "utilities-trapfocus--mode-action-menu",
+					"name": "mode: action-menu",
 					"snippet": "const modeActionMenu = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"action-menu\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: action-menu\",\n                    \"up/down arrow navigation, tab and shift+tab release the focus and follows natural tab order\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeActionBar",
+					"id": "utilities-trapfocus--mode-action-bar",
+					"name": "mode: action-bar",
 					"snippet": "const modeActionBar = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"action-bar\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: action-bar\",\n                    \"left/right arrow navigation, tab and shift+tab release the focus and follows natural tab order\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeContentMenu",
+					"id": "utilities-trapfocus--mode-content-menu",
+					"name": "mode: content-menu",
 					"snippet": "const modeContentMenu = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"content-menu\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: content-menu\",\n                    \"tab navigation, tabbing outside the content will trigger the release\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utilities-trapfocus--include-trigger",
 					"name": "includeTrigger",
 					"snippet": "const includeTrigger = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n            includeTrigger: true,\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utilities-trapfocus--initial-focus-el",
 					"name": "initialFocusEl",
 					"snippet": "const initialFocusEl = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const initialFocusRef = React.useRef<HTMLButtonElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n            initialFocusEl: initialFocusRef.current,\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View\n                            gap={4}\n                            direction=\"row\"\n                            padding={4}\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            attributes={{ ref: rootRef }}\n                        >\n                            <Button onClick={() => {}}>Action 1</Button>\n                            <Button onClick={() => {}} attributes={{ ref: initialFocusRef }}>\n                                Action 2\n                            </Button>\n                            <Button onClick={() => {}}>Action 3</Button>\n                            <Button onClick={trapToggle.deactivate}>Release</Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "focusableElements",
+					"id": "utilities-trapfocus--focusable-elements",
+					"name": "test: focusable elements",
 					"snippet": "const focusableElements = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current);\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title=\"test with all types of focusable elements\">\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={trapToggle.activate}>Activate</Button>\n                    </View.Item>\n\n                    {trapToggle.active && (\n                        <View\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            padding={4}\n                            gap={4}\n                            attributes={{ ref: rootRef }}\n                            align=\"start\"\n                        >\n                            <Link href=\"#\" attributes={{ \"data-testid\": \"test-link\" }}>\n                                Link\n                            </Link>\n\n                            <TextField\n                                name=\"input\"\n                                placeholder=\"Input\"\n                                inputAttributes={{ \"data-testid\": \"test-text-field\" }}\n                            />\n\n                            <TextArea name=\"textarea\" inputAttributes={{ \"data-testid\": \"test-text-area\" }} />\n\n                            <Select\n                                name=\"select\"\n                                options={[\n                                    { label: \"Option 1\", value: \"1\" },\n                                    { label: \"Option 2\", value: \"2\" },\n                                ]}\n                                inputAttributes={{ \"data-testid\": \"test-select\" }}\n                            />\n\n                            <RadioGroup name=\"radio\">\n                                <Radio value=\"1\" inputAttributes={{ \"data-testid\": \"test-radio-1\" }}>\n                                    Option 1\n                                </Radio>\n                                <Radio value=\"2\" inputAttributes={{ \"data-testid\": \"test-radio-2\" }}>\n                                    Option 2\n                                </Radio>\n                            </RadioGroup>\n\n                            <Editor />\n\n                            <div tabIndex={0} role=\"button\" data-testid=\"test-tabindex\">\n                                div with tabIndex\n                            </div>\n\n                            <div style={{ display: \"none\" }}>\n                                <Button onClick={() => {}} attributes={{ \"data-testid\": \"test-hidden-button\" }}>\n                                    Hidden\n                                </Button>\n                            </div>\n\n                            <Button\n                                onClick={() => {}}\n                                attributes={{ tabIndex: -1, \"data-testid\": \"test-button-negative-tabindex\" }}\n                            >\n                                Excluded\n                            </Button>\n\n                            <input type=\"hidden\" data-testid=\"test-input-hidden\" />\n\n                            <Button\n                                onClick={trapToggle.deactivate}\n                                attributes={{ \"data-testid\": \"test-button\" }}\n                            >\n                                Release button\n                            </Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "nested",
+					"id": "utilities-trapfocus--nested",
+					"name": "test: nested",
 					"snippet": "const nested = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const innerRootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n    const innerTrapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    React.useEffect(() => {\n        if (!innerTrapToggle.active) return;\n        if (!innerRootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(innerRootRef.current, {\n            mode: \"dialog\",\n        });\n\n        return () => trapFocus.release();\n    }, [innerTrapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"nested, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View gap={4}>\n                            <View\n                                gap={4}\n                                direction=\"row\"\n                                padding={4}\n                                backgroundColor=\"neutral-faded\"\n                                borderRadius=\"medium\"\n                                attributes={{ ref: rootRef }}\n                            >\n                                <Button onClick={() => {}}>Action</Button>\n                                <Button onClick={innerTrapToggle.activate}>Inner trap focus</Button>\n                                <Button onClick={trapToggle.deactivate}>Release</Button>\n                            </View>\n\n                            {innerTrapToggle.active && (\n                                <View\n                                    gap={4}\n                                    direction=\"row\"\n                                    padding={4}\n                                    backgroundColor=\"neutral-faded\"\n                                    borderRadius=\"medium\"\n                                    attributes={{ ref: innerRootRef }}\n                                >\n                                    <Button onClick={() => {}}>Action</Button>\n                                    <Button onClick={innerTrapToggle.deactivate}>Release</Button>\n                                </View>\n                            )}\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "mutationObserver",
+					"id": "utilities-trapfocus--mutation-observer",
+					"name": "test: mutation observer",
 					"snippet": "const mutationObserver = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n    const [mutated, setMutated] = React.useState(false);\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n        });\n\n        setTimeout(() => {\n            setMutated(true);\n        }, 50);\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View\n                            gap={4}\n                            direction=\"row\"\n                            padding={4}\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            attributes={{ ref: rootRef }}\n                        >\n                            {!mutated && (\n                                <>\n                                    <Button onClick={() => {}}>Action 1</Button>\n                                    <Button onClick={() => {}}>Action 2</Button>\n                                </>\n                            )}\n                            <Button onClick={() => {}}>Action 3</Button>\n                            <Button onClick={trapToggle.deactivate}>Release</Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
@@ -3428,15 +16830,35 @@
 			"path": "./src/components/_private/Portal/tests/Portal.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "internal-portal--base",
+					"name": "Base",
 					"snippet": "const base = () => {\n\tconst ref = React.useRef<HTMLDivElement>(null);\n\tconst [mounted, setMounted] = React.useState(false);\n\n\tReact.useEffect(() => {\n\t\tsetMounted(true);\n\t}, []);\n\n\treturn (\n\t\t<>\n\t\t\t<div style={{ border: \"2px solid #333\", padding: 16 }}>\n\t\t\t\tApp\n\t\t\t\t{mounted && <Portal targetRef={ref}>Ported to green</Portal>}\n\t\t\t</div>\n\t\t\t<div ref={ref} style={{ border: \"2px solid green\", padding: 16 }} />\n\t\t</>\n\t);\n};"
 				}
 			],
 			"import": "import { Portal } from \"reshaped\";",
 			"jsDocTags": {},
-			"error": {
-				"name": "No component definition found",
-				"message": "File: /Users/shilman/projects/design-systems/reshaped/src/components/_private/Portal/index.ts\nError:\nNo suitable component definition found.\nYou can debug your component file in this playground: https://react-docgen.dev/playground\nCode:\nimport Portal, { PortalScope } from \"./Portal\";\n\nconst PortalRoot = Portal as typeof Portal & {\n\tScope: typeof PortalScope;\n};\n\nPortalRoot.Scope = PortalScope;\n\nexport default PortalRoot;\nexport type { Props as PortalProps } from \"./Portal.types\";\n\n\nFile: /Users/shilman/projects/design-systems/reshaped/src/components/_private/Portal/Portal.types.ts\nError:\nNo suitable component definition found.\nYou can debug your component file in this playground: https://react-docgen.dev/playground\nCode:\nimport React from \"react\";\n\nexport type Props = {\n\tchildren?: React.ReactNode;\n\ttargetRef?: React.RefObject<HTMLElement | ShadowRoot | null>;\n};\n\nexport type ScopeProps<T extends HTMLElement> = {\n\tchildren: (ref: React.RefObject<T | null>) => React.ReactNode;\n};\n\nexport type Context = {\n\tscopeRef: React.RefObject<HTMLElement | null>;\n};\n"
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/_private/Portal/index.ts",
+				"description": "",
+				"displayName": "Portal",
+				"methods": [],
+				"props": {
+					"targetRef": {
+						"defaultValue": null,
+						"description": "",
+						"name": "targetRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/_private/Portal/Portal.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | ShadowRoot | null>" }
+					}
+				},
+				"exportName": "Portal"
 			}
 		},
 		"internal-usedrag": {
@@ -3444,24 +16866,33 @@
 			"name": "useDrag",
 			"path": "./src/hooks/tests/useDrag.stories.tsx",
 			"stories": [
-				{ "name": "base", "snippet": "const base = () => <Example />;" },
 				{
-					"name": "mouseEvents",
+					"id": "internal-usedrag--base",
+					"name": "base",
+					"snippet": "const base = () => <Example />;"
+				},
+				{
+					"id": "internal-usedrag--mouse-events",
+					"name": "onDrag, mouse events",
 					"snippet": "const mouseEvents = () => {\n    return <Demo onDrag={fn()} />;\n};"
 				},
 				{
-					"name": "touchEvents",
+					"id": "internal-usedrag--touch-events",
+					"name": "onDrag, touch events",
 					"snippet": "const touchEvents = () => {\n    return <Demo onDrag={fn()} />;\n};"
 				},
 				{
-					"name": "orientationHorizontal",
+					"id": "internal-usedrag--orientation-horizontal",
+					"name": "orientation horizontal",
 					"snippet": "const orientationHorizontal = () => {\n    return <Demo onDrag={fn()} orientation=\"horizontal\" />;\n};"
 				},
 				{
-					"name": "orientationVertical",
+					"id": "internal-usedrag--orientation-vertical",
+					"name": "orientation vertical",
 					"snippet": "const orientationVertical = () => {\n    return <Demo onDrag={fn()} orientation=\"vertical\" />;\n};"
 				},
 				{
+					"id": "internal-usedrag--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => {\n    return <Demo onDrag={fn()} disabled />;\n};"
 				}
@@ -3479,7 +16910,8 @@
 			"path": "./src/tests/ShadowDOM.stories.tsx",
 			"stories": [
 				{
-					"name": "behavior",
+					"id": "internal-shadowdom--behavior",
+					"name": "Behavior",
 					"snippet": "const behavior = () => (\n\t<Example>\n\t\t<Example.Item title=\"base\">\n\t\t\t<Component />\n\t\t</Example.Item>\n\t</Example>\n);"
 				}
 			],
@@ -3496,30 +16928,94 @@
 			"path": "./src/tests/themes.stories.tsx",
 			"stories": [
 				{
-					"name": "test",
+					"id": "internal-themes--test",
+					"name": "Test",
 					"snippet": "const test = () => {\n\tconst { colorMode } = useTheme();\n\tconst [activeColor, setColor] = useState(colors[0]);\n\tconst [theme, setTheme] = useState(\"\");\n\tconst [algo, setAlgo] = useState<\"wcag\" | \"apca\">(\"wcag\");\n\n\tuseLayoutEffect(() => {\n\t\tsetTheme(\n\t\t\tgetThemeCSS(\n\t\t\t\t\"test\",\n\t\t\t\t{\n\t\t\t\t\tcolor: generateThemeColors({\n\t\t\t\t\t\tprimary: activeColor === colors[0] ? undefined : activeColor,\n\t\t\t\t\t}),\n\t\t\t\t},\n\t\t\t\t{\n\t\t\t\t\tcolorContrastAlgorithm: algo,\n\t\t\t\t}\n\t\t\t)\n\t\t);\n\t}, [activeColor, algo]);\n\n\treturn (\n\t\t<>\n\t\t\t<style>{theme}</style>\n\t\t\t<Theme name=\"test\">\n\t\t\t\t<View gap={4}>\n\t\t\t\t\t<View direction=\"row\" align=\"center\" gap={4}>\n\t\t\t\t\t\t{colors.map((color) => {\n\t\t\t\t\t\t\tconst hex = colorMode === \"dark\" && color === \"#000000\" ? \"#ffffff\" : color;\n\n\t\t\t\t\t\t\treturn (\n\t\t\t\t\t\t\t\t<Actionable key={color} onClick={() => setColor(color)} borderRadius=\"inherit\">\n\t\t\t\t\t\t\t\t\t<View\n\t\t\t\t\t\t\t\t\t\twidth={5}\n\t\t\t\t\t\t\t\t\t\theight={5}\n\t\t\t\t\t\t\t\t\t\tborderRadius=\"circular\"\n\t\t\t\t\t\t\t\t\t\tattributes={{\n\t\t\t\t\t\t\t\t\t\t\tstyle: {\n\t\t\t\t\t\t\t\t\t\t\t\ttransition: `box-shadow var(--rs-duration-fast) var(--rs-easing-standard)`,\n\t\t\t\t\t\t\t\t\t\t\t\tbackground: hex,\n\t\t\t\t\t\t\t\t\t\t\t\tboxShadow:\n\t\t\t\t\t\t\t\t\t\t\t\t\tcolor === activeColor\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t? `0 0 0 3px var(--rs-color-background-elevation-base), 0 0 0 5px ${hex}`\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t: undefined,\n\t\t\t\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t\t\t\t}}\n\t\t\t\t\t\t\t\t\t/>\n\t\t\t\t\t\t\t\t</Actionable>\n\t\t\t\t\t\t\t);\n\t\t\t\t\t\t})}\n\t\t\t\t\t\t<View.Item gapBefore=\"auto\">\n\t\t\t\t\t\t\t<Switch name=\"algo\" onChange={(args) => setAlgo(args.checked ? \"apca\" : \"wcag\")}>\n\t\t\t\t\t\t\t\tUse APCA\n\t\t\t\t\t\t\t</Switch>\n\t\t\t\t\t\t</View.Item>\n\t\t\t\t\t</View>\n\n\t\t\t\t\t<ThemePlayground />\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</>\n\t);\n};"
 				},
 				{
-					"name": "base",
+					"id": "internal-themes--base",
+					"name": "Base",
 					"snippet": "const base = () => (\n\t<Example>\n\t\t<Example.Item title=\"custom runtime theme\">\n\t\t\t<style>{css}</style>\n\t\t\t<Theme name=\"green\">\n\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"on colors generation\">\n\t\t\t<style>{css2}</style>\n\t\t\t<Theme name=\"peach\">\n\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "generation",
+					"id": "internal-themes--generation",
+					"name": "Generation",
 					"snippet": "const generation = () => (\n\t<div>\n\t\t<style>{cssGenerated}</style>\n\t\t<Theme name=\"generated\">{componentExamples}</Theme>\n\t</div>\n);"
 				},
 				{
-					"name": "onColors",
+					"id": "internal-themes--on-colors",
+					"name": "On Colors",
 					"snippet": "const onColors = () => (\n\t<Example>\n\t\t<Example.Item title=\"custom on color values\">\n\t\t\t<style>{onColorsCss}</style>\n\t\t\t<Theme name=\"on-color\">\n\t\t\t\t<View gap={2} direction=\"row\">\n\t\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t\t\t<Button color=\"critical\">Critical button</Button>\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"custom on color values, apca\">\n\t\t\t<style>{onColorsCssApca}</style>\n\t\t\t<Theme name=\"on-color-apca\">\n\t\t\t\t<View gap={2} direction=\"row\">\n\t\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t\t\t<Button color=\"critical\">Critical button</Button>\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t</Example>\n);"
 				}
 			],
 			"import": "import {\n    Actionable,\n    Alert,\n    Avatar,\n    Badge,\n    Button,\n    Card,\n    DropdownMenu,\n    Example,\n    Link,\n    Switch,\n    Text,\n    TextField,\n    Theme,\n    ThemePlayground,\n    View,\n} from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Theme/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Theme",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Theme/Theme.tsx",
-				"actualName": "Theme",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the theme to use, enables controlled mode",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"defaultName": {
+						"defaultValue": null,
+						"description": "Default name of the theme to use, enables uncontrolled mode",
+						"name": "defaultName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode to use",
+						"name": "colorMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode | \"inverted\"",
+							"value": [
+								{ "value": "\"light\"" },
+								{ "value": "\"dark\"" },
+								{ "value": "\"inverted\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -3529,7 +17025,8 @@
 			"path": "./src/Sandbox.stories.tsx",
 			"stories": [
 				{
-					"name": "preview",
+					"id": "sandbox--preview",
+					"name": "Preview",
 					"snippet": "const preview = () => {\n\treturn (\n\t\t<Preview>\n\t\t\t<Component />\n\t\t</Preview>\n\t);\n};"
 				}
 			],
@@ -3540,5 +17037,6 @@
 				"message": "We could not detect the component from your story file. Specify meta.component.\n   7 | import MenuItem from \"components/MenuItem\";\n   8 |\n>  9 | export default {\n     | ^\n  10 | \ttitle: \"Sandbox\",\n  11 | \tchromatic: { disableSnapshot: true },\n  12 | };\n\n./src/Sandbox.stories.tsx:\nimport View from \"components/View\";\nimport Image from \"components/Image\";\nimport React from \"react\";\nimport Select from \"components/Select\";\nimport useToggle from \"hooks/useToggle\";\nimport Modal from \"components/Modal\";\nimport MenuItem from \"components/MenuItem\";\n\nexport default {\n\ttitle: \"Sandbox\",\n\tchromatic: { disableSnapshot: true },\n};\n\nconst Preview: React.FC<{ children: React.ReactNode }> = (props) => {\n\treturn (\n\t\t<View padding={20} gap={6}>\n\t\t\t<View position=\"absolute\" insetTop={0} insetStart={0}>\n\t\t\t\t<Image src=\"./logo.svg\" />\n\t\t\t</View>\n\n\t\t\t{props.children}\n\t\t</View>\n\t);\n};\n\nexport const preview = () => {\n\treturn (\n\t\t<Preview>\n\t\t\t<Component />\n\t\t</Preview>\n\t);\n};\n\nconst Component = () => {\n\tconst toggle = useToggle();\n\tconst [value, setValue] = React.useState(\"Dog\");\n\n\tconst handleClick = () => {\n\t\ttoggle.toggle();\n\t};\n\n\treturn (\n\t\t<>\n\t\t\t<Select name=\"animal\" placeholder=\"Select an animal\" onClick={handleClick}>\n\t\t\t\t{value}\n\t\t\t</Select>\n\t\t\t<Modal active={toggle.active} onClose={toggle.deactivate} position=\"bottom\" padding={2}>\n\t\t\t\t<MenuItem\n\t\t\t\t\troundedCorners\n\t\t\t\t\tonClick={() => {\n\t\t\t\t\t\tsetValue(\"Dog\");\n\t\t\t\t\t\ttoggle.deactivate();\n\t\t\t\t\t}}\n\t\t\t\t\tattributes={{\n\t\t\t\t\t\trole: \"option\",\n\t\t\t\t\t}}\n\t\t\t\t>\n\t\t\t\t\tDog\n\t\t\t\t</MenuItem>\n\t\t\t\t<MenuItem\n\t\t\t\t\troundedCorners\n\t\t\t\t\tattributes={{\n\t\t\t\t\t\trole: \"option\",\n\t\t\t\t\t}}\n\t\t\t\t\tonClick={() => {\n\t\t\t\t\t\tsetValue(\"Turtle\");\n\t\t\t\t\t\ttoggle.deactivate();\n\t\t\t\t\t}}\n\t\t\t\t>\n\t\t\t\t\tTurtle\n\t\t\t\t</MenuItem>\n\t\t\t</Modal>\n\t\t</>\n\t);\n};\n"
 			}
 		}
-	}
+	},
+	"meta": { "docgen": "react-docgen-typescript", "durationMs": 2919 }
 }

--- a/eval/tasks/110-flight-booking-reshaped/manifests/components.json
+++ b/eval/tasks/110-flight-booking-reshaped/manifests/components.json
@@ -7,46 +7,201 @@
 			"path": "./src/components/ActionBar/tests/ActionBar.stories.tsx",
 			"stories": [
 				{
-					"name": "positionRelative",
+					"id": "components-actionbar--position-relative",
+					"name": "position, positionType: relative",
 					"snippet": "const positionRelative = () => (\n    <Example>\n        <Example.Item title=\"position: top\">\n            <ActionBar position=\"top\">\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <ActionBar position=\"bottom\">\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positionAbsolute",
+					"id": "components-actionbar--position-absolute",
+					"name": "position, positionType: absolute",
 					"snippet": "const positionAbsolute = () => (\n    <Example>\n        <Example.Item title=\"position: top-start\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top-start\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: top\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: top-end\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top-end\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom-start\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom-start\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom-end\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positionFixed",
+					"id": "components-actionbar--position-fixed",
+					"name": "position, positionType: fixed",
 					"snippet": "const positionFixed = () => (\n    <>\n        <ActionBar padding={2} position=\"top-start\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"top\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"top-end\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom-start\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom-end\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <div style={{ height: 2000 }} />\n    </>\n);"
 				},
 				{
+					"id": "components-actionbar--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated, position: top\">\n            <ActionBar position=\"top\" elevated>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"elevated, position: bottom\">\n            <ActionBar elevated>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"auto elevated, position: bottom\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-actionbar--offset",
 					"name": "offset",
 					"snippet": "const offset = () => (\n    <Example>\n        <Example.Item title=\"offset 2, position: top\">\n            <Fixtures.Container>\n                <ActionBar position=\"top\" positionType=\"absolute\" offset={2}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"offset 2, position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\" offset={2}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"offset s: 2, m: 4, position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\" offset={{ s: 2, m: 4 }}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-actionbar--active",
 					"name": "active",
 					"snippet": "const active = () => {\n    const barToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => barToggle.toggle()}>Toggle</Button>\n            <ActionBar active={barToggle.active} positionType=\"fixed\" position=\"top-end\">\n                <Fixtures.Actions />\n            </ActionBar>\n        </>\n    );\n};"
 				},
 				{
-					"name": "padding",
+					"id": "components-actionbar--padding",
+					"name": "padding, paddingBlock, paddingInline",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 6\">\n            <ActionBar padding={6}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"paddingBlock: 2, paddingInline: 4\">\n            <ActionBar paddingBlock={2} paddingInline={4}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"padding: [s] 4, [m+] 6\">\n            <ActionBar padding={{ s: 4, m: 6 }}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-actionbar--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ActionBar className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </ActionBar>\n    </div>\n);"
 				}
 			],
 			"import": "import { ActionBar, Button, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ActionBar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ActionBar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ActionBar/ActionBar.tsx",
-				"actualName": "ActionBar",
+				"methods": [],
+				"props": {
+					"paddingBlock": {
+						"defaultValue": null,
+						"description": "Padding block, base unit token number multiplier",
+						"name": "paddingBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingInline": {
+						"defaultValue": null,
+						"description": "Padding inline, base unit token number multiplier",
+						"name": "paddingInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Padding style for all sides, base unit token number multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Show or hide the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"offset": {
+						"defaultValue": null,
+						"description": "Offset from the container bounds",
+						"name": "offset",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"position": {
+						"defaultValue": { "value": "\"bottom\"" },
+						"description": "Position based on the container bounds",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"top-end\" | \"top-start\" | \"bottom\" | \"bottom-start\" | \"bottom-end\"",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" }
+							]
+						}
+					},
+					"positionType": {
+						"defaultValue": null,
+						"description": "CSS position style",
+						"name": "positionType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"relative\" | \"absolute\" | \"fixed\">" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Display above the content with elevated shadow and background",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -56,30 +211,138 @@
 			"path": "./src/components/Alert/tests/Alert.stories.tsx",
 			"stories": [
 				{
+					"id": "components-alert--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        {([\"neutral\", \"primary\", \"critical\", \"positive\", \"warning\"] as const).map((color) => (\n            <Example.Item title={`color: ${color}`} key={color}>\n                <Alert\n                    color={color}\n                    title=\"Alert title goes here\"\n                    icon={IconZap}\n                    actionsSlot={\n                        <>\n                            <Link\n                                variant=\"plain\"\n                                color={color === \"neutral\" ? \"primary\" : color}\n                                onClick={() => {}}\n                            >\n                                View now\n                            </Link>\n                            <Link\n                                variant=\"plain\"\n                                color={color === \"neutral\" ? \"primary\" : color}\n                                onClick={() => {}}\n                            >\n                                Dismiss\n                            </Link>\n                        </>\n                    }\n                >\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard\n                </Alert>\n            </Example.Item>\n        ))}\n    </Example>\n);"
 				},
 				{
+					"id": "components-alert--inline",
 					"name": "inline",
 					"snippet": "const inline = () => (\n    <Example>\n        <Example.Item title=\"inline: true\">\n            <Alert\n                inline\n                title=\"Alert title goes here\"\n                icon={IconZap}\n                actionsSlot={\n                    <>\n                        <Link variant=\"plain\" onClick={() => {}}>\n                            View now\n                        </Link>\n                        <Link variant=\"plain\" onClick={() => {}}>\n                            Dismiss\n                        </Link>\n                    </>\n                }\n            >\n                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has\n                been the industry's standard\n            </Alert>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-alert--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4\">\n            <Alert bleed={4} icon={IconZap}>\n                Content\n            </Alert>\n        </Example.Item>\n        <Example.Item title=\"bleed: [s] 4, [m+] 0\">\n            <Alert bleed={{ s: 4, m: 0 }} icon={IconZap}>\n                Content\n            </Alert>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-alert--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Alert className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </Alert>\n    </div>\n);"
 				}
 			],
 			"import": "import { Alert, Example, Link, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Alert/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Alert",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Alert/Alert.tsx",
-				"actualName": "Alert",
+				"methods": [],
+				"props": {
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"title": {
+						"defaultValue": null,
+						"description": "Title slot",
+						"name": "title",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Slot for rendering the main content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"actionsSlot": {
+						"defaultValue": null,
+						"description": "Actions slot, usually used for Buttons and Links, automatically adds a gap between the actions",
+						"name": "actionsSlot",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Color scheme of the alert elements",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"inline": {
+						"defaultValue": null,
+						"description": "Display action to the right of the content",
+						"name": "inline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margin and remove side borders, base unit token number multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -89,35 +352,573 @@
 			"path": "./src/components/Autocomplete/tests/Autocomplete.stories.tsx",
 			"stories": [
 				{
-					"name": "active",
+					"id": "components-autocomplete--active",
+					"name": "active, onOpen, onClose",
 					"snippet": "const active = (args) => {\n    const toggle = useToggle(true);\n\n    return (\n        <Example>\n            <Example.Item title=\"active, onOpen, onClose\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete\n                        name=\"fruit\"\n                        placeholder=\"Pick your food\"\n                        active={toggle.active}\n                        onOpen={() => {\n                            args.handleOpen();\n                            toggle.activate();\n                        }}\n                        onClose={() => {\n                            args.handleClose();\n                            toggle.deactivate();\n                        }}\n                        onChange={(args) => console.log(args)}\n                    >\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "base",
+					"id": "components-autocomplete--base",
+					"name": "onInput, onItemSelect, onBackspace",
 					"snippet": "const base = () => {\n    const [value, setValue] = React.useState(\"\");\n\n    return (\n        <Example>\n            <Example.Item title=\"Base\">\n                <FormControl>\n                    <FormControl.Label>Food</FormControl.Label>\n                    <Autocomplete\n                        name=\"fruit\"\n                        placeholder=\"Pick your food\"\n                        value={value}\n                        onChange={(args) => setValue(args.value)}\n                        onBackspace={fn()}\n                        onItemSelect={fn()}>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "itemData",
+					"id": "components-autocomplete--item-data",
+					"name": "item data",
 					"snippet": "const itemData = () => {\n    return (\n        <Example>\n            <Example.Item title=\"item data\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete name=\"fruit\" placeholder=\"Pick your food\" onItemSelect={fn()} active>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v} data={i === 1 ? { foo: true } : undefined}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "itemDisabled",
+					"id": "components-autocomplete--item-disabled",
+					"name": "item disabled",
 					"snippet": "const itemDisabled = () => {\n    return (\n        <Example>\n            <Example.Item title=\"item disabled\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete name=\"fruit\" placeholder=\"Pick your food\" active>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v} disabled={i === 1}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "multiselect",
+					"id": "components-autocomplete--multiselect",
+					"name": "test: multiselect",
 					"snippet": "const multiselect = () => {\n    const options = [\n        \"Pizza\",\n        \"Pie\",\n        \"Ice-cream\",\n        \"Fries\",\n        \"Salad\",\n        \"Option 4\",\n        \"Option 5\",\n        \"Option 6\",\n    ];\n\n    const inputRef = React.useRef<HTMLInputElement>(null);\n    const [values, setValues] = React.useState<string[]>([\n        \"Option 4\",\n        \"Option 5\",\n        \"Option 6\",\n        \"Pizza\",\n        \"Ice-cream\",\n    ]);\n    const [query, setQuery] = React.useState(\"\");\n\n    const handleDismiss = (dismissedValue: string) => {\n        const nextValues = values.filter((value) => value !== dismissedValue);\n        setValues(nextValues);\n        inputRef.current?.focus();\n    };\n\n    const valuesNode = values.map((value) => (\n        <Badge dismissAriaLabel=\"Dismiss value\" onDismiss={() => handleDismiss(value)} key={value}>\n            {value}\n        </Badge>\n    ));\n\n    return (\n        <FormControl>\n            <FormControl.Label>Food</FormControl.Label>\n            <Autocomplete\n                name=\"fruit\"\n                value={query}\n                placeholder=\"Pick your food\"\n                startSlot={valuesNode}\n                multiline\n                inputAttributes={{ ref: inputRef }}\n                onChange={(args) => setQuery(args.value)}\n                onBackspace={() => {\n                    if (query.length === 0) {\n                        setValues((prev) => prev.slice(0, -1));\n                    }\n                }}\n                onItemSelect={(args) => {\n                    setQuery(\"\");\n                    setValues((prev) => [...prev, args.value]);\n                }}\n            >\n                {options.map((v) => {\n                    if (!v.toLowerCase().includes(query.toLowerCase())) return;\n                    if (values.includes(v)) return;\n\n                    return (\n                        <Autocomplete.Item key={v} value={v}>\n                            {v}\n                        </Autocomplete.Item>\n                    );\n                })}\n            </Autocomplete>\n        </FormControl>\n    );\n};"
 				}
 			],
 			"import": "import { Autocomplete, Badge, Example, FormControl } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Autocomplete/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Autocomplete",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Autocomplete/Autocomplete.tsx",
-				"actualName": "Autocomplete",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"multiline": {
+						"defaultValue": null,
+						"description": "Enable multiline text field wrapping",
+						"name": "multiline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to be fully rounded",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content after the text field value",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text field value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the text field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the text field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"onInput": {
+						"defaultValue": null,
+						"description": "Callback for when value changes from user input",
+						"name": "onInput",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onItemSelect": {
+						"defaultValue": null,
+						"description": "Callback for when an item is selected in the dropdown",
+						"name": "onItemSelect",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: SelectArgs) => void)" }
+					},
+					"onBackspace": {
+						"defaultValue": null,
+						"description": "Callback for when the backspace key is pressed while the input is focused",
+						"name": "onBackspace",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onEnter": {
+						"defaultValue": null,
+						"description": "Callback for when the enter key is pressed while the input is focused",
+						"name": "onEnter",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Slot for rendering the Autocomplete.Item components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					}
+				},
+				"exportName": "Autocomplete"
 			}
 		},
 		"components-avatar": {
@@ -126,46 +927,230 @@
 			"path": "./src/components/Avatar/tests/Avatar.stories.tsx",
 			"stories": [
 				{
-					"name": "src",
+					"id": "components-avatar--src",
+					"name": "src, alt",
 					"snippet": "const src = () => (\n    <Example>\n        <Example.Item title=\"src, alt\">\n            <Avatar\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n                alt=\"Amsterdam canal\"\n                size={12}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"src\">\n            <Avatar src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "initials",
+					"id": "components-avatar--initials",
+					"name": "initials, icon",
 					"snippet": "const initials = () => (\n    <Example>\n        <Example.Item title=\"initials\">\n            <Avatar initials=\"RS\" />\n        </Example.Item>\n\n        <Example.Item title=\"icon\">\n            <Avatar icon={IconZap} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-avatar--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: 6\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={6} icon={IconZap} />\n                <Avatar size={6} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: 15\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={15} icon={IconZap} />\n                <Avatar size={15} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: 40\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={40} icon={IconZap} />\n                <Avatar size={40} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] 10\", \"[m+] 20\"]}>\n            <View direction=\"row\" gap={3}>\n                <Avatar size={{ s: 10, m: 20 }} icon={IconZap} />\n                <Avatar size={{ s: 10, m: 20 }} icon={IconZap} squared />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-avatar--squared",
 					"name": "squared",
 					"snippet": "const squared = () => (\n    <Example>\n        <Example.Item title=\"squared, with image\">\n            <Avatar\n                squared\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n            />\n        </Example.Item>\n        <Example.Item title=\"squared, with initials\">\n            <Avatar squared initials=\"RS\" />\n        </Example.Item>\n        <Example.Item title=\"squared, with initials\">\n            <Avatar squared icon={IconZap} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "colors",
+					"id": "components-avatar--colors",
+					"name": "color, variant",
 					"snippet": "const colors = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"neutral\" icon={IconZap} />\n                <Avatar color=\"neutral\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"primary\" icon={IconZap} />\n                <Avatar color=\"primary\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"positive\" icon={IconZap} />\n                <Avatar color=\"positive\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"warning\" icon={IconZap} />\n                <Avatar color=\"warning\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"critical\" icon={IconZap} />\n                <Avatar color=\"critical\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "fallback",
+					"id": "components-avatar--fallback",
+					"name": "test: fallback",
 					"snippet": "const fallback = (args) => {\n    const [error, setError] = useState(false);\n\n    return (\n        <Avatar\n            src={error ? undefined : \"/foo\"}\n            icon={IconZap}\n            imageAttributes={{\n                onError: () => {\n                    setError(true);\n                    args.handleError();\n                },\n            }}\n        />\n    );\n};"
 				},
 				{
+					"id": "components-avatar--render-image",
 					"name": "renderImage",
 					"snippet": "const renderImage = () => (\n    <Example>\n        <Example.Item title=\"renderImage\">\n            <Avatar\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n                alt=\"Amsterdam canal\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image\" />}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-avatar--class-name",
+					"name": "className, attributes, imageAttributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Avatar\n            src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            imageAttributes={{ id: \"test-image-id\", alt: \"test image\" }}\n        />\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Avatar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Avatar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Avatar/Avatar.tsx",
-				"actualName": "Avatar",
+				"methods": [],
+				"props": {
+					"src": {
+						"defaultValue": null,
+						"description": "Image URL",
+						"name": "src",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"alt": {
+						"defaultValue": null,
+						"description": "Image alt text",
+						"name": "alt",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"imageAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the image element",
+						"name": "imageAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"img\">" }
+					},
+					"renderImage": {
+						"defaultValue": null,
+						"description": "Render prop for the image element, useful for integrating with the Image component from third party frameworks",
+						"name": "renderImage",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Omit<Attributes<\"img\">, \"src\" | \"alt\"> & { src: string; alt: string; }) => ReactNode)"
+						}
+					},
+					"initials": {
+						"defaultValue": null,
+						"description": "Initials to display if no image is provided",
+						"name": "initials",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon, used when no image is provided",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"squared": {
+						"defaultValue": null,
+						"description": "Change the shape to rounded square",
+						"name": "squared",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"faded\"",
+							"value": [{ "value": "\"solid\"" }, { "value": "\"faded\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "12" },
+						"description": "Size of the component, base unit token number multiplier",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -175,63 +1160,273 @@
 			"path": "./src/components/Badge/tests/Badge.stories.tsx",
 			"stories": [
 				{
+					"id": "components-badge--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Badge>Badge</Badge>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <Badge variant=\"faded\">Badge</Badge>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <Badge variant=\"outline\">Badge</Badge>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"primary\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"primary\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"primary\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: positive, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"positive\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"positive\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"positive\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: critical, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"critical\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"critical\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"critical\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: warning, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"warning\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"warning\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"warning\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"small\">Badge</Badge>\n                <Badge rounded size=\"small\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge>Badge</Badge>\n                <Badge rounded>Badge</Badge>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"large\">Badge</Badge>\n                <Badge rounded size=\"large\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={3} direction=\"row\">\n                <Badge icon={IconCheckmark} endIcon={IconChevronRight} size=\"small\">\n                    Badge\n                </Badge>\n                <Badge icon={IconCheckmark} size=\"small\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={3} direction=\"row\">\n                <Badge icon={IconCheckmark} endIcon={IconChevronRight}>\n                    Badge\n                </Badge>\n                <Badge icon={IconCheckmark} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"large\" icon={IconCheckmark} endIcon={IconChevronRight}>\n                    Badge\n                </Badge>\n\n                <Badge icon={IconCheckmark} size=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onDismiss",
+					"id": "components-badge--on-dismiss",
+					"name": "onDismiss, dismissAriaLabel",
 					"snippet": "const onDismiss = () => <Example>\n    <Example.Item title=\"onDismiss\">\n        <Badge onDismiss={fn()} dismissAriaLabel=\"Dismiss\">Badge\n                            </Badge>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-badge--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded>Badge</Badge>\n                <Badge rounded variant=\"faded\">\n                    Badge\n                </Badge>\n                <Badge rounded variant=\"outline\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"rounded, all sizes, color: critical\", \"one character, renders as circle\"]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Badge rounded color=\"critical\" size=\"small\">\n                    2\n                </Badge>\n                <Badge rounded color=\"critical\">\n                    2\n                </Badge>\n                <Badge rounded color=\"critical\" size=\"large\">\n                    2\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--empty",
 					"name": "empty",
 					"snippet": "const empty = () => (\n    <Example>\n        <Example.Item title=\"empty, not rounded, all sizes, color: critical\">\n            <View direction=\"row\" gap={3}>\n                <Badge size=\"small\" color=\"critical\" />\n                <Badge color=\"critical\" />\n                <Badge size=\"large\" color=\"critical\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"empty, rounded, all sizes, color: critical\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded size=\"small\" color=\"critical\" />\n                <Badge rounded color=\"critical\" />\n                <Badge rounded size=\"large\" color=\"critical\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"empty, rounded, all sizes, color: neutral\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded size=\"small\" color=\"neutral\" />\n                <Badge rounded />\n                <Badge rounded size=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--highlighted",
 					"name": "highlighted",
 					"snippet": "const highlighted = () => (\n    <Example>\n        <Example.Item title=\"highlighted, color: neutral\">\n            <View gap={3} direction=\"row\">\n                <Badge highlighted>Badge</Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--container",
 					"name": "container",
 					"snippet": "const container = () => {\n    const [hidden, setHidden] = React.useState(false);\n\n    return (\n        <Example title={<Button onClick={() => setHidden(!hidden)}>Toggle badges</Button>}>\n            <Example.Item title=\"position: top-end\">\n                <Badge.Container>\n                    <Badge color=\"primary\" hidden={hidden}>\n                        5\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: bottom-end\">\n                <Badge.Container position=\"bottom-end\">\n                    <Badge color=\"primary\" hidden={hidden}>\n                        5\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: top-end, rounded, multiple digits\">\n                <Badge.Container>\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        123\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: top-end, rounded, empty\">\n                <Badge.Container>\n                    <Badge color=\"primary\" rounded hidden={hidden} />\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: top-end, overlap\", \"should cover the circular avatar\"]}>\n                <Badge.Container overlap>\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        2\n                    </Badge>\n                    <Avatar initials=\"A\" />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: bottom-end, overlap\", \"should cover the circular avatar\"]}>\n                <Badge.Container overlap position=\"bottom-end\">\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        2\n                    </Badge>\n                    <Avatar initials=\"A\" />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: top-end, overlap\", \"should cover the icon\"]}>\n                <Badge.Container overlap position=\"top-end\">\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden} />\n                    <Icon svg={IconCheckmark} size={5} />\n                </Badge.Container>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-badge--href",
 					"name": "href",
 					"snippet": "const href = () => (\n    <Badge href=\"https://reshaped.so\" dismissAriaLabel=\"Dismiss\">\n        Badge\n    </Badge>\n);"
 				},
 				{
+					"id": "components-badge--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Badge onClick={fn()}>Badge</Badge>;"
 				},
 				{
-					"name": "className",
+					"id": "components-badge--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Badge color=\"primary\" className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Badge, Button, Example, Icon, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Badge/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Badge",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Badge/Badge.tsx",
-				"actualName": "Badge",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"large\" | \"medium\"",
+							"value": [
+								{ "value": "\"small\"" },
+								{ "value": "\"large\"" },
+								{ "value": "\"medium\"" }
+							]
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "highlighted",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hidden": {
+						"defaultValue": null,
+						"description": "Transition the component to hidden state",
+						"name": "hidden",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting text or other content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"onDismiss": {
+						"defaultValue": null,
+						"description": "Callback triggered when the dismiss button is pressed",
+						"name": "onDismiss",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"dismissAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the dismiss button",
+						"name": "dismissAriaLabel",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "Badge"
 			}
 		},
 		"components-breadcrumbs": {
@@ -240,51 +1435,185 @@
 			"path": "./src/components/Breadcrumbs/tests/Breadcrumbs.stories.tsx",
 			"stories": [
 				{
+					"id": "components-breadcrumbs--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <Breadcrumbs ariaLabel=\"breadcrumb neutral\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"color: primary\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb primary\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "item",
+					"id": "components-breadcrumbs--item",
+					"name": "item, disabled",
 					"snippet": "const item = () => (\n    <Example>\n        <Example.Item title=\"disabled item\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb disabled\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}} disabled>\n                    Disabled item 2\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "icon",
+					"id": "components-breadcrumbs--icon",
+					"name": "item, icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"item with icon\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb with icon\">\n                <Breadcrumbs.Item icon={IconZap} onClick={() => {}}>\n                    Item 1\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "slots",
+					"id": "components-breadcrumbs--slots",
+					"name": "separator, children",
 					"snippet": "const slots = () => (\n    <Example>\n        <Example.Item title=\"slot: separator\">\n            <Breadcrumbs color=\"primary\" separator=\"/\" ariaLabel=\"breadcrumb with separator\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"custom child content\">\n            <Breadcrumbs ariaLabel=\"breadcrumb with custom children\">\n                <Breadcrumbs.Item onClick={() => {}}>\n                    <Badge>Item 1</Badge>\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>\n                    <Badge>Item 2</Badge>\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-breadcrumbs--collapsed",
 					"name": "collapsed",
 					"snippet": "const collapsed = () => (\n    <Example>\n        <Example.Item title=\"collapsed, 3 items shown by default\">\n            <Breadcrumbs\n                defaultVisibleItems={3}\n                ariaLabel=\"breadcrumbs one\"\n                expandAriaLabel=\"Expand items\"\n            >\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"collapsed, 4 items shown by default\">\n            <Breadcrumbs\n                defaultVisibleItems={4}\n                ariaLabel=\"breadcrumb two\"\n                expandAriaLabel=\"Expand items\"\n            >\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"collapsed, 3 items shown by default, not expandable\">\n            <Breadcrumbs defaultVisibleItems={3} ariaLabel=\"breadcrumb three\" disableExpand>\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "multiline",
+					"id": "components-breadcrumbs--multiline",
+					"name": "composition, multiline",
 					"snippet": "const multiline = () => (\n    <Example>\n        <Example.Item title=\"wraps content when multiline\">\n            <Breadcrumbs ariaLabel=\"breadcrumb multiline\">\n                {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((i) => (\n                    <Breadcrumbs.Item onClick={() => {}} key={i}>\n                        Item {i}\n                    </Breadcrumbs.Item>\n                ))}\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onClick",
+					"id": "components-breadcrumbs--on-click",
+					"name": "item, onClick, disabled",
 					"snippet": "const onClick = () => <Breadcrumbs>\n    <Breadcrumbs.Item onClick={fn()}>Trigger</Breadcrumbs.Item>\n    <Breadcrumbs.Item onClick={fn()} disabled>Trigger\n                    </Breadcrumbs.Item>\n</Breadcrumbs>;"
 				},
 				{
-					"name": "href",
+					"id": "components-breadcrumbs--href",
+					"name": "item, href",
 					"snippet": "const href = () => (\n    <Breadcrumbs>\n        <Breadcrumbs.Item href=\"https://reshaped.so\">Trigger</Breadcrumbs.Item>\n    </Breadcrumbs>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-breadcrumbs--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Breadcrumbs className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Breadcrumbs.Item>Trigger</Breadcrumbs.Item>\n        </Breadcrumbs>\n    </div>\n);"
 				}
 			],
 			"import": "import { Badge, Breadcrumbs, Example } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Breadcrumbs/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Breadcrumbs",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Breadcrumbs/Breadcrumbs.tsx",
-				"actualName": "Breadcrumbs",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children to position items",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ReactElement<unknown, string | JSXElementConstructor<any>>[]"
+						}
+					},
+					"separator": {
+						"defaultValue": null,
+						"description": "Node for defining custom separator between items",
+						"name": "separator",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"neutral\"",
+							"value": [{ "value": "\"primary\"" }, { "value": "\"neutral\"" }]
+						}
+					},
+					"defaultVisibleItems": {
+						"defaultValue": null,
+						"description": "Number of items to show by default, others will be hidden and can be expanded",
+						"name": "defaultVisibleItems",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"expandAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the expand button",
+						"name": "expandAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disableExpand": {
+						"defaultValue": null,
+						"description": "Turn expand button into static text and disable the expand functionality",
+						"name": "disableExpand",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the component",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"nav\">" }
+					}
+				},
+				"exportName": "Breadcrumbs"
 			}
 		},
 		"components-button": {
@@ -293,87 +1622,599 @@
 			"path": "./src/components/Button/tests/Button.stories.tsx",
 			"stories": [
 				{
-					"name": "variantAndColor",
+					"id": "components-button--variant-and-color",
+					"name": "variant, color",
 					"snippet": "const variantAndColor = () => (\n    <Example>\n        <Example.Item title=\"variant: solid\">\n            <View gap={4} direction=\"row\">\n                <Button onClick={() => {}}>Button</Button>\n                <Button onClick={() => {}} color=\"primary\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"faded\">\n                    Button\n                </Button>\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"outline\">\n                    Button\n                </Button>\n\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: ghost\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"ghost\">\n                    Button\n                </Button>\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: media\">\n            <View backgroundColor=\"primary\" borderRadius=\"medium\" padding={4} direction=\"row\" gap={4}>\n                <Button onClick={() => {}} color=\"media\">\n                    Button\n                </Button>\n\n                <Button onClick={() => {}} color=\"media\" variant=\"faded\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Button onClick={() => {}} icon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"endIcon\">\n            <Button onClick={() => {}} endIcon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"icon, endIcon\">\n            <Button onClick={() => {}} icon={IconZap} endIcon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"icon only\">\n            <Button onClick={() => {}} icon={IconZap} attributes={{ \"aria-label\": \"Action\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"small\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"small\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Button icon={IconZap}>Button</Button>\n                <Button variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"large\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"large\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"xlarge\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"xlarge\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"xlarge\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large, [m+] medium\">\n            <Button size={{ s: \"large\", m: \"medium\" }} icon={IconZap}>\n                Responsive\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated, color: neutral\">\n            <View direction=\"row\" gap={4}>\n                <Button elevated onClick={() => {}}>\n                    Button\n                </Button>\n                <Button elevated variant=\"outline\" onClick={() => {}}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"elevated, color\">\n            <View direction=\"row\" gap={4}>\n                <Button elevated color=\"primary\">\n                    Button\n                </Button>\n                <Button elevated variant=\"outline\" color=\"primary\">\n                    Button\n                </Button>\n                <View backgroundColor=\"primary\" padding={4} borderRadius=\"medium\">\n                    <Button color=\"media\" elevated>\n                        Button\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded, size: small, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, size: medium, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, size: large, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, icon only, all sizes\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"small\" icon={IconZap} />\n                <Button rounded icon={IconZap} />\n                <Button rounded size=\"large\" icon={IconZap} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--full-width",
 					"name": "fullWidth",
 					"snippet": "const fullWidth = () => (\n    <Example>\n        <Example.Item title=\"fullWidth, all variants\">\n            <View gap={3}>\n                <Button fullWidth>Neutral</Button>\n                <Button fullWidth variant=\"faded\">\n                    Faded\n                </Button>\n                <Button fullWidth variant=\"outline\">\n                    Outline\n                </Button>\n                <Button fullWidth variant=\"ghost\">\n                    Ghost\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive fullWidth\", \"[s] true\", \"[m+] false\"]}>\n            <Button fullWidth={{ s: true, m: false }}>Button</Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--loading",
 					"name": "loading",
 					"snippet": "const loading = () => (\n    <Example>\n        <Example.Item title=\"loading, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"loading, color critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"loading, color positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"loading, color: media\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n\n                <div style={{ position: \"absolute\", top: 16, left: 16 }}>\n                    <View gap={3} direction=\"row\">\n                        <Button color=\"media\" loading loadingAriaLabel=\"Loading\">\n                            Button\n                        </Button>\n                        <Button color=\"media\" variant=\"faded\" loading loadingAriaLabel=\"Loading\">\n                            Button\n                        </Button>\n                    </View>\n                </div>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"loading, long button text\", \"button size should stay the same\"]}>\n            <Button loading loadingAriaLabel=\"Loading\" color=\"primary\">\n                Long button text\n            </Button>\n        </Example.Item>\n\n        <Example.Item title={[\"loading, icon only\", \"button keep square 1/1 ratio\"]}>\n            <Button icon={IconZap} rounded loading loadingAriaLabel=\"Loading\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--highlighted",
 					"name": "highlighted",
 					"snippet": "const highlighted = () => (\n    <Example>\n        <Example.Item title=\"highlighted, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"highlighted, color: critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted color=\"critical\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"highlighted, color: positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted color=\"positive\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled icon={IconZap} onClick={() => {}}>\n                    Button\n                </Button>\n                <Button disabled variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"disabled, color: critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled color=\"critical\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"disabled, color: positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled color=\"positive\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"disabled, color: media\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n\n                <div style={{ position: \"absolute\", top: 16, left: 16 }}>\n                    <View gap={3} direction=\"row\">\n                        <Button color=\"media\" disabled>\n                            Button\n                        </Button>\n                        <Button color=\"media\" variant=\"faded\" disabled>\n                            Button\n                        </Button>\n                    </View>\n                </div>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner: all\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>Content</View.Item>\n                <Button.Aligner>\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: top\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"top\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: top and end\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side={[\"top\", \"end\"]}>\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: bottom\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2} align=\"end\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"bottom\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: start\">\n            <View padding={4} borderColor=\"neutral-faded\" gap={2} align=\"start\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"start\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: end\">\n            <View padding={4} borderColor=\"neutral-faded\" gap={2} align=\"end\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"end\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "components-button--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"slot gap\">\n            <Button variant=\"outline\">\n                <Avatar size={6} initials=\"RS\" />\n                Label\n                <Hotkey>B</Hotkey>\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--href",
 					"name": "href",
 					"snippet": "const href = () => <Button href=\"https://reshaped.so\">Trigger</Button>;"
 				},
 				{
+					"id": "components-button--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Button onClick={fn()}>Trigger</Button>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-button--href-on-click",
+					"name": "href, onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <Button\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </Button>\n);"
 				},
 				{
+					"id": "components-button--as",
 					"name": "as",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"as: span\">\n            <Button onClick={() => {}} as=\"span\">\n                Trigger\n            </Button>\n        </Example.Item>\n        <Example.Item title=\"render, disabled\">\n            <Button\n                disabled\n                onClick={() => {}}\n                render={(props) => <section {...props} />}\n                attributes={{ \"data-testid\": \"render-el\" }}\n            >\n                Trigger\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-button--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Button className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Button>\n    </div>\n);"
 				},
 				{
+					"id": "components-button--group",
 					"name": "group",
 					"snippet": "const group = () => (\n    <Example>\n        <Example.Item title=\"with icon\">\n            <Button.Group>\n                <Button rounded>Submit</Button>\n                <Button rounded icon={IconZap} />\n            </Button.Group>\n        </Example.Item>\n        <Example.Item title=\"variant: solid\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\", \"media\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color}>One</Button>\n                        <Button color={color}>Two</Button>\n                        <Button color={color}>Three</Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"outline\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"outline\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"outline\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\", \"media\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"faded\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"faded\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"faded\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"variant: ghost\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"ghost\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"ghost\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"ghost\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "groupClassName",
+					"id": "components-button--group-class-name",
+					"name": "group className, attributes",
 					"snippet": "const groupClassName = () => (\n    <div data-testid=\"root\">\n        <Button.Group className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Button>Trigger</Button>\n        </Button.Group>\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Button, Example, Hotkey, Image, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Button/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Button",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Button/Button.tsx",
-				"actualName": "Button",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"ghost\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"ghost\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loading": {
+						"defaultValue": null,
+						"description": "Show loading state",
+						"name": "loading",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loadingAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the loading indicator",
+						"name": "loadingAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Make the component take the full width of the parent element",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "highlighted",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Button"
 			}
 		},
 		"components-calendar": {
@@ -382,54 +2223,363 @@
 			"path": "./src/components/Calendar/tests/Calendar.stories.tsx",
 			"stories": [
 				{
+					"id": "components-calendar--default-month",
 					"name": "defaultMonth",
 					"snippet": "const defaultMonth = () => (\n    <Example>\n        <Example.Item title=\"defaultMonth: 2020 January\">\n            <Calendar defaultMonth={new Date(2020, 0)} range />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "uncontrolled",
+					"id": "components-calendar--uncontrolled",
+					"name": "defaultValue, range",
 					"snippet": "const uncontrolled = () => <Example>\n    <Example.Item title=\"defaultValue\">\n        <Calendar\n            defaultMonth={new Date(2020, 0)}\n            defaultValue={new Date(2020, 0, 10)}\n            onChange={fn()} />\n    </Example.Item>\n    <Example.Item title=\"defaultValue, range\">\n        <Calendar\n            range\n            defaultMonth={new Date(2020, 0)}\n            defaultValue={{ start: new Date(2020, 0, 10), end: new Date(2020, 0, 15) }}\n            onChange={fn()} />\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "controlled",
+					"id": "components-calendar--controlled",
+					"name": "value, range",
 					"snippet": "const controlled = () => <Example>\n    <Example.Item title=\"value\">\n        <Calendar\n            defaultMonth={new Date(2020, 0)}\n            value={new Date(2020, 0, 10)}\n            onChange={fn()} />\n    </Example.Item>\n    <Example.Item title=\"defaultValue, range\">\n        <Calendar\n            range\n            defaultMonth={new Date(2020, 0)}\n            value={{ start: new Date(2020, 0, 10), end: new Date(2020, 0, 15) }}\n            onChange={fn()} />\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-calendar--selected-dates",
 					"name": "selectedDates",
 					"snippet": "const selectedDates = () => (\n    <Example>\n        <Example.Item title=\"selectedDates: [4,8]\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                value={null}\n                selectedDates={[new Date(2020, 0, 4), new Date(2020, 0, 8)]}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "minMax",
+					"id": "components-calendar--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <Example>\n        <Example.Item title=\"min: 4, max: 20\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                min={new Date(2020, 0, 4)}\n                max={new Date(2020, 0, 20)}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-calendar--first-week-day",
 					"name": "firstWeekDay",
 					"snippet": "const firstWeekDay = () => (\n    <Example>\n        <Example.Item title=\"firstWeekDay: 3 (Wed)\">\n            <Calendar defaultMonth={new Date(2020, 0)} firstWeekDay={3} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "translation",
+					"id": "components-calendar--translation",
+					"name": "render functions",
 					"snippet": "const translation = () => (\n    <Example>\n        <Example.Item title=\"translated to NL\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                renderMonthLabel={({ date }) => date.toLocaleDateString(\"nl\", { month: \"short\" })}\n                renderSelectedMonthLabel={({ date }) =>\n                    date.toLocaleDateString(\"nl\", { month: \"long\", year: \"numeric\" })\n                }\n                renderWeekDay={({ date }) => date.toLocaleDateString(\"nl\", { weekday: \"short\" })}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "ariaLabels",
+					"id": "components-calendar--aria-labels",
+					"name": "aria labels",
 					"snippet": "const ariaLabels = () => (\n    <Example>\n        <Example.Item title=\"aria labels\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                nextYearAriaLabel=\"Test next year\"\n                nextMonthAriaLabel=\"Test next month\"\n                renderDateAriaLabel={() => \"Test date\"}\n                renderMonthAriaLabel={() => \"Test month\"}\n                previousYearAriaLabel=\"Test previous year\"\n                previousMonthAriaLabel=\"Test previous month\"\n                monthSelectionAriaLabel=\"Test month selection\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "monthSelection",
+					"id": "components-calendar--month-selection",
+					"name": "test: month selection",
 					"snippet": "const monthSelection = () => (\n    <Example>\n        <Example.Item title=\"month selection\">\n            <Calendar defaultMonth={new Date(2020, 1)} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "keyboardNavigation",
+					"id": "components-calendar--keyboard-navigation",
+					"name": "test: keyboard navigation",
 					"snippet": "const keyboardNavigation = () => (\n    <Example>\n        <Example.Item title=\"keyboard navigation\">\n            <Calendar defaultMonth={new Date(2020, 0)} />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Calendar, Example } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Calendar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Calendar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Calendar/Calendar.tsx",
-				"actualName": "Calendar",
+				"methods": [],
+				"props": {
+					"range": {
+						"defaultValue": null,
+						"description": "Disable range selection\nEnable range selection",
+						"name": "range",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Current selected date value, enables controlled mode\nCurrent selected range value, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date | RangeValue | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default selected date value, enables uncontrolled mode\nDefault selected range value, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date | RangeValue" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when date selection changes\nCallback when range selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { value: Date; }) => void) | ((args: { value: Date; }) => void) | ((args: { value: RangeValue; }) => void) | ((args: { value: RangeValue; }) => void)"
+						}
+					},
+					"defaultMonth": {
+						"defaultValue": { "value": "Date.now()" },
+						"description": "Default month to display",
+						"name": "defaultMonth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum date that can be selected",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum date that can be selected",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"firstWeekDay": {
+						"defaultValue": { "value": "1, Monday" },
+						"description": "First day of the week",
+						"name": "firstWeekDay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"selectedDates": {
+						"defaultValue": null,
+						"description": "Dates that are selected",
+						"name": "selectedDates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date[]" }
+					},
+					"renderWeekDay": {
+						"defaultValue": null,
+						"description": "Render a custom weekday label, can be used for localization",
+						"name": "renderWeekDay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { weekDay: number; date: Date; }) => string)" }
+					},
+					"renderSelectedMonthLabel": {
+						"defaultValue": null,
+						"description": "Render a custom month label, can be used for localization",
+						"name": "renderSelectedMonthLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { date: Date; }) => string)" }
+					},
+					"renderMonthLabel": {
+						"defaultValue": null,
+						"description": "Render a custom month label, can be used for localization",
+						"name": "renderMonthLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { month: number; date: Date; }) => string)" }
+					},
+					"previousMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the previous month button",
+						"name": "previousMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"nextMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "",
+						"name": "nextMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"previousYearAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the previous year button",
+						"name": "previousYearAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"nextYearAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the next year button",
+						"name": "nextYearAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"monthSelectionAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the month selection button",
+						"name": "monthSelectionAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"renderDateAriaLabel": {
+						"defaultValue": null,
+						"description": "Dynamic aria label applied to each date cell based on the arguments",
+						"name": "renderDateAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { date: Date; }) => string)" }
+					},
+					"renderMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "Dynamic aria label applied to each month element based on the arguments",
+						"name": "renderMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { month: number; }) => string)" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -439,50 +2589,356 @@
 			"path": "./src/components/Card/tests/Card.stories.tsx",
 			"stories": [
 				{
+					"id": "components-card--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: default\">\n            <Card>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title=\"padding: 2\">\n            <Card padding={2}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title=\"padding: 0\">\n            <Card padding={0}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive padding\", \"[s] 4\", \"[m+] 8\"]}>\n            <Card padding={{ s: 4, m: 8 }}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--selected",
 					"name": "selected",
 					"snippet": "const selected = () => (\n    <Example>\n        <Example.Item title=\"selected\">\n            <Card selected>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated\">\n            <Card elevated>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4\">\n            <Card bleed={4}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n        <Example.Item title={[\"responsive bleed\", \"[s] 4\", \"[m+] 0\"]}>\n            <Card bleed={{ s: 4, m: 0 }}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--height",
 					"name": "height",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"height: 200px\">\n            <Card height=\"200px\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Card onClick={fn()}>Trigger</Card>;"
 				},
 				{
+					"id": "components-card--href",
 					"name": "href",
 					"snippet": "const href = () => <Card href=\"https://reshaped.so\">Trigger</Card>;"
 				},
 				{
+					"id": "components-card--as",
 					"name": "as",
 					"snippet": "const as = () => <Card as=\"span\" attributes={{ \"data-testid\": \"root\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-card--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Card className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Card, Example, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Card/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Card",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Card/Card.tsx",
-				"actualName": "Card",
+				"methods": [],
+				"props": {
+					"padding": {
+						"defaultValue": null,
+						"description": "Component padding, base unit multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Remove side borders and apply negative margins, base unit multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"selected": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "selected",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when the component is clicked, turns component into a button",
+						"name": "onClick",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL to navigate to when the component is clicked, turns component into a link",
+						"name": "href",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"as": {
+						"defaultValue": { "value": "\"div\"" },
+						"description": "Custom component tag name",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(Attributes<keyof IntrinsicElements> & (Attributes))" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -492,56 +2948,181 @@
 			"path": "./src/components/Carousel/tests/Carousel.stories.tsx",
 			"stories": [
 				{
+					"id": "components-carousel--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Carousel attributes={{ \"data-testid\": \"test-id\" }} visibleItems={3}>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n    </Carousel>\n);"
 				},
 				{
+					"id": "components-carousel--visible-items",
 					"name": "visibleItems",
 					"snippet": "const visibleItems = () => (\n    <Example>\n        <Example.Item title=\"visibleItems: 3\">\n            <Carousel visibleItems={3}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive visibleItems\", \"s: 2, m+ 3\"]}>\n            <Carousel visibleItems={{ s: 2, m: 3 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title=\"visibleItems: auto\">\n            <Carousel>\n                <Placeholder h={100} />\n                <Placeholder h={100} w={200} />\n                <Placeholder h={100} w={300} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 2, visibleItems 3\">\n            <Carousel visibleItems={3} gap={2}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"gap: responsive, visibleItems: 3\", \"s: 2, l: 8\"]}>\n            <Carousel visibleItems={3} gap={{ s: 2, l: 8 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4, visibleItems: 3\">\n            <Carousel visibleItems={3} bleed={4}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive bleed, visibleItems: 3\", \"[s] 4, [l+] 0\"]}>\n            <Carousel visibleItems={3} bleed={{ s: 4, l: 0 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--navigation-display",
 					"name": "navigationDisplay",
 					"snippet": "const navigationDisplay = () => (\n    <Example>\n        <Example.Item title=\"navigationDisplay: hidden\">\n            <Carousel\n                visibleItems={3}\n                navigationDisplay=\"hidden\"\n                attributes={{ \"data-testid\": \"test-id\" }}\n            >\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "instanceRef",
+					"id": "components-carousel--instance-ref",
+					"name": "instanceRef, onChange",
 					"snippet": "const instanceRef = (args) => {\n    const carouselRef = React.useRef<CarouselInstanceRef>(null);\n    const [index, setIndex] = React.useState(0);\n\n    return (\n        <Example>\n            <Example.Item title=\"instanceRef, onChange\">\n                <View gap={3}>\n                    <View gap={3} direction=\"row\" align=\"center\">\n                        <Button onClick={() => carouselRef.current?.navigateBack()}>Back</Button>\n                        <Button onClick={() => carouselRef.current?.navigateForward()}>Forward</Button>\n                        <Button onClick={() => carouselRef.current?.navigateTo(3)}>To 3</Button>\n                        <View.Item>Index: {index}</View.Item>\n                    </View>\n                    <Carousel\n                        visibleItems={2}\n                        instanceRef={carouselRef}\n                        navigationDisplay=\"hidden\"\n                        onChange={(changeArgs) => {\n                            args.handleChange(changeArgs);\n                            setIndex(changeArgs.index);\n                        }}\n                    >\n                        <Placeholder h={100}>Item 0</Placeholder>\n                        <Placeholder h={100}>Item 1</Placeholder>\n                        <Placeholder h={100}>Item 2</Placeholder>\n                        <Placeholder h={100}>Item 3</Placeholder>\n                        <Placeholder h={100}>Item 4</Placeholder>\n                        <Placeholder h={100}>Item 5</Placeholder>\n                    </Carousel>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-carousel--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Carousel visibleItems={2} className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder h={100}>Item 0</Placeholder>\n            <Placeholder h={100}>Item 1</Placeholder>\n            <Placeholder h={100}>Item 2</Placeholder>\n            <Placeholder h={100}>Item 3</Placeholder>\n            <Placeholder h={100}>Item 4</Placeholder>\n            <Placeholder h={100}>Item 5</Placeholder>\n        </Carousel>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Carousel, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Carousel/index.ts",
 				"description": "",
-				"methods": [
-					{
-						"name": "navigateTo",
-						"docblock": null,
-						"modifiers": [],
-						"params": [
+				"displayName": "Carousel",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, each child is rendered as a carousel item",
+						"name": "children",
+						"declarations": [
 							{
-								"name": "index",
-								"optional": false,
-								"type": { "name": "number" }
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
 							}
 						],
-						"returns": null
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"visibleItems": {
+						"defaultValue": null,
+						"description": "Number of items visible at once in the container",
+						"name": "visibleItems",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between items in the container, base unit multiplier",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margins, base unit multiplier, can be used to make sure the items don't get clipped when scrolling",
+						"name": "bleed",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"navigationDisplay": {
+						"defaultValue": null,
+						"description": "Hide navigation controls",
+						"name": "navigationDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"hidden\"", "value": [{ "value": "\"hidden\"" }] }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the carousel methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the first visible carousel index changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { index: number; }) => void)" }
+					},
+					"onScroll": {
+						"defaultValue": null,
+						"description": "Callback when the carousel scrolls",
+						"name": "onScroll",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: UIEvent<HTMLUListElement, UIEvent>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
 					}
-				],
-				"displayName": "Carousel",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Carousel/Carousel.tsx",
-				"actualName": "Carousel",
+				},
 				"exportName": "default"
 			}
 		},
@@ -551,46 +3132,259 @@
 			"path": "./src/components/Checkbox/tests/Checkbox.stories.tsx",
 			"stories": [
 				{
-					"name": "render",
+					"id": "components-checkbox--render",
+					"name": "name, value",
 					"snippet": "const render = () => (\n    <Checkbox name=\"test-name\" value=\"test-value\">\n        Content\n    </Checkbox>\n);"
 				},
 				{
+					"id": "components-checkbox--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"small\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"small\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"medium\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"medium\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"large\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"large\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: responsive, s: small, m: large\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size={{ s: \"small\", m: \"large\" }} defaultChecked>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-checkbox--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Checkbox name=\"animal\" value=\"dog\" hasError>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-checkbox--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n        <Example.Item title=\"disabled, checked\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled checked>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n        <Example.Item title=\"disabled, indeterminate\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled indeterminate>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "checked",
+					"id": "components-checkbox--checked",
+					"name": "checked, controlled",
 					"snippet": "const checked = () => <Checkbox name=\"test-name\" value=\"test-value\" checked onChange={fn()}>Content\n            </Checkbox>;"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-checkbox--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Checkbox name=\"test-name\" value=\"test-value\" defaultChecked onChange={fn()}>Content\n            </Checkbox>;"
 				},
 				{
+					"id": "components-checkbox--indeterminate",
 					"name": "indeterminate",
 					"snippet": "const indeterminate = () => (\n    <Checkbox name=\"test-name\" value=\"test-value\" indeterminate>\n        Content\n    </Checkbox>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-checkbox--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Checkbox className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Checkbox>\n    </div>\n);"
 				}
 			],
 			"import": "import { Checkbox, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Checkbox/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Checkbox",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Checkbox/Checkbox.tsx",
-				"actualName": "Checkbox",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the label",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Component name attribute",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the component",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Component value used for form submission",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"indeterminate": {
+						"defaultValue": null,
+						"description": "Show a indeterminate state, used for \"select all\" checkboxes with some of the individual checkboxes selected",
+						"name": "indeterminate",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the component is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the component is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Component checked state, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default checked state, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -600,26 +3394,143 @@
 			"path": "./src/components/CheckboxGroup/tests/CheckboxGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "value",
+					"id": "components-checkboxgroup--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <View gap={2}>\n    <CheckboxGroup name=\"test-name\" value={[\"1\"]} onChange={fn()}>\n        {/* checked should be ignored */}\n        <Checkbox value=\"1\" checked={false}>Content\n                            </Checkbox>\n        <Checkbox value=\"2\">Content 2</Checkbox>\n    </CheckboxGroup>\n</View>;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-checkboxgroup--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <View gap={2}>\n    <CheckboxGroup name=\"test-name\" defaultValue={[\"1\"]} onChange={fn()}>\n        {/* checked should be ignored */}\n        <Checkbox value=\"1\" checked={false}>Content\n                            </Checkbox>\n        <Checkbox value=\"2\">Content 2</Checkbox>\n    </CheckboxGroup>\n</View>;"
 				},
 				{
+					"id": "components-checkboxgroup--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <CheckboxGroup name=\"test-name\" disabled>\n        <Checkbox value=\"test-value\">Item 1</Checkbox>\n        <Checkbox value=\"test-value-2\">Item 2</Checkbox>\n    </CheckboxGroup>\n);"
 				}
 			],
 			"import": "import { Checkbox, CheckboxGroup, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/CheckboxGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "CheckboxGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/CheckboxGroup/CheckboxGroup.tsx",
-				"actualName": "CheckboxGroup",
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Component id attribute",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting checkboxes or custom layout components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the component from form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Component name attribute",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string[], ChangeEvent<HTMLInputElement>>" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Component value, enables controlled mode\nComponent value, enables uncontrolled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -629,23 +3540,346 @@
 			"path": "./src/components/ContextMenu/tests/ContextMenu.stories.tsx",
 			"stories": [
 				{
+					"id": "components-contextmenu--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"base\">\n            <div style={{ height: 200, overflow: \"auto\" }}>\n                <ContextMenu>\n                    <View height=\"400px\" backgroundColor=\"neutral-faded\" borderRadius=\"medium\" />\n\n                    <ContextMenu.Content>\n                        <ContextMenu.Item>Item 1</ContextMenu.Item>\n                        <ContextMenu.Item>Item 2</ContextMenu.Item>\n                    </ContextMenu.Content>\n                </ContextMenu>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "components-contextmenu--handlers",
+					"name": "handleOpen, handleClose",
 					"snippet": "const handlers = () => <div style={{ height: 200, overflow: \"auto\" }} data-testid=\"scroll\">\n    <ContextMenu onOpen={fn()} onClose={fn()}>\n        <View\n            height=\"400px\"\n            backgroundColor=\"neutral-faded\"\n            borderRadius=\"medium\"\n            attributes={{ \"data-testid\": \"root\" }} />\n        <ContextMenu.Content>\n            <ContextMenu.Item>Item</ContextMenu.Item>\n        </ContextMenu.Content>\n    </ContextMenu>\n</div>;"
 				}
 			],
 			"import": "import { ContextMenu, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ContextMenu/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ContextMenu",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ContextMenu/ContextMenu.tsx",
-				"actualName": "ContextMenu",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/DropdownMenu/DropdownMenu.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | \"action-menu\" | \"selection-menu\"" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					}
+				},
+				"exportName": "ContextMenu"
 			}
 		},
 		"components-divider": {
@@ -654,30 +3888,118 @@
 			"path": "./src/components/Divider/tests/Divider.stories.tsx",
 			"stories": [
 				{
-					"name": "rendering",
+					"id": "components-divider--rendering",
+					"name": "base",
 					"snippet": "const rendering = () => (\n    <Example>\n        <Example.Item title=\"default rendering\">\n            <Divider />\n        </Example.Item>\n\n        <Example.Item title={[\"blank rendering\", \"box should overlap with divider\"]}>\n            <View width=\"40px\" height=\"10px\" backgroundColor=\"primary\" />\n            <Divider blank />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-divider--vertical",
 					"name": "vertical",
 					"snippet": "const vertical = () => (\n    <Example>\n        <Example.Item title=\"vertical\">\n            <View gap={3} direction=\"row\" align=\"stretch\">\n                <Placeholder />\n                <View.Item>\n                    <Divider vertical />\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive vertical\", \"[s] true\", \"[m+]: false\"]}>\n            <View gap={3} direction={{ s: \"row\", m: \"column\" }} align=\"stretch\">\n                <Placeholder />\n                <View.Item>\n                    <Divider vertical={{ s: true, m: false }} />\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "label",
+					"id": "components-divider--label",
+					"name": "children, contentPosition",
 					"snippet": "const label = () => {\n    return (\n        <Example>\n            <Example.Item title=\"alignment\">\n                <View gap={4}>\n                    <Divider>Centered label</Divider>\n                    <Divider contentPosition=\"start\">Start label</Divider>\n                    <Divider contentPosition=\"end\">End label</Divider>\n                </View>\n            </Example.Item>\n\n            <Example.Item title=\"responsive\">\n                <View gap={3} direction={{ s: \"column\", m: \"row\" }} align=\"stretch\">\n                    <Placeholder />\n                    <View.Item>\n                        <Divider vertical={{ s: false, m: true }}>or pick second option</Divider>\n                    </View.Item>\n                    <Placeholder />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-divider--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Divider className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Divider, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Divider/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Divider",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Divider/Divider.tsx",
-				"actualName": "Divider",
+				"methods": [],
+				"props": {
+					"blank": {
+						"defaultValue": null,
+						"description": "Change component to take no space, useful for using it as a border in components like Tabs",
+						"name": "blank",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"vertical": {
+						"defaultValue": null,
+						"description": "Change component to render vertically",
+						"name": "vertical",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"contentPosition": {
+						"defaultValue": null,
+						"description": "Position for rendering children",
+						"name": "contentPosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"center\" | \"start\" | \"end\"",
+							"value": [{ "value": "\"center\"" }, { "value": "\"start\"" }, { "value": "\"end\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting text labels or custom components as a part of divider",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"hr\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -687,51 +4009,415 @@
 			"path": "./src/components/DropdownMenu/tests/DropdownMenu.stories.tsx",
 			"stories": [
 				{
+					"id": "components-dropdownmenu--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: default\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <DropdownMenu position=\"end\">\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n\n        <Example.Item title={[\"position: top-start\", \"should change to top-start to fit viewport\"]}>\n            <DropdownMenu position=\"top-end\">\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n        <div style={{ height: 2000 }} />\n    </Example>\n);"
 				},
 				{
+					"id": "components-dropdownmenu--sections",
 					"name": "sections",
 					"snippet": "const sections = () => (\n    <Example>\n        <Example.Item title=\"2 sections\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Section>\n                        <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                    </DropdownMenu.Section>\n\n                    <DropdownMenu.Section>\n                        <DropdownMenu.Item>Item 3</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 4</DropdownMenu.Item>\n                    </DropdownMenu.Section>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-dropdownmenu--submenu",
 					"name": "submenu",
 					"snippet": "const submenu = () => (\n    <Example>\n        <Example.Item title=\"submenu\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item onClick={() => {}}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger>Item 2</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger>Item 3</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2-1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2-2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger disabled>Item 4, disabled</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 3-1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 3-2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-dropdownmenu--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <DropdownMenu onOpen={fn()} onClose={fn()} defaultActive>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "active",
+					"id": "components-dropdownmenu--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <DropdownMenu onOpen={fn()} onClose={fn()} active>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "components-dropdownmenu--active-false",
+					"name": "active false, controlled",
 					"snippet": "const activeFalse = () => <DropdownMenu onOpen={fn()} onClose={fn()} active={false}>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "className",
+					"id": "components-dropdownmenu--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <DropdownMenu active>\n            <DropdownMenu.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </DropdownMenu.Trigger>\n            <DropdownMenu.Content className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n                <DropdownMenu.Item>Item</DropdownMenu.Item>\n            </DropdownMenu.Content>\n        </DropdownMenu>\n    </div>\n);"
 				},
 				{
-					"name": "testScroll",
+					"id": "components-dropdownmenu--test-scroll",
+					"name": "test: scroll",
 					"snippet": "const testScroll = () => (\n    <Example>\n        <Example.Item title=\"Scrolls on page mount to the dropdown\">\n            <div style={{ height: 1000 }} />\n            <DropdownMenu position=\"end\" key=\"scroll\" defaultActive>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testTheme",
+					"id": "components-dropdownmenu--test-theme",
+					"name": "test: theme",
 					"snippet": "const testTheme = () => (\n    <Example>\n        <Example.Item title=\"switch color mode while dropdown is active and check that it still works\">\n            <ThemeSwitching />\n        </Example.Item>\n        <Example.Item title=\"dropdown inherits multiple themes\">\n            <ThemeMultiple />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, DropdownMenu, Example, Theme, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/DropdownMenu/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "DropdownMenu",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/DropdownMenu/DropdownMenu.tsx",
-				"actualName": "DropdownMenu",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/DropdownMenu/DropdownMenu.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | \"action-menu\" | \"selection-menu\"" }
+					}
+				},
+				"exportName": "DropdownMenu"
 			}
 		},
 		"components-fileupload": {
@@ -740,35 +4426,165 @@
 			"path": "./src/components/FileUpload/tests/FileUpload.stories.tsx",
 			"stories": [
 				{
+					"id": "components-fileupload--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"Base upload with previews\">\n            <Demo />\n        </Example.Item>\n        <Example.Item title=\"With trigger\">\n            <FileUpload name=\"file\">\n                <div>\n                    Drop files to attach, or{\" \"}\n                    <FileUpload.Trigger>\n                        <Link variant=\"plain\">browse</Link>\n                    </FileUpload.Trigger>\n                </div>\n            </FileUpload>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "inline",
+					"id": "components-fileupload--inline",
+					"name": "inline, variant, render props",
 					"snippet": "const inline = () => {\n    return (\n        <Example>\n            <Example.Item title=\"inline\">\n                <FileUpload name=\"file\" inline onChange={console.log}>\n                    <View padding={2} paddingInline={3}>\n                        Upload\n                    </View>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"variant headless\">\n                <FileUpload name=\"file2\" variant=\"headless\" onChange={console.log}>\n                    <Button variant=\"outline\" fullWidth>\n                        Upload\n                    </Button>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"variant headless, inline\">\n                <FileUpload name=\"file2\" variant=\"headless\" inline onChange={console.log}>\n                    <Button>Upload</Button>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"inline, render props\">\n                <FileUpload name=\"file3\" variant=\"headless\" inline onChange={console.log}>\n                    {(props) => <Button highlighted={props.highlighted}>Upload</Button>}\n                </FileUpload>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-fileupload--height",
 					"name": "height",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"Custom height\">\n            <FileUpload name=\"file\" height=\"300px\">\n                <View gap={3}>\n                    <Icon svg={IconMic} size={8} />\n                    Drop files to attach\n                </View>\n            </FileUpload>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onChange",
+					"id": "components-fileupload--on-change",
+					"name": "name, onChange",
 					"snippet": "const onChange = () => <div data-testid=\"root\">\n    <FileUpload name=\"test-name\" onChange={fn()}>Content\n                    </FileUpload>\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "components-fileupload--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <FileUpload\n            name=\"name\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ id: \"test-input-id\" }}\n        >\n            Content\n        </FileUpload>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, FileUpload, Icon, Image, Link, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/FileUpload/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "FileUpload",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/FileUpload/FileUpload.tsx",
-				"actualName": "FileUpload",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, can be a render function that receives component state",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode | ((props: { highlighted?: boolean; }) => ReactNode)" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component value is changed",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ChangeHandler<File[], ChangeEvent<HTMLInputElement> | DragEvent<HTMLDivElement>>"
+						}
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Component height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component variant, headless variant is useful for rendering custom triggers like a Button",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"headless\"",
+							"value": [{ "value": "\"outline\"" }, { "value": "\"headless\"" }]
+						}
+					},
+					"inline": {
+						"defaultValue": null,
+						"description": "Change component to render inline making it more compact",
+						"name": "inline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					}
+				},
+				"exportName": "FileUpload"
 			}
 		},
 		"components-hotkey": {
@@ -777,22 +4593,78 @@
 			"path": "./src/components/Hotkey/tests/Hotkey.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "components-hotkey--base",
+					"name": "Base",
 					"snippet": "const base = () => (\n\t<Example>\n\t\t<Example.Item title=\"Base\">\n\t\t\t<Demo />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"Active\">\n\t\t\t<Hotkey active>⌘K</Hotkey>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"Inside input slot\">\n\t\t\t<View width=\"300px\">\n\t\t\t\t<TextField\n\t\t\t\t\tname=\"hey\"\n\t\t\t\t\tendSlot={<Demo />}\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"hotkey test\" }}\n\t\t\t\t/>\n\t\t\t</View>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-hotkey--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Hotkey className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            ⌘K\n        </Hotkey>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Hotkey, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Hotkey/Hotkey.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Hotkey",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Hotkey/Hotkey.tsx",
-				"actualName": "Hotkey",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Highlight the component, can be used to show when hotkey is pressed",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -802,54 +4674,241 @@
 			"path": "./src/components/Link/tests/Link.stories.tsx",
 			"stories": [
 				{
+					"id": "components-link--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: underline\">\n            <Link href=\"http://reshaped.so\" attributes={{ target: \"_blank\" }}>\n                Reshaped\n            </Link>\n        </Example.Item>\n        <Example.Item title=\"variant: plain\">\n            <Link onClick={() => {}} variant=\"plain\">\n                Link\n            </Link>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary\">\n            <Link color=\"primary\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Link color=\"critical\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Link color=\"positive\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <Link color=\"warning\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <Link color=\"inherit\">Link</Link>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon, variant: underline\">\n            <Link icon={IconZap}>Link</Link>\n        </Example.Item>\n        <Example.Item title=\"icon, variant: plain\">\n            <Link icon={IconZap} variant=\"plain\">\n                Link\n            </Link>\n        </Example.Item>\n        <Example.Item\n            title={[\"icon, variant: underline\", \"should inherit display-1 size from the parent\"]}\n        >\n            <Text variant=\"title-3\">\n                <Link icon={IconZap} variant=\"underline\">\n                    Instant delivery\n                </Link>\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--href",
 					"name": "href",
 					"snippet": "const href = () => <Link href=\"https://reshaped.so\">Trigger</Link>;"
 				},
 				{
+					"id": "components-link--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Link onClick={fn()}>Trigger</Link>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-link--href-on-click",
+					"name": "href + onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <Link\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </Link>\n);"
 				},
 				{
+					"id": "components-link--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Link disabled onClick={() => {}}>\n        Trigger\n    </Link>\n);"
 				},
 				{
+					"id": "components-link--render",
 					"name": "render",
 					"snippet": "const render = () => <Link render={(props) => <section {...props} />}>Trigger</Link>;"
 				},
 				{
-					"name": "className",
+					"id": "components-link--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Link className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Link>\n    </div>\n);"
 				},
 				{
-					"name": "testMultilineInText",
+					"id": "components-link--test-multiline-in-text",
+					"name": "test: multiline",
 					"snippet": "const testMultilineInText = () => (\n    <Example>\n        <Example.Item title=\"should wrap inside the text\">\n            <div>\n                Someone asked me to write this text that is boring to ready for everyone and to add&nbsp;\n                <Link href=\"/\">this very very long link</Link> to it.\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Link, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Link/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Link",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Link/Link.tsx",
-				"actualName": "Link",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon at the start position",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"primary\"" },
+						"description": "Link color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"inherit\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"inherit\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"underline\"" },
+						"description": "Link render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"plain\" | \"underline\"",
+							"value": [{ "value": "\"plain\"" }, { "value": "\"underline\"" }]
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -859,30 +4918,110 @@
 			"path": "./src/components/Loader/tests/Loader.stories.tsx",
 			"stories": [
 				{
+					"id": "components-loader--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: medium\">\n                <Loader size=\"medium\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title=\"size: small\">\n                <Loader size=\"small\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title=\"size: large\">\n                <Loader size=\"large\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title={[\"responsive size\", \"[s] small\", \"[m+] medium\"]}>\n                <Loader size={{ s: \"small\", m: \"medium\" }} ariaLabel=\"Loading\" />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-loader--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary\">\n            <Loader ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Loader color=\"critical\" ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Loader color=\"positive\" ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <Loader color=\"inherit\" ariaLabel=\"Loading\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-loader--aria-label",
 					"name": "ariaLabel",
 					"snippet": "const ariaLabel = () => <Loader ariaLabel=\"Loading\" attributes={{ \"data-testid\": \"root\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-loader--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Loader className=\"test-classname\" attributes={{ id: \"test-id\" }} ariaLabel=\"Loading\" />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Loader } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Loader/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Loader",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Loader/Loader.tsx",
-				"actualName": "Loader",
+				"methods": [],
+				"props": {
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"inherit\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -892,67 +5031,504 @@
 			"path": "./src/components/MenuItem/tests/MenuItem.stories.tsx",
 			"stories": [
 				{
+					"id": "components-menuitem--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <MenuItem size=\"small\" icon={IconZap} onClick={() => {}} endSlot={<Hotkey>⌘K</Hotkey>}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <MenuItem icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <MenuItem size=\"large\" icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title={[\"responsive size\", \"[s] small\", \"[m] medium\", \"[l+] large\"]}>\n            <MenuItem size={{ s: \"small\", m: \"medium\", l: \"large\" }} icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <MenuItem color=\"neutral\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <MenuItem color=\"primary\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <MenuItem color=\"critical\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--selected",
 					"name": "selected",
 					"snippet": "const selected = () => (\n    <Example>\n        <Example.Item title=\"selected, color: neutral\">\n            <MenuItem color=\"neutral\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"selected, color: primary\">\n            <MenuItem color=\"primary\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"selected, color: critical\">\n            <MenuItem color=\"critical\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--rounded-corners",
 					"name": "roundedCorners",
 					"snippet": "const roundedCorners = () => (\n    <Example>\n        <Example.Item title=\"roundedCorners\">\n            <MenuItem roundedCorners selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive roundedCorners\", \"[s]: false\", \"[m+]: true\"]}>\n            <MenuItem roundedCorners={{ s: false, m: true }} selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "slots",
+					"id": "components-menuitem--slots",
+					"name": "startSlot, endSlot",
 					"snippet": "const slots = () => (\n    <Example>\n        <Example.Item title=\"startSlot, endSlot, selected\">\n            <MenuItem startSlot={<Placeholder h={20} />} endSlot={<Placeholder h={20} />} selected>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem size=\"small\" selected onClick={() => {}}>\n                        Menu item\n                    </MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem selected>Menu item</MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem size=\"large\" selected>\n                        Menu item\n                    </MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--href",
 					"name": "href",
 					"snippet": "const href = () => <MenuItem href=\"https://reshaped.so\">Trigger</MenuItem>;"
 				},
 				{
+					"id": "components-menuitem--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <MenuItem onClick={fn()}>Trigger</MenuItem>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-menuitem--href-on-click",
+					"name": "href + onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <MenuItem\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </MenuItem>\n);"
 				},
 				{
+					"id": "components-menuitem--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <MenuItem disabled onClick={() => {}}>\n        Trigger\n    </MenuItem>\n);"
 				},
 				{
-					"name": "as",
+					"id": "components-menuitem--as",
+					"name": "as, render",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"render, disabled\">\n            <MenuItem\n                disabled\n                onClick={() => {}}\n                render={(props) => <section {...props} />}\n                attributes={{ \"data-testid\": \"render-el\" }}\n            >\n                Trigger\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-menuitem--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <MenuItem className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </MenuItem>\n    </div>\n);"
 				},
 				{
-					"name": "alignerClassName",
+					"id": "components-menuitem--aligner-class-name",
+					"name": "aligner, className, attributes",
 					"snippet": "const alignerClassName = () => (\n    <div data-testid=\"root\">\n        <MenuItem.Aligner className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <MenuItem>Trigger</MenuItem>\n        </MenuItem.Aligner>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Hotkey, MenuItem, Placeholder, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/MenuItem/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "MenuItem",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/MenuItem/MenuItem.tsx",
-				"actualName": "MenuItem",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content\nNode for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"neutral\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"neutral\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content at the start side of the component",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content at the end side of the component",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component as hovered or focused. For example, when displaying currently focused item in Autocomplete",
+						"name": "highlighted",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"selected": {
+						"defaultValue": null,
+						"description": "Highlight the component as selected",
+						"name": "selected",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"roundedCorners": {
+						"defaultValue": null,
+						"description": "Round the corners of the component",
+						"name": "roundedCorners",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					}
+				},
+				"exportName": "MenuItem"
 			}
 		},
 		"components-modal": {
@@ -961,67 +5537,301 @@
 			"path": "./src/components/Modal/tests/Modal.stories.tsx",
 			"stories": [
 				{
+					"id": "components-modal--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title={[\"responsive position\", \"[s] full-screen\", \"[m] center\", \"[l] end\"]}>\n            <Demo position={{ s: \"full-screen\", m: \"center\", l: \"end\" }} />\n        </Example.Item>\n        <Example.Item title=\"position: center\">\n            <Demo position=\"center\" />\n        </Example.Item>\n        <Example.Item title=\"position: bottom\">\n            <Demo position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"position: start\">\n            <Demo position=\"start\" />\n        </Example.Item>\n        <Example.Item title=\"position: end\">\n            <Demo position=\"end\" />\n        </Example.Item>\n        <Example.Item title=\"position: full-screen\">\n            <Demo position=\"full-screen\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: default\">\n                <Demo />\n            </Example.Item>\n            <Example.Item title=\"size: 300px\">\n                <Demo size=\"300px\" />\n            </Example.Item>\n            <Example.Item\n                title={[\"size: 800px\", \"should have max width of 100% minus gaps on the sides\"]}\n            >\n                <Demo size=\"800px\" />\n            </Example.Item>\n            <Example.Item\n                title={[\n                    \"responsive size, responsive position\",\n                    \"[s] auto\",\n                    \"[m+] 600px\",\n                    \"bottom position changes height instead of width\",\n                ]}\n            >\n                <Demo\n                    position={{ s: \"bottom\", m: \"center\", l: \"end\" }}\n                    size={{ s: \"auto\", m: \"600px\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-modal--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 0\">\n            <Demo padding={0} />\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <Demo padding={6} />\n        </Example.Item>\n        <Example.Item title={[\"responsive padding\", \"[s] 2\", \"[m+]: 6\"]}>\n            <Demo padding={{ s: 2, m: 6 }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--overflow",
 					"name": "overflow",
 					"snippet": "const overflow = () => (\n    <Example>\n        <Example.Item title=\"default overflow\">\n            <Demo>\n                <div\n                    style={{\n                        position: \"absolute\",\n                        top: -32,\n                        left: -32,\n                        height: 100,\n                        width: 100,\n                        background: \"tomato\",\n                    }}\n                />\n            </Demo>\n        </Example.Item>\n\n        <Example.Item title=\"overflow: visible\">\n            <Demo overflow=\"visible\">\n                <div\n                    style={{\n                        position: \"absolute\",\n                        top: -32,\n                        left: -32,\n                        height: 100,\n                        width: 100,\n                        background: \"tomato\",\n                    }}\n                />\n            </Demo>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--composition",
 					"name": "composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"title, subtitle, dismissible\">\n            <Demo title=\"Modal title\" subtitle=\"Modal subtitle\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--overlay",
 					"name": "overlay",
 					"snippet": "const overlay = () => (\n    <Example>\n        <Example.Item title=\"transparentOverlay, doesn't lock scroll\">\n            <Demo transparentOverlay />\n        </Example.Item>\n        <Example.Item title=\"blurredOverlay\">\n            <Demo blurredOverlay />\n        </Example.Item>\n        <View height=\"1000px\" />\n    </Example>\n);"
 				},
 				{
-					"name": "flags",
+					"id": "components-modal--flags",
+					"name": "disableCloseOnOutsideClick",
 					"snippet": "const flags = () => {\n    return (\n        <Example>\n            <Example.Item title=\"disableCloseOnOutsideClick\">\n                <Demo disableCloseOnOutsideClick onClose={fn()} active />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-modal--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const containerRef2 = React.useRef<HTMLDivElement>(null);\n    const toggle = useToggle();\n    const toggle2 = useToggle();\n\n    return (\n        <Example>\n            <Example.Item title={[\"in scrollable container\", \"scroll and then open\"]}>\n                <View\n                    attributes={{ ref: containerRef2 }}\n                    borderRadius=\"medium\"\n                    height=\"400px\"\n                    overflow=\"auto\"\n                    backgroundColor=\"neutral-faded\"\n                    padding={4}\n                >\n                    <View gap={4} align=\"start\">\n                        <Button onClick={toggle2.activate}>Open modal</Button>\n                        <View height=\"500px\" backgroundColor=\"primary\" width=\"500px\" borderRadius=\"medium\" />\n                    </View>\n                    <Modal\n                        containerRef={containerRef2}\n                        active={toggle2.active}\n                        onClose={toggle2.deactivate}\n                        position=\"end\"\n                    >\n                        <Placeholder />\n                    </Modal>\n                </View>\n            </Example.Item>\n            <Example.Item title=\"in static container\">\n                <View\n                    attributes={{ ref: containerRef }}\n                    borderRadius=\"medium\"\n                    height=\"400px\"\n                    overflow=\"hidden\"\n                    backgroundColor=\"neutral-faded\"\n                    padding={4}\n                >\n                    <Button onClick={toggle.activate}>Open modal</Button>\n                    <Modal\n                        containerRef={containerRef}\n                        active={toggle.active}\n                        onClose={toggle.deactivate}\n                        position=\"end\"\n                    >\n                        <Placeholder />\n                    </Modal>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "renderProps",
+					"id": "components-modal--render-props",
+					"name": "children, render props",
 					"snippet": "const renderProps = () => (\n    <Modal active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        <Modal.Title>Title</Modal.Title>\n        Content\n    </Modal>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "components-modal--handlers",
+					"name": "onOpen, onClose, onAfterOpen, onAfterClose",
 					"snippet": "const handlers = () => {\n    const overlayToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => overlayToggle.toggle()}>Open overlay</Button>\n            <Modal\n                active={overlayToggle.active}\n                onClose={(closeArgs) => {\n                    overlayToggle.deactivate();\n                    args.handleClose(closeArgs);\n                }}\n                onOpen={fn()}\n                onAfterOpen={fn()}\n                onAfterClose={fn()}>\n                <Modal.Title>Title</Modal.Title>Content\n                                </Modal>\n        </>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-modal--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <Modal active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        <Modal.Title>Title</Modal.Title>\n        Content\n    </Modal>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-modal--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => {\n    const menuModalToggle = useToggle();\n    const menuModalToggleInner = useToggle();\n    const scrollModalToggle = useToggle();\n    const inputRef = React.useRef<HTMLInputElement>(null);\n\n    return (\n        <Example>\n            <Example.Item title=\"Scrolls with long content on touch devices\">\n                <Demo position=\"center\">\n                    <Button onClick={() => {}}>Action</Button>\n                    <View height=\"2000px\" backgroundColor=\"primary-faded\" />\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"keyboard focus stays on the modal first\">\n                <Demo title=\"Modal title\" autoFocus={false} />\n            </Example.Item>\n            <Example.Item title=\"trap focus works with custom children components\">\n                <Demo title=\"Modal title\">\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <Switch name=\"switch\" />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"focus moves to the input\">\n                <Demo\n                    title=\"Modal title\"\n                    onOpen={() => {\n                        inputRef.current?.focus();\n                    }}\n                >\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <TextField name=\"name\" inputAttributes={{ ref: inputRef }} />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"Focus moves to the input with autoFocus\">\n                <Demo title=\"Modal title\">\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <TextField\n                            name=\"name\"\n                            placeholder=\"autofocus\"\n                            inputAttributes={{ autoFocus: true }}\n                        />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"scrollable area in modal ignores swipe-to-close\">\n                <View gap={3} direction=\"row\">\n                    <Button onClick={scrollModalToggle.activate}>Open</Button>\n                    <Modal\n                        active={scrollModalToggle.active}\n                        onClose={scrollModalToggle.deactivate}\n                        size=\"300px\"\n                        position=\"bottom\"\n                    >\n                        <View\n                            height=\"1000px\"\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            padding={4}\n                        >\n                            Content\n                        </View>\n                    </Modal>\n                </View>\n            </Example.Item>\n            <Example.Item\n                title={[\n                    \"trap focus works correctly when it was already trapped\",\n                    \"focus return back to the dropdown trigger on modal close\",\n                    \"closing dropdown inside the modal doesn't close the modal\",\n                ]}\n            >\n                <DropdownMenu>\n                    <DropdownMenu.Trigger>\n                        {(attributes) => <Button attributes={attributes}>Open menu</Button>}\n                    </DropdownMenu.Trigger>\n                    <DropdownMenu.Content>\n                        <DropdownMenu.Item onClick={menuModalToggle.activate}>Open dialog</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                    </DropdownMenu.Content>\n                </DropdownMenu>\n                <Modal active={menuModalToggle.active} onClose={menuModalToggle.deactivate}>\n                    <View gap={3}>\n                        <DropdownMenu>\n                            <DropdownMenu.Trigger>\n                                {(attributes) => <Button attributes={attributes}>Open menu</Button>}\n                            </DropdownMenu.Trigger>\n                            <DropdownMenu.Content>\n                                <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                                <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                            </DropdownMenu.Content>\n                        </DropdownMenu>\n                        <Button onClick={menuModalToggleInner.activate}>Open dialog</Button>\n                        <Button onClick={menuModalToggle.deactivate}>Close</Button>\n                        <Modal active={menuModalToggleInner.active} onClose={menuModalToggleInner.deactivate}>\n                            <Button onClick={menuModalToggleInner.deactivate}>Close</Button>\n                        </Modal>\n                    </View>\n                </Modal>\n            </Example.Item>\n\n            <Example.Item title=\"disableSwipeGesture\">\n                <Demo disableSwipeGesture position=\"start\" />\n            </Example.Item>\n\n            <Example.Item title=\"scroll locks on open\">\n                <Demo />\n                <View height=\"1000px\" />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "trapFocusEdgeCases",
+					"id": "components-modal--trap-focus-edge-cases",
+					"name": "test: trap focus edge cases",
 					"snippet": "const trapFocusEdgeCases = () => {\n    const toggle = useToggle();\n\n    return (\n        <Example>\n            <Example.Item title=\"Radio should be navigatable with arrow keys\">\n                <Button onClick={toggle.activate}>Open modal</Button>\n                <Modal active={toggle.active} onClose={toggle.deactivate}>\n                    <View gap={2}>\n                        <Button onClick={() => {}}>Action 1</Button>\n                        <Radio name=\"radio\" value=\"1\">\n                            Option 1\n                        </Radio>\n                        <Radio name=\"radio\" value=\"2\">\n                            Option 2\n                        </Radio>\n                        <Button onClick={() => {}}>Action 2</Button>\n                    </View>\n                </Modal>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import {\n    Button,\n    Dismissible,\n    DropdownMenu,\n    Example,\n    Modal,\n    Placeholder,\n    Radio,\n    Switch,\n    TextField,\n    View,\n} from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Modal/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Modal",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Modal/Modal.tsx",
-				"actualName": "Modal",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Component position on the screen",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<\"bottom\" | \"center\" | \"start\" | \"end\" | \"full-screen\">"
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size, literal css value",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Component padding, unit token multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Remove overflow from the component content",
+						"name": "overflow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"visible\"", "value": [{ "value": "\"visible\"" }] }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is closed",
+						"name": "onClose",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((args: { reason: CloseReason | \"drag\"; }) => void)" }
+					},
+					"transparentOverlay": {
+						"defaultValue": null,
+						"description": "Make the overlay transparent",
+						"name": "transparentOverlay",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"blurredOverlay": {
+						"defaultValue": null,
+						"description": "Make the overlay blurred",
+						"name": "blurredOverlay",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableSwipeGesture": {
+						"defaultValue": null,
+						"description": "Disable swipe gesture to close the component on touch devices",
+						"name": "disableSwipeGesture",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable closing the component on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Focus the first focusable element in the component when it is opened, when false, focus will be set on the component content container",
+						"name": "autoFocus",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element, useful when there is no visible title",
+						"name": "ariaLabel",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"overlayClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the overlay element",
+						"name": "overlayClassName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "(Attributes<\"div\"> & { ref?: RefObject<HTMLDivElement | null>; })"
+						}
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the visibility of the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the component is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"containerRef": {
+						"defaultValue": null,
+						"description": "Element to render the component in",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"onAfterOpen": {
+						"defaultValue": null,
+						"description": "Callback after the component open transition is complete",
+						"name": "onAfterOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onAfterClose": {
+						"defaultValue": null,
+						"description": "Callback after the component close transition is complete",
+						"name": "onAfterClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					}
+				},
+				"exportName": "Modal"
 			}
 		},
 		"components-numberfield": {
@@ -1030,54 +5840,450 @@
 			"path": "./src/components/NumberField/tests/NumberField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-numberfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => {\n    return (\n        <Example>\n            <Example.Item title=\"variant: outline\">\n                <NumberField\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"variant: faded\">\n                <NumberField\n                    variant=\"faded\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"variant: headless\">\n                <NumberField\n                    variant=\"headless\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-numberfield--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: small\">\n                <NumberField\n                    size=\"small\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    suffix=\"m2\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: medium\">\n                <NumberField\n                    size=\"medium\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: large\">\n                <NumberField\n                    size=\"large\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: xlarge\">\n                <NumberField\n                    size=\"xlarge\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-numberfield--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <NumberField\n    name=\"test-name\"\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    disabled\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-numberfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <NumberField\n    name=\"test-name\"\n    defaultValue={2}\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-numberfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <NumberField\n    name=\"test-name\"\n    value={2}\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "minMax",
+					"id": "components-numberfield--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <NumberField\n        name=\"test-name\"\n        defaultValue={6}\n        min={5}\n        max={10}\n        increaseAriaLabel=\"Increase\"\n        decreaseAriaLabel=\"Decrease\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-numberfield--step",
 					"name": "step",
 					"snippet": "const step = () => (\n    <NumberField\n        name=\"test-name\"\n        defaultValue={6}\n        step={0.5}\n        increaseAriaLabel=\"Increase\"\n        decreaseAriaLabel=\"Decrease\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-numberfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <NumberField\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n            increaseAriaLabel=\"Increase\"\n            decreaseAriaLabel=\"Decrease\"\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-numberfield--form-control",
+					"name": "test: FormControl",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"FormControl\">\n            <FormControl>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"FormControl, disabled\">\n            <FormControl disabled>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"FormControl, error\">\n            <FormControl hasError>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "valueChanges",
+					"id": "components-numberfield--value-changes",
+					"name": "test: keyboard",
 					"snippet": "const valueChanges = () => (\n    <Example>\n        <Example.Item title=\"keyboard\">\n            <NumberField\n                name=\"name\"\n                increaseAriaLabel=\"Increase\"\n                decreaseAriaLabel=\"Decrease\"\n                inputAttributes={{ \"aria-label\": \"Label\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, FormControl, NumberField } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/NumberField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "NumberField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/NumberField/NumberField.tsx",
-				"actualName": "NumberField",
+				"methods": [],
+				"props": {
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component value is changed",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<number, ChangeEvent<HTMLInputElement>>" }
+					},
+					"increaseAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the increase button",
+						"name": "increaseAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"decreaseAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the decrease button",
+						"name": "decreaseAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum value supported in the form field",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum value supported in the form field",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"step": {
+						"defaultValue": null,
+						"description": "Step at which the value will increase or decrease when clicking the button controls",
+						"name": "step",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the form field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the form field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1087,34 +6293,166 @@
 			"path": "./src/components/Pagination/tests/Pagination.stories.tsx",
 			"stories": [
 				{
+					"id": "components-pagination--truncate",
 					"name": "truncate",
 					"snippet": "const truncate = () => {\n    return (\n        <Example>\n            <Example.Item title=\"start\">\n                <Pagination\n                    total={10}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"middle\">\n                <Pagination\n                    total={10}\n                    defaultPage={5}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"end\">\n                <Pagination\n                    total={10}\n                    defaultPage={10}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"no truncation\">\n                <Pagination\n                    total={4}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "render",
+					"id": "components-pagination--render",
+					"name": "rendering",
 					"snippet": "const render = () => (\n    <div data-testid=\"root\">\n        <Pagination\n            total={10}\n            previousAriaLabel=\"Previous\"\n            nextAriaLabel=\"Next\"\n            pageAriaLabel={(args) => `Page ${args.page}`}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "defaultPage",
+					"id": "components-pagination--default-page",
+					"name": "defaultPage, uncontrolled",
 					"snippet": "const defaultPage = () => <div data-testid=\"root\">\n    <Pagination\n        total={10}\n        defaultPage={2}\n        onChange={fn()}\n        previousAriaLabel=\"Previous\"\n        nextAriaLabel=\"Next\" />\n</div>;"
 				},
 				{
-					"name": "page",
+					"id": "components-pagination--page",
+					"name": "page, controlled",
 					"snippet": "const page = () => <div data-testid=\"root\">\n    <Pagination\n        total={10}\n        page={2}\n        onChange={fn()}\n        previousAriaLabel=\"Previous\"\n        nextAriaLabel=\"Next\" />\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "components-pagination--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Pagination\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            total={10}\n            previousAriaLabel=\"Previous\"\n            nextAriaLabel=\"Next\"\n        />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Pagination } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Pagination/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Pagination",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Pagination/Pagination.tsx",
-				"actualName": "Pagination",
+				"methods": [],
+				"props": {
+					"total": {
+						"defaultValue": null,
+						"description": "Total number of pages available",
+						"name": "total",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "number" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the current page changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { page: number; }) => void)" }
+					},
+					"pageAriaLabel": {
+						"defaultValue": null,
+						"description": "Function to dynamically get an aria-label for each page",
+						"name": "pageAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { page: number; }) => string)" }
+					},
+					"previousAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the previous page button",
+						"name": "previousAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"nextAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the next page button",
+						"name": "nextAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"page": {
+						"defaultValue": null,
+						"description": "Currently selected page number, starts with 1, enables controlled mode",
+						"name": "page",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultPage": {
+						"defaultValue": null,
+						"description": "Default selected page number, starts with 1, enables uncontrolled mode",
+						"name": "defaultPage",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1124,54 +6462,229 @@
 			"path": "./src/components/PinField/tests/PinField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-pinfield--base",
 					"name": "base",
 					"snippet": "const base = () => <PinField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-pinfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <PinField name=\"pin\" variant=\"faded\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-pinfield--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <PinField name=\"pin\" size=\"small\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <PinField name=\"pin\" size=\"medium\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <PinField name=\"pin\" size=\"large\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <PinField name=\"pin\" size=\"xlarge\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: responsive, s: medium, m+: xlarge\">\n            <PinField\n                name=\"pin\"\n                size={{ s: \"medium\", m: \"xlarge\" }}\n                inputAttributes={{ \"aria-label\": \"Pin\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-pinfield--value-length",
 					"name": "valueLength",
 					"snippet": "const valueLength = () => (\n    <PinField name=\"test-name\" valueLength={6} inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-pinfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <PinField\n    name=\"test-name\"\n    onChange={fn()}\n    defaultValue=\"12\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-pinfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <PinField\n    name=\"test-name\"\n    onChange={fn()}\n    value=\"12\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-pinfield--pattern",
 					"name": "pattern",
 					"snippet": "const pattern = () => <PinField\n    name=\"test-name\"\n    pattern=\"alphabetic\"\n    defaultValue=\"ab\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-pinfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <PinField\n            name=\"test-name\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ \"aria-label\": \"Label\", id: \"test-input-id\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-pinfield--form-control",
+					"name": "test: with FormControl",
 					"snippet": "const formControl = () => (\n    <FormControl>\n        <FormControl.Label>Label</FormControl.Label>\n        <PinField name=\"test-name\" />\n    </FormControl>\n);"
 				},
 				{
-					"name": "keyboard",
+					"id": "components-pinfield--keyboard",
+					"name": "test: keyboard navigation",
 					"snippet": "const keyboard = () => <PinField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				}
 			],
 			"import": "import { Example, FormControl, PinField } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/PinField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "PinField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/PinField/PinField.tsx",
-				"actualName": "PinField",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"valueLength": {
+						"defaultValue": null,
+						"description": "Amount of characters in the pin",
+						"name": "valueLength",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"pattern": {
+						"defaultValue": null,
+						"description": "Character pattern used in the input value",
+						"name": "pattern",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"numeric\" | \"alphabetic\" | \"alphanumeric\"",
+							"value": [
+								{ "value": "\"numeric\"" },
+								{ "value": "\"alphabetic\"" },
+								{ "value": "\"alphanumeric\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Input fields render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\"",
+							"value": [{ "value": "\"outline\"" }, { "value": "\"faded\"" }]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the input element, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1181,75 +6694,514 @@
 			"path": "./src/components/Popover/tests/Popover.stories.tsx",
 			"stories": [
 				{
+					"id": "components-popover--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: bottom\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"bottom-start\" />\n                <Demo position=\"bottom\" />\n                <Demo position=\"bottom-end\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: top\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"top-start\" />\n                <Demo position=\"top\" />\n                <Demo position=\"top-end\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: start\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"start-top\" />\n                <Demo position=\"start\" />\n                <Demo position=\"start-bottom\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: end\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"end-top\" />\n                <Demo position=\"end\" />\n                <Demo position=\"end-bottom\" defaultActive />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "widthNumber",
+					"id": "components-popover--width-number",
+					"name": "width: px",
 					"snippet": "const widthNumber = () => <Demo width=\"400px\" defaultActive />;"
 				},
 				{
-					"name": "widthFull",
+					"id": "components-popover--width-full",
+					"name": "width: 100%",
 					"snippet": "const widthFull = () => <Demo width=\"100%\" defaultActive />;"
 				},
 				{
+					"id": "components-popover--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 0\">\n            <Demo padding={0} />\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <Demo padding={6} defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-popover--elevation",
 					"name": "elevation",
 					"snippet": "const elevation = () => (\n    <Example>\n        <Example.Item title=\"elevation: raised\">\n            <Demo elevation=\"raised\" defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-popover--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <Popover onOpen={fn()} onClose={fn()} defaultActive>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "active",
+					"id": "components-popover--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <Popover onOpen={fn()} onClose={fn()} active>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "components-popover--active-false",
+					"name": "active false, controlled",
 					"snippet": "const activeFalse = () => <Popover onOpen={fn()} onClose={fn()} active={false}>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "dismissible",
+					"id": "components-popover--dismissible",
+					"name": "dismissible, onClose, className, attributes, closeAriaLabel",
 					"snippet": "const dismissible = () => <Popover onClose={fn()} defaultActive>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>\n        <Popover.Dismissible\n            closeAriaLabel=\"Close\"\n            attributes={{ \"data-testid\": \"test-id\" }}\n            className=\"test-classname\">Content\n                            </Popover.Dismissible>\n    </Popover.Content>\n</Popover>;"
 				},
 				{
+					"id": "components-popover--auto-focus",
 					"name": "autoFocus",
 					"snippet": "const autoFocus = () => (\n    <Example>\n        <Example.Item title=\"autoFocus=false\">\n            <Demo autoFocus={false} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-popover--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Popover active>\n            <Popover.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </Popover.Trigger>\n            <Popover.Content className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n                Content\n            </Popover.Content>\n        </Popover>\n    </div>\n);"
 				},
 				{
-					"name": "testNested",
+					"id": "components-popover--test-nested",
+					"name": "test: nested",
 					"snippet": "const testNested = () => (\n    <Popover position=\"bottom\">\n        <Popover.Trigger>\n            {(attributes) => <Button attributes={attributes}>Open</Button>}\n        </Popover.Trigger>\n        <Popover.Content>\n            <View gap={2} align=\"start\">\n                Popover content\n                <Popover>\n                    <Popover.Trigger>\n                        {(attributes) => <Button attributes={attributes}>Open</Button>}\n                    </Popover.Trigger>\n                    <Popover.Content>Hello</Popover.Content>\n                </Popover>\n            </View>\n        </Popover.Content>\n    </Popover>\n);"
 				},
 				{
-					"name": "testWithTooltip",
+					"id": "components-popover--test-with-tooltip",
+					"name": "test: with tooltip",
 					"snippet": "const testWithTooltip = () => (\n    <View paddingTop={10}>\n        <Tooltip position=\"top\" text=\"Hello\">\n            {(tooltipAttributes) => (\n                <Popover position=\"bottom\">\n                    <Popover.Trigger>\n                        {(attributes) => (\n                            <Button\n                                attributes={{\n                                    ...attributes,\n                                    ...tooltipAttributes,\n                                }}\n                            >\n                                Open\n                            </Button>\n                        )}\n                    </Popover.Trigger>\n                    <Popover.Content>\n                        <View gap={2} align=\"start\">\n                            Popover content\n                            <Button onClick={() => {}}>Button</Button>\n                        </View>\n                    </Popover.Content>\n                </Popover>\n            )}\n        </Tooltip>\n    </View>\n);"
 				},
 				{
-					"name": "testContentEditable",
+					"id": "components-popover--test-content-editable",
+					"name": "test: contenteditable",
 					"snippet": "const testContentEditable = () => {\n    const [active, setActive] = useState(false);\n\n    return (\n        <Popover>\n            <Popover.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </Popover.Trigger>\n            <Popover.Content>\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={() => {}}>Hello</Button>\n                    </View.Item>\n\n                    <ScrollArea height=\"100px\">\n                        <div\n                            style={{ height: \"200px\" }}\n                            contentEditable\n                            tabIndex={0}\n                            onInput={(e) => {\n                                setActive(e.currentTarget.innerText.startsWith(\"@\"));\n                            }}\n                            onKeyDown={(e) => {\n                                console.log(e.key);\n                                if (e.key === \"Enter\" && active) {\n                                    e.preventDefault();\n                                    e.currentTarget.innerText = \"@hello\";\n                                    setActive(false);\n                                }\n                            }}\n                        />\n                    </ScrollArea>\n\n                    <Popover\n                        active={active}\n                        onClose={() => setActive(false)}\n                        originCoordinates={{ x: 300, y: 300 }}\n                        trapFocusMode=\"selection-menu\"\n                    >\n                        <Popover.Content>\n                            <View gap={4}>\n                                <MenuItem onClick={() => {}}>Action</MenuItem>\n                                <MenuItem onClick={() => {}}>Close</MenuItem>\n                            </View>\n                        </Popover.Content>\n                    </Popover>\n                </View>\n            </Popover.Content>\n        </Popover>\n    );\n};"
 				},
 				{
-					"name": "variant",
+					"id": "components-popover--variant",
+					"name": "variant [deprecated]",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: headless\">\n            <Popover variant=\"headless\" defaultActive position=\"bottom-start\">\n                <Popover.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </Popover.Trigger>\n                <Popover.Content>\n                    <View\n                        height=\"100px\"\n                        width=\"100px\"\n                        borderColor=\"primary\"\n                        borderRadius=\"medium\"\n                        backgroundColor=\"primary-faded\"\n                    />\n                </Popover.Content>\n            </Popover>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, MenuItem, Popover, ScrollArea, Tooltip, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Popover/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Popover",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Popover/Popover.tsx",
-				"actualName": "Popover",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Automatically focus the first focusable element in the content, when false the content container will be focused instead",
+						"name": "autoFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | TrapMode" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Content element padding, unit token multiplier",
+						"name": "padding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "@deprecated use Flyout utility instead, will be removed in v4",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"elevated\" | \"headless\"",
+							"value": [{ "value": "\"elevated\"" }, { "value": "\"headless\"" }]
+						}
+					}
+				},
+				"exportName": "Popover"
 			}
 		},
 		"components-progress": {
@@ -1258,38 +7210,177 @@
 			"path": "./src/components/Progress/tests/Progress.stories.tsx",
 			"stories": [
 				{
+					"id": "components-progress--value",
 					"name": "value",
 					"snippet": "const value = () => (\n    <Example>\n        <Example.Item title=\"value: 50\">\n            <Progress value={50} ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"value: 20, min: 0, max: 40\">\n            <Progress value={20} min={0} max={40} ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"value: 50, min: 0, max: 40\">\n            <Progress value={50} min={0} max={40} ariaLabel=\"rating value\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small, value: 50\">\n            <Progress value={50} size=\"small\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"size: medium, value: 50\">\n            <Progress value={50} size=\"medium\" ariaLabel=\"rating value\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: critical, value: 50\">\n            <Progress value={50} color=\"critical\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: warning, value: 50\">\n            <Progress value={50} color=\"warning\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive, value: 50\">\n            <Progress value={50} color=\"positive\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: media, value: 50\">\n            <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                <Progress value={50} color=\"media\" ariaLabel=\"rating value\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--duration",
 					"name": "duration",
 					"snippet": "const duration = () => {\n    const [active, setActive] = React.useState(false);\n\n    const handleChange = () => {\n        setActive((state) => !state);\n    };\n\n    return (\n        <Example>\n            <Example.Item title=\"duration: 2000\">\n                <View gap={3}>\n                    <View.Item>\n                        <Button onClick={handleChange}>Change</Button>\n                    </View.Item>\n\n                    <Progress value={active ? 100 : 0} duration={2000} ariaLabel=\"rating value\" />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "render",
+					"id": "components-progress--render",
+					"name": "rendering",
 					"snippet": "const render = () => <Progress value={75} min={50} max={100} ariaLabel=\"progress\" />;"
 				},
 				{
-					"name": "className",
+					"id": "components-progress--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Progress className=\"test-classname\" attributes={{ id: \"test-id\" }} ariaLabel=\"progress\" />\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, Progress, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Progress/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Progress",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Progress/Progress.tsx",
-				"actualName": "Progress",
+				"methods": [],
+				"props": {
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the progress bar controlling the size of the fill",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Lower value boundary of the progress bar",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Upper value boundary of the progress bar",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"warning\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"duration": {
+						"defaultValue": null,
+						"description": "Duration of the progress bar animation in milliseconds",
+						"name": "duration",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1299,30 +7390,135 @@
 			"path": "./src/components/ProgressIndicator/tests/ProgressIndicator.stories.tsx",
 			"stories": [
 				{
+					"id": "components-progressindicator--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const [activeIndex, setActiveIndex] = React.useState(0);\n    const total = 10;\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <View gap={4}>\n                    <View direction=\"row\" gap={2} align=\"center\">\n                        <Button\n                            onClick={() => {\n                                setActiveIndex((prev) => Math.max(0, prev - 1));\n                            }}\n                        >\n                            Previous\n                        </Button>\n                        <Button\n                            onClick={() => {\n                                setActiveIndex((prev) => Math.min(total - 1, prev + 1));\n                            }}\n                        >\n                            Next\n                        </Button>\n                        <Text weight=\"medium\">Index: {activeIndex}</Text>\n                    </View>\n\n                    <View borderRadius=\"medium\" overflow=\"hidden\" width=\"300px\">\n                        <Scrim\n                            position=\"bottom\"\n                            backgroundSlot={<View aspectRatio={16 / 9} backgroundColor=\"neutral-faded\" />}\n                        >\n                            <View align=\"center\">\n                                <ProgressIndicator total={total} activeIndex={activeIndex} color=\"media\" />\n                            </View>\n                        </Scrim>\n                    </View>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-progressindicator--color",
 					"name": "color",
 					"snippet": "const color = () => {\n    return (\n        <Example>\n            <Example.Item title=\"color: primary\">\n                <ProgressIndicator total={10} activeIndex={5} color=\"primary\" />\n            </Example.Item>\n            <Example.Item title=\"color: media\">\n                <View borderRadius=\"medium\" overflow=\"hidden\" width=\"300px\">\n                    <Scrim\n                        position=\"bottom\"\n                        backgroundSlot={<View aspectRatio={16 / 9} backgroundColor=\"neutral-faded\" />}\n                    >\n                        <View align=\"center\">\n                            <ProgressIndicator total={10} activeIndex={5} color=\"media\" />\n                        </View>\n                    </Scrim>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-progressindicator--aria-label",
 					"name": "ariaLabel",
 					"snippet": "const ariaLabel = () => <ProgressIndicator total={10} className=\"test-classname\" ariaLabel=\"Progress\" />;"
 				},
 				{
-					"name": "className",
+					"id": "components-progressindicator--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ProgressIndicator total={10} className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, ProgressIndicator, Scrim, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ProgressIndicator/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ProgressIndicator",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ProgressIndicator/ProgressIndicator.tsx",
-				"actualName": "ProgressIndicator",
+				"methods": [],
+				"props": {
+					"total": {
+						"defaultValue": null,
+						"description": "Total amount of progress indicator dots",
+						"name": "total",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "number" }
+					},
+					"activeIndex": {
+						"defaultValue": null,
+						"description": "Index of the active progress indicator dot",
+						"name": "activeIndex",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\"",
+							"value": [{ "value": "\"media\"" }, { "value": "\"primary\"" }]
+						}
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1332,50 +7528,203 @@
 			"path": "./src/components/Radio/tests/Radio.stories.tsx",
 			"stories": [
 				{
+					"id": "components-radio--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"small\" defaultChecked>\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"medium\">\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"large\">\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: responsive, s: small, m: large\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size={{ s: \"small\", m: \"large\" }}>\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-radio--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Radio name=\"error\" value=\"dog\" hasError>\n                Radio\n            </Radio>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-radio--render",
+					"name": "name, value",
 					"snippet": "const render = () => (\n    <Radio name=\"test-name\" value=\"test-value\">\n        Content\n    </Radio>\n);"
 				},
 				{
-					"name": "checked",
+					"id": "components-radio--checked",
+					"name": "checked, controlled",
 					"snippet": "const checked = () => <Radio name=\"test-name\" value=\"test-value\" checked onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "checkedFalse",
+					"id": "components-radio--checked-false",
+					"name": "checked false, controlled",
 					"snippet": "const checkedFalse = () => <Radio name=\"test-name\" value=\"test-value\" checked={false} onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-radio--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Radio name=\"test-name\" value=\"test-value\" defaultChecked onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "defaultCheckedFalse",
+					"id": "components-radio--default-checked-false",
+					"name": "defaultChecked false, uncontrolled",
 					"snippet": "const defaultCheckedFalse = () => <Radio name=\"test-name\" value=\"test-value\" onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
+					"id": "components-radio--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Radio name=\"test-name\" value=\"test-value\" disabled>\n        Content\n    </Radio>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-radio--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Radio className=\"test-classname\" attributes={{ id: \"test-id\" }} value=\"value\">\n            Content\n        </Radio>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Radio, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Radio/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Radio",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Radio/Radio.tsx",
-				"actualName": "Radio",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the form field from the form submission",
+						"name": "disabled",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Indicate that the form field has an error",
+						"name": "hasError",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element",
+						"name": "value",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the input is focused",
+						"name": "onFocus",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the input is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "",
+						"name": "checked",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultChecked",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1385,26 +7734,169 @@
 			"path": "./src/components/RadioGroup/tests/RadioGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "value",
+					"id": "components-radiogroup--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <RadioGroup name=\"test-name\" value=\"1\" onChange={fn()}>\n    {/* checked should be ignored */}\n    <Radio value=\"1\" checked={false}>Content\n                    </Radio>\n    <Radio value=\"2\">Content 2</Radio>\n</RadioGroup>;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-radiogroup--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <RadioGroup name=\"test-name\" defaultValue=\"1\" onChange={fn()}>\n    {/* checked should be ignored */}\n    <Radio value=\"1\" checked={false}>Content\n                    </Radio>\n    <Radio value=\"2\">Content 2</Radio>\n</RadioGroup>;"
 				},
 				{
+					"id": "components-radiogroup--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <RadioGroup name=\"test-name\" disabled>\n        <Radio value=\"test-value\">Content</Radio>\n    </RadioGroup>\n);"
 				}
 			],
 			"import": "import { Radio, RadioGroup } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/RadioGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "RadioGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/RadioGroup/RadioGroup.tsx",
-				"actualName": "RadioGroup",
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the radio group",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the form field from the form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Indicate that the form field has an error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the input element, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1414,39 +7906,131 @@
 			"path": "./src/components/Resizable/tests/Resizable.stories.tsx",
 			"stories": [
 				{
+					"id": "components-resizable--direction",
 					"name": "direction",
 					"snippet": "const direction = () => {\n    return (\n        <Example>\n            <Example.Item title=\"row\">\n                <Resizable height=\"200px\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n            <Example.Item title=\"column\">\n                <Resizable height=\"400px\" direction=\"column\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n\n            {/* Test that page doesn't scroll on dragging */}\n            <div style={{ height: 2000 }} />\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-resizable--children",
 					"name": "children",
 					"snippet": "const children = () => {\n    return (\n        <Example>\n            <Example.Item title=\"render props, row\">\n                <Resizable height=\"200px\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n            <Example.Item title=\"render props, column\">\n                <Resizable height=\"400px\" direction=\"column\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-resizable--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"bordered, row\">\n            <Resizable height=\"200px\" variant=\"bordered\">\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n            </Resizable>\n        </Example.Item>\n        <Example.Item title=\"bordered, column\">\n            <Resizable height=\"400px\" direction=\"column\" variant=\"bordered\">\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n            </Resizable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "components-resizable--size",
+					"name": "minSize, maxSize, defaultSize",
 					"snippet": "const size = () => (\n    <Resizable className=\"test-classname\" attributes={{ id: \"test-id\" }} height=\"200px\">\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n        <Resizable.Handle />\n        <Resizable.Item minSize=\"200px\" maxSize=\"500px\" defaultSize=\"300px\">\n            <Panel />\n        </Resizable.Item>\n    </Resizable>\n);"
 				},
 				{
-					"name": "layout",
+					"id": "components-resizable--layout",
+					"name": "height, gap",
 					"snippet": "const layout = () => (\n    <Resizable height=\"100px\" gap={8}>\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n        <Resizable.Handle />\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n    </Resizable>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-resizable--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Resizable className=\"test-classname\" attributes={{ id: \"test-id\" }} height=\"200px\">\n            <Resizable.Item>\n                <Panel />\n            </Resizable.Item>\n            <Resizable.Handle />\n            <Resizable.Item>\n                <Panel />\n            </Resizable.Item>\n        </Resizable>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, Resizable, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Resizable/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Resizable",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Resizable/Resizable.tsx",
-				"actualName": "Resizable",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Resizable/Resizable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"bordered\" | \"borderless\"",
+							"value": [{ "value": "\"bordered\"" }, { "value": "\"borderless\"" }]
+						}
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Component content direction with the resize handle rendered in between the chidlren",
+						"name": "direction",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Resizable/Resizable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between children, base unit token number multiplier",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					}
+				},
+				"exportName": "Resizable"
 			}
 		},
 		"components-scrim": {
@@ -1455,26 +8039,101 @@
 			"path": "./src/components/Scrim/tests/Scrim.stories.tsx",
 			"stories": [
 				{
+					"id": "components-scrim--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: center\">\n            <Scrim backgroundSlot={<Placeholder h={200} />}>Scrim</Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <Scrim position=\"bottom\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: top\">\n            <Scrim position=\"top\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: start\">\n            <Scrim position=\"start\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <Scrim position=\"end\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-scrim--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Scrim className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Scrim>\n    </div>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "components-scrim--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"without backgroundSlot, size is based on the parent component\">\n            <div style={{ height: 300, position: \"relative\" }}>\n                <Scrim>Text</Scrim>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Placeholder, Scrim } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Scrim/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Scrim",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Scrim/Scrim.tsx",
-				"actualName": "Scrim",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"backgroundSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting background content behind the scrim",
+						"name": "backgroundSlot",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Component content position",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"bottom\" | \"start\" | \"end\" | \"full\"",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"full\"" }
+							]
+						}
+					},
+					"scrimClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the scrim element",
+						"name": "scrimClassName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1484,79 +8143,398 @@
 			"path": "./src/components/Select/tests/Select.stories.tsx",
 			"stories": [
 				{
-					"name": "nativeRender",
+					"id": "components-select--native-render",
+					"name": "native rendering, options, name, id",
 					"snippet": "const nativeRender = () => (\n    <Example>\n        <Example.Item title=\"native with options prop\">\n            <Select\n                name=\"animal\"\n                id=\"animal-1\"\n                placeholder=\"Select an animal\"\n                options={[\n                    { label: \"Dog\", value: \"dog\" },\n                    { label: \"Turtle\", value: \"turtle\" },\n                ]}\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            />\n        </Example.Item>\n        <Example.Item title=\"native with option tags\">\n            <Select\n                name=\"animal\"\n                id=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "customRender",
+					"id": "components-select--custom-render",
+					"name": "custom rendering, name, id, option groups",
 					"snippet": "const customRender = () => (\n    <Example>\n        <Example.Item title=\"custom with options\">\n            <Select.Custom\n                name=\"animal\"\n                id=\"animal-1\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"native with option tags\">\n            <Select.Custom\n                name=\"animal-2\"\n                id=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Group label=\"Birds\">\n                    <Select.Option value=\"pigeon\">Pigeon</Select.Option>\n                    <Select.Option value=\"parrot\">Parrot</Select.Option>\n                </Select.Group>\n                <Select.Group label=\"Sea Mammals\">\n                    <Select.Option value=\"whale\">Whale</Select.Option>\n                    <Select.Option value=\"dolphin\">Dolphin</Select.Option>\n                </Select.Group>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "nativeHandlers",
+					"id": "components-select--native-handlers",
+					"name": "native, controlled, uncontrolled, onFocus, onBlur, onChange",
 					"snippet": "const nativeHandlers = () => <Example>\n    <Example.Item title=\"native, uncontrolled, onChange\">\n        <Select\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n    <Example.Item title=\"native, controlled, onChange\">\n        <Select\n            name=\"animal-2\"\n            placeholder=\"Select an animal\"\n            value=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n    <Example.Item title=\"native, onFocus, onBlur, onClick\">\n        <Select\n            name=\"animal-3\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onFocus={fn()}\n            onBlur={fn()}\n            onClick={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "customHandlers",
+					"id": "components-select--custom-handlers",
+					"name": "custom, controlled, uncontrolled, onFocus, onBlur, onChange",
 					"snippet": "const customHandlers = () => <Example>\n    <Example.Item title=\"custom, uncontrolled, onChange\">\n        <Select.Custom\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n    <Example.Item title=\"custom, controlled, onChange\">\n        <Select.Custom\n            name=\"animal-2\"\n            placeholder=\"Select an animal\"\n            value=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n    <Example.Item title=\"native, onFocus, onBlur, onClick\">\n        <Select.Custom\n            name=\"animal-3\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onFocus={fn()}\n            onBlur={fn()}\n            onClick={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "triggerOnly",
+					"id": "components-select--trigger-only",
+					"name": "trigger only, onClick",
 					"snippet": "const triggerOnly = (args) => {\n    const toggle = useToggle();\n    const [value, setValue] = React.useState(\"Dog\");\n\n    const handleClick: SelectProps[\"onClick\"] = (e) => {\n        args.handleClick(e);\n        toggle.toggle();\n    };\n\n    return (\n        <Example>\n            <Example.Item title=\"trigger only, onClick\">\n                <Select\n                    name=\"animal\"\n                    placeholder=\"Select an animal\"\n                    onClick={handleClick}\n                    value=\"dog\"\n                    inputAttributes={{\n                        \"aria-label\": \"Select an animal\",\n                    }}\n                >\n                    {value}\n                </Select>\n                <Modal\n                    active={toggle.active}\n                    onClose={toggle.deactivate}\n                    position=\"bottom\"\n                    padding={2}\n                    attributes={{ \"aria-label\": \"Select an animal\" }}\n                >\n                    <div role=\"listbox\" aria-label=\"Select an animal\">\n                        <MenuItem\n                            roundedCorners\n                            onClick={() => {\n                                setValue(\"Dog\");\n                                toggle.deactivate();\n                            }}\n                            attributes={{\n                                role: \"option\",\n                            }}\n                        >\n                            Dog\n                        </MenuItem>\n                        <MenuItem\n                            roundedCorners\n                            attributes={{\n                                role: \"option\",\n                            }}\n                            onClick={() => {\n                                setValue(\"Turtle\");\n                                toggle.deactivate();\n                            }}\n                        >\n                            Turtle\n                        </MenuItem>\n                    </div>\n                </Modal>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-select--multiple",
 					"name": "multiple",
 					"snippet": "const multiple = () => <Example>\n    <Example.Item title=\"multiple\">\n        <Select.Custom\n            multiple\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue={[\"dog\"]}\n            onChange={fn()}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-select--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded, native\">\n            <Select\n                variant=\"faded\"\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n\n        <Example.Item title=\"variant: faded, custom\">\n            <Select.Custom\n                variant=\"faded\"\n                name=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless, native\">\n            <Select\n                variant=\"headless\"\n                name=\"animal-3\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless, custom\">\n            <Select.Custom\n                variant=\"headless\"\n                name=\"animal-4\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <Select.Custom size=\"small\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <Select.Custom size=\"medium\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <Select.Custom size=\"large\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: xlarge\">\n            <Select.Custom size=\"xlarge\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "startSlot",
+					"id": "components-select--start-slot",
+					"name": "icon,startSlot",
 					"snippet": "const startSlot = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Select.Custom name=\"animal\" placeholder=\"Select an animal\" icon={IconZap}>\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n\n        <Example.Item title=\"startSlot\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                startSlot={<Placeholder h={20} />}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--render-value",
 					"name": "renderValue",
 					"snippet": "const renderValue = () => {\n    const options = [\n        {\n            value: \"1\",\n            label: \"Title 1\",\n            subtitle: \"Subtitle 1\",\n        },\n        {\n            value: \"2\",\n            label: \"Title 2\",\n            subtitle: \"Subtitle 2\",\n        },\n    ];\n\n    return (\n        <Example>\n            <Example.Item title=\"default renderer, single\">\n                <Select.Custom name=\"animal\" defaultValue=\"1\" placeholder=\"Nothing selected\">\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"default renderer, multiple\">\n                <Select.Custom name=\"animal\" defaultValue={[\"1\"]} multiple placeholder=\"Nothing selected\">\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"renderValue, single\">\n                <Select.Custom\n                    name=\"animal\"\n                    defaultValue=\"1\"\n                    placeholder=\"Nothing selected\"\n                    renderValue={(args) => <Badge>Title {args.value}</Badge>}\n                >\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"renderValue, multiple\">\n                <Select.Custom\n                    name=\"animal\"\n                    defaultValue={[\"1\"]}\n                    multiple\n                    placeholder=\"Nothing selected\"\n                    renderValue={(args) => <Badge>Titles {args.value.join(\", \")}</Badge>}\n                >\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-select--error",
 					"name": "error",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Select.Custom name=\"animal\" placeholder=\"Select an animal\" hasError>\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, native\">\n            <Select\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                disabled\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n        <Example.Item title=\"disabled, custom\">\n            <Select.Custom\n                name=\"animal-2\"\n                placeholder=\"Select an animal\"\n                disabled\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-select--class-name",
+					"name": "className, attributes, inputAttributes",
 					"snippet": "const className = () => (\n    <Example>\n        <Example.Item title=\"native, className, attributes, inputAttributes\">\n            <Select\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                className=\"native-class\"\n                attributes={{ id: \"test-id\" }}\n                inputAttributes={{ \"aria-label\": \"test-label\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n        <Example.Item title=\"custom, className, attributes, inputAttributes\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                className=\"custom-class\"\n                attributes={{ id: \"test-id\" }}\n                inputAttributes={{ \"aria-label\": \"test-label\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "fallback",
+					"id": "components-select--fallback",
+					"name": "test: fallbackAdjustLayout",
 					"snippet": "const fallback = () => (\n    <Example>\n        <Example.Item title=\"fallback\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                {[...Array(100)].map((_, index) => (\n                    <Select.Option key={index} value={`item-${index}`}>\n                        Item {index + 1}\n                    </Select.Option>\n                ))}\n            </Select.Custom>\n            <div style={{ height: \"1000px\" }}></div>\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                {[...Array(100)].map((_, index) => (\n                    <Select.Option key={index} value={`item-${index}`}>\n                        Item {index + 1}\n                    </Select.Option>\n                ))}\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-select--form-control",
+					"name": "test: with FormControl",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"FormControl\">\n            <FormControl hasError>\n                <FormControl.Label>Animal</FormControl.Label>\n                <Select.Custom name=\"animal\" placeholder=\"Select an animal\">\n                    <Select.Option value=\"dog\">Dog</Select.Option>\n                    <Select.Option value=\"turtle\">Turtle</Select.Option>\n                </Select.Custom>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "components-select--test-composition",
+					"name": "test: composition",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item title=\"custom with options\">\n            <Select.Custom\n                name=\"animal\"\n                id=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Group>\n                    <Select.Option value=\"dog\">Dog</Select.Option>\n                    <Select.Option value=\"turtle\">Turtle</Select.Option>\n                </Select.Group>\n                <Select.Group>Hello</Select.Group>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Badge, Example, FormControl, MenuItem, Modal, Placeholder, Select, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Select/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Select",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Select/Select.tsx",
-				"actualName": "Select",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the select user interaction and form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value selected",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon to display in the select start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the select value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when the trigger is clicked",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"options": {
+						"defaultValue": null,
+						"description": "@deprecated Use <option /> children instead",
+						"name": "options",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NativeOption[]" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the input is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLSelectElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the input is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLSelectElement, Element>) => void)" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"select\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"renderValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "renderValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "undefined" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLSelectElement>>" }
+					}
+				},
+				"exportName": "Select"
 			}
 		},
 		"components-skeleton": {
@@ -1565,26 +8543,87 @@
 			"path": "./src/components/Skeleton/tests/Skeleton.stories.tsx",
 			"stories": [
 				{
+					"id": "components-skeleton--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"text\">\n            <Skeleton />\n        </Example.Item>\n\n        <Example.Item title=\"view, rectangle\">\n            <Skeleton width=\"100px\" height=\"100px\" />\n        </Example.Item>\n\n        <Example.Item title=\"view, circle\">\n            <Skeleton width=\"100px\" height=\"100px\" borderRadius=\"circular\" />\n        </Example.Item>\n\n        <Example.Item title=\"view, rectangle, responsive\">\n            <Skeleton width={{ s: \"100px\", m: \"200px\" }} height={{ s: \"100px\", m: \"200px\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-skeleton--radius",
 					"name": "radius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius=small\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"small\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=medium\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"medium\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=large\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"large\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=circular\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"circular\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-skeleton--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Skeleton className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Skeleton } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Skeleton/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Skeleton",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Skeleton/Skeleton.tsx",
-				"actualName": "Skeleton",
+				"methods": [],
+				"props": {
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width style, literal string value or a base unit token number multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Radius>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Skeleton/Skeleton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Skeleton/Skeleton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1594,66 +8633,421 @@
 			"path": "./src/components/Slider/tests/Slider.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "components-slider--base",
+					"name": "name, minName, maxName, range",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"single, name\">\n            <Slider name=\"slider-single\" defaultValue={30} />\n        </Example.Item>\n        <Example.Item title=\"range, name\">\n            <Slider range name=\"slider-range\" defaultMinValue={30} defaultMaxValue={85} />\n        </Example.Item>\n        <Example.Item title=\"range, minName, maxName\">\n            <Slider\n                range\n                minName=\"slider-min\"\n                maxName=\"slider-max\"\n                defaultMinValue={30}\n                defaultMaxValue={85}\n            />\n        </Example.Item>\n        <div style={{ height: 2000 }} />\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--orientation",
 					"name": "orientation",
 					"snippet": "const orientation = () => (\n    <Example>\n        <Example.Item title=\"orientation: vertical\">\n            <View height=\"200px\">\n                <Slider\n                    range\n                    name=\"slider\"\n                    defaultMinValue={30}\n                    defaultMaxValue={85}\n                    orientation=\"vertical\"\n                />\n            </View>\n        </Example.Item>\n        <View height=\"2000px\" />\n    </Example>\n);"
 				},
 				{
-					"name": "minMax",
+					"id": "components-slider--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <Example>\n        <Example.Item title=\"min, max\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={60} />\n        </Example.Item>\n        <Example.Item title=\"min, max, value < min\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={30} />\n        </Example.Item>\n        <Example.Item title=\"min, max, value > max\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={80} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--step",
 					"name": "step",
 					"snippet": "const step = () => (\n    <Example>\n        <Example.Item title=\"step: 5\">\n            <Slider name=\"slider\" defaultValue={30} step={5} />\n        </Example.Item>\n\n        <Example.Item title=\"step: 5, defaultValue: 31, rounded down to 30\">\n            <Slider name=\"slider\" defaultValue={31} step={5} />\n        </Example.Item>\n\n        <Example.Item title=\"step: 0.01, float\">\n            <Slider name=\"slider\" defaultValue={30} step={0.01} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <Slider name=\"slider\" defaultValue={30} disabled />\n        </Example.Item>\n\n        <Example.Item title=\"disabled, range\">\n            <Slider name=\"slider\" range defaultMinValue={30} defaultMaxValue={80} disabled />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--render-value",
 					"name": "renderValue",
 					"snippet": "const renderValue = () => (\n    <Example>\n        <Example.Item title=\"renderValue: $\">\n            <Slider name=\"name\" defaultValue={50} renderValue={(args) => `$${args.value}`} />\n        </Example.Item>\n        <Example.Item title=\"renderValue: false\">\n            <Slider name=\"name\" defaultValue={50} renderValue={false} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-slider--default-value",
+					"name": "defaultValue, onChange, onChangeCommit",
 					"snippet": "const defaultValue = () => <View paddingTop={10}>\n    <Slider name=\"test-name\" defaultValue={50} onChange={fn()} onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "value",
+					"id": "components-slider--value",
+					"name": "value, onChange, onChangeCommit",
 					"snippet": "const value = () => <View paddingTop={10}>\n    <Slider name=\"test-name\" value={50} onChange={fn()} onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "rangeDefaultValue",
+					"id": "components-slider--range-default-value",
+					"name": "range, defaultValue, onChange, onChangeCommit",
 					"snippet": "const rangeDefaultValue = () => <View paddingTop={10}>\n    <Slider\n        range\n        name=\"test-name\"\n        defaultMinValue={50}\n        defaultMaxValue={70}\n        onChange={fn()}\n        onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "rangeValue",
+					"id": "components-slider--range-value",
+					"name": "range, value, onChange, onChangeCommit, minName, maxName",
 					"snippet": "const rangeValue = () => <View paddingTop={10}>\n    <Slider\n        range\n        minName=\"test-name-min\"\n        maxName=\"test-name-max\"\n        minValue={50}\n        maxValue={70}\n        onChange={fn()}\n        onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "className",
+					"id": "components-slider--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Slider name=\"name\" className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				},
 				{
-					"name": "testForm",
+					"id": "components-slider--test-form",
+					"name": "test: form onChange",
 					"snippet": "const testForm = (args) => {\n    const formRef = React.useRef<HTMLFormElement>(null);\n    const [data, setData] = React.useState<[string, FormDataEntryValue][]>([]);\n\n    const handleChange = (e: React.FormEvent<HTMLFormElement>) => {\n        const formData = new FormData(e.currentTarget);\n        const nextState = [...formData.entries()];\n\n        args.handleFormChange({ formData: nextState });\n        setData(nextState);\n    };\n\n    return (\n        <View paddingTop={10} gap={4}>\n            <form onChange={handleChange} ref={formRef}>\n                <Slider\n                    range\n                    minName=\"slider-min\"\n                    maxName=\"slider-max\"\n                    defaultMinValue={30}\n                    defaultMaxValue={50}\n                />\n            </form>\n\n            {data.map((v) => v.join(\": \")).join(\", \")}\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testSwipe",
+					"id": "components-slider--test-swipe",
+					"name": "test: prevents parent swipe",
 					"snippet": "const testSwipe = () => {\n    const toggle = useToggle(true);\n\n    return (\n        <Modal active={toggle.active} onClose={toggle.deactivate} position=\"end\">\n            <View gap={4}>\n                <Modal.Title>Modal</Modal.Title>\n                <Slider name=\"slider\" defaultValue={30} />\n            </View>\n        </Modal>\n    );\n};"
 				}
 			],
 			"import": "import { Example, Modal, Slider, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Slider/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Slider",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Slider/Slider.tsx",
-				"actualName": "Slider",
+				"methods": [],
+				"props": {
+					"step": {
+						"defaultValue": null,
+						"description": "Step of the slider",
+						"name": "step",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the slider user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum value of the slider",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum value of the slider",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"orientation": {
+						"defaultValue": null,
+						"description": "Orientation of the slider",
+						"name": "orientation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"vertical\" | \"horizontal\"",
+							"value": [{ "value": "\"vertical\"" }, { "value": "\"horizontal\"" }]
+						}
+					},
+					"renderValue": {
+						"defaultValue": null,
+						"description": "Render a custom value in the thumb tooltip",
+						"name": "renderValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | ((args: { value: number; }) => string)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the slider, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the slider, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"range": {
+						"defaultValue": null,
+						"description": "Enables range slider with two thumbs",
+						"name": "range",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the slider input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"minName": {
+						"defaultValue": null,
+						"description": "Name of the slider min value input element, overrides the name",
+						"name": "minName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"maxName": {
+						"defaultValue": null,
+						"description": "Name of the slider max value input element, overrides the name",
+						"name": "maxName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the slider value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: SingleChangeArgs) => void) | ((args: RangeChangeArgs) => void) | ((args: RangeChangeArgs) => void)"
+						}
+					},
+					"onChangeCommit": {
+						"defaultValue": null,
+						"description": "Callback when the user commits the change by releasing the thumb\nCallback when the user commits the change by releasing the thumbs",
+						"name": "onChangeCommit",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: SingleChangeArgs) => void) | ((args: RangeChangeArgs) => void) | ((args: RangeChangeArgs) => void)"
+						}
+					},
+					"minValue": {
+						"defaultValue": null,
+						"description": "Minimum value of the slider",
+						"name": "minValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"maxValue": {
+						"defaultValue": null,
+						"description": "Maximum value of the slider",
+						"name": "maxValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultMinValue": {
+						"defaultValue": null,
+						"description": "Default minimum value of the slider, enables uncontrolled mode",
+						"name": "defaultMinValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultMaxValue": {
+						"defaultValue": null,
+						"description": "Default maximum value of the slider, enables uncontrolled mode",
+						"name": "defaultMaxValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1663,35 +9057,137 @@
 			"path": "./src/components/Stepper/tests/Stepper.stories.tsx",
 			"stories": [
 				{
+					"id": "components-stepper--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example>\n        <Example.Item title=\"direction: row\">\n            <Stepper activeId=\"1\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <Stepper activeId=\"1\" direction=\"column\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-stepper--label-display",
 					"name": "labelDisplay",
 					"snippet": "const labelDisplay = () => (\n    <Example>\n        <Example.Item title=\"direction: row, labels hidden\">\n            <Stepper activeId=\"1\" labelDisplay=\"hidden\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: column, labels hiden\">\n            <Stepper activeId=\"1\" direction=\"column\" labelDisplay=\"hidden\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: row, labels hidden on s\">\n            <Stepper activeId=\"1\" labelDisplay={{ s: \"hidden\", m: \"inline\" }}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-stepper--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 6, direction: row\">\n            <Stepper activeId=\"1\" gap={6}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"gap: 6, direction: column\">\n            <Stepper activeId=\"1\" direction=\"column\" gap={6}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap\", \"[s] 2\", \"[m+] 5\"]}>\n            <Stepper activeId=\"1\" gap={{ s: 2, m: 5 }}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-stepper--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Stepper className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Stepper.Item attributes={{ id: \"test-item-id\" }} className=\"test-item-classname\" />\n        </Stepper>\n    </div>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-stepper--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"multiline subtitle\",\n                \"should wrap the text correctly\",\n                \"should display the connector correctly\",\n            ]}\n        >\n            <Demo\n                activeId={0}\n                subtitle=\"It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, Placeholder, Stepper, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Stepper/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Stepper",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Stepper/Stepper.tsx",
-				"actualName": "Stepper",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"activeId": {
+						"defaultValue": null,
+						"description": "Id of the item to display as active",
+						"name": "activeId",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string | number" }
+					},
+					"labelDisplay": {
+						"defaultValue": null,
+						"description": "Display variant for the item label",
+						"name": "labelDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"hidden\" | \"inline\">" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Direction of the stepper",
+						"name": "direction",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between items (default: 3)",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
+				"exportName": "Stepper"
 			}
 		},
 		"components-switch": {
@@ -1700,38 +9196,236 @@
 			"path": "./src/components/Switch/tests/Switch.stories.tsx",
 			"stories": [
 				{
-					"name": "size",
+					"id": "components-switch--size",
+					"name": "Size",
 					"snippet": "const size = () => (\n\t<Example>\n\t\t<Example.Item title=\"size: medium\">\n\t\t\t<Switch name=\"active\" size=\"medium\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: small\">\n\t\t\t<Switch name=\"active\" size=\"small\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: large\">\n\t\t\t<Switch name=\"active\" size=\"large\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: responsive, s: small, m: large\">\n\t\t\t<Switch\n\t\t\t\tname=\"active\"\n\t\t\t\tsize={{ s: \"small\", m: \"large\" }}\n\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t/>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "label",
+					"id": "components-switch--label",
+					"name": "Label",
 					"snippet": "const label = () => (\n\t<Example>\n\t\t<Example.Item title=\"size: medium\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch reversed name=\"active\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: small\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" size=\"small\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch\n\t\t\t\t\treversed\n\t\t\t\t\tname=\"active\"\n\t\t\t\t\tsize=\"small\"\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t\t>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\n\t\t<Example.Item title=\"size: large\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" size=\"large\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch\n\t\t\t\t\treversed\n\t\t\t\t\tname=\"active\"\n\t\t\t\t\tsize=\"large\"\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t\t>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-switch--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Switch name=\"test-name\" defaultChecked onChange={fn()}>Label\n            </Switch>;"
 				},
 				{
-					"name": "checked",
+					"id": "components-switch--checked",
+					"name": "checked, uncontrolled",
 					"snippet": "const checked = () => <Switch name=\"test-name\" checked onChange={fn()}>Label\n            </Switch>;"
 				},
 				{
+					"id": "components-switch--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, unselected\">\n            <Switch name=\"active\" disabled inputAttributes={{ \"aria-label\": \"test switch\" }} />\n        </Example.Item>\n        <Example.Item title=\"disabled, selected\">\n            <Switch\n                name=\"active\"\n                disabled\n                defaultChecked\n                inputAttributes={{ \"aria-label\": \"test switch\" }}\n            />\n        </Example.Item>\n        <Example.Item title=\"disabled, with label\">\n            <Switch name=\"active\" disabled>\n                Switch\n            </Switch>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-switch--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Switch\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ \"aria-label\": \"test select\", id: \"test-input-id\" }}\n            name=\"name\"\n        >\n            Label\n        </Switch>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Switch, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Switch/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Switch",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Switch/Switch.tsx",
-				"actualName": "Switch",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the switch",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the switch input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the switch user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"reversed": {
+						"defaultValue": null,
+						"description": "Reverse the children position",
+						"name": "reversed",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the switch value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the switch is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the switch is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default value of the switch, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Value of the switch, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1741,51 +9435,112 @@
 			"path": "./src/components/Table/tests/Table.stories.tsx",
 			"stories": [
 				{
-					"name": "layout",
+					"id": "components-table--layout",
+					"name": "base",
 					"snippet": "const layout = () => (\n    <Example>\n        <Example.Item title=\"base\">\n            <Table>\n                <Table.Head>\n                    <Table.Row>\n                        <Table.Heading>Column 1</Table.Heading>\n                        <Table.Heading>Column 2</Table.Heading>\n                    </Table.Row>\n                </Table.Head>\n                <Table.Body>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell>Cell 2</Table.Cell>\n                    </Table.Row>\n                </Table.Body>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"colspan: 2 for col 2, rowspan: 2 for cell 3\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading colSpan={2}>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                    <Table.Cell rowSpan={2}>Cell 3</Table.Cell>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"align: center for heading 1, align: end for heading 2\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading align=\"center\">Column 1</Table.Heading>\n                    <Table.Heading align=\"end\">Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"valign: center for cell 2, valign: end for cell 3\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>\n                        <View height={15} backgroundColor=\"neutral-faded\" />\n                    </Table.Cell>\n                    <Table.Cell verticalAlign=\"center\">Cell 2</Table.Cell>\n                    <Table.Cell verticalAlign=\"end\">Cell 3</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"width: 40%, minWidth: 200px for col 1\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"40%\" minWidth=\"200px\">\n                        Column 1\n                    </Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-table--border",
 					"name": "border",
 					"snippet": "const border = () => (\n    <Example>\n        <Example.Item title=\"border: true\">\n            <Table border>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"columnBorder: true\">\n            <Table columnBorder>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"columnBorder: true, border: true\">\n            <Table columnBorder border>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-table--rows",
 					"name": "rows",
 					"snippet": "const rows = () => (\n    <Example>\n        <Example.Item title=\"highlighted for row 2\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row highlighted>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"clickable row 2, focus ring\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row onClick={() => {}}>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-table--render",
+					"name": "rendering",
 					"snippet": "const render = () => (\n    <Table>\n        <Table.Head>\n            <Table.Row>\n                <Table.Heading>Heading</Table.Heading>\n                <Table.Heading>Heading</Table.Heading>\n            </Table.Row>\n        </Table.Head>\n        <Table.Body>\n            <Table.Row>\n                <Table.Cell>Content</Table.Cell>\n                <Table.Cell>Content</Table.Cell>\n            </Table.Row>\n        </Table.Body>\n    </Table>\n);"
 				},
 				{
-					"name": "tbody",
+					"id": "components-table--tbody",
+					"name": "tbody rendering",
 					"snippet": "const tbody = () => (\n    <Table>\n        <Table.Row>\n            <Table.Heading>Heading</Table.Heading>\n            <Table.Heading>Heading</Table.Heading>\n        </Table.Row>\n    </Table>\n);"
 				},
 				{
-					"name": "tabIndex",
+					"id": "components-table--tab-index",
+					"name": "adds tabIndex for clickable rows",
 					"snippet": "const tabIndex = () => (\n    <Table>\n        <Table.Row>\n            <Table.Cell />\n        </Table.Row>\n        <Table.Row onClick={() => {}}>\n            <Table.Cell />\n        </Table.Row>\n        <Table.Row attributes={{ onClick: () => {} }}>\n            <Table.Cell />\n        </Table.Row>\n    </Table>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-table--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Table className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Table.Row attributes={{ id: \"test-row-id\" }}>\n                <Table.Cell attributes={{ id: \"test-cell-id\" }}></Table.Cell>\n            </Table.Row>\n        </Table>\n    </div>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-table--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"scroll fade\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"500px\">Column 1</Table.Heading>\n                    <Table.Heading width=\"500px\">Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"card with highlighted heading\">\n            <Card elevated padding={0}>\n                <Table>\n                    <Table.Row highlighted>\n                        <Table.Heading width=\"50%\" minWidth=\"200px\">\n                            Column 1\n                        </Table.Heading>\n                        <Table.Heading colSpan={2} align=\"end\">\n                            Column 2\n                        </Table.Heading>\n                    </Table.Row>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell align=\"center\">Cell 2</Table.Cell>\n                        <Table.Cell align=\"end\">Cell 3</Table.Cell>\n                    </Table.Row>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell align=\"center\">Cell 2</Table.Cell>\n                        <Table.Cell align=\"end\">Cell 3</Table.Cell>\n                    </Table.Row>\n                </Table>\n            </Card>\n        </Example.Item>\n        <Example.Item title=\"width: auto, nowrap\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"50%\">Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                    <Table.Heading>Column 3</Table.Heading>\n                    <Table.Heading width=\"auto\">Long heading title</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                    <Table.Cell>Cell 3</Table.Cell>\n                    <Table.Cell>Cell 4</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "examples",
+					"id": "components-table--examples",
+					"name": "test: selectable",
 					"snippet": "const examples = () => (\n    <Example>\n        <Example.Item title=\"selectable\">\n            <SelectionDemo />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Card, Checkbox, Example, Table, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Table/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Table",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Table/Table.tsx",
-				"actualName": "Table",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"border": {
+						"defaultValue": null,
+						"description": "Add border around the table",
+						"name": "border",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"columnBorder": {
+						"defaultValue": null,
+						"description": "Add border between the table columns",
+						"name": "columnBorder",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
+				"exportName": "Table"
 			}
 		},
 		"components-tabs": {
@@ -1794,71 +9549,196 @@
 			"path": "./src/components/Tabs/tests/Tabs.stories.tsx",
 			"stories": [
 				{
+					"id": "components-tabs--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Tabs>\n        <Tabs.List>\n            <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n            <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n        </Tabs.List>\n\n        <Tabs.Panel value=\"1\">\n            <View padding={4}>Content 1</View>\n        </Tabs.Panel>\n        <Tabs.Panel value=\"2\">\n            <View padding={4}>Content 2</View>\n        </Tabs.Panel>\n    </Tabs>\n);"
 				},
 				{
+					"id": "components-tabs--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Tabs defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills\">\n            <Tabs variant=\"pills\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills-elevated\">\n            <Tabs variant=\"pills-elevated\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: borderless\">\n            <Tabs variant=\"borderless\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"variant: default, size: large\">\n            <Tabs size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills, size: large\">\n            <Tabs variant=\"pills\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills-elevated, size: large\">\n            <Tabs variant=\"pills-elevated\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: borderless, size: large\">\n            <Tabs variant=\"borderless\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example>\n        <Example.Item title=\"direction: column, variant: underline\">\n            <Tabs direction=\"column\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: pills\">\n            <Tabs direction=\"column\" variant=\"pills\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: pills-elevated\">\n            <Tabs direction=\"column\" variant=\"pills-elevated\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: borderless\">\n            <Tabs direction=\"column\" variant=\"borderless\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Tabs>\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"1\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"icon only\">\n            <Tabs variant=\"pills-elevated\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap} attributes={{ \"aria-label\": \"Tab 1\" }} />\n                    <Tabs.Item value=\"1\" icon={IconZap} attributes={{ \"aria-label\": \"Tab 2\" }} />\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "equalWidth",
+					"id": "components-tabs--equal-width",
+					"name": "itemWidth",
 					"snippet": "const equalWidth = () => (\n    <Example>\n        <Example.Item title=\"equal width items\">\n            <Tabs onChange={console.log} itemWidth=\"equal\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"1\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                    <Tabs.Item value=\"2\" icon={IconZap}>\n                        Very long item 3\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--href",
 					"name": "href",
 					"snippet": "const href = () => (\n    <Example>\n        <Example.Item title=\"href, no onChange\">\n            <Tabs value=\"2\">\n                <Tabs.List>\n                    <Tabs.Item value=\"1\" href=\"#item-1\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"2\" href=\"#item-2\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                    <Tabs.Item value=\"3\" href=\"#item-3\" icon={IconZap}>\n                        Very long item 3\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "disabled",
+					"id": "components-tabs--disabled",
+					"name": "item, disabled",
 					"snippet": "const disabled = () => {\n    return (\n        <Example>\n            <Example.Item title=\"disabled\">\n                <Tabs defaultValue=\"1\">\n                    <Tabs.List>\n                        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"2\" disabled icon={IconZap}>\n                            Item 2\n                        </Tabs.Item>\n                        <Tabs.Item value=\"3\">Item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"1\">\n                        <View padding={4}>Content 1</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <View padding={4}>Content 2</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"3\">\n                        <View padding={4}>Content 3</View>\n                    </Tabs.Panel>\n                </Tabs>\n            </Example.Item>\n\n            <Example.Item title=\"disabled, href\">\n                <Tabs defaultValue=\"1\">\n                    <Tabs.List>\n                        <Tabs.Item href=\"#item1\" value=\"1\">\n                            Item 1\n                        </Tabs.Item>\n                        <Tabs.Item href=\"#item2\" value=\"2\" disabled icon={IconZap}>\n                            Item 2\n                        </Tabs.Item>\n                        <Tabs.Item href=\"#item3\" value=\"3\">\n                            Item 3\n                        </Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"1\">\n                        <View padding={4}>Content 1</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <View padding={4}>Content 2</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"3\">\n                        <View padding={4}>Content 3</View>\n                    </Tabs.Panel>\n                </Tabs>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-tabs--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <Tabs defaultValue=\"2\" onChange={fn()}>\n    <Tabs.List>\n        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n        <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n    </Tabs.List>\n    <Tabs.Panel value=\"1\">Content 1</Tabs.Panel>\n    <Tabs.Panel value=\"2\">Content 2</Tabs.Panel>\n</Tabs>;"
 				},
 				{
-					"name": "value",
+					"id": "components-tabs--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <Tabs value=\"2\" onChange={fn()}>\n    <Tabs.List>\n        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n        <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n    </Tabs.List>\n    <Tabs.Panel value=\"1\">Content 1</Tabs.Panel>\n    <Tabs.Panel value=\"2\">Content 2</Tabs.Panel>\n</Tabs>;"
 				},
 				{
-					"name": "className",
+					"id": "components-tabs--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Tabs>\n            <Tabs.List attributes={{ id: \"test-list-id\" }} className=\"test-list-classname\">\n                <Tabs.Item attributes={{ id: \"test-item-id\" }} value=\"1\">\n                    Item\n                </Tabs.Item>\n            </Tabs.List>\n\n            <Tabs.Panel\n                attributes={{ \"data-testid\": \"test-panel-id\" }}\n                className=\"test-panel-classname\"\n                value=\"1\"\n            />\n        </Tabs>\n    </div>\n);"
 				},
 				{
-					"name": "testFocusableContent",
+					"id": "components-tabs--test-focusable-content",
+					"name": "test: focusable content",
 					"snippet": "const testFocusableContent = () => (\n    <Example>\n        <Example.Item title=\"panels without focusable content\">\n            <Tabs>\n                <View gap={4}>\n                    <Tabs.List>\n                        <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                        <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"0\">Tab 1</Tabs.Panel>\n                    <Tabs.Panel value=\"1\">Tab 2</Tabs.Panel>\n                    <Tabs.Panel value=\"2\">Tab 3</Tabs.Panel>\n                </View>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"panels with focusable content\">\n            <Tabs>\n                <View gap={4}>\n                    <Tabs.List>\n                        <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                        <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"0\">\n                        <Button onClick={() => {}}>Tab 1 action</Button>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"1\">\n                        <Button onClick={() => {}}>Tab 2 action</Button>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <Button onClick={() => {}}>Tab 3 action</Button>\n                    </Tabs.Panel>\n                </View>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "components-tabs--test-composition",
+					"name": "test: composition",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item title=\"Viewport overflow\">\n            <Tabs>\n                <Tabs.List>\n                    {[...Array(8)].map((_, i) => (\n                        <Tabs.Item value={`${i}`} key={i} icon={IconZap}>\n                            Very long item {i}\n                        </Tabs.Item>\n                    ))}\n                </Tabs.List>\n\n                {[...Array(8)].map((_, i) => (\n                    <Tabs.Panel value={`${i}`} key={i}>\n                        Tab {i}\n                    </Tabs.Panel>\n                ))}\n            </Tabs>\n        </Example.Item>\n        <Example.Item>\n            <Tabs onChange={console.log} variant=\"pills-elevated\" name=\"hey\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">\n                        <View borderColor=\"neutral-faded\" padding={5}>\n                            Item 3\n                        </View>\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"Custom non-interactive list children\">\n            <Tabs direction=\"column\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <View height={6} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testEdgeCaseDom",
+					"id": "components-tabs--test-edge-case-dom",
+					"name": "test: scroll subscription",
 					"snippet": "const testEdgeCaseDom = () => {\n    const [activeItem, setActiveItem] = React.useState(\"1\");\n    const sectionsRef = React.useRef(null);\n\n    return (\n        <Example>\n            <Example.Item title=\"active item changes on scroll\">\n                <View justify=\"center\" align=\"center\" padding={10}>\n                    <View width={60} gap={2}>\n                        <Tabs value={activeItem} onChange={(args) => setActiveItem(args.value)}>\n                            <Tabs.List>\n                                <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                                <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n                                <Tabs.Item value=\"3\">Item 3</Tabs.Item>\n                                <Tabs.Item value=\"4\">Item 4</Tabs.Item>\n                            </Tabs.List>\n                        </Tabs>\n\n                        <ScrollArea\n                            attributes={{ ref: sectionsRef }}\n                            height={70}\n                            onScroll={(args) => {\n                                setActiveItem(Math.min(4, Math.floor(args.y * 10) + 1).toString());\n                            }}\n                        >\n                            <View gap={4}>\n                                <View gap={2}>\n                                    <Text>Section 1</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View grow height=\"100px\" backgroundColor=\"neutral-faded\" key={i} />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 2</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 3</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 4</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n                            </View>\n                        </ScrollArea>\n                    </View>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Example, ScrollArea, Tabs, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Tabs/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Tabs",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Tabs/Tabs.tsx",
-				"actualName": "Tabs",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Direction of the tab buttons",
+						"name": "direction",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"itemWidth": {
+						"defaultValue": null,
+						"description": "Equal width for the tab buttons",
+						"name": "itemWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"equal\"", "value": [{ "value": "\"equal\"" }] }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Render variant for component",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"bordered\" | \"borderless\" | \"pills\" | \"pills-elevated\"",
+							"value": [
+								{ "value": "\"bordered\"" },
+								{ "value": "\"borderless\"" },
+								{ "value": "\"pills\"" },
+								{ "value": "\"pills-elevated\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"large\" | \"medium\"",
+							"value": [{ "value": "\"large\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the tab buttons group when used as a form control",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the active tab value changes",
+						"name": "onChange",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((args: { value: string; name?: string; }) => void)" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the active tab, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the active tab, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "Tabs"
 			}
 		},
 		"components-textarea": {
@@ -1867,71 +9747,315 @@
 			"path": "./src/components/TextArea/tests/TextArea.stories.tsx",
 			"stories": [
 				{
-					"name": "variants",
+					"id": "components-textarea--variants",
+					"name": "variant",
 					"snippet": "const variants = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <TextArea variant=\"faded\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless\">\n            <TextArea variant=\"headless\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: medium\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"medium\" />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"large\" />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"xlarge\" />\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] large\", \"[m+] medium\"]}>\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size={{ s: \"xlarge\", m: \"medium\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--resize",
 					"name": "resize",
 					"snippet": "const resize = () => (\n    <Example>\n        <Example.Item title=\"resize: none\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" resize=\"none\" />\n        </Example.Item>\n        <Example.Item title=\"resize: auto\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" resize=\"auto\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-textarea--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" hasError />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner\">\n            <View gap={2}>\n                <Text variant=\"featured-2\">What problem are you trying to solve?</Text>\n                <TextArea.Aligner>\n                    <TextArea\n                        variant=\"headless\"\n                        placeholder=\"Try something like 'I have a job'\"\n                        name=\"description\"\n                    />\n                </TextArea.Aligner>\n                <View.Item>\n                    <Button>Next</Button>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-textarea--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"long value without breaks\">\n            <TextArea\n                name=\"hey\"\n                defaultValue={`<div style=\"position:relative;width:100%;padding-top:calc(150% + 72px)\">\n<iframe src=\"nskjdfdsdkjfsjkdfhbsjlhdfbsjlhfbs;jhbsdljfhsbljhfsbljhfbsjlfdhbsljhfbsdljhfbsljhfbslufbhsdlfds\" />\n</div>`}\n                resize=\"auto\"\n                placeholder=\"Placeholder\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-textarea--render",
+					"name": "base",
 					"snippet": "const render = () => <TextArea name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-textarea--placeholder",
 					"name": "placeholder",
 					"snippet": "const placeholder = () => (\n    <TextArea\n        name=\"test-name\"\n        placeholder=\"Placeholder\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-textarea--id",
 					"name": "id",
 					"snippet": "const id = () => (\n    <TextArea name=\"test-name\" id=\"test-id\" inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
+					"id": "components-textarea--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <TextArea name=\"test-name\" disabled inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-textarea--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <TextArea\n    name=\"test-name\"\n    defaultValue=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-textarea--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <TextArea\n    name=\"test-name\"\n    value=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-textarea--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <TextArea\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-textarea--form-control",
+					"name": "test: form control",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"with helper\">\n            <FormControl>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextArea name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n        <Example.Item title=\"with error\">\n            <FormControl hasError>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextArea name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, FormControl, Text, TextArea, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/TextArea/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "TextArea",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/TextArea/TextArea.tsx",
-				"actualName": "TextArea",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text area",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text area input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text area user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text area value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLTextAreaElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text area is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLTextAreaElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text area is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLTextAreaElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"textarea\">" }
+					},
+					"resize": {
+						"defaultValue": null,
+						"description": "Enable or disable the text area resizing, supports auto-sizing",
+						"name": "resize",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"none\" | \"auto\"",
+							"value": [{ "value": "\"none\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "TextArea"
 			}
 		},
 		"components-textfield": {
@@ -1940,71 +10064,445 @@
 			"path": "./src/components/TextField/tests/TextField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-textfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <TextField variant=\"faded\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless\">\n            <TextField variant=\"headless\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded\">\n            <TextField\n                rounded\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                icon={IconZap}\n                prefix=\"+31\"\n                endSlot={<Button rounded size=\"small\" icon={IconZap} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"rounded, variant: faded\">\n            <View direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <TextField\n                        rounded\n                        variant=\"faded\"\n                        name=\"Name\"\n                        placeholder=\"Enter your name\"\n                        startSlot={\n                            <Badge rounded size=\"small\">\n                                Hello\n                            </Badge>\n                        }\n                    />\n                </View.Item>\n                <Button rounded>Submit</Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-textfield--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" hasError />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "attachments",
+					"id": "components-textfield--attachments",
+					"name": "icon, endIcon, suffix, prefix, startSlot, endSlot, startSlotPadding, endSlotPadding",
 					"snippet": "const attachments = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" value=\"Reshaped\" icon={IconZap} />\n        </Example.Item>\n        <Example.Item title=\"endIcon\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" value=\"Reshaped\" endIcon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title={[\"startSlot\", \"vertical and horizontal padding aligned\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title={[\"endSlot\", \"vertical and horizontal padding aligned\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                endSlot={\n                    <Button\n                        icon={IconZap}\n                        size=\"small\"\n                        onClick={() => {}}\n                        attributes={{ \"aria-label\": \"Action\" }}\n                    />\n                }\n            />\n        </Example.Item>\n\n        <Example.Item title=\"paddingSlotStart=4, paddingSlotEnd=2\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlotPadding={4}\n                endSlotPadding={2}\n                startSlot={<Placeholder h={20} />}\n                endSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"with all affixes\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                endIcon={IconZap}\n                icon={IconZap}\n                prefix=\"Estimated value\"\n                suffix=\"m2\"\n                startSlot={<Placeholder h={20} />}\n                endSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"multiline wrap\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlot={[...Array(10).keys()].map((i) => (\n                    <Badge size=\"small\" key={i}>\n                        Item {i + 1}\n                    </Badge>\n                ))}\n                multiline\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"small\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"medium\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"large\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"xlarge\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] xlarge\", \"[m+] medium\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                size={{ s: \"xlarge\", m: \"medium\" }}\n                icon={IconZap}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner\">\n            <View gap={2}>\n                <Text variant=\"featured-2\">What problem are you trying to solve?</Text>\n                <TextField.Aligner>\n                    <TextField\n                        variant=\"headless\"\n                        placeholder=\"Try something like 'I have a job'\"\n                        name=\"description\"\n                    />\n                </TextField.Aligner>\n                <View.Item>\n                    <Button>Next</Button>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-textfield--render",
+					"name": "base",
 					"snippet": "const render = () => <TextField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-textfield--placeholder",
 					"name": "placeholder",
 					"snippet": "const placeholder = () => (\n    <TextField\n        name=\"test-name\"\n        placeholder=\"Placeholder\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-textfield--id",
 					"name": "id",
 					"snippet": "const id = () => (\n    <TextField name=\"test-name\" id=\"test-id\" inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
+					"id": "components-textfield--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <TextField name=\"test-name\" disabled inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-textfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <TextField\n    name=\"test-name\"\n    defaultValue=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-textfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <TextField\n    name=\"test-name\"\n    value=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-textfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <TextField\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-textfield--form-control",
+					"name": "test: form control",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"with helper\">\n            <FormControl>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextField name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n        <Example.Item title=\"with error\">\n            <FormControl hasError>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextField name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Badge, Button, Example, FormControl, Placeholder, Text, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/TextField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "TextField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/TextField/TextField.tsx",
-				"actualName": "TextField",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"multiline": {
+						"defaultValue": null,
+						"description": "Enable multiline text field wrapping",
+						"name": "multiline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to be fully rounded",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content after the text field value",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text field value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the text field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the text field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "TextField"
 			}
 		},
 		"components-timeline": {
@@ -2013,27 +10511,71 @@
 			"path": "./src/components/Timeline/tests/Timeline.stories.tsx",
 			"stories": [
 				{
+					"id": "components-timeline--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"children passed directly\">\n            <Timeline>\n                <Placeholder />\n                <Placeholder />\n                <Placeholder />\n            </Timeline>\n        </Example.Item>\n        <Example.Item title=\"children wrapped with Timeline.Item\">\n            <Timeline>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "marker",
+					"id": "components-timeline--marker",
+					"name": "markerSlot",
 					"snippet": "const marker = () => (\n    <Example>\n        <Example.Item title=\"slot\">\n            <Timeline>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n\n        <Example.Item title=\"null marker\">\n            <Timeline>\n                <Timeline.Item markerSlot={null}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={null}>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-timeline--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Timeline className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Timeline.Item className=\"test-item-classname\" attributes={{ id: \"test-item-id\" }}>\n                Content\n            </Timeline.Item>\n            <Timeline.Item>Content</Timeline.Item>\n        </Timeline>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Placeholder, Timeline } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Timeline/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Timeline",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Timeline/Timeline.tsx",
-				"actualName": "Timeline",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"ul\">" }
+					}
+				},
+				"exportName": "Timeline"
 			}
 		},
 		"components-toast": {
@@ -2041,32 +10583,54 @@
 			"name": "Toast",
 			"path": "./src/components/Toast/tests/Toast.stories.tsx",
 			"stories": [
-				{ "name": "size", "snippet": "const size = () => <Size />;" },
 				{
+					"id": "components-toast--size",
+					"name": "size",
+					"snippet": "const size = () => <Size />;"
+				},
+				{
+					"id": "components-toast--position",
 					"name": "position",
 					"snippet": "const position = () => <Position />;"
 				},
-				{ "name": "color", "snippet": "const color = () => <Color />;" },
-				{ "name": "timeout", "snippet": "const timeout = () => <Timeout />;" },
 				{
-					"name": "regionOptions",
+					"id": "components-toast--color",
+					"name": "color",
+					"snippet": "const color = () => <Color />;"
+				},
+				{
+					"id": "components-toast--timeout",
+					"name": "timeout",
+					"snippet": "const timeout = () => <Timeout />;"
+				},
+				{
+					"id": "components-toast--region-options",
+					"name": "expanded",
 					"snippet": "const regionOptions = () => <Expanded />;"
 				},
-				{ "name": "slots", "snippet": "const slots = () => <Slots />;" },
 				{
+					"id": "components-toast--slots",
+					"name": "slots",
+					"snippet": "const slots = () => <Slots />;"
+				},
+				{
+					"id": "components-toast--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const toast = useToast();\n\n    return (\n        <Button\n            onClick={() => {\n                const id = toast.show({\n                    title: \"Title\",\n                    text: \"Text\",\n                    children: \"Children\",\n                    startSlot: \"Slot\",\n                    actionsSlot: (\n                        <Button attributes={{ \"data-testid\": \"trigger-id\" }} onClick={() => toast.hide(id)}>\n                            Trigger\n                        </Button>\n                    ),\n                });\n            }}\n        >\n            Show toast\n        </Button>\n    );\n};"
 				},
 				{
-					"name": "nested",
+					"id": "components-toast--nested",
+					"name": "ToastProvider",
 					"snippet": "const nested = () => {\n    return (\n        <div data-testid=\"test-container-id\">\n            <ToastProvider>\n                <NestedDemo />\n            </ToastProvider>\n        </div>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-toast--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => {\n    const toast = useToast();\n\n    return (\n        <Button\n            onClick={() => {\n                const id = toast.show({\n                    text: \"Content\",\n                    attributes: { \"data-testid\": \"test-id\" },\n                    className: \"test-classname\",\n                });\n            }}\n        >\n            Show toast\n        </Button>\n    );\n};"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-toast--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"Multiline, should support dynamic height\">\n            <Multiline />\n        </Example.Item>\n        <Example.Item title=\"Nested ToastProvider\">\n            <ToastProvider>\n                <Nested />\n            </ToastProvider>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
@@ -2083,30 +10647,601 @@
 			"path": "./src/components/ToggleButton/tests/ToggleButton.stories.tsx",
 			"stories": [
 				{
+					"id": "components-togglebutton--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"outline\">\n            <ToggleButton>Button</ToggleButton>\n        </Example.Item>\n        <Example.Item title=\"ghost\">\n            <ToggleButton variant=\"ghost\">Button</ToggleButton>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-togglebutton--selected-color",
 					"name": "selectedColor",
 					"snippet": "const selectedColor = () => (\n    <Example>\n        <Example.Item title=\"selectedColor: primary\">\n            <ToggleButton selectedColor=\"primary\" defaultChecked>\n                Button\n            </ToggleButton>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onChange",
+					"id": "components-togglebutton--on-change",
+					"name": "checked, defaultChecked, onChange",
 					"snippet": "const onChange = () => <Example>\n    <Example.Item title=\"defaultChecked, onChange\">\n        <ToggleButton defaultChecked onChange={fn()} value=\"1\">Button\n                                </ToggleButton>\n    </Example.Item>\n    <Example.Item title=\"checked, onChange\">\n        <ToggleButton checked onChange={fn()} value=\"2\">Button\n                                </ToggleButton>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-togglebutton--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <ToggleButton onClick={fn()}>Button</ToggleButton>;"
 				}
 			],
 			"import": "import { Example, ToggleButton } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ToggleButton/ToggleButton.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "ToggleButton",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ToggleButton/ToggleButton.tsx",
-				"actualName": "ToggleButton",
+				"methods": [],
+				"props": {
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loading": {
+						"defaultValue": null,
+						"description": "Show loading state",
+						"name": "loading",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loadingAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the loading indicator",
+						"name": "loadingAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Make the component take the full width of the parent element",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"ghost\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"ghost\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"selectedColor": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme when selected",
+						"name": "selectedColor",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the toggle button, enables controlled mode for the ToggleButtonGroup",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the toggle button value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { checked: boolean; value: string; event: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>; }) => void)"
+						}
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default value of the toggle button, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Value of the toggle button, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2116,34 +11251,194 @@
 			"path": "./src/components/ToggleButtonGroup/tests/ToggleButtonGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "single",
+					"id": "components-togglebuttongroup--single",
+					"name": "checked, defaultChecked, onChange",
 					"snippet": "const single = () => <Example>\n    <Example.Item title=\"single, uncontrolled, onChange\">\n        <ToggleButtonGroup onChange={fn()}>\n            <ToggleButton value=\"1\" onChange={fn()}>Button\n                                    </ToggleButton>\n            <ToggleButton value=\"2\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n    <Example.Item title=\"single, controlled, onChange\">\n        <ToggleButtonGroup onChange={fn()} value={[]}>\n            <ToggleButton value=\"3\" onChange={fn()}>Button\n                                    </ToggleButton>\n            <ToggleButton value=\"4\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "multiple",
+					"id": "components-togglebuttongroup--multiple",
+					"name": "selectionMode, checked, defaultChecked, onChange",
 					"snippet": "const multiple = () => <Example>\n    <Example.Item title=\"multiple, uncontrolled, onChange\">\n        <ToggleButtonGroup onChange={fn()} selectionMode=\"multiple\">\n            <ToggleButton value=\"1\">Button</ToggleButton>\n            <ToggleButton value=\"2\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n    <Example.Item title=\"multiple, controlled, onChange\">\n        <ToggleButtonGroup onChange={fn()} value={[]} selectionMode=\"multiple\">\n            <ToggleButton value=\"3\">Button</ToggleButton>\n            <ToggleButton value=\"4\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "selectedColor",
+					"id": "components-togglebuttongroup--selected-color",
+					"name": "color,selectedColor",
 					"snippet": "const selectedColor = () => (\n    <Example>\n        <Example.Item title=\"selectedColor: primary\">\n            <ToggleButtonGroup selectedColor=\"primary\" defaultValue={[\"2\"]}>\n                <ToggleButton value=\"1\">Button</ToggleButton>\n                <ToggleButton value=\"2\">Button</ToggleButton>\n                <ToggleButton value=\"3\">Button</ToggleButton>\n            </ToggleButtonGroup>\n        </Example.Item>\n        <Example.Item title=\"color: primary, selectedColor: critical\">\n            <ToggleButtonGroup color=\"primary\" selectedColor=\"critical\" defaultValue={[\"2\"]}>\n                <ToggleButton value=\"1\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n                <ToggleButton value=\"2\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n                <ToggleButton value=\"3\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n            </ToggleButtonGroup>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-togglebuttongroup--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ToggleButtonGroup className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <ToggleButton>Button 1</ToggleButton>\n            <ToggleButton>Button 1</ToggleButton>\n        </ToggleButtonGroup>\n    </div>\n);"
 				},
 				{
-					"name": "testIcon",
+					"id": "components-togglebuttongroup--test-icon",
+					"name": "test: icon only",
 					"snippet": "const testIcon = () => (\n    <Example>\n        <Example.Item title=\"icon only\">\n            <ToggleButtonGroup selectedColor=\"primary\">\n                <ToggleButton value=\"1\" icon={IconPlus} />\n                <ToggleButton value=\"2\" icon={IconMinus} />\n                <ToggleButton value=\"3\" icon={IconCheckmark} />\n            </ToggleButtonGroup>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, ToggleButton, ToggleButtonGroup } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ToggleButtonGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ToggleButtonGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx",
-				"actualName": "ToggleButtonGroup",
+				"methods": [],
+				"props": {
+					"selectionMode": {
+						"defaultValue": { "value": "\"single\"" },
+						"description": "Selection mode for the toggle button group",
+						"name": "selectionMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"single\" | \"multiple\"",
+							"value": [{ "value": "\"single\"" }, { "value": "\"multiple\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme applied to each button",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"selectedColor": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme for the selected button",
+						"name": "selectedColor",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the toggle button group value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { value: string[]; event: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>; }) => void)"
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting child Button components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Selected values in the group, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default selected values in the group, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2153,30 +11448,269 @@
 			"path": "./src/components/Tooltip/tests/Tooltip.stories.tsx",
 			"stories": [
 				{
+					"id": "components-tooltip--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: bottom-start\">\n            <View direction=\"row\" gap={2}>\n                <Demo position=\"bottom-start\" text=\"Tooltip 1\" />\n                <Demo position=\"bottom-start\" text=\"Tooltip 2\" />\n                <Demo position=\"bottom-start\" text=\"Tooltip 3\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: bottom\">\n            <Demo position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"position: bottom-end\">\n            <Demo position=\"bottom-end\" />\n        </Example.Item>\n        <Example.Item title=\"position: top-start\">\n            <Demo position=\"top-start\" />\n        </Example.Item>\n        <Example.Item title=\"position: top\">\n            <Demo position=\"top\" />\n        </Example.Item>\n        <Example.Item title=\"position: top-end\">\n            <Demo position=\"top-end\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: start\">\n            <View align=\"end\">\n                <Demo position=\"start\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: start-top\">\n            <View align=\"end\">\n                <Demo position=\"start-top\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: start-bottom\">\n            <View align=\"end\">\n                <Demo position=\"start-bottom\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <Demo position=\"end\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: end-top\">\n            <Demo position=\"end-top\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: end-bottom\">\n            <Demo position=\"end-bottom\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tooltip--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: inverted\">\n            <Demo color=\"inverted\" position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"color: dark\">\n            <Demo color=\"dark\" position=\"bottom\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-tooltip--default-active",
+					"name": "uncontrolled",
 					"snippet": "const defaultActive = () => <Tooltip text=\"Content\" onOpen={fn()} onClose={fn()}>\n    {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n</Tooltip>;"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-tooltip--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"responsive visibility\">\n            <DemoResponsive text=\"Responsive\" />\n        </Example.Item>\n\n        <Example.Item title=\"without text\">\n            <Tooltip>{() => <Button>Button</Button>}</Tooltip>\n        </Example.Item>\n\n        <Example.Item title=\"tooltip with popover\">\n            <Tooltip text=\"Tooltip\" position=\"top\">\n                {(attributes) => (\n                    <Popover position=\"bottom\">\n                        <Popover.Trigger>\n                            {(popoverAttributes) => (\n                                <Button attributes={{ ...attributes, ...popoverAttributes }}>Action</Button>\n                            )}\n                        </Popover.Trigger>\n                        <Popover.Content>Popover</Popover.Content>\n                    </Popover>\n                )}\n            </Tooltip>\n        </Example.Item>\n\n        <Example.Item title=\"nested popovers inside a tooltip\">\n            <View direction=\"row\" gap={2}>\n                <Tooltip position=\"top\" text=\"Hello\">\n                    {(tooltipAttributes) => (\n                        <Popover position=\"bottom\" width=\"300px\">\n                            <Popover.Trigger>\n                                {(attributes) => (\n                                    <Button attributes={{ ...tooltipAttributes, ...attributes }}>\n                                        Tooltip with popover\n                                    </Button>\n                                )}\n                            </Popover.Trigger>\n                            <Popover.Content>\n                                <View gap={2} align=\"center\" direction=\"row\" justify=\"space-between\">\n                                    Popover content\n                                    <Popover position=\"bottom\" width=\"300px\">\n                                        <Popover.Trigger>\n                                            {(attributes) => <Button attributes={attributes}>Open</Button>}\n                                        </Popover.Trigger>\n                                        <Popover.Content>\n                                            <Popover.Dismissible align=\"center\" closeAriaLabel=\"Close\">\n                                                Another popover content\n                                            </Popover.Dismissible>\n                                        </Popover.Content>\n                                    </Popover>\n                                </View>\n                            </Popover.Content>\n                        </Popover>\n                    )}\n                </Tooltip>\n                <Tooltip position=\"top\" text=\"Hello\">\n                    {(tooltipAttributes) => <Button attributes={tooltipAttributes}>Just a tooltip</Button>}\n                </Tooltip>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, Popover, Tooltip, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Tooltip/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Tooltip",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Tooltip/Tooltip.tsx",
-				"actualName": "Tooltip",
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the flyout content interactivity",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"contentAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the content element",
+						"name": "contentAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"contentClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the content element",
+						"name": "contentClassName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "(attributes: TriggerAttributes) => ReactNode" }
+					},
+					"text": {
+						"defaultValue": null,
+						"description": "Text content for the tooltip",
+						"name": "text",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"inverted\"" },
+						"description": "Color of the tooltip",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"dark\" | \"inverted\"",
+							"value": [{ "value": "\"dark\"" }, { "value": "\"inverted\"" }]
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2186,51 +11720,191 @@
 			"path": "./src/components/Accordion/tests/Accordion.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-accordion--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Accordion defaultActive>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--icon-size",
 					"name": "iconSize",
 					"snippet": "const iconSize = () => (\n    <Accordion iconSize={6}>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--icon-position",
 					"name": "iconPosition",
 					"snippet": "const iconPosition = () => (\n    <Accordion iconPosition=\"start\">\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Accordion defaultActive gap={4}>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <Placeholder />\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--on-toggle",
 					"name": "onToggle",
 					"snippet": "const onToggle = () => <Accordion onToggle={fn()}>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
+					"id": "utility-components-accordion--active",
 					"name": "active",
 					"snippet": "const active = () => <Accordion onToggle={fn()} active>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
+					"id": "utility-components-accordion--default-active",
 					"name": "defaultActive",
 					"snippet": "const defaultActive = () => <Accordion onToggle={fn()} defaultActive>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
-					"name": "renderProps",
+					"id": "utility-components-accordion--render-props",
+					"name": "children: render props",
 					"snippet": "const renderProps = () => <Accordion onToggle={fn()}>\n    <Accordion.Trigger>\n        {(attributes, { active }) => (\n            <Button attributes={{ ...attributes, \"data-active\": active }}>Trigger</Button>\n        )}\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-accordion--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Accordion className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Accordion.Trigger>\n                <Placeholder>Trigger</Placeholder>\n            </Accordion.Trigger>\n            <Accordion.Content>\n                <View paddingTop={2}>\n                    <Placeholder />\n                </View>\n            </Accordion.Content>\n        </Accordion>\n    </div>\n);"
 				}
 			],
 			"import": "import { Accordion, Button, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Accordion/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Accordion",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Accordion/Accordion.tsx",
-				"actualName": "Accordion",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"iconSize": {
+						"defaultValue": null,
+						"description": "Expand / collapse icon size in units",
+						"name": "iconSize",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"iconPosition": {
+						"defaultValue": null,
+						"description": "Position of the expand / collapse icon",
+						"name": "iconPosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"start\" | \"end\"",
+							"value": [{ "value": "\"start\"" }, { "value": "\"end\"" }]
+						}
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between the trigger and the content",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the trigger and the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onToggle": {
+						"defaultValue": null,
+						"description": "Callback when the accordion is expanded or collapsed",
+						"name": "onToggle",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((active: boolean) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control whether the accordion is expanded or collapsed, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control whether the accordion is expanded or collapsed by default, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Accordion"
 			}
 		},
 		"utility-components-actionable": {
@@ -2239,54 +11913,456 @@
 			"path": "./src/components/Actionable/tests/Actionable.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "utility-components-actionable--base",
+					"name": "href, onClick",
 					"snippet": "const base = () => <Example>\n    <Example.Item title=\"span\">\n        <Actionable>Span</Actionable>\n    </Example.Item>\n    <Example.Item title=\"onClick\">\n        <Actionable onClick={fn()}>Button</Actionable>\n    </Example.Item>\n    <Example.Item title=\"href\">\n        <Actionable href=\"https://reshaped.so\" attributes={{ target: \"_blank\" }}>Link\n                            </Actionable>\n    </Example.Item>\n    <Example.Item title=\"attributes.href\">\n        <Actionable attributes={{ href: \"https://reshaped.so\" }}>Link with attributes</Actionable>\n    </Example.Item>\n    <Example.Item title=\"href, onClick\">\n        <Actionable\n            onClick={(e) => {\n                e.preventDefault();\n                args.handleSecondClick(e);\n            }}\n            href=\"https://reshaped.so\">Link with onClick\n                            </Actionable>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "utility-components-actionable--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, button\">\n            <Actionable disabled onClick={() => {}}>\n                Button\n            </Actionable>\n        </Example.Item>\n        <Example.Item title=\"disabled, link\">\n            <Actionable disabled href=\"https://reshaped.so\">\n                Link\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--full-width",
 					"name": "fullWidth",
 					"snippet": "const fullWidth = () => (\n    <Example>\n        <Example.Item title=\"fullWidth\">\n            <Actionable fullWidth href=\"https://reshaped.so\">\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--inset-focus",
 					"name": "insetFocus",
 					"snippet": "const insetFocus = () => (\n    <Example>\n        <Example.Item title=\"insetFocus\">\n            <Actionable insetFocus onClick={() => {}}>\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--disable-focus-ring",
 					"name": "disableFocusRing",
 					"snippet": "const disableFocusRing = () => (\n    <Example>\n        <Example.Item title=\"disableFocusRing\">\n            <Actionable disableFocusRing onClick={() => {}}>\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--border-radius",
 					"name": "borderRadius",
 					"snippet": "const borderRadius = () => (\n    <Example>\n        <Example.Item title=\"borderRadius: inherit\">\n            <Actionable borderRadius=\"inherit\" onClick={() => {}}>\n                <View borderRadius=\"large\">Actionable</View>\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--type",
 					"name": "type",
 					"snippet": "const type = (args) => (\n    <Example>\n        <Example.Item title=\"type: submit\">\n            <form\n                onSubmit={(e) => {\n                    e.preventDefault();\n                    args.handleSubmit();\n                }}\n            >\n                <Actionable onClick={() => {}} type=\"submit\">\n                    Submit\n                </Actionable>\n            </form>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "as",
+					"id": "utility-components-actionable--as",
+					"name": "as, render",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"as: span\">\n            <Actionable onClick={() => {}} as=\"span\">\n                Trigger\n            </Actionable>\n        </Example.Item>\n        <Example.Item title=\"render, disabled\">\n            <Actionable disabled onClick={() => {}} render={(props) => <section {...props} />}>\n                Trigger\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--stop-propagation",
 					"name": "stopPropagation",
 					"snippet": "const stopPropagation = () => <div onClick={fn()}>\n    <Actionable stopPropagation onClick={() => {}}>Trigger\n                    </Actionable>\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-actionable--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Actionable className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Actionable>\n    </div>\n);"
 				}
 			],
 			"import": "import { Actionable, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Actionable/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Actionable",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Actionable/Actionable.tsx",
-				"actualName": "Actionable",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"touchHitbox": {
+						"defaultValue": null,
+						"description": "Enable a minimum required touch hitbox",
+						"name": "touchHitbox",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Take up the full width of its parent",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"insetFocus": {
+						"defaultValue": null,
+						"description": "Enable a focus ring inside the element bounds",
+						"name": "insetFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableFocusRing": {
+						"defaultValue": null,
+						"description": "Don't show a focus ring on focus, can be used when it is within a container with a focus ring",
+						"name": "disableFocusRing",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Apply the focus ring to the child and rely on its border radius",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"inherit\"", "value": [{ "value": "\"inherit\"" }] }
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2296,30 +12372,149 @@
 			"path": "./src/components/Container/tests/Container.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-container--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: default\">\n            <Container>\n                <Placeholder />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"padding: 0\">\n            <Container padding={0}>\n                <Placeholder />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "utility-components-container--size",
+					"name": "width, height, maxHeight",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"width: 200px, height: 200px\">\n            <Container width=\"200px\" height=\"200px\">\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width: 200px, height: 200px, maxHeight: 100px\">\n            <Container width=\"200px\" height=\"200px\" maxHeight=\"100px\">\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width, height: [s] 100px, [m+] 200px\">\n            <Container width={{ s: \"100px\", m: \"200px\" }} height={{ s: \"100px\", m: \"200px\" }}>\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width, height: [s] 100px, [m+] 200px, maxHeight: [s] 50px, [m+]: 100px\">\n            <Container\n                width={{ s: \"100px\", m: \"200px\" }}\n                height={{ s: \"100px\", m: \"200px\" }}\n                maxHeight={{ s: \"50px\", m: \"100px\" }}\n            >\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "flex",
+					"id": "utility-components-container--flex",
+					"name": "align, justify",
 					"snippet": "const flex = () => (\n    <Example>\n        <Example.Item title=\"align: center, justify: center\">\n            <Container align=\"center\" justify=\"center\" height=\"200px\">\n                <Placeholder />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-container--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Container className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </Container>\n    </div>\n);"
 				}
 			],
 			"import": "import { Container, Example, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Container/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Container",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Container/Container.tsx",
-				"actualName": "Container",
+				"methods": [],
+				"props": {
+					"align": {
+						"defaultValue": null,
+						"description": "Flex align-items for the content",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Flex justify-content for the content",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier\nComponent height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" },
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height style, literal string value or a base unit token number multiplier\nComponent max height, literal css value or unit token multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" },
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Component inline padding",
+						"name": "padding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Component width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2329,34 +12524,157 @@
 			"path": "./src/components/Dismissible/tests/Dismissible.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-dismissible--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Dismissible closeAriaLabel=\"Close banner\" onClose={() => {}}>\n                <Placeholder />\n            </Dismissible>\n        </Example.Item>\n        <Example.Item title=\"variant: media\">\n            <View width=\"300px\">\n                <Dismissible variant=\"media\" closeAriaLabel=\"Close banner\" onClose={() => {}}>\n                    <View aspectRatio={16 / 9}>\n                        <Image\n                            height=\"100%\"\n                            src=\"https://images.unsplash.com/photo-1607030529528-ca6923e27f77?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1867&q=80)\"\n                        />\n                    </View>\n                </Dismissible>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-dismissible--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: center\">\n            <Dismissible align=\"center\" closeAriaLabel=\"Close\" onClose={() => {}}>\n                <Placeholder />\n            </Dismissible>\n        </Example.Item>\n\n        <Example.Item title=\"align: center, variant: media\">\n            <Dismissible align=\"center\" closeAriaLabel=\"Close\" variant=\"media\" onClose={() => {}}>\n                <View aspectRatio={16 / 9}>\n                    <Image\n                        height=\"100%\"\n                        src=\"https://images.unsplash.com/photo-1607030529528-ca6923e27f77?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1867&q=80)\"\n                    />\n                </View>\n            </Dismissible>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-dismissible--hide-close-button",
 					"name": "hideCloseButton",
 					"snippet": "const hideCloseButton = () => (\n    <Example>\n        <Example.Item title=\"hide close button\">\n            <div id=\"root\">\n                <Dismissible hideCloseButton>\n                    <Placeholder />\n                </Dismissible>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "closeAriaLabel",
+					"id": "utility-components-dismissible--close-aria-label",
+					"name": "onClose, closeAriaLabel",
 					"snippet": "const closeAriaLabel = () => <Dismissible closeAriaLabel=\"Close\" onClose={fn()}>\n    <Placeholder />\n</Dismissible>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-dismissible--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Dismissible\n            closeAriaLabel=\"Close\"\n            onClose={() => {}}\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n        >\n            <Placeholder />\n        </Dismissible>\n    </div>\n);"
 				}
 			],
 			"import": "import { Dismissible, Example, Image, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Dismissible/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Dismissible",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Dismissible/Dismissible.tsx",
-				"actualName": "Dismissible",
+				"methods": [],
+				"props": {
+					"hideCloseButton": {
+						"defaultValue": null,
+						"description": "Hide the close button\nShow the close button",
+						"name": "hideCloseButton",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"closeAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the close button",
+						"name": "closeAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"media\"", "value": [{ "value": "\"media\"" }] }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Close button alignment",
+						"name": "align",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"center\"",
+							"value": [{ "value": "\"top\"" }, { "value": "\"center\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is dismissed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2366,135 +12684,577 @@
 			"path": "./src/components/Flyout/tests/Flyout.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-flyout--position",
 					"name": "position",
 					"snippet": "const position = () => {\n    return (\n        <View gap={4} padding={50} align=\"center\" justify=\"center\" height=\"100vh\" width=\"120%\">\n            <View gap={4} direction=\"row\">\n                <Demo position=\"top-start\" defaultActive />\n                <Demo position=\"top\" />\n                <Demo position=\"top-end\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"end-top\" />\n                <Demo position=\"end\" />\n                <Demo position=\"end-bottom\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"start-top\" />\n                <Demo position=\"start\" />\n                <Demo position=\"start-bottom\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"bottom-start\" />\n                <Demo position=\"bottom\" />\n                <Demo position=\"bottom-end\" />\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "defaultActive",
+					"id": "utility-components-flyout--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <Flyout onOpen={fn()} onClose={fn()} defaultActive>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "active",
+					"id": "utility-components-flyout--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <Flyout onOpen={fn()} onClose={fn()} active>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "utility-components-flyout--active-false",
+					"name": "active: false, controlled",
 					"snippet": "const activeFalse = () => <Flyout onOpen={fn()} onClose={fn()} active={false}>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "modes",
+					"id": "utility-components-flyout--modes",
+					"name": "triggerType, trapFocusMode",
 					"snippet": "const modes = () => {\n    return (\n        <Example>\n            <Example.Item title=\"triggerType: click\">\n                <View direction=\"row\" gap={4}>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"dialog\" text=\"dialog\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"action-menu\" text=\"action-menu\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"action-bar\" text=\"action-bar\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"content-menu\" text=\"content-menu\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode={false} text=\"false\">\n                        {modeContent}\n                    </Demo>\n                </View>\n            </Example.Item>\n\n            <Example.Item title=\"triggerType: hover\">\n                <View direction=\"row\" gap={4}>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"dialog\" triggerType=\"hover\" text=\"dialog\">\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"action-menu\"\n                        triggerType=\"hover\"\n                        text=\"action-menu\"\n                    >\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"action-bar\"\n                        triggerType=\"hover\"\n                        text=\"action-bar\"\n                    >\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"content-menu\"\n                        triggerType=\"hover\"\n                        text=\"content-menu\"\n                    >\n                        {modeContent}\n                    </Demo>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "positionFallbacks",
+					"id": "utility-components-flyout--position-fallbacks",
+					"name": "fallbackPositions",
 					"snippet": "const positionFallbacks = () => {\n    return (\n        <Example>\n            <Example.Item title=\"position: top, default fallbacks\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" />\n                </View>\n            </Example.Item>\n            <Example.Item title=\"position: top, fallbackPositions: [start]\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" fallbackPositions={[\"start\"]} contentHeight={200} defaultActive />\n                </View>\n            </Example.Item>\n            <Example.Item title=\"position: top, fallbackPositions: false\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" fallbackPositions={false} contentHeight={400} />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--fallback-adjust-layout",
 					"name": "fallbackAdjustLayout",
 					"snippet": "const fallbackAdjustLayout = () => {\n    return (\n        <Demo\n            contentHeight={false}\n            position=\"bottom-start\"\n            width=\"200px\"\n            fallbackAdjustLayout\n            defaultActive\n        >\n            <div style={{ height: \"600px\" }}>Content</div>\n        </Demo>\n    );\n};"
 				},
 				{
-					"name": "fallbackAdjustLayoutShift",
+					"id": "utility-components-flyout--fallback-adjust-layout-shift",
+					"name": "fallbackAdjustLayout, shift",
 					"snippet": "const fallbackAdjustLayoutShift = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={10}>\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    attributes={{ ref: containerRef }}\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls containerRef={containerRef} />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <FallbackAdjustLayoutControls />\n            <div style={{ height: \"100vh\", width: \"250%\" }} />\n        </View>\n    );\n};"
 				},
 				{
-					"name": "fallbackAdjustLayoutSize",
+					"id": "utility-components-flyout--fallback-adjust-layout-size",
+					"name": "fallbackAdjustLayout, size",
 					"snippet": "const fallbackAdjustLayoutSize = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={10}>\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls large />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    attributes={{ ref: containerRef }}\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls containerRef={containerRef} large />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <FallbackAdjustLayoutControls large />\n            <div style={{ height: \"100vh\", width: \"250%\" }} />\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--origin-coordinates",
 					"name": "originCoordinates",
 					"snippet": "const originCoordinates = () => {\n    return (\n        <View gap={4} direction=\"row\">\n            <Demo position=\"bottom-start\" originCoordinates={{ x: 150, y: 150 }} defaultActive />\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--width",
 					"name": "width",
 					"snippet": "const width = () => (\n    <Example>\n        <Example.Item title=\"width: 300px\">\n            <Demo width=\"300px\" position=\"bottom\" />\n        </Example.Item>\n\n        <Example.Item title=\"width: trigger\">\n            <Demo width=\"trigger\" contentWidth={false} defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-flyout--content-gap",
 					"name": "contentGap",
 					"snippet": "const contentGap = () => <Demo contentGap={10} defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--content-shift",
 					"name": "contentShift",
 					"snippet": "const contentShift = () => <Demo contentShift={10} defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-content-hover",
 					"name": "disableContentHover",
 					"snippet": "const disableContentHover = () => <Demo triggerType=\"hover\" disableContentHover />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-close-on-outside-click",
 					"name": "disableCloseOnOutsideClick",
 					"snippet": "const disableCloseOnOutsideClick = () => <Demo disableCloseOnOutsideClick />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-hide-animation",
 					"name": "disableHideAnimation",
 					"snippet": "const disableHideAnimation = () => <Demo disableHideAnimation defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Flyout disabled>\n        <Flyout.Trigger>\n            {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n        </Flyout.Trigger>\n        <Flyout.Content>\n            <Content />\n        </Flyout.Content>\n    </Flyout>\n);"
 				},
 				{
+					"id": "utility-components-flyout--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const portalRef = React.useRef<HTMLDivElement>(null);\n    const portalRef2 = React.useRef<HTMLDivElement>(null);\n    const portalRef3 = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={4} direction=\"row\">\n            <View\n                grow\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef, \"data-testid\": \"container\" }}\n                justify=\"end\"\n                align=\"start\"\n                padding={4}\n            >\n                <Demo containerRef={portalRef} position=\"bottom-start\" defaultActive />\n            </View>\n            <View\n                grow\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef2 }}\n                justify=\"start\"\n                align=\"end\"\n                padding={4}\n            >\n                <Demo containerRef={portalRef2} position=\"top-end\" />\n            </View>\n            <View\n                width={50}\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef3 }}\n                padding={4}\n                overflow=\"auto\"\n            >\n                <View height={120} width=\"120%\" justify=\"center\" align=\"center\">\n                    <Demo containerRef={portalRef3} position=\"bottom-end\" />\n                </View>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--initial-focus-ref",
 					"name": "initialFocusRef",
 					"snippet": "const initialFocusRef = () => {\n    const initialFocusRef = React.useRef<HTMLInputElement>(null);\n\n    return (\n        <Demo initialFocusRef={initialFocusRef}>\n            <View gap={4}>\n                <Button onClick={() => {}}>Action 1</Button>\n                <TextField name=\"foo\" inputAttributes={{ ref: initialFocusRef }} />\n            </View>\n        </Demo>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--instance-ref",
 					"name": "instanceRef",
 					"snippet": "const instanceRef = () => {\n    const flyoutRef = React.useRef<FlyoutInstance>(null);\n\n    return (\n        <View direction=\"row\" gap={4}>\n            <Demo\n                instanceRef={flyoutRef}\n                disableCloseOnOutsideClick\n                onOpen={fn()}\n                onClose={fn()} />\n            <Button onClick={() => flyoutRef.current?.open()}>Open</Button>\n            <Button onClick={() => flyoutRef.current?.close()}>Close</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "contentAttributes",
+					"id": "utility-components-flyout--content-attributes",
+					"name": "content: className, attributes",
 					"snippet": "const contentAttributes = () => {\n    return (\n        <Flyout position=\"bottom\" defaultActive>\n            <Flyout.Trigger>\n                {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n            </Flyout.Trigger>\n            <Flyout.Content attributes={{ \"data-testid\": \"test-id\" }} className=\"test-classname\">\n                <Content />\n            </Flyout.Content>\n        </Flyout>\n    );\n};"
 				},
 				{
-					"name": "testShadowDom",
+					"id": "utility-components-flyout--test-shadow-dom",
+					"name": "test: shadow dom",
 					"snippet": "const testShadowDom = () => <custom-element-flyout />;"
 				},
 				{
-					"name": "testInsideFixed",
+					"id": "utility-components-flyout--test-inside-fixed",
+					"name": "test: inside position fixed",
 					"snippet": "const testInsideFixed = () => (\n    <React.Fragment>\n        <View\n            position=\"fixed\"\n            insetBottom={2}\n            insetStart={2}\n            insetEnd={2}\n            backgroundColor=\"elevation-overlay\"\n            borderColor=\"neutral-faded\"\n            borderRadius=\"small\"\n            padding={4}\n            zIndex={10}\n            attributes={{ \"data-testid\": \"container\" }}\n            height={20}\n        >\n            <Demo defaultActive position=\"top-start\" />\n        </View>\n        <View paddingTop={18} gap={4}>\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n        </View>\n    </React.Fragment>\n);"
 				},
 				{
-					"name": "testInsideSticky",
+					"id": "utility-components-flyout--test-inside-sticky",
+					"name": "test: inside position sticky",
 					"snippet": "const testInsideSticky = () => (\n    <React.Fragment>\n        <View\n            position=\"sticky\"\n            insetTop={4}\n            insetStart={0}\n            insetEnd={0}\n            backgroundColor=\"elevation-overlay\"\n            borderColor=\"neutral-faded\"\n            borderRadius=\"small\"\n            padding={4}\n            zIndex={10}\n            attributes={{ \"data-testid\": \"container\" }}\n        >\n            <Demo defaultActive />\n        </View>\n        <View gap={4} paddingTop={2}>\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n        </View>\n    </React.Fragment>\n);"
 				},
 				{
-					"name": "testInsideScrollable",
+					"id": "utility-components-flyout--test-inside-scrollable",
+					"name": "test: inside scrollable",
 					"snippet": "const testInsideScrollable = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View padding={20}>\n            <View height={30} overflow=\"auto\" backgroundColor=\"neutral-faded\" borderRadius=\"small\">\n                <View height={50} attributes={{ ref: containerRef }} padding={20} paddingBottom={30}>\n                    <Demo position=\"bottom\" />\n                </View>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testInsideModal",
+					"id": "utility-components-flyout--test-inside-modal",
+					"name": "test: inside modal",
 					"snippet": "const testInsideModal = () => {\n    return (\n        <Modal active position=\"end\">\n            <View gap={4} align=\"start\">\n                <Modal.Title>Title</Modal.Title>\n                <Demo position=\"bottom-start\" />\n                <View height={300} width={25} backgroundColor=\"neutral-faded\" />\n                <Demo position=\"start\" />\n                <View height={300} width={25} backgroundColor=\"neutral-faded\" />\n                <Demo position=\"bottom-start\" />\n            </View>\n        </Modal>\n    );\n};"
 				},
 				{
-					"name": "testDynamicBounds",
+					"id": "utility-components-flyout--test-dynamic-bounds",
+					"name": "test: auto position update",
 					"snippet": "const testDynamicBounds = () => {\n    const [left, setLeft] = React.useState(50);\n    const [top, setTop] = React.useState(50);\n    const [size, setSize] = React.useState<\"medium\" | \"large\">(\"medium\");\n    const flyoutRef = React.useRef<FlyoutInstance>(null);\n\n    React.useEffect(() => {\n        flyoutRef.current?.updatePosition();\n    }, [left, top]);\n\n    return (\n        <View gap={4}>\n            <View direction=\"row\" gap={2}>\n                <Button onClick={() => setLeft((prev) => prev - 10)}>Left</Button>\n                <Button onClick={() => setLeft((prev) => prev + 10)}>Right</Button>\n                <Button onClick={() => setTop((prev) => prev - 10)}>Up</Button>\n                <Button onClick={() => setTop((prev) => prev + 10)}>Down</Button>\n                <Button\n                    onClick={() => {\n                        setLeft(50);\n                        setTop(50);\n                    }}\n                >\n                    Center\n                </Button>\n                <Button onClick={() => setSize(\"large\")}>Large button</Button>\n                <Button onClick={() => setSize(\"medium\")}>Small button</Button>\n            </View>\n            <View height={100}>\n                <Flyout\n                    position=\"bottom\"\n                    instanceRef={flyoutRef}\n                    disableCloseOnOutsideClick\n                    defaultActive\n                >\n                    <Flyout.Trigger>\n                        {(attributes) => (\n                            <div style={{ position: \"absolute\", left: `${left}%`, top: `${top}%` }}>\n                                <Button color=\"primary\" attributes={attributes} size={size}>\n                                    Open\n                                </Button>\n                            </div>\n                        )}\n                    </Flyout.Trigger>\n                    <Flyout.Content>\n                        <Content />\n                    </Flyout.Content>\n                </Flyout>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testScopedTheming",
+					"id": "utility-components-flyout--test-scoped-theming",
+					"name": "test: content uses scope theme",
 					"snippet": "const testScopedTheming = () => (\n    <View gap={3} align=\"start\">\n        <Button color=\"primary\">Slate button</Button>\n        <Theme name=\"reshaped\">\n            <Flyout triggerType=\"click\" active position=\"bottom-start\">\n                <Flyout.Trigger>\n                    {(attributes) => (\n                        <Button color=\"primary\" attributes={attributes}>\n                            Reshaped button\n                        </Button>\n                    )}\n                </Flyout.Trigger>\n                <Flyout.Content>\n                    <Content>\n                        <View gap={1}>\n                            <View.Item>Portal content, rendered in body</View.Item>\n                            <Button color=\"primary\">Reshaped button</Button>\n                        </View>\n                    </Content>\n                </Flyout.Content>\n            </Flyout>\n        </Theme>\n    </View>\n);"
 				},
 				{
-					"name": "testWithoutFocusable",
+					"id": "utility-components-flyout--test-without-focusable",
+					"name": "test: without focusable content",
 					"snippet": "const testWithoutFocusable = () => <Demo position=\"bottom-start\" />;"
 				},
 				{
-					"name": "testChangeSize",
+					"id": "utility-components-flyout--test-change-size",
+					"name": "test: size updates",
 					"snippet": "const testChangeSize = () => {\n    const [position, setPosition] = React.useState<FlyoutProps[\"position\"]>(\"bottom-start\");\n    const [updatedHeight, setUpdatedHeight] = React.useState(false);\n\n    return (\n        <>\n            <View direction=\"row\" gap={4} align=\"center\">\n                <Select\n                    name=\"position\"\n                    options={[\n                        \"bottom-start\",\n                        \"bottom\",\n                        \"bottom-end\",\n                        \"top-start\",\n                        \"top\",\n                        \"top-end\",\n                        \"start-top\",\n                        \"start\",\n                        \"start-bottom\",\n                        \"end-top\",\n                        \"end\",\n                        \"end-bottom\",\n                    ].map((p) => ({ label: p, value: p }))}\n                    onChange={(args) => setPosition(args.value as FlyoutProps[\"position\"])}\n                    value={position}\n                />\n                <Switch name=\"height\" onChange={(args) => setUpdatedHeight(args.checked)}>\n                    Change height\n                </Switch>\n            </View>\n            <div\n                style={{\n                    position: \"fixed\",\n                    top: \"50%\",\n                    left: \"50%\",\n                    transform: \"translate(-50%, -50%)\",\n                }}\n            >\n                <Demo position={position} disableCloseOnOutsideClick active contentHeight={false}>\n                    <View\n                        backgroundColor=\"neutral-faded\"\n                        borderRadius=\"small\"\n                        height={updatedHeight ? 50 : 25}\n                        attributes={{ style: { transition: \"0.2s ease-in-out\" } }}\n                    />\n                </Demo>\n            </div>\n        </>\n    );\n};"
 				}
 			],
 			"import": "import {\n    Button,\n    Example,\n    Flyout,\n    Modal,\n    Reshaped,\n    Select,\n    Switch,\n    TextField,\n    Theme,\n    View,\n} from \"reshaped\";\nimport React from \"react\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Flyout/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Flyout",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Flyout/Flyout.tsx",
-				"actualName": "Flyout",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"groupTimeouts": {
+						"defaultValue": null,
+						"description": "Removes the content display delay if another flyout is already active",
+						"name": "groupTimeouts",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | TrapMode" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the flyout content interactivity",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Automatically focus the first focusable element in the content, when false the content container will be focused instead",
+						"name": "autoFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the content element",
+						"name": "contentClassName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"contentAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the content element",
+						"name": "contentAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Flyout"
 			}
 		},
 		"utility-components-formcontrol": {
@@ -2503,43 +13263,147 @@
 			"path": "./src/components/FormControl/tests/FormControl.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-formcontrol--status",
 					"name": "status",
 					"snippet": "const status = () => (\n    <Example>\n        <Example.Item title=\"status: default\">\n            <FormControl>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"status: error\">\n            <FormControl hasError>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: medium\">\n            <FormControl size=\"medium\">\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <FormControl size=\"large\">\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" size=\"large\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <FormControl disabled>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--required",
 					"name": "required",
 					"snippet": "const required = () => (\n    <Example>\n        <Example.Item title=\"required\">\n            <FormControl required>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "utility-components-formcontrol--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"horizontal\">\n            <FormControl>\n                <View direction=\"row\" gap={10} align=\"center\">\n                    <View width=\"100px\">\n                        <FormControl.Label>Label</FormControl.Label>\n                    </View>\n                    <View.Item grow>\n                        <TextField name=\"name\" placeholder=\"Enter value\" />\n                    </View.Item>\n                </View>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-formcontrol--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <FormControl id=\"test-id\" hasError>\n        <FormControl.Label>Label</FormControl.Label>\n        <TextField name=\"name\" />\n        <FormControl.Helper>Caption</FormControl.Helper>\n        <FormControl.Error>Error</FormControl.Error>\n    </FormControl>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--group",
 					"name": "group",
 					"snippet": "const group = () => (\n    <FormControl group>\n        <FormControl.Label>Label</FormControl.Label>\n        <RadioGroup name=\"name\">\n            <View gap={2}>\n                <Radio value=\"1\">One</Radio>\n                <Radio value=\"2\">Two</Radio>\n            </View>\n        </RadioGroup>\n    </FormControl>\n);"
 				}
 			],
 			"import": "import { Example, FormControl, Radio, RadioGroup, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/FormControl/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "FormControl",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/FormControl/FormControl.tsx",
-				"actualName": "FormControl",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size, to be used together with the other form component sizes",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"large\" | \"medium\"",
+							"value": [{ "value": "\"large\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"required": {
+						"defaultValue": null,
+						"description": "Change component to show a required indicator",
+						"name": "required",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Apply disabled styles",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"group": {
+						"defaultValue": null,
+						"description": "Apply semantic html markup when used for displaying multiple form fields together with a single label",
+						"name": "group",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Custom id for the form control",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "FormControl"
 			}
 		},
 		"utility-components-grid": {
@@ -2548,43 +13412,421 @@
 			"path": "./src/components/Grid/tests/Grid.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "utility-components-grid--base",
+					"name": "gap, columnGap, rowGap, align, justify, maxWidth, width, height",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"gap: 2\">\n            <Grid gap={2} columns={2}>\n                {[1, 2].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"columnGap: 2, rowGap: 4\">\n            <Grid columnGap={2} rowGap={4} columns={2}>\n                {[1, 2, 3, 4].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"align: center\">\n            <Grid gap={2} columns={2} align=\"center\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={8}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"justify: center\">\n            <Grid gap={2} columns=\"200px 200px\" justify=\"center\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"maxWidth: 400px\">\n            <Grid gap={2} columns=\"200px 200px\" maxWidth=\"400px\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"width: 400px, height: 200px\">\n            <Grid gap={2} columns={2} width=\"400px\" height=\"200px\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "layout",
+					"id": "utility-components-grid--layout",
+					"name": "rows, columns",
 					"snippet": "const layout = () => (\n    <Example>\n        <Example.Item title=\"simple: 2 rows, 3 columns\">\n            <Grid gap={4} columns={3} rows={2}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"columns template, 1fr 2fr 1fr\">\n            <Grid gap={4} columns=\"1fr 2fr 1fr\" rows={2}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"rows template, 1fr 2fr\">\n            <Grid gap={4} columns={3} rows=\"1fr 2fr\">\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"responsive\">\n            <Grid gap={4} columns={{ s: 3, m: \"1fr 2fr 1fr\" }} rows={{ s: 2, m: \"1fr 2fr\" }}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemLayout",
+					"id": "utility-components-grid--item-layout",
+					"name": "colStart, colEnd, rowStart, rowEnd",
 					"snippet": "const itemLayout = () => (\n    <Example>\n        <Example.Item title=\"column, start 1, end 3\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item colStart={1} colEnd={3}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"column, start 1, span 2\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item colStart={1} colSpan={2}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"row, start 1, end 3\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowEnd={3}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"row, start 1, span 2\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowSpan={2}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"responsive\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowSpan={{ s: 1, m: 2 }} colStart={1} colSpan={{ s: 1, m: 2 }}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-grid--areas",
 					"name": "areas",
 					"snippet": "const areas = () => (\n    <Example>\n        <Example.Item title=\"simple: 2 rows, 3 columns\">\n            <Grid gap={4} rows={2} areas={[\"a .\", \"a b\"]}>\n                {[\"a\", \"b\"].map((area) => (\n                    <Grid.Item area={area} key={area}>\n                        <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                            {area}\n                        </View>\n                    </Grid.Item>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "auto",
+					"id": "utility-components-grid--auto",
+					"name": "autoFlow, autoColumns, autoRows",
 					"snippet": "const auto = () => (\n    <Example>\n        <Example.Item title=\"auto flow: column\">\n            <Grid gap={4} autoFlow=\"column\" rows={2} columns={2}>\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"auto rows\">\n            <Grid gap={4} autoRows=\"100px\" columns={2}>\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"auto columns\">\n            <Grid gap={4} autoColumns=\"100px\" autoFlow=\"column\">\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-grid--as",
 					"name": "as",
 					"snippet": "const as = () => (\n    <Grid as=\"ul\">\n        <Grid.Item as=\"li\">Content</Grid.Item>\n    </Grid>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-grid--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Grid className=\"test-class\" attributes={{ id: \"test-id\" }}>\n            <Grid.Item className=\"test-item-class\" attributes={{ id: \"test-item-id\" }}>\n                Content\n            </Grid.Item>\n        </Grid>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Grid, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Grid/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Grid",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Grid/Grid.tsx",
-				"actualName": "Grid",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between grid items",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"columnGap": {
+						"defaultValue": null,
+						"description": "Horizontal gap between grid items",
+						"name": "columnGap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"rowGap": {
+						"defaultValue": null,
+						"description": "Vertical gap between grid items",
+						"name": "rowGap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Align grid items vertically",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Justify grid items horizontally",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"rows": {
+						"defaultValue": null,
+						"description": "Grid template rows",
+						"name": "rows",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<number | \"inherit\" | \"none\" | \"auto\" | (string & {}) | \"-moz-initial\" | \"initial\" | \"revert\" | \"revert-layer\" | \"unset\" | \"max-content\" | \"min-content\" | \"subgrid\">"
+						}
+					},
+					"columns": {
+						"defaultValue": null,
+						"description": "Grid template columns",
+						"name": "columns",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<number | \"inherit\" | \"none\" | \"auto\" | (string & {}) | \"-moz-initial\" | \"initial\" | \"revert\" | \"revert-layer\" | \"unset\" | \"max-content\" | \"min-content\" | \"subgrid\">"
+						}
+					},
+					"areas": {
+						"defaultValue": null,
+						"description": "Grid areas for template syntax",
+						"name": "areas",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string[]>" }
+					},
+					"autoFlow": {
+						"defaultValue": null,
+						"description": "Grid auto flow",
+						"name": "autoFlow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoFlow>" }
+					},
+					"autoColumns": {
+						"defaultValue": null,
+						"description": "Grid auto columns",
+						"name": "autoColumns",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoColumns<0 | (string & {})>>" }
+					},
+					"autoRows": {
+						"defaultValue": null,
+						"description": "Grid auto rows",
+						"name": "autoRows",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoRows<0 | (string & {})>>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Maximum width of the grid container, literal css value or unit token multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width of the grid container, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height of the grid container, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Custom root element html tag",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					}
+				},
+				"exportName": "Grid"
 			}
 		},
 		"utility-components-hidden": {
@@ -2593,22 +13835,261 @@
 			"path": "./src/components/Hidden/tests/Hidden.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-hidden--visibility",
 					"name": "visibility",
 					"snippet": "const visibility = () => (\n    <Example>\n        <Example.Item title=\"hide: always\">\n            <Hidden hide={true}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on s\">\n            <Hidden hide={{ s: false, m: true }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on l/xl\">\n            <Hidden hide={{ s: true, l: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on m/l/xl\">\n            <Hidden hide={{ s: true, m: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on m\">\n            <Hidden hide={{ s: true, m: false, l: true }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on s/xl\">\n            <Hidden hide={{ s: false, m: true, xl: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"hide: always, visibility\">\n            <Hidden hide visibility>\n                Content\n            </Hidden>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-hidden--as",
 					"name": "as",
 					"snippet": "const as = () => <Hidden as=\"span\">Content</Hidden>;"
 				}
 			],
 			"import": "import { Example, Hidden } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Hidden/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Hidden",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Hidden/Hidden.tsx",
-				"actualName": "Hidden",
+				"methods": [],
+				"props": {
+					"hide": {
+						"defaultValue": null,
+						"description": "Pick at which viewport sizes to hide the children",
+						"name": "hide",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"visibility": {
+						"defaultValue": null,
+						"description": "Use visibility hidden instead of display none",
+						"name": "visibility",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Custom root element html tag",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2618,22 +14099,39 @@
 			"path": "./src/components/HiddenVisually/tests/HiddenVisually.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-hiddenvisually--visibility",
 					"name": "visibility",
 					"snippet": "const visibility = () => (\n    <Example>\n        <Example.Item title=\"pronounced by screen readers\">\n            <HiddenVisually>Screen-reader only</HiddenVisually>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-hiddenvisually--children",
 					"name": "children",
 					"snippet": "const children = () => <HiddenVisually>Content</HiddenVisually>;"
 				}
 			],
 			"import": "import { Example, HiddenVisually } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/HiddenVisually/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "HiddenVisually",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/HiddenVisually/HiddenVisually.tsx",
-				"actualName": "HiddenVisually",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/HiddenVisually/HiddenVisually.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2643,34 +14141,115 @@
 			"path": "./src/components/Icon/tests/Icon.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-icon--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: 4\">\n            <Icon svg={IconZap} size={4} />\n        </Example.Item>\n        <Example.Item title=\"size: 8\">\n            <Icon svg={IconZap} size={8} />\n        </Example.Item>\n        <Example.Item title=\"size: 100%\">\n            <View width={25} height={25}>\n                <Icon svg={IconZap} size=\"100%\" />\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive size\", \"[s] 5\", \"[m]: 10\"]}>\n            <Icon svg={IconZap} size={{ s: 5, m: 10 }} />\n        </Example.Item>\n        <Example.Item title=\"size: inherit from font\">\n            <Text variant=\"title-6\">\n                <View direction=\"row\" align=\"center\" gap={2}>\n                    <Icon svg={IconZap} />\n                    <View.Item>Reshaped</View.Item>\n                </View>\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-icon--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <Icon svg={IconZap} color=\"neutral\" />\n        </Example.Item>\n        <Example.Item title=\"color: neutral-faded\">\n            <Icon svg={IconZap} color=\"neutral-faded\" />\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <Icon svg={IconZap} color=\"primary\" />\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Icon svg={IconZap} color=\"critical\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Icon svg={IconZap} color=\"positive\" />\n        </Example.Item>\n        <Example.Item title=\"color: disabled\">\n            <Icon svg={IconZap} color=\"disabled\" />\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <div style={{ color: \"tomato\" }}>\n                <Icon svg={IconZap} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "autoWidth",
+					"id": "utility-components-icon--auto-width",
+					"name": "autoWidth, blank",
 					"snippet": "const autoWidth = () => (\n    <Example>\n        <Example.Item title=\"square boundaries\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={IconMic} size={10} />\n            </div>\n        </Example.Item>\n        <Example.Item title=\"auto width boundaries\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={IconMic} size={10} autoWidth />\n            </div>\n        </Example.Item>\n        <Example.Item title=\"blank\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={null} size={10} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-icon--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Icon svg={IconZap} className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				},
 				{
-					"name": "render",
+					"id": "utility-components-icon--render",
+					"name": "test: hidden from sr",
 					"snippet": "const render = () => (\n    <div data-testid=\"root\">\n        <Icon svg={IconZap} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Icon, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Icon/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Icon",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Icon/Icon.tsx",
-				"actualName": "Icon",
+				"methods": [],
+				"props": {
+					"svg": {
+						"defaultValue": null,
+						"description": "Icon svg component or node",
+						"name": "svg",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Icon size, literal css value or unit token multiplier",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Icon color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"warning\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"autoWidth": {
+						"defaultValue": null,
+						"description": "Use the width of the svg asset instead of providing a square bounding box",
+						"name": "autoWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2680,54 +14259,230 @@
 			"path": "./src/components/Image/tests/Image.stories.tsx",
 			"stories": [
 				{
-					"name": "src",
+					"id": "utility-components-image--src",
+					"name": "src, alt",
 					"snippet": "const src = () => (\n    <Example>\n        <Example.Item title=\"src, alt\">\n            <Image src={imgUrl} alt=\"Image alt\" />\n        </Example.Item>\n\n        <Example.Item title=\"src\">\n            <Image src={imgUrl} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "utility-components-image--size",
+					"name": "width, height, maxWidth, aspectRatio",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"width: 200px\">\n            <Image src={imgUrl} width=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"height: 200px\">\n            <Image src={imgUrl} height=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"maxWidth: 200px\">\n            <Image src={imgUrl} maxWidth=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"aspectRatio: 1/1\">\n            <Image src={imgUrl} aspectRatio={1 / 1} width=\"300px\" />\n        </Example.Item>\n        <Example.Item title={[\"responsive width\", \"[s] 200px\", \"[m+] 300px\"]}>\n            <Image src={imgUrl} width={{ s: \"200px\", m: \"300px\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "radius",
+					"id": "utility-components-image--radius",
+					"name": "borderRadius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius: small\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"small\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"radius: medium\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"medium\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"radius: large\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--display-mode",
 					"name": "displayMode",
 					"snippet": "const displayMode = () => (\n    <Example>\n        <Example.Item title=\"mode: cover\">\n            <Image src={imgUrl} height=\"200px\" width=\"100%\" displayMode=\"cover\" />\n        </Example.Item>\n        <Example.Item title=\"mode: contain\">\n            <Image src={imgUrl} height=\"200px\" width=\"100%\" displayMode=\"contain\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--on-load",
 					"name": "onLoad",
 					"snippet": "const onLoad = () => <Image src={imgUrl} alt=\"photo\" onLoad={fn()} />;"
 				},
 				{
+					"id": "utility-components-image--on-error",
 					"name": "onError",
 					"snippet": "const onError = () => <Image src=\"/invalid.png\" alt=\"photo\" onError={fn()} />;"
 				},
 				{
+					"id": "utility-components-image--fallback",
 					"name": "fallback",
 					"snippet": "const fallback = () => (\n    <Example>\n        <Example.Item title=\"fallback, background, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"fallback, image, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback={imgUrl} />\n                </View>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"fallback, icon, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback={<Icon svg={IconZap} size={10} />} />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"fallback, icon, no url\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image fallback={<Icon svg={IconZap} size={10} />} />\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--render-image",
 					"name": "renderImage",
 					"snippet": "const renderImage = () => (\n    <Example>\n        <Example.Item title=\"renderImage\">\n            <Image\n                src={imgUrl}\n                alt=\"Amsterdam canal\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image\" />}\n            />\n        </Example.Item>\n        <Example.Item title=\"renderImage, fallback\">\n            <Image\n                src=\"error\"\n                fallback={imgUrl}\n                alt=\"Amsterdam canal 2\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image-fallback\" />}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "imageAttributes",
+					"id": "utility-components-image--image-attributes",
+					"name": "className, attributes,imageAttributes",
 					"snippet": "const imageAttributes = () => (\n    <div data-testid=\"root\">\n        <Image\n            src={imgUrl}\n            alt=\"photo\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            imageAttributes={{ \"data-testid\": \"test-img-id\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "ratio",
+					"id": "utility-components-image--ratio",
+					"name": "test: aspectRatio",
 					"snippet": "const ratio = () => (\n    <Example>\n        <Example.Item title=\"ratio: 16/9\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"ratio: 16/9, displayMode: contain\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} displayMode=\"contain\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Icon, Image, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Image/Image.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Image",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Image/Image.tsx",
-				"actualName": "Image",
+				"methods": [],
+				"props": {
+					"src": {
+						"defaultValue": null,
+						"description": "Image URL",
+						"name": "src",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"alt": {
+						"defaultValue": null,
+						"description": "Image alt text",
+						"name": "alt",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Image width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Image height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Image max width, literal css value or unit token multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"aspectRatio": {
+						"defaultValue": null,
+						"description": "Image aspect ratio, width / height",
+						"name": "aspectRatio",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Image border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"large\" | \"medium\"",
+							"value": [
+								{ "value": "\"small\"" },
+								{ "value": "\"large\"" },
+								{ "value": "\"medium\"" }
+							]
+						}
+					},
+					"displayMode": {
+						"defaultValue": null,
+						"description": "Image display mode for controlling how it fits into the provided boundaries",
+						"name": "displayMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"cover\" | \"contain\"",
+							"value": [{ "value": "\"cover\"" }, { "value": "\"contain\"" }]
+						}
+					},
+					"onLoad": {
+						"defaultValue": null,
+						"description": "Image on load event",
+						"name": "onLoad",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: SyntheticEvent<Element, Event>) => void)" }
+					},
+					"onError": {
+						"defaultValue": null,
+						"description": "Image on error event",
+						"name": "onError",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: SyntheticEvent<Element, Event>) => void)" }
+					},
+					"fallback": {
+						"defaultValue": null,
+						"description": "Image fallback content if the image fails to load or was not provided",
+						"name": "fallback",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"renderImage": {
+						"defaultValue": null,
+						"description": "Image render function, can be used for integrating with Image component in 3rd party frameworks",
+						"name": "renderImage",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Omit<Attributes<\"img\">, \"src\" | \"alt\"> & { src: string; alt: string; }) => ReactNode)"
+						}
+					},
+					"imageAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the image element",
+						"name": "imageAttributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"img\">" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(Attributes<\"div\"> & Attributes<\"img\">)" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2737,46 +14492,229 @@
 			"path": "./src/components/Overlay/tests/Overlay.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-overlay--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate}>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--transparent",
 					"name": "transparent",
 					"snippet": "const transparent = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate} transparent>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--blurred",
 					"name": "blurred",
 					"snippet": "const blurred = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate} blurred>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "renderProps",
+					"id": "utility-components-overlay--render-props",
+					"name": "children, render props",
 					"snippet": "const renderProps = () => (\n    <Overlay active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        {(args) => (args.active ? \"Opened\" : \"Closed\")}\n    </Overlay>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "utility-components-overlay--handlers",
+					"name": "onOpen, onClose, onAfterOpen, onAfterClose",
 					"snippet": "const handlers = () => {\n    const overlayToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => overlayToggle.toggle()}>Open overlay</Button>\n            <Overlay\n                active={overlayToggle.active}\n                onClose={(closeArgs) => {\n                    overlayToggle.deactivate();\n                    args.handleClose(closeArgs);\n                }}\n                onOpen={fn()}\n                onAfterOpen={fn()}\n                onAfterClose={fn()}>Content\n                                </Overlay>\n        </>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--disable-close-on-click",
 					"name": "disableCloseOnClick",
 					"snippet": "const disableCloseOnClick = (args) => (\n    <Overlay\n        active\n        disableCloseOnClick\n        onClose={(closeArgs) => {\n            args.handleClose(closeArgs);\n        }}\n    >\n        Content\n    </Overlay>\n);"
 				},
 				{
+					"id": "utility-components-overlay--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <>\n            <div ref={containerRef} data-testid=\"test-id\" style={{ height: 200 }} />\n            <Overlay active containerRef={containerRef}>\n                Content\n            </Overlay>\n        </>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-overlay--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <Overlay active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        Content\n    </Overlay>\n);"
 				}
 			],
 			"import": "import { Button, Example, Overlay } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Overlay/index.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Overlay",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Overlay/Overlay.tsx",
-				"actualName": "Overlay",
+				"methods": [],
+				"props": {
+					"transparent": {
+						"defaultValue": null,
+						"description": "Make the overlay transparent",
+						"name": "transparent",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number | boolean" }
+					},
+					"blurred": {
+						"defaultValue": null,
+						"description": "Make the overlay blurred",
+						"name": "blurred",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Control the overflow of the component content",
+						"name": "overflow",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"auto\"",
+							"value": [{ "value": "\"hidden\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, render function receives the state of the component as an argument",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode | ((props: { active: boolean; }) => ReactNode)" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the visibility of the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason: CloseReason; }) => void)" }
+					},
+					"onAfterClose": {
+						"defaultValue": null,
+						"description": "Callback after the component close transition is complete",
+						"name": "onAfterClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the component is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onAfterOpen": {
+						"defaultValue": null,
+						"description": "Callback after the component open transition is complete",
+						"name": "onAfterOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"disableCloseOnClick": {
+						"defaultValue": null,
+						"description": "Disable closing the component on outside click",
+						"name": "disableCloseOnClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": null,
+						"description": "Element to render the component in",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2786,42 +14724,213 @@
 			"path": "./src/components/Reshaped/tests/Reshaped.stories.tsx",
 			"stories": [
 				{
-					"name": "rtl",
+					"id": "utility-components-reshaped--rtl",
+					"name": "defaultRTL",
 					"snippet": "const rtl = () => (\n    <Reshaped defaultRTL theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				},
 				{
-					"name": "controlledMode",
+					"id": "utility-components-reshaped--controlled-mode",
+					"name": "colorMode, controlled",
 					"snippet": "const controlledMode = () => {\n    const [mode, setMode] = useState<G.ColorMode>(\"dark\");\n\n    return (\n        <Reshaped theme=\"reshaped\" colorMode={mode}>\n            <Button\n                onClick={() => {\n                    setMode(mode === \"dark\" ? \"light\" : \"dark\");\n                }}\n            >\n                Toggle color mode\n            </Button>\n        </Reshaped>\n    );\n};"
 				},
 				{
-					"name": "lightMode",
+					"id": "utility-components-reshaped--light-mode",
+					"name": "defaultColorMode=light",
 					"snippet": "const lightMode = () => <Reshaped theme=\"reshaped\">Hello</Reshaped>;"
 				},
 				{
-					"name": "darkMode",
+					"id": "utility-components-reshaped--dark-mode",
+					"name": "defaultColorMode=dark",
 					"snippet": "const darkMode = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				},
 				{
+					"id": "utility-components-reshaped--scoped",
 					"name": "scoped",
 					"snippet": "const scoped = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\" scoped>\n        Hello\n    </Reshaped>\n);"
 				},
 				{
-					"name": "testScoped",
+					"id": "utility-components-reshaped--test-scoped",
+					"name": "test: scoped switch",
 					"snippet": "const testScoped = () => (\n    <Reshaped theme=\"reshaped\">\n        <Reshaped theme=\"slate\" scoped>\n            <ScopedComponent />\n        </Reshaped>\n    </Reshaped>\n);"
 				},
 				{
-					"name": "keyboardMode",
+					"id": "utility-components-reshaped--keyboard-mode",
+					"name": "test: keyboard mode",
 					"snippet": "const keyboardMode = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				}
 			],
 			"import": "import { Button, Reshaped } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Reshaped/Reshaped.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Reshaped",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Reshaped/Reshaped.tsx",
-				"actualName": "Reshaped",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"theme": {
+						"defaultValue": null,
+						"description": "Theme of the application, enables controlled mode",
+						"name": "theme",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NonNullable<Theme>" }
+					},
+					"defaultTheme": {
+						"defaultValue": null,
+						"description": "Default theme of the application, enables uncontrolled mode",
+						"name": "defaultTheme",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NonNullable<Theme>" }
+					},
+					"defaultRTL": {
+						"defaultValue": null,
+						"description": "Default content direction of the application",
+						"name": "defaultRTL",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode of the application, enables controlled mode",
+						"name": "colorMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode",
+							"value": [{ "value": "\"light\"" }, { "value": "\"dark\"" }]
+						}
+					},
+					"defaultColorMode": {
+						"defaultValue": null,
+						"description": "Default color mode of the application, enables uncontrolled mode",
+						"name": "defaultColorMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode",
+							"value": [{ "value": "\"light\"" }, { "value": "\"dark\"" }]
+						}
+					},
+					"defaultViewport": {
+						"defaultValue": null,
+						"description": "Default viewport size of the application",
+						"name": "defaultViewport",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Viewport",
+							"value": [
+								{ "value": "\"s\"" },
+								{ "value": "\"m\"" },
+								{ "value": "\"l\"" },
+								{ "value": "\"xl\"" }
+							]
+						}
+					},
+					"toastOptions": {
+						"defaultValue": null,
+						"description": "Global options for the ToastProvider",
+						"name": "toastOptions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "Partial<Record<Position, { width?: string; expanded?: boolean; }>> | undefined"
+						}
+					},
+					"scoped": {
+						"defaultValue": null,
+						"description": "Enable scoped mode for applications not using Reshaped provider at the application root",
+						"name": "scoped",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2831,42 +14940,150 @@
 			"path": "./src/components/ScrollArea/tests/ScrollArea.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-scrollarea--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"vertical scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"horizontal scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\" height=\"100px\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"horizontal and vertical scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-scrollarea--scrollbar-display",
 					"name": "scrollbarDisplay",
 					"snippet": "const scrollbarDisplay = () => (\n    <Example>\n        <Example.Item title=\"scrollbarDisplay: hover\">\n            <ScrollArea height=\"100px\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"scrollbarDisplay: hidden\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"hidden\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"scrollbarDisplay: visible\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "height",
+					"id": "utility-components-scrollarea--height",
+					"name": "height, maxHeight",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"height: 80px\">\n            <ScrollArea height=\"80px\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"responsive height: s 80px, m: 120px\">\n            <ScrollArea height={{ s: \"80px\", m: \"120px\" }}>\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"maxHeight: 80px\">\n            <ScrollArea maxHeight=\"80px\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"responsive max height: s 80px, m: 200px\">\n            <ScrollArea maxHeight={{ s: \"80px\", m: \"200px\" }}>\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onScroll",
+					"id": "utility-components-scrollarea--on-scroll",
+					"name": "ref, onScroll",
 					"snippet": "const onScroll = () => {\n    const ref = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={4}>\n            <View.Item>\n                <Button onClick={() => ref.current?.scrollBy({ top: 50, left: 50 })}>Scroll</Button>\n            </View.Item>\n            <ScrollArea height=\"100px\" ref={ref} scrollbarDisplay=\"visible\" onScroll={fn()}>\n                <View backgroundColor=\"neutral-faded\" padding={4} width=\"1000px\" height=\"200px\">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                                            has been the industry's standard dummy text ever since the 1500s, when an unknown\n                                            printer took a galley of type and scrambled it to make a type specimen book. It has\n                                            survived not only five centuries, but also the leap into electronic typesetting,\n                                            remaining essentially unchanged. It was popularised in the 1960s with the release of\n                                            Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                                            publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                                        </View>\n            </ScrollArea>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-scrollarea--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ScrollArea className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </ScrollArea>\n    </div>\n);"
 				},
 				{
-					"name": "testNested",
+					"id": "utility-components-scrollarea--test-nested",
+					"name": "test: nested",
 					"snippet": "const testNested = () => (\n    <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n        <View padding={4} paddingInline={16}>\n            <ScrollArea height=\"200px\" scrollbarDisplay=\"visible\">\n                {Array(20)\n                    .fill(\"\")\n                    .map((_, index) => {\n                        return <div key={index}>Item {index + 1}</div>;\n                    })}\n            </ScrollArea>\n        </View>\n    </ScrollArea>\n);"
 				},
 				{
-					"name": "testDynamicHeight",
+					"id": "utility-components-scrollarea--test-dynamic-height",
+					"name": "test: dynamic height change",
 					"snippet": "const testDynamicHeight = () => {\n    const [count, setCount] = React.useState(10);\n\n    return (\n        <View gap={4}>\n            <View.Item>\n                <Button onClick={() => setCount((prev) => prev + 10)}>Add more items</Button>\n            </View.Item>\n\n            <ScrollArea height=\"200px\" scrollbarDisplay=\"visible\">\n                <View gap={2}>\n                    {new Array(count).fill(\"\").map((_, i) => (\n                        <View.Item key={i}>Item {i + 1}</View.Item>\n                    ))}\n                </View>\n            </ScrollArea>\n        </View>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Example, ScrollArea, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ScrollArea/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ScrollArea",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ScrollArea/ScrollArea.tsx",
-				"actualName": "ScrollArea",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"scrollbarDisplay": {
+						"defaultValue": null,
+						"description": "Scrollbar visibility behavior based on the user interaction",
+						"name": "scrollbarDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"hover\" | \"visible\"",
+							"value": [
+								{ "value": "\"hidden\"" },
+								{ "value": "\"hover\"" },
+								{ "value": "\"visible\"" }
+							]
+						}
+					},
+					"onScroll": {
+						"defaultValue": null,
+						"description": "Callback when the scroll area is scrolled",
+						"name": "onScroll",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: Coordinates) => void)" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height of the scroll area, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height of the scroll area, literal css value or unit token multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2876,54 +15093,387 @@
 			"path": "./src/components/Text/tests/Text.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-text--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: title-1\">\n            <Text variant=\"title-1\">Title 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-2\">\n            <Text variant=\"title-2\">Title 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-3\">\n            <Text variant=\"title-3\">Title 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-4\">\n            <Text variant=\"title-4\">Title 4</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-5\">\n            <Text variant=\"title-5\">Title 5</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-6\">\n            <Text variant=\"title-6\">Title 6</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-1\">\n            <Text variant=\"featured-1\">Featured 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-2\">\n            <Text variant=\"featured-2\">Featured 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-3\">\n            <Text variant=\"featured-3\">Featured 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-1\">\n            <Text variant=\"body-1\">Body 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-2\">\n            <Text variant=\"body-2\">Body 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-3\">\n            <Text variant=\"body-3\">Body 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: caption-1\">\n            <Text variant=\"caption-1\">Caption 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: caption-2\">\n            <Text variant=\"caption-2\">Caption 2</Text>\n        </Example.Item>\n        <Example.Item title={[\"responsive variant\", \"[s] body-3\", \"[m+] title-4\"]}>\n            <Text variant={{ s: \"body-3\", m: \"title-4\" }}>Responsive</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--weight",
 					"name": "weight",
 					"snippet": "const weight = () => (\n    <Example>\n        <Example.Item title=\"weight: regular\">\n            <Text weight=\"regular\">Regular</Text>\n        </Example.Item>\n        <Example.Item title=\"weight: medium\">\n            <Text weight=\"medium\">Medium</Text>\n        </Example.Item>\n        <Example.Item title=\"weight: bold\">\n            <Text weight=\"bold\">Bold</Text>\n        </Example.Item>\n        <Example.Item title={[\"responsive\", \"[s] weight: regular\", \"[m+] bold\"]}>\n            <Text weight={{ s: \"regular\", m: \"bold\" }}>Responsive</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: inherit\">\n            <Text>Neutral</Text>\n        </Example.Item>\n        <Example.Item title=\"color: neutral-faded\">\n            <Text color=\"neutral-faded\">Faded</Text>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Text color=\"positive\">Positive</Text>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <Text color=\"warning\">Warning</Text>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Text color=\"critical\">Critical</Text>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <Text color=\"primary\">Primary</Text>\n        </Example.Item>\n        <Example.Item title=\"color: disabled\">\n            <Text color=\"disabled\" attributes={{ \"aria-disabled\": true }}>\n                Disabled\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--decoration",
 					"name": "decoration",
 					"snippet": "const decoration = () => (\n    <Example>\n        <Example.Item title=\"decoration: line-through\">\n            <Text decoration=\"line-through\">Line through</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--wrap",
 					"name": "wrap",
 					"snippet": "const wrap = () => (\n    <Example>\n        <Example.Item title=\"wrap: balance\">\n            <Text wrap=\"balance\" variant=\"title-3\">\n                The design system you want to build\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "mono",
+					"id": "utility-components-text--mono",
+					"name": "monospace",
 					"snippet": "const mono = () => (\n    <Example>\n        <Example.Item title=\"monospace\">\n            <Text monospace>Content</Text>\n        </Example.Item>\n        <Example.Item title=\"monospace, variant, weight\">\n            <Text monospace variant=\"title-1\" weight=\"regular\">\n                Content\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--max-lines",
 					"name": "maxLines",
 					"snippet": "const maxLines = () => (\n    <Example>\n        <Example.Item title=\"maxLines: 2\">\n            <Text maxLines={2}>\n                There are many variations of passages of Lorem Ipsum available, but the majority have\n                suffered alteration in some form, by injected humour, or randomised words which don't look\n                even slightly believable. If you are going to use a passage of Lorem Ipsum, you need to be\n                sure there isn't anything embarrassing hidden in the middle of text. All the Lorem Ipsum\n                generators on the Internet tend to repeat predefined chunks as necessary, making this the\n                first true generator on the Internet. It uses a dictionary of over 200 Latin words,\n                combined with a handful of model sentence structures, to generate Lorem Ipsum which looks\n                reasonable. The generated Lorem Ipsum is therefore always free from repetition, injected\n                humour, or non-characteristic words etc.\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: start\">\n            <Text align=\"start\">Text content</Text>\n        </Example.Item>\n        <Example.Item title=\"align: center\">\n            <Text align=\"center\">Text content</Text>\n        </Example.Item>\n        <Example.Item title=\"align: end\">\n            <Text align=\"end\">Text content</Text>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive alignment\", \"[s]: center\", \"[m+] start\"]}>\n            <Text align={{ s: \"center\", m: \"start\" }}>Text content</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "asProp",
+					"id": "utility-components-text--as-prop",
+					"name": "as",
 					"snippet": "const asProp = () => (\n    <>\n        <Text as=\"h1\">Content</Text>\n        <Text variant=\"title-3\">Content</Text>\n        <Text variant={{ s: \"title-3\", m: \"title-4\" }}>Content</Text>\n    </>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-text--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Text className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Text>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Text/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Text",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Text/Text.tsx",
-				"actualName": "Text",
+				"methods": [],
+				"props": {
+					"variant": {
+						"defaultValue": null,
+						"description": "Text render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Variant>" }
+					},
+					"weight": {
+						"defaultValue": null,
+						"description": "Text font weight",
+						"name": "weight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"medium\" | \"bold\" | \"regular\">" }
+					},
+					"monospace": {
+						"defaultValue": null,
+						"description": "Render monospace font",
+						"name": "monospace",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Text color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"warning\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Text alignment",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"center\" | \"start\" | \"end\">" }
+					},
+					"wrap": {
+						"defaultValue": null,
+						"description": "CSS wrapping style",
+						"name": "wrap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"balance\"", "value": [{ "value": "\"balance\"" }] }
+					},
+					"decoration": {
+						"defaultValue": null,
+						"description": "CSS text decoration style",
+						"name": "decoration",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"line-through\"",
+							"value": [{ "value": "\"line-through\"" }]
+						}
+					},
+					"maxLines": {
+						"defaultValue": null,
+						"description": "Maximum number of lines to render, used for text truncation",
+						"name": "maxLines",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different html tag",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2933,46 +15483,114 @@
 			"path": "./src/components/Theme/tests/Theme.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-theme--scoped",
 					"name": "scoped",
 					"snippet": "const scoped = () => (\n    <Example>\n        <Example.Item title=\"scoped, single\">\n            <Theme name=\"reshaped\">\n                <Card attributes={{ \"data-testid\": \"test-id\" }}>\n                    <Button color=\"primary\">Action</Button>\n                </Card>\n            </Theme>\n        </Example.Item>\n\n        <Example.Item title=\"scoped, multiple\">\n            <Theme name={[\"reshaped\", \"figma\"]}>\n                <Card attributes={{ \"data-testid\": \"test-id-multi\" }}>\n                    <View direction=\"row\" gap={4}>\n                        <Button color=\"primary\">Action</Button>\n\n                        <Popover>\n                            <Popover.Trigger>\n                                {(attributes) => <Button attributes={attributes}>Popover</Button>}\n                            </Popover.Trigger>\n                            <Popover.Content>Content</Popover.Content>\n                        </Popover>\n                    </View>\n                </Card>\n            </Theme>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-theme--light",
 					"name": "light",
 					"snippet": "const light = () => (\n    <Theme name=\"reshaped\" colorMode=\"light\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--dark",
 					"name": "dark",
 					"snippet": "const dark = () => (\n    <Theme name=\"reshaped\" colorMode=\"dark\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--inherited",
 					"name": "inherited",
 					"snippet": "const inherited = () => (\n    <Theme name=\"reshaped\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--inverted",
 					"name": "inverted",
 					"snippet": "const inverted = () => (\n    <Theme name=\"reshaped\" colorMode=\"inverted\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--controlled",
 					"name": "controlled",
 					"snippet": "const controlled = () => {\n    const Internal = () => {\n        const { setTheme, theme } = useTheme();\n\n        return (\n            <Button color=\"primary\" onClick={() => setTheme(\"slate\")}>\n                Switch to slate\n            </Button>\n        );\n    };\n\n    return (\n        <div data-testid=\"root\">\n            <Theme name=\"reshaped\">\n                <Internal />\n            </Theme>\n        </div>\n    );\n};"
 				},
 				{
+					"id": "utility-components-theme--uncontrolled",
 					"name": "uncontrolled",
 					"snippet": "const uncontrolled = () => {\n    const Internal = () => {\n        const { setTheme } = useTheme();\n\n        return (\n            <Button color=\"primary\" onClick={() => setTheme(\"slate\")}>\n                Switch to slate\n            </Button>\n        );\n    };\n\n    return (\n        <div data-testid=\"root\">\n            <Theme defaultName=\"reshaped\">\n                <Internal />\n            </Theme>\n        </div>\n    );\n};"
 				},
 				{
-					"name": "disabledTransition",
+					"id": "utility-components-theme--disabled-transition",
+					"name": "disabled transitions",
 					"snippet": "const disabledTransition = () => {\n    const { invertColorMode } = useTheme();\n\n    return (\n        <Example>\n            <Example.Item title=\"should have no transitions while switching color mode\">\n                <View gap={3}>\n                    <Button onClick={invertColorMode}>Invert mode</Button>\n\n                    <MenuItem selected>Test transition</MenuItem>\n\n                    <Card>Default card</Card>\n\n                    <Theme colorMode=\"inverted\">\n                        <Card>Inverted card</Card>\n                    </Theme>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Card, Example, MenuItem, Popover, Theme, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Theme/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Theme",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Theme/Theme.tsx",
-				"actualName": "Theme",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the theme to use, enables controlled mode",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"defaultName": {
+						"defaultValue": null,
+						"description": "Default name of the theme to use, enables uncontrolled mode",
+						"name": "defaultName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode to use",
+						"name": "colorMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode | \"inverted\"",
+							"value": [
+								{ "value": "\"light\"" },
+								{ "value": "\"dark\"" },
+								{ "value": "\"inverted\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2982,147 +15600,880 @@
 			"path": "./src/components/View/tests/View.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-view--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example title=\"Border is used to highlight the padding value\">\n        <Example.Item title=\"padding: 4\">\n            <View padding={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <View padding={6} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: 0\">\n            <View padding={0} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: vertical 2, horizontal 4\">\n            <View paddingInline={4} paddingBlock={2} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingTop: 4\">\n            <View paddingTop={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingBottom: 4\">\n            <View paddingBottom={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingStart: 4\">\n            <View paddingStart={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingEnd: 4\">\n            <View paddingEnd={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive padding:\",\n                \"[s] vertical 2, horizontal 4\",\n                \"[m+] vertical 4, horizontal 8\",\n            ]}\n        >\n            <View paddingInline={{ s: 4, m: 8 }} paddingBlock={{ s: 2, m: 4 }} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"responsive padding:\", \"[s] top 2, bottom 4\", \"[m+] top 4, bottom 0, start: 8\"]}\n        >\n            <View\n                paddingTop={{ s: 2, m: 4 }}\n                paddingBottom={{ s: 4, m: 0 }}\n                paddingStart={{ s: 0, m: 8 }}\n                borderColor=\"neutral\"\n            >\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"nested padding, child view should have no horizontal padding\">\n            <View paddingStart={4} borderColor=\"neutral\">\n                <View borderColor=\"primary\" paddingBlock={4}>\n                    <Placeholder />\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example title=\"Item 1 is another component, Item 2 is View.Item, Item 3 is text\">\n        <Example.Item title=\"direction: column as default\">\n            <View gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <View gap={3} direction=\"column\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column-reverse\">\n            <View gap={3} direction=\"column-reverse\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row\">\n            <View gap={3} direction=\"row\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row-reverse\">\n            <View gap={3} direction=\"row-reverse\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"responsive direction\", \"[s] column-reverse\", \"[m] row-reverse\", \"[l+] row\"]}\n        >\n            <View direction={{ s: \"column-reverse\", m: \"row-reverse\", l: \"row\" }} gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 4, direction: row\">\n            <View direction=\"row\" gap={4} divided>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n                <Placeholder>Item 3</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 0, direction: row\">\n            <View direction=\"row\" gap={0}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap, direction: row\", \"[s] 4\", \"[m+] 8\"]}>\n            <View direction=\"row\" gap={{ s: 4, m: 8 }}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 4, direction: column\">\n            <View gap={4}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 0, direction: column\">\n            <View gap={0}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap, direction: column\", \"[s] 4\", \"[m+] 8\"]}>\n            <View gap={{ s: 4, m: 8 }}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--divided",
 					"name": "divided",
 					"snippet": "const divided = () => (\n    <Example>\n        <Example.Item title=\"direction: row\">\n            <View divided direction=\"row\" gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <View divided gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive divided\", \"[s] direction: row\", \"[m+] direction: column\"]}>\n            <View divided direction={{ s: \"row\", m: \"column\" }} gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row, columns\">\n            <View divided gap={3} direction=\"row\">\n                <View.Item columns={2}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={8}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={2}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"with React.Fragment\">\n            <View direction=\"row\" gap={4} divided>\n                <Placeholder>Item 1</Placeholder>\n                <>\n                    <Placeholder>Item 2</Placeholder>\n                    <Placeholder>Item 3</Placeholder>\n                </>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example title=\"Removes side borders and border radius when applied\">\n        <Example.Item title=\"bleed: 4\">\n            <View bleed={4} padding={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive bleed\", \"[s] 4\", \"[m+] 0\"]}>\n            <View bleed={{ s: 4, m: 0 }} padding={4} borderRadius=\"small\" borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--wrap",
 					"name": "wrap",
 					"snippet": "const wrap = () => (\n    <Example>\n        <Example.Item title=\"wrap: false\">\n            <View direction=\"row\" wrap={false} gap={3}>\n                <Placeholder w={600} h={100} />\n                <Placeholder w={600} h={100} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: start, direction: row\">\n            <View align=\"start\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: center, direction: row\">\n            <View align=\"center\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: end, direction: row\">\n            <View align=\"end\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"align: stretch, direction: row\",\n                \"2nd item is stretched based on the 1st item height\",\n            ]}\n        >\n            <View align=\"stretch\" direction=\"row\" gap={3}>\n                <Placeholder h={100} />\n                <Placeholder h=\"auto\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: baseline, direction: row\">\n            <View align=\"baseline\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Text variant=\"title-6\">Content</Text>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"align: start, direction: column\">\n            <View align=\"start\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: center, direction: column\">\n            <View align=\"center\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: end, direction: row\">\n            <View align=\"end\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"align: stretch, direction: column\",\n                \"1st item uses its own width, 2nd item is stretched to full width\",\n            ]}\n        >\n            <View align=\"stretch\" direction=\"column\" gap={3}>\n                <Placeholder w={100} />\n                <Placeholder w=\"auto\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--justify",
 					"name": "justify",
 					"snippet": "const justify = () => (\n    <Example>\n        <Example.Item title=\"justify: start, direction: row\">\n            <View justify=\"start\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: center, direction: row\">\n            <View justify=\"center\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: end, direction: row\">\n            <View justify=\"end\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: space-between, direction: row\">\n            <View justify=\"space-between\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"justify: start, direction: column, height: 200px\">\n            <View height=\"200px\" justify=\"start\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: center, direction: column, height: 200px\">\n            <View height=\"200px\" justify=\"center\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: end, direction: column, height: 200px\">\n            <View justify=\"end\" height=\"200px\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: space-between, direction: column, height: 200px\">\n            <View justify=\"space-between\" height=\"200px\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--text-align",
 					"name": "textAlign",
 					"snippet": "const textAlign = () => (\n    <Example>\n        <Example.Item title=\"textAlign: start\">\n            <View textAlign=\"start\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: center\">\n            <View textAlign=\"center\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: end\">\n            <View textAlign=\"end\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: [s] start, [m+] end\">\n            <View textAlign={{ s: \"start\", m: \"end\" }}>Content</View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"height: 100px, width: 100px\">\n            <View backgroundColor=\"neutral-faded\" height=\"100px\" width=\"100px\" />\n        </Example.Item>\n        <Example.Item title=\"height: 25, width: 25\">\n            <View backgroundColor=\"neutral-faded\" height={25} width={25} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive height and width\",\n                \"[s] height: 25, width: 25\",\n                \"[m+] height: 200px, width: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                height={{ s: 25, m: \"200px\" }}\n                width={{ s: 25, m: \"200px\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "ratio",
+					"id": "utility-components-view--ratio",
+					"name": "aspectRatio",
 					"snippet": "const ratio = () => (\n    <Example>\n        <Example.Item title=\"ratio: 16 / 9\">\n            <View backgroundColor=\"neutral-faded\" aspectRatio={16 / 9} width=\"200px\" />\n        </Example.Item>\n        <Example.Item title={[\"responsive ratio\", \"[s] 1/1\", \"[m+] 16/9\"]}>\n            <View backgroundColor=\"neutral-faded\" aspectRatio={{ s: 1, m: 16 / 9 }} width=\"200px\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "maxSize",
+					"id": "utility-components-view--max-size",
+					"name": "width, height, maxWidth, maxHeight",
 					"snippet": "const maxSize = () => (\n    <Example>\n        <Example.Item title=\"maxHeight: 150px, maxWidth: 150px, height: 300px\">\n            <View backgroundColor=\"neutral-faded\" maxHeight=\"150px\" maxWidth=\"150px\" height=\"300px\" />\n        </Example.Item>\n        <Example.Item title=\"maxHeight: 25, maxWidth: 25, height: 50\">\n            <View backgroundColor=\"neutral-faded\" maxHeight={25} maxWidth={25} height={50} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive maxHeight and maxWidth, height: 300\",\n                \"[s] maxHeight: 25, maxWidth: 25\",\n                \"[m+] maxHeight: 200px, maxWidth: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                maxHeight={{ s: 25, m: \"200px\" }}\n                maxWidth={{ s: 25, m: \"200px\" }}\n                height=\"300px\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "minSize",
+					"id": "utility-components-view--min-size",
+					"name": "width, height, minWidth, minHeight",
 					"snippet": "const minSize = () => (\n    <Example>\n        <Example.Item title=\"minHeight: 150px, minWidth: 150px, height: 50px, width: 50px\">\n            <View\n                backgroundColor=\"neutral-faded\"\n                minHeight=\"150px\"\n                minWidth=\"150px\"\n                height=\"50px\"\n                width=\"50px\"\n            />\n        </Example.Item>\n        <Example.Item title=\"minHeight: 25, minWidth: 25, height: 5, width: 5\">\n            <View backgroundColor=\"neutral-faded\" minHeight={25} minWidth={25} height={5} width={5} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive minHeight and minWidth, height: 50px, width: 50px\",\n                \"[s] minHeight: 25, minWidth: 25\",\n                \"[m+] minHeight: 200px, minWidth: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                minHeight={{ s: 25, m: \"200px\" }}\n                minWidth={{ s: 25, m: \"200px\" }}\n                height=\"50px\"\n                width=\"50px\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "background",
+					"id": "utility-components-view--background",
+					"name": "backgroundColor",
 					"snippet": "const background = () => (\n    <Example title=\"border is used to highlight the backround value when it's similar to the page background, text color changes based on the background\">\n        <Example.Item title=\"bg: page\">\n            <View backgroundColor=\"page\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: page-faded\">\n            <View backgroundColor=\"page-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: disabled\">\n            <View backgroundColor=\"disabled\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: disabled-faded\">\n            <View backgroundColor=\"disabled-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-base\">\n            <View backgroundColor=\"elevation-base\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-raised\">\n            <View backgroundColor=\"elevation-raised\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-overlay\">\n            <View backgroundColor=\"elevation-overlay\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: neutral\">\n            <View backgroundColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: neutral-faded\">\n            <View backgroundColor=\"neutral-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: primary\">\n            <View backgroundColor=\"primary\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: primary-faded\">\n            <View backgroundColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: critical\">\n            <View backgroundColor=\"critical\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: critical-faded\">\n            <View backgroundColor=\"critical-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: warning\">\n            <View backgroundColor=\"warning\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: warning-faded\">\n            <View backgroundColor=\"warning-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: positive\">\n            <View backgroundColor=\"positive\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: positive-faded\">\n            <View backgroundColor=\"positive-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--border-color",
 					"name": "borderColor",
 					"snippet": "const borderColor = () => (\n    <Example>\n        <Example.Item title=\"border: neutral\">\n            <View borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: neutral-faded\">\n            <View borderColor=\"neutral-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: primary\">\n            <View borderColor=\"primary\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: primary-faded\">\n            <View borderColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: critical\">\n            <View borderColor=\"critical\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: critical-faded\">\n            <View borderColor=\"critical-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: warning\">\n            <View borderColor=\"warning\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: warning-faded\">\n            <View borderColor=\"warning-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: positive\">\n            <View borderColor=\"positive\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: positive-faded\">\n            <View borderColor=\"positive-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: transparent, background: primary-faded\">\n            <View borderColor=\"transparent\" backgroundColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive\", \"[s] primary\", \"[m+] neutral\"]}>\n            <View borderColor={{ s: \"primary\", m: \"neutral\" }} padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--border",
 					"name": "border",
 					"snippet": "const border = () => (\n    <Example>\n        <Example.Item title=\"border: true\">\n            <View border borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderTop: true\">\n            <View borderTop borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderBottom: true\">\n            <View borderBottom borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderStart: true\">\n            <View borderStart borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderEnd: true\">\n            <View borderEnd borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderInline: true\">\n            <View borderInline borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderBlock: true\">\n            <View borderBlock borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderTop: true, borderStart: true, \">\n            <View borderColor=\"neutral\" borderTop borderStart padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"responsive\",\n                \"[s] borderTop: true, borderStart: true\",\n                \"[m+] borderBottom: true, borderEnd: true\",\n            ]}\n        >\n            <View\n                borderColor=\"neutral\"\n                borderTop={{ s: true, m: false }}\n                borderStart={{ s: true, m: false }}\n                borderBottom={{ s: false, m: true }}\n                borderEnd={{ s: false, m: true }}\n                padding={4}\n            >\n                Content\n            </View>\n        </Example.Item>\n\n        <div style={{ height: 100 }} />\n    </Example>\n);"
 				},
 				{
-					"name": "radius",
+					"id": "utility-components-view--radius",
+					"name": "borderRadius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius: small\">\n            <View borderRadius=\"small\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: medium\">\n            <View borderRadius=\"medium\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: large\">\n            <View borderRadius=\"large\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: circular\">\n            <View borderRadius=\"circular\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--shadow",
 					"name": "shadow",
 					"snippet": "const shadow = () => (\n    <Example>\n        <Example.Item title=\"shadow: raised, radius: medium\">\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                shadow=\"raised\"\n                borderRadius=\"medium\"\n                backgroundColor=\"elevation-raised\"\n            />\n        </Example.Item>\n        <Example.Item title=\"shadow: overlay, radius: medium\">\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                shadow=\"overlay\"\n                borderRadius=\"medium\"\n                backgroundColor=\"elevation-overlay\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--overflow",
 					"name": "overflow",
 					"snippet": "const overflow = () => (\n    <Example>\n        <Example.Item\n            title={[\"overflow: hidden, radius: medium\", \"child background should have radius\"]}\n        >\n            <View height=\"100px\" width=\"100px\" shadow=\"raised\" borderRadius=\"medium\" overflow=\"hidden\">\n                <View backgroundColor=\"primary\" height=\"100%\" width=\"100%\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positioning",
+					"id": "utility-components-view--positioning",
+					"name": "position",
 					"snippet": "const positioning = () => (\n    <Example>\n        <Example.Item title=\"position: relative + absolute\">\n            <View borderColor=\"neutral\" position=\"relative\">\n                <Placeholder />\n                <View\n                    position=\"absolute\"\n                    insetTop={0}\n                    insetEnd={0}\n                    backgroundColor=\"critical\"\n                    zIndex={5}\n                    height={10}\n                    width={10}\n                />\n                <View\n                    position=\"absolute\"\n                    insetTop={0}\n                    insetEnd={0}\n                    backgroundColor=\"primary\"\n                    height={15}\n                    width={15}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: sticky\">\n            <div style={{ overflow: \"auto\", height: 100 }} tabIndex={0}>\n                <View position=\"sticky\" borderColor=\"primary\" insetTop={0}>\n                    Content\n                </View>\n                <Placeholder h={1000} />\n            </div>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive\", \"[s] position: absolute\", \"[m+]: position: relative\"]}>\n            <div style={{ overflow: \"auto\", height: 100, position: \"relative\" }} tabIndex={0}>\n                <View position={{ s: \"absolute\", m: \"relative\" }} borderColor=\"primary\" insetTop={0}>\n                    Content\n                </View>\n                <Placeholder h={1000} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--inset",
 					"name": "inset",
 					"snippet": "const inset = () => (\n    <Example>\n        <Example.Item title=\"inset: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" inset={4} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetTop: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" insetTop={4} height={10} width={10} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetStart: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetStart={4}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetEnd: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" insetEnd={4} height={10} width={10} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetBottom: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetBottom={4}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"responsive, [s] insetBottom: 4 [m+] insetEnd: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetBottom={{ s: 4, m: \"auto\" }}\n                    insetEnd={{ s: \"auto\", m: 4 }}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--animated",
 					"name": "animated",
 					"snippet": "const animated = () => {\n    const [background, setBackground] = React.useState<ViewProps[\"backgroundColor\"]>(\"neutral\");\n\n    return (\n        <View gap={3} align=\"start\">\n            <Button\n                onClick={() => setBackground((prev) => (prev === \"neutral\" ? \"primary\" : \"neutral\"))}\n            >\n                Change background\n            </Button>\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                backgroundColor={background}\n                align=\"center\"\n                justify=\"center\"\n                animated\n            >\n                Content\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "itemGapBefore",
+					"id": "utility-components-view--item-gap-before",
+					"name": "item, gapBefore",
 					"snippet": "const itemGapBefore = () => (\n    <Example>\n        <Example.Item title={[\"gap: 4, 3rd item gapBefore: 10, direction: row\", \"increased gap\"]}>\n            <View direction=\"row\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={10}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 4, direction: row\", \"reduced gap\"]}>\n            <View direction=\"row\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={4}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 0, direction: row\", \"removed gap\"]}>\n            <View direction=\"row\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={0}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"gap: 4, direction: row, 2nd item gap: auto\">\n            <View direction=\"row\" gap={4}>\n                <Placeholder w={200} />\n                <View.Item gapBefore=\"auto\">\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"gap: 4, 3rd item gapBefore: 10, direction: column\", \"increased gap\"]}>\n            <View direction=\"column\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={10}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 4, direction: column\", \"reduced gap\"]}>\n            <View direction=\"column\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={4}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 0, direction: column\", \"removed gap\"]}>\n            <View direction=\"column\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={0}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"gap: 4, direction: column, height: 200px, 2nd item gap: auto\">\n            <View height=\"200px\" gap={4}>\n                <Placeholder />\n                <View.Item gapBefore=\"auto\">\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"responsive item gap\",\n                \"gap: 4, direction: row\",\n                \"[s] 3rd item gapBefore: 10\",\n                \"[m+] 3rd item gapBefore: 0\",\n            ]}\n        >\n            <View direction=\"row\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={{ s: 10, m: 0 }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemGrow",
+					"id": "utility-components-view--item-grow",
+					"name": "item, grow",
 					"snippet": "const itemGrow = () => (\n    <Example>\n        <Example.Item title=\"direction: row, 2nd item grow\">\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column, height: 200px, 2nd item grow\">\n            <View direction=\"column\" gap={3} height=\"200px\">\n                <Placeholder />\n                <View.Item grow>\n                    <Placeholder h=\"100%\" />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row, 2nd item grow, applied to View\">\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View grow>\n                    <Placeholder />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive item grow, direction: row\",\n                \"[s] 2nd item grow\",\n                \"[m+] 2nd item doesn't grow\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View.Item grow={{ s: true, m: false }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive item grow, direction: column, height: 200px\",\n                \"[s] 2nd item grow\",\n                \"[m+] 2nd item doesn't grow\",\n            ]}\n        >\n            <View direction=\"column\" gap={3} height=\"200px\">\n                <Placeholder />\n                <View.Item grow={{ s: true, m: false }}>\n                    <Placeholder h=\"100%\" />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemColumns",
+					"id": "utility-components-view--item-columns",
+					"name": "item, columns",
 					"snippet": "const itemColumns = () => (\n    <Example>\n        <Example.Item title=\"columns 6, 6, gap: 0\">\n            <View direction=\"row\">\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 3, 9, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={3}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, 9, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive columns\", \"[s] columns 6, 6, 12, gap: 4\", \"[m+]: 4, 4, 4\"]}>\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={{ s: 6, m: 4 }}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 6, m: 4 }}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 12, m: 4 }}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, 9, gap: 4, 2nd item gapBefore: 20\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6} gapBefore={20}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemOrder",
+					"id": "utility-components-view--item-order",
+					"name": "item, order",
 					"snippet": "const itemOrder = () => (\n    <Example>\n        <Example.Item title=\"order: 1 3 2\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={4}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={4} order={1}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={4}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive order\", \"[s] 1 2 3\", \"[m+] 1 3 2\"]}>\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={4}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={4} order={{ s: 0, m: 1 }}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={4}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive order\",\n                \"[s]: 1 3 2, 2 is full width on second row\",\n                \"[m+]: 1 2 3, 2 has grow in the center of the first row\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <View.Item columns={{ s: 6, m: \"auto\" }}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item\n                    grow={{ s: false, m: true }}\n                    order={{ s: 1, m: 0 }}\n                    columns={{ s: 12, m: \"auto\" }}\n                >\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 6, m: \"auto\" }}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "hiddenItem",
+					"id": "utility-components-view--hidden-item",
+					"name": "composition, Hidden item",
 					"snippet": "const hiddenItem = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"[s] 2nd item: visible, grow, 3rd item: !grow\",\n                \"[m+] 2nd item: hidden, 2nd item divider: hidden, 3rd item: grow\",\n            ]}\n        >\n            <View direction=\"row\" divided gap={3}>\n                <Placeholder />\n                <Hidden hide={{ s: false, m: true }}>\n                    <View.Item grow key=\"3\">\n                        <Placeholder />\n                    </View.Item>\n                </Hidden>\n                <View.Item grow={{ s: false, m: true }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"[s] 2nd item: visible, grow, 3rd item: !grow\",\n                \"[m+] 2nd item: hidden, 2nd item: grow doesn't push 3rd item, 3rd item: grow\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Placeholder />\n                <Hidden hide={{ s: false, m: true }}>\n                    <View.Item grow>\n                        <Placeholder />\n                    </View.Item>\n                </Hidden>\n                <View.Item grow={{ s: false, m: true }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "keys",
+					"id": "utility-components-view--keys",
+					"name": "item, key",
 					"snippet": "const keys = () => {\n    const toggle = useToggle();\n\n    return (\n        <View gap={2}>\n            <Button onClick={() => toggle.toggle()}>Toggle</Button>\n            <View.Item>Item 1</View.Item>\n            {toggle.active && <KeyItem>Item 2</KeyItem>}\n            <KeyItem>Item 3</KeyItem>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "nestedGaps",
+					"id": "utility-components-view--nested-gaps",
+					"name": "composition, nested gap",
 					"snippet": "const nestedGaps = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"direction: column, gap: 10\",\n                \"Child 1: direction: column, gap: 2\",\n                \"Child 2: direction column, gap: 6\",\n                \"Child 3: gapBefore: 0\",\n                \"Child 3 view: direction: row, gap: 2\",\n            ]}\n        >\n            <View gap={10}>\n                <View gap={2}>\n                    <Placeholder>Child 1</Placeholder>\n                    <Placeholder>Child 1</Placeholder>\n                </View>\n\n                <View gap={6}>\n                    <Placeholder>Child 2</Placeholder>\n                    <Placeholder>Child 2</Placeholder>\n                </View>\n\n                <View.Item gapBefore={0}>\n                    <View direction=\"row\" gap={2}>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "utility-components-view--test-composition",
+					"name": "composition, edge cases",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item>\n            <View direction=\"row\" align=\"center\" gap={4} padding={4}>\n                <View width=\"80px\" height=\"60px\" backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n\n                <View direction=\"row\" align=\"center\" gap={1} grow>\n                    <View.Item shrink>\n                        <Text>Text (like Jeff's Puzzles)</Text>\n                    </View.Item>\n\n                    <View minWidth=\"auto\" grow>\n                        <Button size=\"small\" color=\"neutral\" icon={IconPlus} />\n                    </View>\n                </View>\n\n                <Button color=\"primary\" rounded>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"View.Item, MenuItem, Aspect ratio\",\n                \"ratio should increase height on viewport change\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <View.Item>\n                    <Placeholder />\n                </View.Item>\n                <MenuItem selected roundedCorners>\n                    Menu\n                </MenuItem>\n                <View.Item grow>\n                    <View aspectRatio={16 / 9}>\n                        <Placeholder h=\"100%\" />\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"Scrollable tabs inside View.Item with grow\">\n            <View direction=\"row\" align=\"center\" gap={3}>\n                <Placeholder />\n                <View.Item grow>\n                    <View padding={0} align=\"center\">\n                        <Tabs variant=\"pills\">\n                            <Tabs.List>\n                                <Tabs.Item value=\"1\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"2\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"3\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"4\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"5\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"6\">Very long item</Tabs.Item>\n                            </Tabs.List>\n                            {[1, 2, 3, 5, 6].map((i) => (\n                                <Tabs.Panel key={i} value={i.toString()} />\n                            ))}\n                        </Tabs>\n                    </View>\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"2nd item has grow, Avatar stays circle\">\n            <View direction=\"row\" gap={3}>\n                <Avatar initials=\"DB\" />\n                <View.Item grow>\n                    Veggies sunt bona vobis, proinde vos postulo esse magis grape pea sprouts horseradish\n                    courgette maize spinach prairie turnip jícama coriander quandong gourd broccoli seakale\n                    gumbo. Parsley corn lentil zucchini radicchio maize burdock avocado sea lettuce.\n                    Garbanzo tigernut earthnut pea fennel.\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"item gapBefore from parent doesn't affect the child view\",\n                \"columns should take full width\",\n            ]}\n        >\n            <View>\n                <View.Item gapBefore={20}>\n                    <View direction=\"row\" gap={4}>\n                        <View.Item columns={6}>\n                            <Placeholder />\n                        </View.Item>\n                        <View.Item columns={6}>\n                            <Placeholder />\n                        </View.Item>\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"View becomes flexbox if there is a child with grow\">\n            <View height=\"300px\" borderColor=\"neutral-faded\">\n                <View height=\"50px\" />\n                <View grow backgroundColor=\"neutral-faded\" padding={4}>\n                    Grow\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "asProp",
+					"id": "utility-components-view--as-prop",
+					"name": "as",
 					"snippet": "const asProp = () => (\n    <View as=\"ul\">\n        <View.Item as=\"li\">Content</View.Item>\n    </View>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-view--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <View className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </View>\n    </div>\n);"
 				},
 				{
-					"name": "itemClassName",
+					"id": "utility-components-view--item-class-name",
+					"name": "item className, attributes",
 					"snippet": "const itemClassName = () => (\n    <div data-testid=\"root\">\n        <View.Item className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </View.Item>\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Button, Example, Hidden, MenuItem, Placeholder, Tabs, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/View/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "View",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/View/View.tsx",
-				"actualName": "View",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"divided": {
+						"defaultValue": null,
+						"description": "Render a divider between each child",
+						"name": "divided",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Flex direction for the content",
+						"name": "direction",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Direction>" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between children, base unit token number multiplier",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"wrap": {
+						"defaultValue": null,
+						"description": "Flex wrap for the content",
+						"name": "wrap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Flex align-items for the content",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Flex justify-content for the content",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width style, literal string value or a base unit token number multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"aspectRatio": {
+						"defaultValue": null,
+						"description": "Aspect ratio style, represented as width / height",
+						"name": "aspectRatio",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height style, literal string value or a base unit token number multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Maximum width style, literal string value or a base unit token number multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"minHeight": {
+						"defaultValue": null,
+						"description": "Minimum height style, literal string value or a base unit token number multiplier",
+						"name": "minHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"minWidth": {
+						"defaultValue": null,
+						"description": "Minimum width style, literal string value or a base unit token number multiplier",
+						"name": "minWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Padding style for all sides, base unit token number multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingTop": {
+						"defaultValue": null,
+						"description": "Padding top, base unit token number multiplier",
+						"name": "paddingTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingBottom": {
+						"defaultValue": null,
+						"description": "Padding bottom, base unit token number multiplier",
+						"name": "paddingBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingStart": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "paddingStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingEnd": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "paddingEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingInline": {
+						"defaultValue": null,
+						"description": "Padding inline, base unit token number multiplier",
+						"name": "paddingInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingBlock": {
+						"defaultValue": null,
+						"description": "Padding block, base unit token number multiplier",
+						"name": "paddingBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margin and remove side borders, base unit token number multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"textAlign": {
+						"defaultValue": null,
+						"description": "Text align for the content",
+						"name": "textAlign",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<TextAlign>" }
+					},
+					"backgroundColor": {
+						"defaultValue": null,
+						"description": "Background color, based on the color tokens",
+						"name": "backgroundColor",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"critical-faded\" | \"warning\" | \"warning-faded\" | \"positive-faded\" | \"primary-faded\" | \"elevation-base\" | \"elevation-raised\" | \"elevation-overlay\" | \"page\" | \"page-faded\" | \"disabled-faded\" | \"brand\" | \"white\" | \"black\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"critical-faded\"" },
+								{ "value": "\"warning\"" },
+								{ "value": "\"warning-faded\"" },
+								{ "value": "\"positive-faded\"" },
+								{ "value": "\"primary-faded\"" },
+								{ "value": "\"elevation-base\"" },
+								{ "value": "\"elevation-raised\"" },
+								{ "value": "\"elevation-overlay\"" },
+								{ "value": "\"page\"" },
+								{ "value": "\"page-faded\"" },
+								{ "value": "\"disabled-faded\"" },
+								{ "value": "\"brand\"" },
+								{ "value": "\"white\"" },
+								{ "value": "\"black\"" }
+							]
+						}
+					},
+					"borderColor": {
+						"defaultValue": null,
+						"description": "Border color, based on the color tokens",
+						"name": "borderColor",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<BorderColor>" }
+					},
+					"border": {
+						"defaultValue": null,
+						"description": "Add border to all sides",
+						"name": "border",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderTop": {
+						"defaultValue": null,
+						"description": "Add border to the top side",
+						"name": "borderTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderBottom": {
+						"defaultValue": null,
+						"description": "Add border to the bottom side",
+						"name": "borderBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderStart": {
+						"defaultValue": null,
+						"description": "Add border to the inline start side",
+						"name": "borderStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderEnd": {
+						"defaultValue": null,
+						"description": "Add border to the inline end side",
+						"name": "borderEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderInline": {
+						"defaultValue": null,
+						"description": "Add border to the inline direction",
+						"name": "borderInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderBlock": {
+						"defaultValue": null,
+						"description": "Add border to the block direction",
+						"name": "borderBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Radius>" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Position style",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Position>" }
+					},
+					"inset": {
+						"defaultValue": null,
+						"description": "Inset style, base unit token number multiplier when used as a number",
+						"name": "inset",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetStart": {
+						"defaultValue": null,
+						"description": "Inset start, base unit token number multiplier when used as a number",
+						"name": "insetStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetEnd": {
+						"defaultValue": null,
+						"description": "Inset end, base unit token number multiplier when used as a number",
+						"name": "insetEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetTop": {
+						"defaultValue": null,
+						"description": "Inset top, base unit token number multiplier when used as a number",
+						"name": "insetTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetBottom": {
+						"defaultValue": null,
+						"description": "Inset bottom, base unit token number multiplier when used as a number",
+						"name": "insetBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"zIndex": {
+						"defaultValue": null,
+						"description": "z-index style",
+						"name": "zIndex",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"shadow": {
+						"defaultValue": null,
+						"description": "Shadow style, based on the shadow tokens",
+						"name": "shadow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Overflow style",
+						"name": "overflow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"auto\"",
+							"value": [{ "value": "\"hidden\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"animated": {
+						"defaultValue": null,
+						"description": "Add transition for the properties",
+						"name": "animated",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					},
+					"grow": {
+						"defaultValue": null,
+						"description": "Apply flex-grow, using it on View.Item applies additional styles on the parent View",
+						"name": "grow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"shrink": {
+						"defaultValue": null,
+						"description": "Apply flex-shrink",
+						"name": "shrink",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "View"
 			}
 		},
 		"hooks-useelementid": {
@@ -3131,7 +16482,8 @@
 			"path": "./src/hooks/tests/useElementId.stories.tsx",
 			"stories": [
 				{
-					"name": "id",
+					"id": "hooks-useelementid--id",
+					"name": "passed id",
 					"snippet": "const id = () => {\n    return <Component id=\"hey\" />;\n};"
 				}
 			],
@@ -3148,6 +16500,7 @@
 			"path": "./src/hooks/tests/useHandlerRef.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usehandlerref--base",
 					"name": "base",
 					"snippet": "const base = (args) => {\n    const [count, setCount] = React.useState(0);\n\n    // Creating a new handler on each render\n    const handleEffect = () => {\n        args.handleEffect(0);\n    };\n\n    return (\n        <View gap={4}>\n            <Button onClick={() => setCount((prev) => prev + 1)}>Increase count</Button>\n            <Component onEffect={handleEffect} count={count} />\n        </View>\n    );\n};"
 				}
@@ -3165,43 +16518,53 @@
 			"path": "./src/hooks/tests/useHotkeys.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usehotkeys--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const { checkHotkeyState } = useHotkeys({\n        \"shift + b + n\": () => console.log(\"pressed\"),\n        \"c + v\": () => console.log(\"c + v\"),\n        \"Meta + k\": () => console.log(\"meta + k\"),\n        \"Meta + f\": () => console.log(\"meta + f\"),\n        \"Meta + v\": () => console.log(\"meta + v\"),\n        \"Meta + b\": () => console.log(\"meta + b\"),\n        \"control + enter\": () => console.log(\"control + enter\"),\n        \"meta + enter\": () => console.log(\"meta + enter\"),\n        \"mod + enter\": () => console.log(\"mod + enter\"),\n        \"mod + ArrowRight\": () => console.log(\"right\"),\n        \"mod + ArrowUp\": () => console.log(\"top\"),\n        \"shift + ArrowRight\": () => console.log(\"right\"),\n        \"shift + ArrowUp\": () => console.log(\"top\"),\n        \"alt+shift+n\": () => console.log(\"alt+shift+n\"),\n        \"shift+alt+n\": () => console.log(\"shift+alt+n\"),\n        \"alt+shiftLeft+n\": () => console.log(\"alt+shiftLeft+n\"),\n    });\n    const active = checkHotkeyState(\"shift + b + n\");\n    const shiftActive = checkHotkeyState(\"shift\");\n    const bActive = checkHotkeyState(\"b\");\n    const nActive = checkHotkeyState(\"n\");\n\n    return (\n        <View\n            animated\n            gap={2}\n            direction=\"row\"\n            backgroundColor={active ? \"positive-faded\" : undefined}\n            padding={2}\n            borderRadius=\"small\"\n        >\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={shiftActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={shiftActive ? undefined : \"raised\"}\n            >\n                Shift\n            </View>\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={bActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={bActive ? undefined : \"raised\"}\n            >\n                b\n            </View>\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={nActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={nActive ? undefined : \"raised\"}\n            >\n                n\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "singleKey",
+					"id": "hooks-usehotkeys--single-key",
+					"name": "single key",
 					"snippet": "const singleKey = (args) => <Component hotkeys={{ a: args.handleHotkey }} />;"
 				},
 				{
-					"name": "modKey",
+					"id": "hooks-usehotkeys--mod-key",
+					"name": "mod key",
 					"snippet": "const modKey = (args) => <Component hotkeys={{ mod: args.handleHotkey }} />;"
 				},
 				{
-					"name": "modKeyHold",
+					"id": "hooks-usehotkeys--mod-key-hold",
+					"name": "mod key on hold",
 					"snippet": "const modKeyHold = (args) => <Component hotkeys={{ \"Meta + b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyList",
+					"id": "hooks-usehotkeys--key-list",
+					"name": "key list",
 					"snippet": "const keyList = (args) => <Component hotkeys={{ \"a,b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombination",
+					"id": "hooks-usehotkeys--key-combination",
+					"name": "key combination",
 					"snippet": "const keyCombination = (args) => <Component hotkeys={{ \"a+b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationFormat",
+					"id": "hooks-usehotkeys--key-combination-format",
+					"name": "key combination without formatting",
 					"snippet": "const keyCombinationFormat = (args) => <Component hotkeys={{ \"A  + b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationOrder",
+					"id": "hooks-usehotkeys--key-combination-order",
+					"name": "key combination without order",
 					"snippet": "const keyCombinationOrder = (args) => <Component hotkeys={{ \"b+a\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationMoreThanRequired",
+					"id": "hooks-usehotkeys--key-combination-more-than-required",
+					"name": "key combination, more keys pressed",
 					"snippet": "const keyCombinationMoreThanRequired = (args) => <Component hotkeys={{ \"z + x\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "optionModified",
+					"id": "hooks-usehotkeys--option-modified",
+					"name": "modified with alt/option",
 					"snippet": "const optionModified = (args) => (\n    <Component hotkeys={{ \"alt+n\": args.handleHotkeyModified, \"alt+shift\": args.handleHotkey }} />\n);"
 				}
 			],
@@ -3218,22 +16581,27 @@
 			"path": "./src/hooks/tests/useKeyboardArrowNavigation.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usekeyboardarrownavigation--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "horizontal",
+					"id": "hooks-usekeyboardarrownavigation--horizontal",
+					"name": "orientation: horizontal",
 					"snippet": "const horizontal = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, orientation: \"horizontal\" });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "vertical",
+					"id": "hooks-usekeyboardarrownavigation--vertical",
+					"name": "orientation: vertical",
 					"snippet": "const vertical = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, orientation: \"vertical\" });\n\n    return (\n        <View gap={2} direction=\"column\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-usekeyboardarrownavigation--circular",
 					"name": "circular",
 					"snippet": "const circular = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, circular: true });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-usekeyboardarrownavigation--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, disabled: true });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				}
@@ -3249,7 +16617,13 @@
 			"id": "hooks-usekeyboardmode",
 			"name": "useKeyboardMode",
 			"path": "./src/hooks/tests/useKeyboardMode.stories.tsx",
-			"stories": [{ "name": "base", "snippet": "const base = () => <Component />;" }],
+			"stories": [
+				{
+					"id": "hooks-usekeyboardmode--base",
+					"name": "base",
+					"snippet": "const base = () => <Component />;"
+				}
+			],
 			"import": "import { Button, View } from \"reshaped\";",
 			"jsDocTags": {},
 			"error": {
@@ -3263,19 +16637,23 @@
 			"path": "./src/hooks/tests/useOnClickOutside.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-useonclickoutside--base",
 					"name": "base",
 					"snippet": "const base = (args) => {\n    const ref = React.useRef(null);\n    const [target, setTarget] = React.useState<\"inside\" | \"outside\" | null>(null);\n\n    useOnClickOutside([ref], () => {\n        args.handleOutsideClick();\n        setTarget(\"outside\");\n    });\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }} onClick={() => setTarget(\"inside\")}>\n                Trigger\n            </Button>\n            {target && `Clicked ${target}`}\n        </View>\n    );\n};"
 				},
 				{
-					"name": "refs",
+					"id": "hooks-useonclickoutside--refs",
+					"name": "multiple refs",
 					"snippet": "const refs = (args) => {\n    const ref = React.useRef(null);\n    const ref2 = React.useRef(null);\n\n    useOnClickOutside([ref, ref2], () => {\n        args.handleOutsideClick();\n    });\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }}>Trigger</Button>\n            <Button attributes={{ ref: ref2 }}>Trigger 2</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-useonclickoutside--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = (args) => {\n    const ref = React.useRef(null);\n\n    useOnClickOutside(\n        [ref],\n        () => {\n            args.handleOutsideClick();\n        },\n        {\n            disabled: true,\n        }\n    );\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }}>Trigger</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "deps",
+					"id": "hooks-useonclickoutside--deps",
+					"name": "test: handler uses latest state",
 					"snippet": "const deps = (args) => {\n    const ref = React.useRef(null);\n    const [count, setCount] = React.useState(0);\n\n    useOnClickOutside([ref], () => {\n        args.handleOutsideClick({ count });\n    });\n\n    return (\n        <Button attributes={{ ref }} onClick={() => setCount((prev) => prev + 1)}>\n            Trigger\n        </Button>\n    );\n};"
 				}
 			],
@@ -3290,7 +16668,13 @@
 			"id": "hooks-usertl",
 			"name": "useRTL",
 			"path": "./src/hooks/tests/useRTL.stories.tsx",
-			"stories": [{ "name": "setRTL", "snippet": "const setRTL = () => <Component />;" }],
+			"stories": [
+				{
+					"id": "hooks-usertl--set-rtl",
+					"name": "setRTL",
+					"snippet": "const setRTL = () => <Component />;"
+				}
+			],
 			"import": "",
 			"jsDocTags": {},
 			"error": {
@@ -3304,10 +16688,12 @@
 			"path": "./src/hooks/tests/useResponsiveClientValue.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-useresponsiveclientvalue--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const value = useResponsiveClientValue<ViewProps[\"backgroundColor\"]>({\n        s: \"neutral\",\n        m: \"critical\",\n        l: \"positive\",\n    });\n\n    return <View width={25} height={25} backgroundColor={value} />;\n};"
 				},
 				{
+					"id": "hooks-useresponsiveclientvalue--boolean",
 					"name": "boolean",
 					"snippet": "const boolean = () => {\n    const value = useResponsiveClientValue<boolean>({\n        s: true,\n        l: false,\n    });\n\n    return <div>{value?.toString()}</div>;\n};"
 				}
@@ -3325,19 +16711,23 @@
 			"path": "./src/hooks/tests/useScrollLock.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usescrolllock--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock();\n\n    return (\n        <React.Fragment>\n            <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n            <div style={{ height: \"150vh\" }} />\n        </React.Fragment>\n    );\n};"
 				},
 				{
-					"name": "origin",
+					"id": "hooks-usescrolllock--origin",
+					"name": "originRef",
 					"snippet": "const origin = () => {\n    const originRef = React.useRef<HTMLDivElement>(null);\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock({ originRef });\n\n    return (\n        <View overflow=\"auto\" height={25} attributes={{ ref: originRef, \"data-testid\": \"root\" }}>\n            <View height={50} padding={4} backgroundColor=\"neutral-faded\" borderRadius=\"medium\">\n                <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "container",
+					"id": "hooks-usescrolllock--container",
+					"name": "containerRef",
 					"snippet": "const container = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock({ containerRef });\n\n    return (\n        <View height={25} attributes={{ ref: containerRef, \"data-testid\": \"root\" }}>\n            <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testContainerAsync",
+					"id": "hooks-usescrolllock--test-container-async",
+					"name": "test: containerRef locked count",
 					"snippet": "const testContainerAsync = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const globalLock = useScrollLock();\n    const scopedLock = useScrollLock({ containerRef });\n\n    return (\n        <Example>\n            <Example.Item title=\"calling regular lock and lock with a container only requires a single unlock to remove overflow\">\n                <View attributes={{ ref: containerRef }} gap={4} direction=\"row\">\n                    <Button\n                        onClick={globalLock.scrollLocked ? globalLock.unlockScroll : globalLock.lockScroll}\n                    >\n                        Toggle\n                    </Button>\n                    <Button\n                        onClick={scopedLock.scrollLocked ? scopedLock.unlockScroll : scopedLock.lockScroll}\n                    >\n                        Toggle\n                    </Button>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
@@ -3354,14 +16744,17 @@
 			"path": "./src/hooks/tests/useToggle.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usetoggle--toggle",
 					"name": "toggle",
 					"snippet": "const toggle = () => {\n    const { toggle, active } = useToggle();\n\n    return (\n        <Button onClick={() => toggle()} attributes={{ \"data-active\": active }}>\n            {active ? \"Deactivate\" : \"Activate\"}\n        </Button>\n    );\n};"
 				},
 				{
+					"id": "hooks-usetoggle--activate",
 					"name": "activate",
 					"snippet": "const activate = () => {\n    const { activate, active } = useToggle();\n\n    return (\n        <React.Fragment>\n            <Button onClick={activate} attributes={{ \"data-active\": active }}>\n                Activate\n            </Button>\n        </React.Fragment>\n    );\n};"
 				},
 				{
+					"id": "hooks-usetoggle--deactivate",
 					"name": "deactivate",
 					"snippet": "const deactivate = () => {\n    const { deactivate, active } = useToggle(true);\n\n    return (\n        <Button onClick={deactivate} attributes={{ \"data-active\": active }}>\n            Deactivate\n        </Button>\n    );\n};"
 				}
@@ -3379,39 +16772,48 @@
 			"path": "./src/utilities/a11y/tests/TrapFocus.stories.tsx",
 			"stories": [
 				{
-					"name": "modeDialog",
+					"id": "utilities-trapfocus--mode-dialog",
+					"name": "mode: dialog",
 					"snippet": "const modeDialog = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, { mode: \"dialog\" });\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\"mode: dialog\", \"tab navigation, always stays inside until released\"]}\n            >\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View.Item>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeActionMenu",
+					"id": "utilities-trapfocus--mode-action-menu",
+					"name": "mode: action-menu",
 					"snippet": "const modeActionMenu = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"action-menu\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: action-menu\",\n                    \"up/down arrow navigation, tab and shift+tab release the focus and follows natural tab order\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeActionBar",
+					"id": "utilities-trapfocus--mode-action-bar",
+					"name": "mode: action-bar",
 					"snippet": "const modeActionBar = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"action-bar\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: action-bar\",\n                    \"left/right arrow navigation, tab and shift+tab release the focus and follows natural tab order\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeContentMenu",
+					"id": "utilities-trapfocus--mode-content-menu",
+					"name": "mode: content-menu",
 					"snippet": "const modeContentMenu = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"content-menu\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: content-menu\",\n                    \"tab navigation, tabbing outside the content will trigger the release\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utilities-trapfocus--include-trigger",
 					"name": "includeTrigger",
 					"snippet": "const includeTrigger = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n            includeTrigger: true,\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utilities-trapfocus--initial-focus-el",
 					"name": "initialFocusEl",
 					"snippet": "const initialFocusEl = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const initialFocusRef = React.useRef<HTMLButtonElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n            initialFocusEl: initialFocusRef.current,\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View\n                            gap={4}\n                            direction=\"row\"\n                            padding={4}\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            attributes={{ ref: rootRef }}\n                        >\n                            <Button onClick={() => {}}>Action 1</Button>\n                            <Button onClick={() => {}} attributes={{ ref: initialFocusRef }}>\n                                Action 2\n                            </Button>\n                            <Button onClick={() => {}}>Action 3</Button>\n                            <Button onClick={trapToggle.deactivate}>Release</Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "focusableElements",
+					"id": "utilities-trapfocus--focusable-elements",
+					"name": "test: focusable elements",
 					"snippet": "const focusableElements = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current);\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title=\"test with all types of focusable elements\">\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={trapToggle.activate}>Activate</Button>\n                    </View.Item>\n\n                    {trapToggle.active && (\n                        <View\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            padding={4}\n                            gap={4}\n                            attributes={{ ref: rootRef }}\n                            align=\"start\"\n                        >\n                            <Link href=\"#\" attributes={{ \"data-testid\": \"test-link\" }}>\n                                Link\n                            </Link>\n\n                            <TextField\n                                name=\"input\"\n                                placeholder=\"Input\"\n                                inputAttributes={{ \"data-testid\": \"test-text-field\" }}\n                            />\n\n                            <TextArea name=\"textarea\" inputAttributes={{ \"data-testid\": \"test-text-area\" }} />\n\n                            <Select\n                                name=\"select\"\n                                options={[\n                                    { label: \"Option 1\", value: \"1\" },\n                                    { label: \"Option 2\", value: \"2\" },\n                                ]}\n                                inputAttributes={{ \"data-testid\": \"test-select\" }}\n                            />\n\n                            <RadioGroup name=\"radio\">\n                                <Radio value=\"1\" inputAttributes={{ \"data-testid\": \"test-radio-1\" }}>\n                                    Option 1\n                                </Radio>\n                                <Radio value=\"2\" inputAttributes={{ \"data-testid\": \"test-radio-2\" }}>\n                                    Option 2\n                                </Radio>\n                            </RadioGroup>\n\n                            <Editor />\n\n                            <div tabIndex={0} role=\"button\" data-testid=\"test-tabindex\">\n                                div with tabIndex\n                            </div>\n\n                            <div style={{ display: \"none\" }}>\n                                <Button onClick={() => {}} attributes={{ \"data-testid\": \"test-hidden-button\" }}>\n                                    Hidden\n                                </Button>\n                            </div>\n\n                            <Button\n                                onClick={() => {}}\n                                attributes={{ tabIndex: -1, \"data-testid\": \"test-button-negative-tabindex\" }}\n                            >\n                                Excluded\n                            </Button>\n\n                            <input type=\"hidden\" data-testid=\"test-input-hidden\" />\n\n                            <Button\n                                onClick={trapToggle.deactivate}\n                                attributes={{ \"data-testid\": \"test-button\" }}\n                            >\n                                Release button\n                            </Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "nested",
+					"id": "utilities-trapfocus--nested",
+					"name": "test: nested",
 					"snippet": "const nested = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const innerRootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n    const innerTrapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    React.useEffect(() => {\n        if (!innerTrapToggle.active) return;\n        if (!innerRootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(innerRootRef.current, {\n            mode: \"dialog\",\n        });\n\n        return () => trapFocus.release();\n    }, [innerTrapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"nested, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View gap={4}>\n                            <View\n                                gap={4}\n                                direction=\"row\"\n                                padding={4}\n                                backgroundColor=\"neutral-faded\"\n                                borderRadius=\"medium\"\n                                attributes={{ ref: rootRef }}\n                            >\n                                <Button onClick={() => {}}>Action</Button>\n                                <Button onClick={innerTrapToggle.activate}>Inner trap focus</Button>\n                                <Button onClick={trapToggle.deactivate}>Release</Button>\n                            </View>\n\n                            {innerTrapToggle.active && (\n                                <View\n                                    gap={4}\n                                    direction=\"row\"\n                                    padding={4}\n                                    backgroundColor=\"neutral-faded\"\n                                    borderRadius=\"medium\"\n                                    attributes={{ ref: innerRootRef }}\n                                >\n                                    <Button onClick={() => {}}>Action</Button>\n                                    <Button onClick={innerTrapToggle.deactivate}>Release</Button>\n                                </View>\n                            )}\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "mutationObserver",
+					"id": "utilities-trapfocus--mutation-observer",
+					"name": "test: mutation observer",
 					"snippet": "const mutationObserver = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n    const [mutated, setMutated] = React.useState(false);\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n        });\n\n        setTimeout(() => {\n            setMutated(true);\n        }, 50);\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View\n                            gap={4}\n                            direction=\"row\"\n                            padding={4}\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            attributes={{ ref: rootRef }}\n                        >\n                            {!mutated && (\n                                <>\n                                    <Button onClick={() => {}}>Action 1</Button>\n                                    <Button onClick={() => {}}>Action 2</Button>\n                                </>\n                            )}\n                            <Button onClick={() => {}}>Action 3</Button>\n                            <Button onClick={trapToggle.deactivate}>Release</Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
@@ -3428,15 +16830,35 @@
 			"path": "./src/components/_private/Portal/tests/Portal.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "internal-portal--base",
+					"name": "Base",
 					"snippet": "const base = () => {\n\tconst ref = React.useRef<HTMLDivElement>(null);\n\tconst [mounted, setMounted] = React.useState(false);\n\n\tReact.useEffect(() => {\n\t\tsetMounted(true);\n\t}, []);\n\n\treturn (\n\t\t<>\n\t\t\t<div style={{ border: \"2px solid #333\", padding: 16 }}>\n\t\t\t\tApp\n\t\t\t\t{mounted && <Portal targetRef={ref}>Ported to green</Portal>}\n\t\t\t</div>\n\t\t\t<div ref={ref} style={{ border: \"2px solid green\", padding: 16 }} />\n\t\t</>\n\t);\n};"
 				}
 			],
 			"import": "import { Portal } from \"reshaped\";",
 			"jsDocTags": {},
-			"error": {
-				"name": "No component definition found",
-				"message": "File: /Users/shilman/projects/design-systems/reshaped/src/components/_private/Portal/index.ts\nError:\nNo suitable component definition found.\nYou can debug your component file in this playground: https://react-docgen.dev/playground\nCode:\nimport Portal, { PortalScope } from \"./Portal\";\n\nconst PortalRoot = Portal as typeof Portal & {\n\tScope: typeof PortalScope;\n};\n\nPortalRoot.Scope = PortalScope;\n\nexport default PortalRoot;\nexport type { Props as PortalProps } from \"./Portal.types\";\n\n\nFile: /Users/shilman/projects/design-systems/reshaped/src/components/_private/Portal/Portal.types.ts\nError:\nNo suitable component definition found.\nYou can debug your component file in this playground: https://react-docgen.dev/playground\nCode:\nimport React from \"react\";\n\nexport type Props = {\n\tchildren?: React.ReactNode;\n\ttargetRef?: React.RefObject<HTMLElement | ShadowRoot | null>;\n};\n\nexport type ScopeProps<T extends HTMLElement> = {\n\tchildren: (ref: React.RefObject<T | null>) => React.ReactNode;\n};\n\nexport type Context = {\n\tscopeRef: React.RefObject<HTMLElement | null>;\n};\n"
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/_private/Portal/index.ts",
+				"description": "",
+				"displayName": "Portal",
+				"methods": [],
+				"props": {
+					"targetRef": {
+						"defaultValue": null,
+						"description": "",
+						"name": "targetRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/_private/Portal/Portal.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | ShadowRoot | null>" }
+					}
+				},
+				"exportName": "Portal"
 			}
 		},
 		"internal-usedrag": {
@@ -3444,24 +16866,33 @@
 			"name": "useDrag",
 			"path": "./src/hooks/tests/useDrag.stories.tsx",
 			"stories": [
-				{ "name": "base", "snippet": "const base = () => <Example />;" },
 				{
-					"name": "mouseEvents",
+					"id": "internal-usedrag--base",
+					"name": "base",
+					"snippet": "const base = () => <Example />;"
+				},
+				{
+					"id": "internal-usedrag--mouse-events",
+					"name": "onDrag, mouse events",
 					"snippet": "const mouseEvents = () => {\n    return <Demo onDrag={fn()} />;\n};"
 				},
 				{
-					"name": "touchEvents",
+					"id": "internal-usedrag--touch-events",
+					"name": "onDrag, touch events",
 					"snippet": "const touchEvents = () => {\n    return <Demo onDrag={fn()} />;\n};"
 				},
 				{
-					"name": "orientationHorizontal",
+					"id": "internal-usedrag--orientation-horizontal",
+					"name": "orientation horizontal",
 					"snippet": "const orientationHorizontal = () => {\n    return <Demo onDrag={fn()} orientation=\"horizontal\" />;\n};"
 				},
 				{
-					"name": "orientationVertical",
+					"id": "internal-usedrag--orientation-vertical",
+					"name": "orientation vertical",
 					"snippet": "const orientationVertical = () => {\n    return <Demo onDrag={fn()} orientation=\"vertical\" />;\n};"
 				},
 				{
+					"id": "internal-usedrag--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => {\n    return <Demo onDrag={fn()} disabled />;\n};"
 				}
@@ -3479,7 +16910,8 @@
 			"path": "./src/tests/ShadowDOM.stories.tsx",
 			"stories": [
 				{
-					"name": "behavior",
+					"id": "internal-shadowdom--behavior",
+					"name": "Behavior",
 					"snippet": "const behavior = () => (\n\t<Example>\n\t\t<Example.Item title=\"base\">\n\t\t\t<Component />\n\t\t</Example.Item>\n\t</Example>\n);"
 				}
 			],
@@ -3496,30 +16928,94 @@
 			"path": "./src/tests/themes.stories.tsx",
 			"stories": [
 				{
-					"name": "test",
+					"id": "internal-themes--test",
+					"name": "Test",
 					"snippet": "const test = () => {\n\tconst { colorMode } = useTheme();\n\tconst [activeColor, setColor] = useState(colors[0]);\n\tconst [theme, setTheme] = useState(\"\");\n\tconst [algo, setAlgo] = useState<\"wcag\" | \"apca\">(\"wcag\");\n\n\tuseLayoutEffect(() => {\n\t\tsetTheme(\n\t\t\tgetThemeCSS(\n\t\t\t\t\"test\",\n\t\t\t\t{\n\t\t\t\t\tcolor: generateThemeColors({\n\t\t\t\t\t\tprimary: activeColor === colors[0] ? undefined : activeColor,\n\t\t\t\t\t}),\n\t\t\t\t},\n\t\t\t\t{\n\t\t\t\t\tcolorContrastAlgorithm: algo,\n\t\t\t\t}\n\t\t\t)\n\t\t);\n\t}, [activeColor, algo]);\n\n\treturn (\n\t\t<>\n\t\t\t<style>{theme}</style>\n\t\t\t<Theme name=\"test\">\n\t\t\t\t<View gap={4}>\n\t\t\t\t\t<View direction=\"row\" align=\"center\" gap={4}>\n\t\t\t\t\t\t{colors.map((color) => {\n\t\t\t\t\t\t\tconst hex = colorMode === \"dark\" && color === \"#000000\" ? \"#ffffff\" : color;\n\n\t\t\t\t\t\t\treturn (\n\t\t\t\t\t\t\t\t<Actionable key={color} onClick={() => setColor(color)} borderRadius=\"inherit\">\n\t\t\t\t\t\t\t\t\t<View\n\t\t\t\t\t\t\t\t\t\twidth={5}\n\t\t\t\t\t\t\t\t\t\theight={5}\n\t\t\t\t\t\t\t\t\t\tborderRadius=\"circular\"\n\t\t\t\t\t\t\t\t\t\tattributes={{\n\t\t\t\t\t\t\t\t\t\t\tstyle: {\n\t\t\t\t\t\t\t\t\t\t\t\ttransition: `box-shadow var(--rs-duration-fast) var(--rs-easing-standard)`,\n\t\t\t\t\t\t\t\t\t\t\t\tbackground: hex,\n\t\t\t\t\t\t\t\t\t\t\t\tboxShadow:\n\t\t\t\t\t\t\t\t\t\t\t\t\tcolor === activeColor\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t? `0 0 0 3px var(--rs-color-background-elevation-base), 0 0 0 5px ${hex}`\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t: undefined,\n\t\t\t\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t\t\t\t}}\n\t\t\t\t\t\t\t\t\t/>\n\t\t\t\t\t\t\t\t</Actionable>\n\t\t\t\t\t\t\t);\n\t\t\t\t\t\t})}\n\t\t\t\t\t\t<View.Item gapBefore=\"auto\">\n\t\t\t\t\t\t\t<Switch name=\"algo\" onChange={(args) => setAlgo(args.checked ? \"apca\" : \"wcag\")}>\n\t\t\t\t\t\t\t\tUse APCA\n\t\t\t\t\t\t\t</Switch>\n\t\t\t\t\t\t</View.Item>\n\t\t\t\t\t</View>\n\n\t\t\t\t\t<ThemePlayground />\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</>\n\t);\n};"
 				},
 				{
-					"name": "base",
+					"id": "internal-themes--base",
+					"name": "Base",
 					"snippet": "const base = () => (\n\t<Example>\n\t\t<Example.Item title=\"custom runtime theme\">\n\t\t\t<style>{css}</style>\n\t\t\t<Theme name=\"green\">\n\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"on colors generation\">\n\t\t\t<style>{css2}</style>\n\t\t\t<Theme name=\"peach\">\n\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "generation",
+					"id": "internal-themes--generation",
+					"name": "Generation",
 					"snippet": "const generation = () => (\n\t<div>\n\t\t<style>{cssGenerated}</style>\n\t\t<Theme name=\"generated\">{componentExamples}</Theme>\n\t</div>\n);"
 				},
 				{
-					"name": "onColors",
+					"id": "internal-themes--on-colors",
+					"name": "On Colors",
 					"snippet": "const onColors = () => (\n\t<Example>\n\t\t<Example.Item title=\"custom on color values\">\n\t\t\t<style>{onColorsCss}</style>\n\t\t\t<Theme name=\"on-color\">\n\t\t\t\t<View gap={2} direction=\"row\">\n\t\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t\t\t<Button color=\"critical\">Critical button</Button>\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"custom on color values, apca\">\n\t\t\t<style>{onColorsCssApca}</style>\n\t\t\t<Theme name=\"on-color-apca\">\n\t\t\t\t<View gap={2} direction=\"row\">\n\t\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t\t\t<Button color=\"critical\">Critical button</Button>\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t</Example>\n);"
 				}
 			],
 			"import": "import {\n    Actionable,\n    Alert,\n    Avatar,\n    Badge,\n    Button,\n    Card,\n    DropdownMenu,\n    Example,\n    Link,\n    Switch,\n    Text,\n    TextField,\n    Theme,\n    ThemePlayground,\n    View,\n} from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Theme/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Theme",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Theme/Theme.tsx",
-				"actualName": "Theme",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the theme to use, enables controlled mode",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"defaultName": {
+						"defaultValue": null,
+						"description": "Default name of the theme to use, enables uncontrolled mode",
+						"name": "defaultName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode to use",
+						"name": "colorMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode | \"inverted\"",
+							"value": [
+								{ "value": "\"light\"" },
+								{ "value": "\"dark\"" },
+								{ "value": "\"inverted\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -3529,7 +17025,8 @@
 			"path": "./src/Sandbox.stories.tsx",
 			"stories": [
 				{
-					"name": "preview",
+					"id": "sandbox--preview",
+					"name": "Preview",
 					"snippet": "const preview = () => {\n\treturn (\n\t\t<Preview>\n\t\t\t<Component />\n\t\t</Preview>\n\t);\n};"
 				}
 			],
@@ -3540,5 +17037,6 @@
 				"message": "We could not detect the component from your story file. Specify meta.component.\n   7 | import MenuItem from \"components/MenuItem\";\n   8 |\n>  9 | export default {\n     | ^\n  10 | \ttitle: \"Sandbox\",\n  11 | \tchromatic: { disableSnapshot: true },\n  12 | };\n\n./src/Sandbox.stories.tsx:\nimport View from \"components/View\";\nimport Image from \"components/Image\";\nimport React from \"react\";\nimport Select from \"components/Select\";\nimport useToggle from \"hooks/useToggle\";\nimport Modal from \"components/Modal\";\nimport MenuItem from \"components/MenuItem\";\n\nexport default {\n\ttitle: \"Sandbox\",\n\tchromatic: { disableSnapshot: true },\n};\n\nconst Preview: React.FC<{ children: React.ReactNode }> = (props) => {\n\treturn (\n\t\t<View padding={20} gap={6}>\n\t\t\t<View position=\"absolute\" insetTop={0} insetStart={0}>\n\t\t\t\t<Image src=\"./logo.svg\" />\n\t\t\t</View>\n\n\t\t\t{props.children}\n\t\t</View>\n\t);\n};\n\nexport const preview = () => {\n\treturn (\n\t\t<Preview>\n\t\t\t<Component />\n\t\t</Preview>\n\t);\n};\n\nconst Component = () => {\n\tconst toggle = useToggle();\n\tconst [value, setValue] = React.useState(\"Dog\");\n\n\tconst handleClick = () => {\n\t\ttoggle.toggle();\n\t};\n\n\treturn (\n\t\t<>\n\t\t\t<Select name=\"animal\" placeholder=\"Select an animal\" onClick={handleClick}>\n\t\t\t\t{value}\n\t\t\t</Select>\n\t\t\t<Modal active={toggle.active} onClose={toggle.deactivate} position=\"bottom\" padding={2}>\n\t\t\t\t<MenuItem\n\t\t\t\t\troundedCorners\n\t\t\t\t\tonClick={() => {\n\t\t\t\t\t\tsetValue(\"Dog\");\n\t\t\t\t\t\ttoggle.deactivate();\n\t\t\t\t\t}}\n\t\t\t\t\tattributes={{\n\t\t\t\t\t\trole: \"option\",\n\t\t\t\t\t}}\n\t\t\t\t>\n\t\t\t\t\tDog\n\t\t\t\t</MenuItem>\n\t\t\t\t<MenuItem\n\t\t\t\t\troundedCorners\n\t\t\t\t\tattributes={{\n\t\t\t\t\t\trole: \"option\",\n\t\t\t\t\t}}\n\t\t\t\t\tonClick={() => {\n\t\t\t\t\t\tsetValue(\"Turtle\");\n\t\t\t\t\t\ttoggle.deactivate();\n\t\t\t\t\t}}\n\t\t\t\t>\n\t\t\t\t\tTurtle\n\t\t\t\t</MenuItem>\n\t\t\t</Modal>\n\t\t</>\n\t);\n};\n"
 			}
 		}
-	}
+	},
+	"meta": { "docgen": "react-docgen-typescript", "durationMs": 2919 }
 }

--- a/eval/tasks/901-create-component-atom-reshaped/manifests/components.json
+++ b/eval/tasks/901-create-component-atom-reshaped/manifests/components.json
@@ -7,46 +7,201 @@
 			"path": "./src/components/ActionBar/tests/ActionBar.stories.tsx",
 			"stories": [
 				{
-					"name": "positionRelative",
+					"id": "components-actionbar--position-relative",
+					"name": "position, positionType: relative",
 					"snippet": "const positionRelative = () => (\n    <Example>\n        <Example.Item title=\"position: top\">\n            <ActionBar position=\"top\">\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <ActionBar position=\"bottom\">\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positionAbsolute",
+					"id": "components-actionbar--position-absolute",
+					"name": "position, positionType: absolute",
 					"snippet": "const positionAbsolute = () => (\n    <Example>\n        <Example.Item title=\"position: top-start\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top-start\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: top\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: top-end\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top-end\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom-start\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom-start\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom-end\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positionFixed",
+					"id": "components-actionbar--position-fixed",
+					"name": "position, positionType: fixed",
 					"snippet": "const positionFixed = () => (\n    <>\n        <ActionBar padding={2} position=\"top-start\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"top\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"top-end\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom-start\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom-end\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <div style={{ height: 2000 }} />\n    </>\n);"
 				},
 				{
+					"id": "components-actionbar--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated, position: top\">\n            <ActionBar position=\"top\" elevated>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"elevated, position: bottom\">\n            <ActionBar elevated>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"auto elevated, position: bottom\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-actionbar--offset",
 					"name": "offset",
 					"snippet": "const offset = () => (\n    <Example>\n        <Example.Item title=\"offset 2, position: top\">\n            <Fixtures.Container>\n                <ActionBar position=\"top\" positionType=\"absolute\" offset={2}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"offset 2, position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\" offset={2}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"offset s: 2, m: 4, position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\" offset={{ s: 2, m: 4 }}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-actionbar--active",
 					"name": "active",
 					"snippet": "const active = () => {\n    const barToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => barToggle.toggle()}>Toggle</Button>\n            <ActionBar active={barToggle.active} positionType=\"fixed\" position=\"top-end\">\n                <Fixtures.Actions />\n            </ActionBar>\n        </>\n    );\n};"
 				},
 				{
-					"name": "padding",
+					"id": "components-actionbar--padding",
+					"name": "padding, paddingBlock, paddingInline",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 6\">\n            <ActionBar padding={6}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"paddingBlock: 2, paddingInline: 4\">\n            <ActionBar paddingBlock={2} paddingInline={4}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"padding: [s] 4, [m+] 6\">\n            <ActionBar padding={{ s: 4, m: 6 }}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-actionbar--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ActionBar className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </ActionBar>\n    </div>\n);"
 				}
 			],
 			"import": "import { ActionBar, Button, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ActionBar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ActionBar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ActionBar/ActionBar.tsx",
-				"actualName": "ActionBar",
+				"methods": [],
+				"props": {
+					"paddingBlock": {
+						"defaultValue": null,
+						"description": "Padding block, base unit token number multiplier",
+						"name": "paddingBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingInline": {
+						"defaultValue": null,
+						"description": "Padding inline, base unit token number multiplier",
+						"name": "paddingInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Padding style for all sides, base unit token number multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Show or hide the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"offset": {
+						"defaultValue": null,
+						"description": "Offset from the container bounds",
+						"name": "offset",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"position": {
+						"defaultValue": { "value": "\"bottom\"" },
+						"description": "Position based on the container bounds",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"top-end\" | \"top-start\" | \"bottom\" | \"bottom-start\" | \"bottom-end\"",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" }
+							]
+						}
+					},
+					"positionType": {
+						"defaultValue": null,
+						"description": "CSS position style",
+						"name": "positionType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"relative\" | \"absolute\" | \"fixed\">" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Display above the content with elevated shadow and background",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -56,30 +211,138 @@
 			"path": "./src/components/Alert/tests/Alert.stories.tsx",
 			"stories": [
 				{
+					"id": "components-alert--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        {([\"neutral\", \"primary\", \"critical\", \"positive\", \"warning\"] as const).map((color) => (\n            <Example.Item title={`color: ${color}`} key={color}>\n                <Alert\n                    color={color}\n                    title=\"Alert title goes here\"\n                    icon={IconZap}\n                    actionsSlot={\n                        <>\n                            <Link\n                                variant=\"plain\"\n                                color={color === \"neutral\" ? \"primary\" : color}\n                                onClick={() => {}}\n                            >\n                                View now\n                            </Link>\n                            <Link\n                                variant=\"plain\"\n                                color={color === \"neutral\" ? \"primary\" : color}\n                                onClick={() => {}}\n                            >\n                                Dismiss\n                            </Link>\n                        </>\n                    }\n                >\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard\n                </Alert>\n            </Example.Item>\n        ))}\n    </Example>\n);"
 				},
 				{
+					"id": "components-alert--inline",
 					"name": "inline",
 					"snippet": "const inline = () => (\n    <Example>\n        <Example.Item title=\"inline: true\">\n            <Alert\n                inline\n                title=\"Alert title goes here\"\n                icon={IconZap}\n                actionsSlot={\n                    <>\n                        <Link variant=\"plain\" onClick={() => {}}>\n                            View now\n                        </Link>\n                        <Link variant=\"plain\" onClick={() => {}}>\n                            Dismiss\n                        </Link>\n                    </>\n                }\n            >\n                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has\n                been the industry's standard\n            </Alert>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-alert--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4\">\n            <Alert bleed={4} icon={IconZap}>\n                Content\n            </Alert>\n        </Example.Item>\n        <Example.Item title=\"bleed: [s] 4, [m+] 0\">\n            <Alert bleed={{ s: 4, m: 0 }} icon={IconZap}>\n                Content\n            </Alert>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-alert--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Alert className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </Alert>\n    </div>\n);"
 				}
 			],
 			"import": "import { Alert, Example, Link, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Alert/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Alert",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Alert/Alert.tsx",
-				"actualName": "Alert",
+				"methods": [],
+				"props": {
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"title": {
+						"defaultValue": null,
+						"description": "Title slot",
+						"name": "title",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Slot for rendering the main content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"actionsSlot": {
+						"defaultValue": null,
+						"description": "Actions slot, usually used for Buttons and Links, automatically adds a gap between the actions",
+						"name": "actionsSlot",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Color scheme of the alert elements",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"inline": {
+						"defaultValue": null,
+						"description": "Display action to the right of the content",
+						"name": "inline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margin and remove side borders, base unit token number multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -89,35 +352,573 @@
 			"path": "./src/components/Autocomplete/tests/Autocomplete.stories.tsx",
 			"stories": [
 				{
-					"name": "active",
+					"id": "components-autocomplete--active",
+					"name": "active, onOpen, onClose",
 					"snippet": "const active = (args) => {\n    const toggle = useToggle(true);\n\n    return (\n        <Example>\n            <Example.Item title=\"active, onOpen, onClose\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete\n                        name=\"fruit\"\n                        placeholder=\"Pick your food\"\n                        active={toggle.active}\n                        onOpen={() => {\n                            args.handleOpen();\n                            toggle.activate();\n                        }}\n                        onClose={() => {\n                            args.handleClose();\n                            toggle.deactivate();\n                        }}\n                        onChange={(args) => console.log(args)}\n                    >\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "base",
+					"id": "components-autocomplete--base",
+					"name": "onInput, onItemSelect, onBackspace",
 					"snippet": "const base = () => {\n    const [value, setValue] = React.useState(\"\");\n\n    return (\n        <Example>\n            <Example.Item title=\"Base\">\n                <FormControl>\n                    <FormControl.Label>Food</FormControl.Label>\n                    <Autocomplete\n                        name=\"fruit\"\n                        placeholder=\"Pick your food\"\n                        value={value}\n                        onChange={(args) => setValue(args.value)}\n                        onBackspace={fn()}\n                        onItemSelect={fn()}>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "itemData",
+					"id": "components-autocomplete--item-data",
+					"name": "item data",
 					"snippet": "const itemData = () => {\n    return (\n        <Example>\n            <Example.Item title=\"item data\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete name=\"fruit\" placeholder=\"Pick your food\" onItemSelect={fn()} active>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v} data={i === 1 ? { foo: true } : undefined}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "itemDisabled",
+					"id": "components-autocomplete--item-disabled",
+					"name": "item disabled",
 					"snippet": "const itemDisabled = () => {\n    return (\n        <Example>\n            <Example.Item title=\"item disabled\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete name=\"fruit\" placeholder=\"Pick your food\" active>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v} disabled={i === 1}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "multiselect",
+					"id": "components-autocomplete--multiselect",
+					"name": "test: multiselect",
 					"snippet": "const multiselect = () => {\n    const options = [\n        \"Pizza\",\n        \"Pie\",\n        \"Ice-cream\",\n        \"Fries\",\n        \"Salad\",\n        \"Option 4\",\n        \"Option 5\",\n        \"Option 6\",\n    ];\n\n    const inputRef = React.useRef<HTMLInputElement>(null);\n    const [values, setValues] = React.useState<string[]>([\n        \"Option 4\",\n        \"Option 5\",\n        \"Option 6\",\n        \"Pizza\",\n        \"Ice-cream\",\n    ]);\n    const [query, setQuery] = React.useState(\"\");\n\n    const handleDismiss = (dismissedValue: string) => {\n        const nextValues = values.filter((value) => value !== dismissedValue);\n        setValues(nextValues);\n        inputRef.current?.focus();\n    };\n\n    const valuesNode = values.map((value) => (\n        <Badge dismissAriaLabel=\"Dismiss value\" onDismiss={() => handleDismiss(value)} key={value}>\n            {value}\n        </Badge>\n    ));\n\n    return (\n        <FormControl>\n            <FormControl.Label>Food</FormControl.Label>\n            <Autocomplete\n                name=\"fruit\"\n                value={query}\n                placeholder=\"Pick your food\"\n                startSlot={valuesNode}\n                multiline\n                inputAttributes={{ ref: inputRef }}\n                onChange={(args) => setQuery(args.value)}\n                onBackspace={() => {\n                    if (query.length === 0) {\n                        setValues((prev) => prev.slice(0, -1));\n                    }\n                }}\n                onItemSelect={(args) => {\n                    setQuery(\"\");\n                    setValues((prev) => [...prev, args.value]);\n                }}\n            >\n                {options.map((v) => {\n                    if (!v.toLowerCase().includes(query.toLowerCase())) return;\n                    if (values.includes(v)) return;\n\n                    return (\n                        <Autocomplete.Item key={v} value={v}>\n                            {v}\n                        </Autocomplete.Item>\n                    );\n                })}\n            </Autocomplete>\n        </FormControl>\n    );\n};"
 				}
 			],
 			"import": "import { Autocomplete, Badge, Example, FormControl } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Autocomplete/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Autocomplete",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Autocomplete/Autocomplete.tsx",
-				"actualName": "Autocomplete",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"multiline": {
+						"defaultValue": null,
+						"description": "Enable multiline text field wrapping",
+						"name": "multiline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to be fully rounded",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content after the text field value",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text field value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the text field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the text field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"onInput": {
+						"defaultValue": null,
+						"description": "Callback for when value changes from user input",
+						"name": "onInput",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onItemSelect": {
+						"defaultValue": null,
+						"description": "Callback for when an item is selected in the dropdown",
+						"name": "onItemSelect",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: SelectArgs) => void)" }
+					},
+					"onBackspace": {
+						"defaultValue": null,
+						"description": "Callback for when the backspace key is pressed while the input is focused",
+						"name": "onBackspace",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onEnter": {
+						"defaultValue": null,
+						"description": "Callback for when the enter key is pressed while the input is focused",
+						"name": "onEnter",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Slot for rendering the Autocomplete.Item components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					}
+				},
+				"exportName": "Autocomplete"
 			}
 		},
 		"components-avatar": {
@@ -126,46 +927,230 @@
 			"path": "./src/components/Avatar/tests/Avatar.stories.tsx",
 			"stories": [
 				{
-					"name": "src",
+					"id": "components-avatar--src",
+					"name": "src, alt",
 					"snippet": "const src = () => (\n    <Example>\n        <Example.Item title=\"src, alt\">\n            <Avatar\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n                alt=\"Amsterdam canal\"\n                size={12}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"src\">\n            <Avatar src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "initials",
+					"id": "components-avatar--initials",
+					"name": "initials, icon",
 					"snippet": "const initials = () => (\n    <Example>\n        <Example.Item title=\"initials\">\n            <Avatar initials=\"RS\" />\n        </Example.Item>\n\n        <Example.Item title=\"icon\">\n            <Avatar icon={IconZap} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-avatar--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: 6\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={6} icon={IconZap} />\n                <Avatar size={6} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: 15\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={15} icon={IconZap} />\n                <Avatar size={15} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: 40\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={40} icon={IconZap} />\n                <Avatar size={40} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] 10\", \"[m+] 20\"]}>\n            <View direction=\"row\" gap={3}>\n                <Avatar size={{ s: 10, m: 20 }} icon={IconZap} />\n                <Avatar size={{ s: 10, m: 20 }} icon={IconZap} squared />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-avatar--squared",
 					"name": "squared",
 					"snippet": "const squared = () => (\n    <Example>\n        <Example.Item title=\"squared, with image\">\n            <Avatar\n                squared\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n            />\n        </Example.Item>\n        <Example.Item title=\"squared, with initials\">\n            <Avatar squared initials=\"RS\" />\n        </Example.Item>\n        <Example.Item title=\"squared, with initials\">\n            <Avatar squared icon={IconZap} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "colors",
+					"id": "components-avatar--colors",
+					"name": "color, variant",
 					"snippet": "const colors = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"neutral\" icon={IconZap} />\n                <Avatar color=\"neutral\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"primary\" icon={IconZap} />\n                <Avatar color=\"primary\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"positive\" icon={IconZap} />\n                <Avatar color=\"positive\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"warning\" icon={IconZap} />\n                <Avatar color=\"warning\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"critical\" icon={IconZap} />\n                <Avatar color=\"critical\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "fallback",
+					"id": "components-avatar--fallback",
+					"name": "test: fallback",
 					"snippet": "const fallback = (args) => {\n    const [error, setError] = useState(false);\n\n    return (\n        <Avatar\n            src={error ? undefined : \"/foo\"}\n            icon={IconZap}\n            imageAttributes={{\n                onError: () => {\n                    setError(true);\n                    args.handleError();\n                },\n            }}\n        />\n    );\n};"
 				},
 				{
+					"id": "components-avatar--render-image",
 					"name": "renderImage",
 					"snippet": "const renderImage = () => (\n    <Example>\n        <Example.Item title=\"renderImage\">\n            <Avatar\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n                alt=\"Amsterdam canal\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image\" />}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-avatar--class-name",
+					"name": "className, attributes, imageAttributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Avatar\n            src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            imageAttributes={{ id: \"test-image-id\", alt: \"test image\" }}\n        />\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Avatar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Avatar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Avatar/Avatar.tsx",
-				"actualName": "Avatar",
+				"methods": [],
+				"props": {
+					"src": {
+						"defaultValue": null,
+						"description": "Image URL",
+						"name": "src",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"alt": {
+						"defaultValue": null,
+						"description": "Image alt text",
+						"name": "alt",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"imageAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the image element",
+						"name": "imageAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"img\">" }
+					},
+					"renderImage": {
+						"defaultValue": null,
+						"description": "Render prop for the image element, useful for integrating with the Image component from third party frameworks",
+						"name": "renderImage",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Omit<Attributes<\"img\">, \"src\" | \"alt\"> & { src: string; alt: string; }) => ReactNode)"
+						}
+					},
+					"initials": {
+						"defaultValue": null,
+						"description": "Initials to display if no image is provided",
+						"name": "initials",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon, used when no image is provided",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"squared": {
+						"defaultValue": null,
+						"description": "Change the shape to rounded square",
+						"name": "squared",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"faded\"",
+							"value": [{ "value": "\"solid\"" }, { "value": "\"faded\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "12" },
+						"description": "Size of the component, base unit token number multiplier",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -175,63 +1160,273 @@
 			"path": "./src/components/Badge/tests/Badge.stories.tsx",
 			"stories": [
 				{
+					"id": "components-badge--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Badge>Badge</Badge>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <Badge variant=\"faded\">Badge</Badge>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <Badge variant=\"outline\">Badge</Badge>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"primary\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"primary\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"primary\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: positive, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"positive\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"positive\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"positive\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: critical, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"critical\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"critical\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"critical\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: warning, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"warning\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"warning\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"warning\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"small\">Badge</Badge>\n                <Badge rounded size=\"small\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge>Badge</Badge>\n                <Badge rounded>Badge</Badge>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"large\">Badge</Badge>\n                <Badge rounded size=\"large\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={3} direction=\"row\">\n                <Badge icon={IconCheckmark} endIcon={IconChevronRight} size=\"small\">\n                    Badge\n                </Badge>\n                <Badge icon={IconCheckmark} size=\"small\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={3} direction=\"row\">\n                <Badge icon={IconCheckmark} endIcon={IconChevronRight}>\n                    Badge\n                </Badge>\n                <Badge icon={IconCheckmark} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"large\" icon={IconCheckmark} endIcon={IconChevronRight}>\n                    Badge\n                </Badge>\n\n                <Badge icon={IconCheckmark} size=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onDismiss",
+					"id": "components-badge--on-dismiss",
+					"name": "onDismiss, dismissAriaLabel",
 					"snippet": "const onDismiss = () => <Example>\n    <Example.Item title=\"onDismiss\">\n        <Badge onDismiss={fn()} dismissAriaLabel=\"Dismiss\">Badge\n                            </Badge>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-badge--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded>Badge</Badge>\n                <Badge rounded variant=\"faded\">\n                    Badge\n                </Badge>\n                <Badge rounded variant=\"outline\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"rounded, all sizes, color: critical\", \"one character, renders as circle\"]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Badge rounded color=\"critical\" size=\"small\">\n                    2\n                </Badge>\n                <Badge rounded color=\"critical\">\n                    2\n                </Badge>\n                <Badge rounded color=\"critical\" size=\"large\">\n                    2\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--empty",
 					"name": "empty",
 					"snippet": "const empty = () => (\n    <Example>\n        <Example.Item title=\"empty, not rounded, all sizes, color: critical\">\n            <View direction=\"row\" gap={3}>\n                <Badge size=\"small\" color=\"critical\" />\n                <Badge color=\"critical\" />\n                <Badge size=\"large\" color=\"critical\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"empty, rounded, all sizes, color: critical\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded size=\"small\" color=\"critical\" />\n                <Badge rounded color=\"critical\" />\n                <Badge rounded size=\"large\" color=\"critical\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"empty, rounded, all sizes, color: neutral\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded size=\"small\" color=\"neutral\" />\n                <Badge rounded />\n                <Badge rounded size=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--highlighted",
 					"name": "highlighted",
 					"snippet": "const highlighted = () => (\n    <Example>\n        <Example.Item title=\"highlighted, color: neutral\">\n            <View gap={3} direction=\"row\">\n                <Badge highlighted>Badge</Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--container",
 					"name": "container",
 					"snippet": "const container = () => {\n    const [hidden, setHidden] = React.useState(false);\n\n    return (\n        <Example title={<Button onClick={() => setHidden(!hidden)}>Toggle badges</Button>}>\n            <Example.Item title=\"position: top-end\">\n                <Badge.Container>\n                    <Badge color=\"primary\" hidden={hidden}>\n                        5\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: bottom-end\">\n                <Badge.Container position=\"bottom-end\">\n                    <Badge color=\"primary\" hidden={hidden}>\n                        5\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: top-end, rounded, multiple digits\">\n                <Badge.Container>\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        123\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: top-end, rounded, empty\">\n                <Badge.Container>\n                    <Badge color=\"primary\" rounded hidden={hidden} />\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: top-end, overlap\", \"should cover the circular avatar\"]}>\n                <Badge.Container overlap>\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        2\n                    </Badge>\n                    <Avatar initials=\"A\" />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: bottom-end, overlap\", \"should cover the circular avatar\"]}>\n                <Badge.Container overlap position=\"bottom-end\">\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        2\n                    </Badge>\n                    <Avatar initials=\"A\" />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: top-end, overlap\", \"should cover the icon\"]}>\n                <Badge.Container overlap position=\"top-end\">\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden} />\n                    <Icon svg={IconCheckmark} size={5} />\n                </Badge.Container>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-badge--href",
 					"name": "href",
 					"snippet": "const href = () => (\n    <Badge href=\"https://reshaped.so\" dismissAriaLabel=\"Dismiss\">\n        Badge\n    </Badge>\n);"
 				},
 				{
+					"id": "components-badge--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Badge onClick={fn()}>Badge</Badge>;"
 				},
 				{
-					"name": "className",
+					"id": "components-badge--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Badge color=\"primary\" className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Badge, Button, Example, Icon, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Badge/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Badge",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Badge/Badge.tsx",
-				"actualName": "Badge",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"large\" | \"medium\"",
+							"value": [
+								{ "value": "\"small\"" },
+								{ "value": "\"large\"" },
+								{ "value": "\"medium\"" }
+							]
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "highlighted",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hidden": {
+						"defaultValue": null,
+						"description": "Transition the component to hidden state",
+						"name": "hidden",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting text or other content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"onDismiss": {
+						"defaultValue": null,
+						"description": "Callback triggered when the dismiss button is pressed",
+						"name": "onDismiss",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"dismissAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the dismiss button",
+						"name": "dismissAriaLabel",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "Badge"
 			}
 		},
 		"components-breadcrumbs": {
@@ -240,51 +1435,185 @@
 			"path": "./src/components/Breadcrumbs/tests/Breadcrumbs.stories.tsx",
 			"stories": [
 				{
+					"id": "components-breadcrumbs--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <Breadcrumbs ariaLabel=\"breadcrumb neutral\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"color: primary\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb primary\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "item",
+					"id": "components-breadcrumbs--item",
+					"name": "item, disabled",
 					"snippet": "const item = () => (\n    <Example>\n        <Example.Item title=\"disabled item\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb disabled\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}} disabled>\n                    Disabled item 2\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "icon",
+					"id": "components-breadcrumbs--icon",
+					"name": "item, icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"item with icon\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb with icon\">\n                <Breadcrumbs.Item icon={IconZap} onClick={() => {}}>\n                    Item 1\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "slots",
+					"id": "components-breadcrumbs--slots",
+					"name": "separator, children",
 					"snippet": "const slots = () => (\n    <Example>\n        <Example.Item title=\"slot: separator\">\n            <Breadcrumbs color=\"primary\" separator=\"/\" ariaLabel=\"breadcrumb with separator\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"custom child content\">\n            <Breadcrumbs ariaLabel=\"breadcrumb with custom children\">\n                <Breadcrumbs.Item onClick={() => {}}>\n                    <Badge>Item 1</Badge>\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>\n                    <Badge>Item 2</Badge>\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-breadcrumbs--collapsed",
 					"name": "collapsed",
 					"snippet": "const collapsed = () => (\n    <Example>\n        <Example.Item title=\"collapsed, 3 items shown by default\">\n            <Breadcrumbs\n                defaultVisibleItems={3}\n                ariaLabel=\"breadcrumbs one\"\n                expandAriaLabel=\"Expand items\"\n            >\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"collapsed, 4 items shown by default\">\n            <Breadcrumbs\n                defaultVisibleItems={4}\n                ariaLabel=\"breadcrumb two\"\n                expandAriaLabel=\"Expand items\"\n            >\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"collapsed, 3 items shown by default, not expandable\">\n            <Breadcrumbs defaultVisibleItems={3} ariaLabel=\"breadcrumb three\" disableExpand>\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "multiline",
+					"id": "components-breadcrumbs--multiline",
+					"name": "composition, multiline",
 					"snippet": "const multiline = () => (\n    <Example>\n        <Example.Item title=\"wraps content when multiline\">\n            <Breadcrumbs ariaLabel=\"breadcrumb multiline\">\n                {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((i) => (\n                    <Breadcrumbs.Item onClick={() => {}} key={i}>\n                        Item {i}\n                    </Breadcrumbs.Item>\n                ))}\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onClick",
+					"id": "components-breadcrumbs--on-click",
+					"name": "item, onClick, disabled",
 					"snippet": "const onClick = () => <Breadcrumbs>\n    <Breadcrumbs.Item onClick={fn()}>Trigger</Breadcrumbs.Item>\n    <Breadcrumbs.Item onClick={fn()} disabled>Trigger\n                    </Breadcrumbs.Item>\n</Breadcrumbs>;"
 				},
 				{
-					"name": "href",
+					"id": "components-breadcrumbs--href",
+					"name": "item, href",
 					"snippet": "const href = () => (\n    <Breadcrumbs>\n        <Breadcrumbs.Item href=\"https://reshaped.so\">Trigger</Breadcrumbs.Item>\n    </Breadcrumbs>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-breadcrumbs--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Breadcrumbs className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Breadcrumbs.Item>Trigger</Breadcrumbs.Item>\n        </Breadcrumbs>\n    </div>\n);"
 				}
 			],
 			"import": "import { Badge, Breadcrumbs, Example } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Breadcrumbs/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Breadcrumbs",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Breadcrumbs/Breadcrumbs.tsx",
-				"actualName": "Breadcrumbs",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children to position items",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ReactElement<unknown, string | JSXElementConstructor<any>>[]"
+						}
+					},
+					"separator": {
+						"defaultValue": null,
+						"description": "Node for defining custom separator between items",
+						"name": "separator",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"neutral\"",
+							"value": [{ "value": "\"primary\"" }, { "value": "\"neutral\"" }]
+						}
+					},
+					"defaultVisibleItems": {
+						"defaultValue": null,
+						"description": "Number of items to show by default, others will be hidden and can be expanded",
+						"name": "defaultVisibleItems",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"expandAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the expand button",
+						"name": "expandAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disableExpand": {
+						"defaultValue": null,
+						"description": "Turn expand button into static text and disable the expand functionality",
+						"name": "disableExpand",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the component",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"nav\">" }
+					}
+				},
+				"exportName": "Breadcrumbs"
 			}
 		},
 		"components-button": {
@@ -293,87 +1622,599 @@
 			"path": "./src/components/Button/tests/Button.stories.tsx",
 			"stories": [
 				{
-					"name": "variantAndColor",
+					"id": "components-button--variant-and-color",
+					"name": "variant, color",
 					"snippet": "const variantAndColor = () => (\n    <Example>\n        <Example.Item title=\"variant: solid\">\n            <View gap={4} direction=\"row\">\n                <Button onClick={() => {}}>Button</Button>\n                <Button onClick={() => {}} color=\"primary\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"faded\">\n                    Button\n                </Button>\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"outline\">\n                    Button\n                </Button>\n\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: ghost\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"ghost\">\n                    Button\n                </Button>\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: media\">\n            <View backgroundColor=\"primary\" borderRadius=\"medium\" padding={4} direction=\"row\" gap={4}>\n                <Button onClick={() => {}} color=\"media\">\n                    Button\n                </Button>\n\n                <Button onClick={() => {}} color=\"media\" variant=\"faded\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Button onClick={() => {}} icon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"endIcon\">\n            <Button onClick={() => {}} endIcon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"icon, endIcon\">\n            <Button onClick={() => {}} icon={IconZap} endIcon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"icon only\">\n            <Button onClick={() => {}} icon={IconZap} attributes={{ \"aria-label\": \"Action\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"small\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"small\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Button icon={IconZap}>Button</Button>\n                <Button variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"large\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"large\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"xlarge\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"xlarge\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"xlarge\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large, [m+] medium\">\n            <Button size={{ s: \"large\", m: \"medium\" }} icon={IconZap}>\n                Responsive\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated, color: neutral\">\n            <View direction=\"row\" gap={4}>\n                <Button elevated onClick={() => {}}>\n                    Button\n                </Button>\n                <Button elevated variant=\"outline\" onClick={() => {}}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"elevated, color\">\n            <View direction=\"row\" gap={4}>\n                <Button elevated color=\"primary\">\n                    Button\n                </Button>\n                <Button elevated variant=\"outline\" color=\"primary\">\n                    Button\n                </Button>\n                <View backgroundColor=\"primary\" padding={4} borderRadius=\"medium\">\n                    <Button color=\"media\" elevated>\n                        Button\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded, size: small, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, size: medium, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, size: large, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, icon only, all sizes\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"small\" icon={IconZap} />\n                <Button rounded icon={IconZap} />\n                <Button rounded size=\"large\" icon={IconZap} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--full-width",
 					"name": "fullWidth",
 					"snippet": "const fullWidth = () => (\n    <Example>\n        <Example.Item title=\"fullWidth, all variants\">\n            <View gap={3}>\n                <Button fullWidth>Neutral</Button>\n                <Button fullWidth variant=\"faded\">\n                    Faded\n                </Button>\n                <Button fullWidth variant=\"outline\">\n                    Outline\n                </Button>\n                <Button fullWidth variant=\"ghost\">\n                    Ghost\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive fullWidth\", \"[s] true\", \"[m+] false\"]}>\n            <Button fullWidth={{ s: true, m: false }}>Button</Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--loading",
 					"name": "loading",
 					"snippet": "const loading = () => (\n    <Example>\n        <Example.Item title=\"loading, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"loading, color critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"loading, color positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"loading, color: media\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n\n                <div style={{ position: \"absolute\", top: 16, left: 16 }}>\n                    <View gap={3} direction=\"row\">\n                        <Button color=\"media\" loading loadingAriaLabel=\"Loading\">\n                            Button\n                        </Button>\n                        <Button color=\"media\" variant=\"faded\" loading loadingAriaLabel=\"Loading\">\n                            Button\n                        </Button>\n                    </View>\n                </div>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"loading, long button text\", \"button size should stay the same\"]}>\n            <Button loading loadingAriaLabel=\"Loading\" color=\"primary\">\n                Long button text\n            </Button>\n        </Example.Item>\n\n        <Example.Item title={[\"loading, icon only\", \"button keep square 1/1 ratio\"]}>\n            <Button icon={IconZap} rounded loading loadingAriaLabel=\"Loading\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--highlighted",
 					"name": "highlighted",
 					"snippet": "const highlighted = () => (\n    <Example>\n        <Example.Item title=\"highlighted, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"highlighted, color: critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted color=\"critical\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"highlighted, color: positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted color=\"positive\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled icon={IconZap} onClick={() => {}}>\n                    Button\n                </Button>\n                <Button disabled variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"disabled, color: critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled color=\"critical\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"disabled, color: positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled color=\"positive\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"disabled, color: media\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n\n                <div style={{ position: \"absolute\", top: 16, left: 16 }}>\n                    <View gap={3} direction=\"row\">\n                        <Button color=\"media\" disabled>\n                            Button\n                        </Button>\n                        <Button color=\"media\" variant=\"faded\" disabled>\n                            Button\n                        </Button>\n                    </View>\n                </div>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner: all\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>Content</View.Item>\n                <Button.Aligner>\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: top\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"top\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: top and end\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side={[\"top\", \"end\"]}>\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: bottom\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2} align=\"end\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"bottom\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: start\">\n            <View padding={4} borderColor=\"neutral-faded\" gap={2} align=\"start\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"start\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: end\">\n            <View padding={4} borderColor=\"neutral-faded\" gap={2} align=\"end\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"end\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "components-button--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"slot gap\">\n            <Button variant=\"outline\">\n                <Avatar size={6} initials=\"RS\" />\n                Label\n                <Hotkey>B</Hotkey>\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--href",
 					"name": "href",
 					"snippet": "const href = () => <Button href=\"https://reshaped.so\">Trigger</Button>;"
 				},
 				{
+					"id": "components-button--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Button onClick={fn()}>Trigger</Button>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-button--href-on-click",
+					"name": "href, onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <Button\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </Button>\n);"
 				},
 				{
+					"id": "components-button--as",
 					"name": "as",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"as: span\">\n            <Button onClick={() => {}} as=\"span\">\n                Trigger\n            </Button>\n        </Example.Item>\n        <Example.Item title=\"render, disabled\">\n            <Button\n                disabled\n                onClick={() => {}}\n                render={(props) => <section {...props} />}\n                attributes={{ \"data-testid\": \"render-el\" }}\n            >\n                Trigger\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-button--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Button className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Button>\n    </div>\n);"
 				},
 				{
+					"id": "components-button--group",
 					"name": "group",
 					"snippet": "const group = () => (\n    <Example>\n        <Example.Item title=\"with icon\">\n            <Button.Group>\n                <Button rounded>Submit</Button>\n                <Button rounded icon={IconZap} />\n            </Button.Group>\n        </Example.Item>\n        <Example.Item title=\"variant: solid\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\", \"media\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color}>One</Button>\n                        <Button color={color}>Two</Button>\n                        <Button color={color}>Three</Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"outline\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"outline\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"outline\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\", \"media\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"faded\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"faded\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"faded\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"variant: ghost\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"ghost\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"ghost\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"ghost\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "groupClassName",
+					"id": "components-button--group-class-name",
+					"name": "group className, attributes",
 					"snippet": "const groupClassName = () => (\n    <div data-testid=\"root\">\n        <Button.Group className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Button>Trigger</Button>\n        </Button.Group>\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Button, Example, Hotkey, Image, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Button/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Button",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Button/Button.tsx",
-				"actualName": "Button",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"ghost\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"ghost\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loading": {
+						"defaultValue": null,
+						"description": "Show loading state",
+						"name": "loading",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loadingAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the loading indicator",
+						"name": "loadingAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Make the component take the full width of the parent element",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "highlighted",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Button"
 			}
 		},
 		"components-calendar": {
@@ -382,54 +2223,363 @@
 			"path": "./src/components/Calendar/tests/Calendar.stories.tsx",
 			"stories": [
 				{
+					"id": "components-calendar--default-month",
 					"name": "defaultMonth",
 					"snippet": "const defaultMonth = () => (\n    <Example>\n        <Example.Item title=\"defaultMonth: 2020 January\">\n            <Calendar defaultMonth={new Date(2020, 0)} range />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "uncontrolled",
+					"id": "components-calendar--uncontrolled",
+					"name": "defaultValue, range",
 					"snippet": "const uncontrolled = () => <Example>\n    <Example.Item title=\"defaultValue\">\n        <Calendar\n            defaultMonth={new Date(2020, 0)}\n            defaultValue={new Date(2020, 0, 10)}\n            onChange={fn()} />\n    </Example.Item>\n    <Example.Item title=\"defaultValue, range\">\n        <Calendar\n            range\n            defaultMonth={new Date(2020, 0)}\n            defaultValue={{ start: new Date(2020, 0, 10), end: new Date(2020, 0, 15) }}\n            onChange={fn()} />\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "controlled",
+					"id": "components-calendar--controlled",
+					"name": "value, range",
 					"snippet": "const controlled = () => <Example>\n    <Example.Item title=\"value\">\n        <Calendar\n            defaultMonth={new Date(2020, 0)}\n            value={new Date(2020, 0, 10)}\n            onChange={fn()} />\n    </Example.Item>\n    <Example.Item title=\"defaultValue, range\">\n        <Calendar\n            range\n            defaultMonth={new Date(2020, 0)}\n            value={{ start: new Date(2020, 0, 10), end: new Date(2020, 0, 15) }}\n            onChange={fn()} />\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-calendar--selected-dates",
 					"name": "selectedDates",
 					"snippet": "const selectedDates = () => (\n    <Example>\n        <Example.Item title=\"selectedDates: [4,8]\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                value={null}\n                selectedDates={[new Date(2020, 0, 4), new Date(2020, 0, 8)]}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "minMax",
+					"id": "components-calendar--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <Example>\n        <Example.Item title=\"min: 4, max: 20\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                min={new Date(2020, 0, 4)}\n                max={new Date(2020, 0, 20)}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-calendar--first-week-day",
 					"name": "firstWeekDay",
 					"snippet": "const firstWeekDay = () => (\n    <Example>\n        <Example.Item title=\"firstWeekDay: 3 (Wed)\">\n            <Calendar defaultMonth={new Date(2020, 0)} firstWeekDay={3} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "translation",
+					"id": "components-calendar--translation",
+					"name": "render functions",
 					"snippet": "const translation = () => (\n    <Example>\n        <Example.Item title=\"translated to NL\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                renderMonthLabel={({ date }) => date.toLocaleDateString(\"nl\", { month: \"short\" })}\n                renderSelectedMonthLabel={({ date }) =>\n                    date.toLocaleDateString(\"nl\", { month: \"long\", year: \"numeric\" })\n                }\n                renderWeekDay={({ date }) => date.toLocaleDateString(\"nl\", { weekday: \"short\" })}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "ariaLabels",
+					"id": "components-calendar--aria-labels",
+					"name": "aria labels",
 					"snippet": "const ariaLabels = () => (\n    <Example>\n        <Example.Item title=\"aria labels\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                nextYearAriaLabel=\"Test next year\"\n                nextMonthAriaLabel=\"Test next month\"\n                renderDateAriaLabel={() => \"Test date\"}\n                renderMonthAriaLabel={() => \"Test month\"}\n                previousYearAriaLabel=\"Test previous year\"\n                previousMonthAriaLabel=\"Test previous month\"\n                monthSelectionAriaLabel=\"Test month selection\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "monthSelection",
+					"id": "components-calendar--month-selection",
+					"name": "test: month selection",
 					"snippet": "const monthSelection = () => (\n    <Example>\n        <Example.Item title=\"month selection\">\n            <Calendar defaultMonth={new Date(2020, 1)} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "keyboardNavigation",
+					"id": "components-calendar--keyboard-navigation",
+					"name": "test: keyboard navigation",
 					"snippet": "const keyboardNavigation = () => (\n    <Example>\n        <Example.Item title=\"keyboard navigation\">\n            <Calendar defaultMonth={new Date(2020, 0)} />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Calendar, Example } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Calendar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Calendar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Calendar/Calendar.tsx",
-				"actualName": "Calendar",
+				"methods": [],
+				"props": {
+					"range": {
+						"defaultValue": null,
+						"description": "Disable range selection\nEnable range selection",
+						"name": "range",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Current selected date value, enables controlled mode\nCurrent selected range value, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date | RangeValue | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default selected date value, enables uncontrolled mode\nDefault selected range value, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date | RangeValue" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when date selection changes\nCallback when range selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { value: Date; }) => void) | ((args: { value: Date; }) => void) | ((args: { value: RangeValue; }) => void) | ((args: { value: RangeValue; }) => void)"
+						}
+					},
+					"defaultMonth": {
+						"defaultValue": { "value": "Date.now()" },
+						"description": "Default month to display",
+						"name": "defaultMonth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum date that can be selected",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum date that can be selected",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"firstWeekDay": {
+						"defaultValue": { "value": "1, Monday" },
+						"description": "First day of the week",
+						"name": "firstWeekDay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"selectedDates": {
+						"defaultValue": null,
+						"description": "Dates that are selected",
+						"name": "selectedDates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date[]" }
+					},
+					"renderWeekDay": {
+						"defaultValue": null,
+						"description": "Render a custom weekday label, can be used for localization",
+						"name": "renderWeekDay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { weekDay: number; date: Date; }) => string)" }
+					},
+					"renderSelectedMonthLabel": {
+						"defaultValue": null,
+						"description": "Render a custom month label, can be used for localization",
+						"name": "renderSelectedMonthLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { date: Date; }) => string)" }
+					},
+					"renderMonthLabel": {
+						"defaultValue": null,
+						"description": "Render a custom month label, can be used for localization",
+						"name": "renderMonthLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { month: number; date: Date; }) => string)" }
+					},
+					"previousMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the previous month button",
+						"name": "previousMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"nextMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "",
+						"name": "nextMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"previousYearAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the previous year button",
+						"name": "previousYearAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"nextYearAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the next year button",
+						"name": "nextYearAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"monthSelectionAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the month selection button",
+						"name": "monthSelectionAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"renderDateAriaLabel": {
+						"defaultValue": null,
+						"description": "Dynamic aria label applied to each date cell based on the arguments",
+						"name": "renderDateAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { date: Date; }) => string)" }
+					},
+					"renderMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "Dynamic aria label applied to each month element based on the arguments",
+						"name": "renderMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { month: number; }) => string)" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -439,50 +2589,356 @@
 			"path": "./src/components/Card/tests/Card.stories.tsx",
 			"stories": [
 				{
+					"id": "components-card--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: default\">\n            <Card>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title=\"padding: 2\">\n            <Card padding={2}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title=\"padding: 0\">\n            <Card padding={0}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive padding\", \"[s] 4\", \"[m+] 8\"]}>\n            <Card padding={{ s: 4, m: 8 }}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--selected",
 					"name": "selected",
 					"snippet": "const selected = () => (\n    <Example>\n        <Example.Item title=\"selected\">\n            <Card selected>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated\">\n            <Card elevated>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4\">\n            <Card bleed={4}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n        <Example.Item title={[\"responsive bleed\", \"[s] 4\", \"[m+] 0\"]}>\n            <Card bleed={{ s: 4, m: 0 }}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--height",
 					"name": "height",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"height: 200px\">\n            <Card height=\"200px\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Card onClick={fn()}>Trigger</Card>;"
 				},
 				{
+					"id": "components-card--href",
 					"name": "href",
 					"snippet": "const href = () => <Card href=\"https://reshaped.so\">Trigger</Card>;"
 				},
 				{
+					"id": "components-card--as",
 					"name": "as",
 					"snippet": "const as = () => <Card as=\"span\" attributes={{ \"data-testid\": \"root\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-card--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Card className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Card, Example, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Card/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Card",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Card/Card.tsx",
-				"actualName": "Card",
+				"methods": [],
+				"props": {
+					"padding": {
+						"defaultValue": null,
+						"description": "Component padding, base unit multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Remove side borders and apply negative margins, base unit multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"selected": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "selected",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when the component is clicked, turns component into a button",
+						"name": "onClick",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL to navigate to when the component is clicked, turns component into a link",
+						"name": "href",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"as": {
+						"defaultValue": { "value": "\"div\"" },
+						"description": "Custom component tag name",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(Attributes<keyof IntrinsicElements> & (Attributes))" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -492,56 +2948,181 @@
 			"path": "./src/components/Carousel/tests/Carousel.stories.tsx",
 			"stories": [
 				{
+					"id": "components-carousel--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Carousel attributes={{ \"data-testid\": \"test-id\" }} visibleItems={3}>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n    </Carousel>\n);"
 				},
 				{
+					"id": "components-carousel--visible-items",
 					"name": "visibleItems",
 					"snippet": "const visibleItems = () => (\n    <Example>\n        <Example.Item title=\"visibleItems: 3\">\n            <Carousel visibleItems={3}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive visibleItems\", \"s: 2, m+ 3\"]}>\n            <Carousel visibleItems={{ s: 2, m: 3 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title=\"visibleItems: auto\">\n            <Carousel>\n                <Placeholder h={100} />\n                <Placeholder h={100} w={200} />\n                <Placeholder h={100} w={300} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 2, visibleItems 3\">\n            <Carousel visibleItems={3} gap={2}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"gap: responsive, visibleItems: 3\", \"s: 2, l: 8\"]}>\n            <Carousel visibleItems={3} gap={{ s: 2, l: 8 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4, visibleItems: 3\">\n            <Carousel visibleItems={3} bleed={4}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive bleed, visibleItems: 3\", \"[s] 4, [l+] 0\"]}>\n            <Carousel visibleItems={3} bleed={{ s: 4, l: 0 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--navigation-display",
 					"name": "navigationDisplay",
 					"snippet": "const navigationDisplay = () => (\n    <Example>\n        <Example.Item title=\"navigationDisplay: hidden\">\n            <Carousel\n                visibleItems={3}\n                navigationDisplay=\"hidden\"\n                attributes={{ \"data-testid\": \"test-id\" }}\n            >\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "instanceRef",
+					"id": "components-carousel--instance-ref",
+					"name": "instanceRef, onChange",
 					"snippet": "const instanceRef = (args) => {\n    const carouselRef = React.useRef<CarouselInstanceRef>(null);\n    const [index, setIndex] = React.useState(0);\n\n    return (\n        <Example>\n            <Example.Item title=\"instanceRef, onChange\">\n                <View gap={3}>\n                    <View gap={3} direction=\"row\" align=\"center\">\n                        <Button onClick={() => carouselRef.current?.navigateBack()}>Back</Button>\n                        <Button onClick={() => carouselRef.current?.navigateForward()}>Forward</Button>\n                        <Button onClick={() => carouselRef.current?.navigateTo(3)}>To 3</Button>\n                        <View.Item>Index: {index}</View.Item>\n                    </View>\n                    <Carousel\n                        visibleItems={2}\n                        instanceRef={carouselRef}\n                        navigationDisplay=\"hidden\"\n                        onChange={(changeArgs) => {\n                            args.handleChange(changeArgs);\n                            setIndex(changeArgs.index);\n                        }}\n                    >\n                        <Placeholder h={100}>Item 0</Placeholder>\n                        <Placeholder h={100}>Item 1</Placeholder>\n                        <Placeholder h={100}>Item 2</Placeholder>\n                        <Placeholder h={100}>Item 3</Placeholder>\n                        <Placeholder h={100}>Item 4</Placeholder>\n                        <Placeholder h={100}>Item 5</Placeholder>\n                    </Carousel>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-carousel--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Carousel visibleItems={2} className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder h={100}>Item 0</Placeholder>\n            <Placeholder h={100}>Item 1</Placeholder>\n            <Placeholder h={100}>Item 2</Placeholder>\n            <Placeholder h={100}>Item 3</Placeholder>\n            <Placeholder h={100}>Item 4</Placeholder>\n            <Placeholder h={100}>Item 5</Placeholder>\n        </Carousel>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Carousel, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Carousel/index.ts",
 				"description": "",
-				"methods": [
-					{
-						"name": "navigateTo",
-						"docblock": null,
-						"modifiers": [],
-						"params": [
+				"displayName": "Carousel",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, each child is rendered as a carousel item",
+						"name": "children",
+						"declarations": [
 							{
-								"name": "index",
-								"optional": false,
-								"type": { "name": "number" }
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
 							}
 						],
-						"returns": null
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"visibleItems": {
+						"defaultValue": null,
+						"description": "Number of items visible at once in the container",
+						"name": "visibleItems",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between items in the container, base unit multiplier",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margins, base unit multiplier, can be used to make sure the items don't get clipped when scrolling",
+						"name": "bleed",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"navigationDisplay": {
+						"defaultValue": null,
+						"description": "Hide navigation controls",
+						"name": "navigationDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"hidden\"", "value": [{ "value": "\"hidden\"" }] }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the carousel methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the first visible carousel index changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { index: number; }) => void)" }
+					},
+					"onScroll": {
+						"defaultValue": null,
+						"description": "Callback when the carousel scrolls",
+						"name": "onScroll",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: UIEvent<HTMLUListElement, UIEvent>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
 					}
-				],
-				"displayName": "Carousel",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Carousel/Carousel.tsx",
-				"actualName": "Carousel",
+				},
 				"exportName": "default"
 			}
 		},
@@ -551,46 +3132,259 @@
 			"path": "./src/components/Checkbox/tests/Checkbox.stories.tsx",
 			"stories": [
 				{
-					"name": "render",
+					"id": "components-checkbox--render",
+					"name": "name, value",
 					"snippet": "const render = () => (\n    <Checkbox name=\"test-name\" value=\"test-value\">\n        Content\n    </Checkbox>\n);"
 				},
 				{
+					"id": "components-checkbox--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"small\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"small\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"medium\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"medium\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"large\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"large\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: responsive, s: small, m: large\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size={{ s: \"small\", m: \"large\" }} defaultChecked>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-checkbox--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Checkbox name=\"animal\" value=\"dog\" hasError>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-checkbox--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n        <Example.Item title=\"disabled, checked\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled checked>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n        <Example.Item title=\"disabled, indeterminate\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled indeterminate>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "checked",
+					"id": "components-checkbox--checked",
+					"name": "checked, controlled",
 					"snippet": "const checked = () => <Checkbox name=\"test-name\" value=\"test-value\" checked onChange={fn()}>Content\n            </Checkbox>;"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-checkbox--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Checkbox name=\"test-name\" value=\"test-value\" defaultChecked onChange={fn()}>Content\n            </Checkbox>;"
 				},
 				{
+					"id": "components-checkbox--indeterminate",
 					"name": "indeterminate",
 					"snippet": "const indeterminate = () => (\n    <Checkbox name=\"test-name\" value=\"test-value\" indeterminate>\n        Content\n    </Checkbox>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-checkbox--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Checkbox className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Checkbox>\n    </div>\n);"
 				}
 			],
 			"import": "import { Checkbox, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Checkbox/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Checkbox",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Checkbox/Checkbox.tsx",
-				"actualName": "Checkbox",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the label",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Component name attribute",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the component",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Component value used for form submission",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"indeterminate": {
+						"defaultValue": null,
+						"description": "Show a indeterminate state, used for \"select all\" checkboxes with some of the individual checkboxes selected",
+						"name": "indeterminate",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the component is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the component is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Component checked state, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default checked state, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -600,26 +3394,143 @@
 			"path": "./src/components/CheckboxGroup/tests/CheckboxGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "value",
+					"id": "components-checkboxgroup--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <View gap={2}>\n    <CheckboxGroup name=\"test-name\" value={[\"1\"]} onChange={fn()}>\n        {/* checked should be ignored */}\n        <Checkbox value=\"1\" checked={false}>Content\n                            </Checkbox>\n        <Checkbox value=\"2\">Content 2</Checkbox>\n    </CheckboxGroup>\n</View>;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-checkboxgroup--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <View gap={2}>\n    <CheckboxGroup name=\"test-name\" defaultValue={[\"1\"]} onChange={fn()}>\n        {/* checked should be ignored */}\n        <Checkbox value=\"1\" checked={false}>Content\n                            </Checkbox>\n        <Checkbox value=\"2\">Content 2</Checkbox>\n    </CheckboxGroup>\n</View>;"
 				},
 				{
+					"id": "components-checkboxgroup--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <CheckboxGroup name=\"test-name\" disabled>\n        <Checkbox value=\"test-value\">Item 1</Checkbox>\n        <Checkbox value=\"test-value-2\">Item 2</Checkbox>\n    </CheckboxGroup>\n);"
 				}
 			],
 			"import": "import { Checkbox, CheckboxGroup, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/CheckboxGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "CheckboxGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/CheckboxGroup/CheckboxGroup.tsx",
-				"actualName": "CheckboxGroup",
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Component id attribute",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting checkboxes or custom layout components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the component from form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Component name attribute",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string[], ChangeEvent<HTMLInputElement>>" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Component value, enables controlled mode\nComponent value, enables uncontrolled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -629,23 +3540,346 @@
 			"path": "./src/components/ContextMenu/tests/ContextMenu.stories.tsx",
 			"stories": [
 				{
+					"id": "components-contextmenu--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"base\">\n            <div style={{ height: 200, overflow: \"auto\" }}>\n                <ContextMenu>\n                    <View height=\"400px\" backgroundColor=\"neutral-faded\" borderRadius=\"medium\" />\n\n                    <ContextMenu.Content>\n                        <ContextMenu.Item>Item 1</ContextMenu.Item>\n                        <ContextMenu.Item>Item 2</ContextMenu.Item>\n                    </ContextMenu.Content>\n                </ContextMenu>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "components-contextmenu--handlers",
+					"name": "handleOpen, handleClose",
 					"snippet": "const handlers = () => <div style={{ height: 200, overflow: \"auto\" }} data-testid=\"scroll\">\n    <ContextMenu onOpen={fn()} onClose={fn()}>\n        <View\n            height=\"400px\"\n            backgroundColor=\"neutral-faded\"\n            borderRadius=\"medium\"\n            attributes={{ \"data-testid\": \"root\" }} />\n        <ContextMenu.Content>\n            <ContextMenu.Item>Item</ContextMenu.Item>\n        </ContextMenu.Content>\n    </ContextMenu>\n</div>;"
 				}
 			],
 			"import": "import { ContextMenu, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ContextMenu/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ContextMenu",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ContextMenu/ContextMenu.tsx",
-				"actualName": "ContextMenu",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/DropdownMenu/DropdownMenu.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | \"action-menu\" | \"selection-menu\"" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					}
+				},
+				"exportName": "ContextMenu"
 			}
 		},
 		"components-divider": {
@@ -654,30 +3888,118 @@
 			"path": "./src/components/Divider/tests/Divider.stories.tsx",
 			"stories": [
 				{
-					"name": "rendering",
+					"id": "components-divider--rendering",
+					"name": "base",
 					"snippet": "const rendering = () => (\n    <Example>\n        <Example.Item title=\"default rendering\">\n            <Divider />\n        </Example.Item>\n\n        <Example.Item title={[\"blank rendering\", \"box should overlap with divider\"]}>\n            <View width=\"40px\" height=\"10px\" backgroundColor=\"primary\" />\n            <Divider blank />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-divider--vertical",
 					"name": "vertical",
 					"snippet": "const vertical = () => (\n    <Example>\n        <Example.Item title=\"vertical\">\n            <View gap={3} direction=\"row\" align=\"stretch\">\n                <Placeholder />\n                <View.Item>\n                    <Divider vertical />\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive vertical\", \"[s] true\", \"[m+]: false\"]}>\n            <View gap={3} direction={{ s: \"row\", m: \"column\" }} align=\"stretch\">\n                <Placeholder />\n                <View.Item>\n                    <Divider vertical={{ s: true, m: false }} />\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "label",
+					"id": "components-divider--label",
+					"name": "children, contentPosition",
 					"snippet": "const label = () => {\n    return (\n        <Example>\n            <Example.Item title=\"alignment\">\n                <View gap={4}>\n                    <Divider>Centered label</Divider>\n                    <Divider contentPosition=\"start\">Start label</Divider>\n                    <Divider contentPosition=\"end\">End label</Divider>\n                </View>\n            </Example.Item>\n\n            <Example.Item title=\"responsive\">\n                <View gap={3} direction={{ s: \"column\", m: \"row\" }} align=\"stretch\">\n                    <Placeholder />\n                    <View.Item>\n                        <Divider vertical={{ s: false, m: true }}>or pick second option</Divider>\n                    </View.Item>\n                    <Placeholder />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-divider--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Divider className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Divider, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Divider/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Divider",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Divider/Divider.tsx",
-				"actualName": "Divider",
+				"methods": [],
+				"props": {
+					"blank": {
+						"defaultValue": null,
+						"description": "Change component to take no space, useful for using it as a border in components like Tabs",
+						"name": "blank",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"vertical": {
+						"defaultValue": null,
+						"description": "Change component to render vertically",
+						"name": "vertical",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"contentPosition": {
+						"defaultValue": null,
+						"description": "Position for rendering children",
+						"name": "contentPosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"center\" | \"start\" | \"end\"",
+							"value": [{ "value": "\"center\"" }, { "value": "\"start\"" }, { "value": "\"end\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting text labels or custom components as a part of divider",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"hr\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -687,51 +4009,415 @@
 			"path": "./src/components/DropdownMenu/tests/DropdownMenu.stories.tsx",
 			"stories": [
 				{
+					"id": "components-dropdownmenu--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: default\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <DropdownMenu position=\"end\">\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n\n        <Example.Item title={[\"position: top-start\", \"should change to top-start to fit viewport\"]}>\n            <DropdownMenu position=\"top-end\">\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n        <div style={{ height: 2000 }} />\n    </Example>\n);"
 				},
 				{
+					"id": "components-dropdownmenu--sections",
 					"name": "sections",
 					"snippet": "const sections = () => (\n    <Example>\n        <Example.Item title=\"2 sections\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Section>\n                        <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                    </DropdownMenu.Section>\n\n                    <DropdownMenu.Section>\n                        <DropdownMenu.Item>Item 3</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 4</DropdownMenu.Item>\n                    </DropdownMenu.Section>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-dropdownmenu--submenu",
 					"name": "submenu",
 					"snippet": "const submenu = () => (\n    <Example>\n        <Example.Item title=\"submenu\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item onClick={() => {}}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger>Item 2</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger>Item 3</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2-1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2-2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger disabled>Item 4, disabled</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 3-1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 3-2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-dropdownmenu--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <DropdownMenu onOpen={fn()} onClose={fn()} defaultActive>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "active",
+					"id": "components-dropdownmenu--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <DropdownMenu onOpen={fn()} onClose={fn()} active>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "components-dropdownmenu--active-false",
+					"name": "active false, controlled",
 					"snippet": "const activeFalse = () => <DropdownMenu onOpen={fn()} onClose={fn()} active={false}>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "className",
+					"id": "components-dropdownmenu--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <DropdownMenu active>\n            <DropdownMenu.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </DropdownMenu.Trigger>\n            <DropdownMenu.Content className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n                <DropdownMenu.Item>Item</DropdownMenu.Item>\n            </DropdownMenu.Content>\n        </DropdownMenu>\n    </div>\n);"
 				},
 				{
-					"name": "testScroll",
+					"id": "components-dropdownmenu--test-scroll",
+					"name": "test: scroll",
 					"snippet": "const testScroll = () => (\n    <Example>\n        <Example.Item title=\"Scrolls on page mount to the dropdown\">\n            <div style={{ height: 1000 }} />\n            <DropdownMenu position=\"end\" key=\"scroll\" defaultActive>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testTheme",
+					"id": "components-dropdownmenu--test-theme",
+					"name": "test: theme",
 					"snippet": "const testTheme = () => (\n    <Example>\n        <Example.Item title=\"switch color mode while dropdown is active and check that it still works\">\n            <ThemeSwitching />\n        </Example.Item>\n        <Example.Item title=\"dropdown inherits multiple themes\">\n            <ThemeMultiple />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, DropdownMenu, Example, Theme, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/DropdownMenu/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "DropdownMenu",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/DropdownMenu/DropdownMenu.tsx",
-				"actualName": "DropdownMenu",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/DropdownMenu/DropdownMenu.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | \"action-menu\" | \"selection-menu\"" }
+					}
+				},
+				"exportName": "DropdownMenu"
 			}
 		},
 		"components-fileupload": {
@@ -740,35 +4426,165 @@
 			"path": "./src/components/FileUpload/tests/FileUpload.stories.tsx",
 			"stories": [
 				{
+					"id": "components-fileupload--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"Base upload with previews\">\n            <Demo />\n        </Example.Item>\n        <Example.Item title=\"With trigger\">\n            <FileUpload name=\"file\">\n                <div>\n                    Drop files to attach, or{\" \"}\n                    <FileUpload.Trigger>\n                        <Link variant=\"plain\">browse</Link>\n                    </FileUpload.Trigger>\n                </div>\n            </FileUpload>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "inline",
+					"id": "components-fileupload--inline",
+					"name": "inline, variant, render props",
 					"snippet": "const inline = () => {\n    return (\n        <Example>\n            <Example.Item title=\"inline\">\n                <FileUpload name=\"file\" inline onChange={console.log}>\n                    <View padding={2} paddingInline={3}>\n                        Upload\n                    </View>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"variant headless\">\n                <FileUpload name=\"file2\" variant=\"headless\" onChange={console.log}>\n                    <Button variant=\"outline\" fullWidth>\n                        Upload\n                    </Button>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"variant headless, inline\">\n                <FileUpload name=\"file2\" variant=\"headless\" inline onChange={console.log}>\n                    <Button>Upload</Button>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"inline, render props\">\n                <FileUpload name=\"file3\" variant=\"headless\" inline onChange={console.log}>\n                    {(props) => <Button highlighted={props.highlighted}>Upload</Button>}\n                </FileUpload>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-fileupload--height",
 					"name": "height",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"Custom height\">\n            <FileUpload name=\"file\" height=\"300px\">\n                <View gap={3}>\n                    <Icon svg={IconMic} size={8} />\n                    Drop files to attach\n                </View>\n            </FileUpload>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onChange",
+					"id": "components-fileupload--on-change",
+					"name": "name, onChange",
 					"snippet": "const onChange = () => <div data-testid=\"root\">\n    <FileUpload name=\"test-name\" onChange={fn()}>Content\n                    </FileUpload>\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "components-fileupload--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <FileUpload\n            name=\"name\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ id: \"test-input-id\" }}\n        >\n            Content\n        </FileUpload>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, FileUpload, Icon, Image, Link, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/FileUpload/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "FileUpload",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/FileUpload/FileUpload.tsx",
-				"actualName": "FileUpload",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, can be a render function that receives component state",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode | ((props: { highlighted?: boolean; }) => ReactNode)" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component value is changed",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ChangeHandler<File[], ChangeEvent<HTMLInputElement> | DragEvent<HTMLDivElement>>"
+						}
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Component height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component variant, headless variant is useful for rendering custom triggers like a Button",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"headless\"",
+							"value": [{ "value": "\"outline\"" }, { "value": "\"headless\"" }]
+						}
+					},
+					"inline": {
+						"defaultValue": null,
+						"description": "Change component to render inline making it more compact",
+						"name": "inline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					}
+				},
+				"exportName": "FileUpload"
 			}
 		},
 		"components-hotkey": {
@@ -777,22 +4593,78 @@
 			"path": "./src/components/Hotkey/tests/Hotkey.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "components-hotkey--base",
+					"name": "Base",
 					"snippet": "const base = () => (\n\t<Example>\n\t\t<Example.Item title=\"Base\">\n\t\t\t<Demo />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"Active\">\n\t\t\t<Hotkey active>⌘K</Hotkey>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"Inside input slot\">\n\t\t\t<View width=\"300px\">\n\t\t\t\t<TextField\n\t\t\t\t\tname=\"hey\"\n\t\t\t\t\tendSlot={<Demo />}\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"hotkey test\" }}\n\t\t\t\t/>\n\t\t\t</View>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-hotkey--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Hotkey className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            ⌘K\n        </Hotkey>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Hotkey, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Hotkey/Hotkey.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Hotkey",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Hotkey/Hotkey.tsx",
-				"actualName": "Hotkey",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Highlight the component, can be used to show when hotkey is pressed",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -802,54 +4674,241 @@
 			"path": "./src/components/Link/tests/Link.stories.tsx",
 			"stories": [
 				{
+					"id": "components-link--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: underline\">\n            <Link href=\"http://reshaped.so\" attributes={{ target: \"_blank\" }}>\n                Reshaped\n            </Link>\n        </Example.Item>\n        <Example.Item title=\"variant: plain\">\n            <Link onClick={() => {}} variant=\"plain\">\n                Link\n            </Link>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary\">\n            <Link color=\"primary\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Link color=\"critical\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Link color=\"positive\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <Link color=\"warning\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <Link color=\"inherit\">Link</Link>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon, variant: underline\">\n            <Link icon={IconZap}>Link</Link>\n        </Example.Item>\n        <Example.Item title=\"icon, variant: plain\">\n            <Link icon={IconZap} variant=\"plain\">\n                Link\n            </Link>\n        </Example.Item>\n        <Example.Item\n            title={[\"icon, variant: underline\", \"should inherit display-1 size from the parent\"]}\n        >\n            <Text variant=\"title-3\">\n                <Link icon={IconZap} variant=\"underline\">\n                    Instant delivery\n                </Link>\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--href",
 					"name": "href",
 					"snippet": "const href = () => <Link href=\"https://reshaped.so\">Trigger</Link>;"
 				},
 				{
+					"id": "components-link--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Link onClick={fn()}>Trigger</Link>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-link--href-on-click",
+					"name": "href + onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <Link\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </Link>\n);"
 				},
 				{
+					"id": "components-link--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Link disabled onClick={() => {}}>\n        Trigger\n    </Link>\n);"
 				},
 				{
+					"id": "components-link--render",
 					"name": "render",
 					"snippet": "const render = () => <Link render={(props) => <section {...props} />}>Trigger</Link>;"
 				},
 				{
-					"name": "className",
+					"id": "components-link--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Link className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Link>\n    </div>\n);"
 				},
 				{
-					"name": "testMultilineInText",
+					"id": "components-link--test-multiline-in-text",
+					"name": "test: multiline",
 					"snippet": "const testMultilineInText = () => (\n    <Example>\n        <Example.Item title=\"should wrap inside the text\">\n            <div>\n                Someone asked me to write this text that is boring to ready for everyone and to add&nbsp;\n                <Link href=\"/\">this very very long link</Link> to it.\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Link, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Link/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Link",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Link/Link.tsx",
-				"actualName": "Link",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon at the start position",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"primary\"" },
+						"description": "Link color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"inherit\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"inherit\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"underline\"" },
+						"description": "Link render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"plain\" | \"underline\"",
+							"value": [{ "value": "\"plain\"" }, { "value": "\"underline\"" }]
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -859,30 +4918,110 @@
 			"path": "./src/components/Loader/tests/Loader.stories.tsx",
 			"stories": [
 				{
+					"id": "components-loader--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: medium\">\n                <Loader size=\"medium\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title=\"size: small\">\n                <Loader size=\"small\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title=\"size: large\">\n                <Loader size=\"large\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title={[\"responsive size\", \"[s] small\", \"[m+] medium\"]}>\n                <Loader size={{ s: \"small\", m: \"medium\" }} ariaLabel=\"Loading\" />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-loader--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary\">\n            <Loader ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Loader color=\"critical\" ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Loader color=\"positive\" ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <Loader color=\"inherit\" ariaLabel=\"Loading\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-loader--aria-label",
 					"name": "ariaLabel",
 					"snippet": "const ariaLabel = () => <Loader ariaLabel=\"Loading\" attributes={{ \"data-testid\": \"root\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-loader--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Loader className=\"test-classname\" attributes={{ id: \"test-id\" }} ariaLabel=\"Loading\" />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Loader } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Loader/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Loader",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Loader/Loader.tsx",
-				"actualName": "Loader",
+				"methods": [],
+				"props": {
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"inherit\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -892,67 +5031,504 @@
 			"path": "./src/components/MenuItem/tests/MenuItem.stories.tsx",
 			"stories": [
 				{
+					"id": "components-menuitem--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <MenuItem size=\"small\" icon={IconZap} onClick={() => {}} endSlot={<Hotkey>⌘K</Hotkey>}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <MenuItem icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <MenuItem size=\"large\" icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title={[\"responsive size\", \"[s] small\", \"[m] medium\", \"[l+] large\"]}>\n            <MenuItem size={{ s: \"small\", m: \"medium\", l: \"large\" }} icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <MenuItem color=\"neutral\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <MenuItem color=\"primary\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <MenuItem color=\"critical\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--selected",
 					"name": "selected",
 					"snippet": "const selected = () => (\n    <Example>\n        <Example.Item title=\"selected, color: neutral\">\n            <MenuItem color=\"neutral\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"selected, color: primary\">\n            <MenuItem color=\"primary\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"selected, color: critical\">\n            <MenuItem color=\"critical\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--rounded-corners",
 					"name": "roundedCorners",
 					"snippet": "const roundedCorners = () => (\n    <Example>\n        <Example.Item title=\"roundedCorners\">\n            <MenuItem roundedCorners selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive roundedCorners\", \"[s]: false\", \"[m+]: true\"]}>\n            <MenuItem roundedCorners={{ s: false, m: true }} selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "slots",
+					"id": "components-menuitem--slots",
+					"name": "startSlot, endSlot",
 					"snippet": "const slots = () => (\n    <Example>\n        <Example.Item title=\"startSlot, endSlot, selected\">\n            <MenuItem startSlot={<Placeholder h={20} />} endSlot={<Placeholder h={20} />} selected>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem size=\"small\" selected onClick={() => {}}>\n                        Menu item\n                    </MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem selected>Menu item</MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem size=\"large\" selected>\n                        Menu item\n                    </MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--href",
 					"name": "href",
 					"snippet": "const href = () => <MenuItem href=\"https://reshaped.so\">Trigger</MenuItem>;"
 				},
 				{
+					"id": "components-menuitem--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <MenuItem onClick={fn()}>Trigger</MenuItem>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-menuitem--href-on-click",
+					"name": "href + onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <MenuItem\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </MenuItem>\n);"
 				},
 				{
+					"id": "components-menuitem--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <MenuItem disabled onClick={() => {}}>\n        Trigger\n    </MenuItem>\n);"
 				},
 				{
-					"name": "as",
+					"id": "components-menuitem--as",
+					"name": "as, render",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"render, disabled\">\n            <MenuItem\n                disabled\n                onClick={() => {}}\n                render={(props) => <section {...props} />}\n                attributes={{ \"data-testid\": \"render-el\" }}\n            >\n                Trigger\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-menuitem--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <MenuItem className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </MenuItem>\n    </div>\n);"
 				},
 				{
-					"name": "alignerClassName",
+					"id": "components-menuitem--aligner-class-name",
+					"name": "aligner, className, attributes",
 					"snippet": "const alignerClassName = () => (\n    <div data-testid=\"root\">\n        <MenuItem.Aligner className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <MenuItem>Trigger</MenuItem>\n        </MenuItem.Aligner>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Hotkey, MenuItem, Placeholder, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/MenuItem/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "MenuItem",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/MenuItem/MenuItem.tsx",
-				"actualName": "MenuItem",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content\nNode for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"neutral\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"neutral\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content at the start side of the component",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content at the end side of the component",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component as hovered or focused. For example, when displaying currently focused item in Autocomplete",
+						"name": "highlighted",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"selected": {
+						"defaultValue": null,
+						"description": "Highlight the component as selected",
+						"name": "selected",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"roundedCorners": {
+						"defaultValue": null,
+						"description": "Round the corners of the component",
+						"name": "roundedCorners",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					}
+				},
+				"exportName": "MenuItem"
 			}
 		},
 		"components-modal": {
@@ -961,67 +5537,301 @@
 			"path": "./src/components/Modal/tests/Modal.stories.tsx",
 			"stories": [
 				{
+					"id": "components-modal--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title={[\"responsive position\", \"[s] full-screen\", \"[m] center\", \"[l] end\"]}>\n            <Demo position={{ s: \"full-screen\", m: \"center\", l: \"end\" }} />\n        </Example.Item>\n        <Example.Item title=\"position: center\">\n            <Demo position=\"center\" />\n        </Example.Item>\n        <Example.Item title=\"position: bottom\">\n            <Demo position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"position: start\">\n            <Demo position=\"start\" />\n        </Example.Item>\n        <Example.Item title=\"position: end\">\n            <Demo position=\"end\" />\n        </Example.Item>\n        <Example.Item title=\"position: full-screen\">\n            <Demo position=\"full-screen\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: default\">\n                <Demo />\n            </Example.Item>\n            <Example.Item title=\"size: 300px\">\n                <Demo size=\"300px\" />\n            </Example.Item>\n            <Example.Item\n                title={[\"size: 800px\", \"should have max width of 100% minus gaps on the sides\"]}\n            >\n                <Demo size=\"800px\" />\n            </Example.Item>\n            <Example.Item\n                title={[\n                    \"responsive size, responsive position\",\n                    \"[s] auto\",\n                    \"[m+] 600px\",\n                    \"bottom position changes height instead of width\",\n                ]}\n            >\n                <Demo\n                    position={{ s: \"bottom\", m: \"center\", l: \"end\" }}\n                    size={{ s: \"auto\", m: \"600px\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-modal--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 0\">\n            <Demo padding={0} />\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <Demo padding={6} />\n        </Example.Item>\n        <Example.Item title={[\"responsive padding\", \"[s] 2\", \"[m+]: 6\"]}>\n            <Demo padding={{ s: 2, m: 6 }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--overflow",
 					"name": "overflow",
 					"snippet": "const overflow = () => (\n    <Example>\n        <Example.Item title=\"default overflow\">\n            <Demo>\n                <div\n                    style={{\n                        position: \"absolute\",\n                        top: -32,\n                        left: -32,\n                        height: 100,\n                        width: 100,\n                        background: \"tomato\",\n                    }}\n                />\n            </Demo>\n        </Example.Item>\n\n        <Example.Item title=\"overflow: visible\">\n            <Demo overflow=\"visible\">\n                <div\n                    style={{\n                        position: \"absolute\",\n                        top: -32,\n                        left: -32,\n                        height: 100,\n                        width: 100,\n                        background: \"tomato\",\n                    }}\n                />\n            </Demo>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--composition",
 					"name": "composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"title, subtitle, dismissible\">\n            <Demo title=\"Modal title\" subtitle=\"Modal subtitle\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--overlay",
 					"name": "overlay",
 					"snippet": "const overlay = () => (\n    <Example>\n        <Example.Item title=\"transparentOverlay, doesn't lock scroll\">\n            <Demo transparentOverlay />\n        </Example.Item>\n        <Example.Item title=\"blurredOverlay\">\n            <Demo blurredOverlay />\n        </Example.Item>\n        <View height=\"1000px\" />\n    </Example>\n);"
 				},
 				{
-					"name": "flags",
+					"id": "components-modal--flags",
+					"name": "disableCloseOnOutsideClick",
 					"snippet": "const flags = () => {\n    return (\n        <Example>\n            <Example.Item title=\"disableCloseOnOutsideClick\">\n                <Demo disableCloseOnOutsideClick onClose={fn()} active />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-modal--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const containerRef2 = React.useRef<HTMLDivElement>(null);\n    const toggle = useToggle();\n    const toggle2 = useToggle();\n\n    return (\n        <Example>\n            <Example.Item title={[\"in scrollable container\", \"scroll and then open\"]}>\n                <View\n                    attributes={{ ref: containerRef2 }}\n                    borderRadius=\"medium\"\n                    height=\"400px\"\n                    overflow=\"auto\"\n                    backgroundColor=\"neutral-faded\"\n                    padding={4}\n                >\n                    <View gap={4} align=\"start\">\n                        <Button onClick={toggle2.activate}>Open modal</Button>\n                        <View height=\"500px\" backgroundColor=\"primary\" width=\"500px\" borderRadius=\"medium\" />\n                    </View>\n                    <Modal\n                        containerRef={containerRef2}\n                        active={toggle2.active}\n                        onClose={toggle2.deactivate}\n                        position=\"end\"\n                    >\n                        <Placeholder />\n                    </Modal>\n                </View>\n            </Example.Item>\n            <Example.Item title=\"in static container\">\n                <View\n                    attributes={{ ref: containerRef }}\n                    borderRadius=\"medium\"\n                    height=\"400px\"\n                    overflow=\"hidden\"\n                    backgroundColor=\"neutral-faded\"\n                    padding={4}\n                >\n                    <Button onClick={toggle.activate}>Open modal</Button>\n                    <Modal\n                        containerRef={containerRef}\n                        active={toggle.active}\n                        onClose={toggle.deactivate}\n                        position=\"end\"\n                    >\n                        <Placeholder />\n                    </Modal>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "renderProps",
+					"id": "components-modal--render-props",
+					"name": "children, render props",
 					"snippet": "const renderProps = () => (\n    <Modal active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        <Modal.Title>Title</Modal.Title>\n        Content\n    </Modal>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "components-modal--handlers",
+					"name": "onOpen, onClose, onAfterOpen, onAfterClose",
 					"snippet": "const handlers = () => {\n    const overlayToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => overlayToggle.toggle()}>Open overlay</Button>\n            <Modal\n                active={overlayToggle.active}\n                onClose={(closeArgs) => {\n                    overlayToggle.deactivate();\n                    args.handleClose(closeArgs);\n                }}\n                onOpen={fn()}\n                onAfterOpen={fn()}\n                onAfterClose={fn()}>\n                <Modal.Title>Title</Modal.Title>Content\n                                </Modal>\n        </>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-modal--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <Modal active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        <Modal.Title>Title</Modal.Title>\n        Content\n    </Modal>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-modal--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => {\n    const menuModalToggle = useToggle();\n    const menuModalToggleInner = useToggle();\n    const scrollModalToggle = useToggle();\n    const inputRef = React.useRef<HTMLInputElement>(null);\n\n    return (\n        <Example>\n            <Example.Item title=\"Scrolls with long content on touch devices\">\n                <Demo position=\"center\">\n                    <Button onClick={() => {}}>Action</Button>\n                    <View height=\"2000px\" backgroundColor=\"primary-faded\" />\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"keyboard focus stays on the modal first\">\n                <Demo title=\"Modal title\" autoFocus={false} />\n            </Example.Item>\n            <Example.Item title=\"trap focus works with custom children components\">\n                <Demo title=\"Modal title\">\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <Switch name=\"switch\" />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"focus moves to the input\">\n                <Demo\n                    title=\"Modal title\"\n                    onOpen={() => {\n                        inputRef.current?.focus();\n                    }}\n                >\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <TextField name=\"name\" inputAttributes={{ ref: inputRef }} />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"Focus moves to the input with autoFocus\">\n                <Demo title=\"Modal title\">\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <TextField\n                            name=\"name\"\n                            placeholder=\"autofocus\"\n                            inputAttributes={{ autoFocus: true }}\n                        />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"scrollable area in modal ignores swipe-to-close\">\n                <View gap={3} direction=\"row\">\n                    <Button onClick={scrollModalToggle.activate}>Open</Button>\n                    <Modal\n                        active={scrollModalToggle.active}\n                        onClose={scrollModalToggle.deactivate}\n                        size=\"300px\"\n                        position=\"bottom\"\n                    >\n                        <View\n                            height=\"1000px\"\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            padding={4}\n                        >\n                            Content\n                        </View>\n                    </Modal>\n                </View>\n            </Example.Item>\n            <Example.Item\n                title={[\n                    \"trap focus works correctly when it was already trapped\",\n                    \"focus return back to the dropdown trigger on modal close\",\n                    \"closing dropdown inside the modal doesn't close the modal\",\n                ]}\n            >\n                <DropdownMenu>\n                    <DropdownMenu.Trigger>\n                        {(attributes) => <Button attributes={attributes}>Open menu</Button>}\n                    </DropdownMenu.Trigger>\n                    <DropdownMenu.Content>\n                        <DropdownMenu.Item onClick={menuModalToggle.activate}>Open dialog</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                    </DropdownMenu.Content>\n                </DropdownMenu>\n                <Modal active={menuModalToggle.active} onClose={menuModalToggle.deactivate}>\n                    <View gap={3}>\n                        <DropdownMenu>\n                            <DropdownMenu.Trigger>\n                                {(attributes) => <Button attributes={attributes}>Open menu</Button>}\n                            </DropdownMenu.Trigger>\n                            <DropdownMenu.Content>\n                                <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                                <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                            </DropdownMenu.Content>\n                        </DropdownMenu>\n                        <Button onClick={menuModalToggleInner.activate}>Open dialog</Button>\n                        <Button onClick={menuModalToggle.deactivate}>Close</Button>\n                        <Modal active={menuModalToggleInner.active} onClose={menuModalToggleInner.deactivate}>\n                            <Button onClick={menuModalToggleInner.deactivate}>Close</Button>\n                        </Modal>\n                    </View>\n                </Modal>\n            </Example.Item>\n\n            <Example.Item title=\"disableSwipeGesture\">\n                <Demo disableSwipeGesture position=\"start\" />\n            </Example.Item>\n\n            <Example.Item title=\"scroll locks on open\">\n                <Demo />\n                <View height=\"1000px\" />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "trapFocusEdgeCases",
+					"id": "components-modal--trap-focus-edge-cases",
+					"name": "test: trap focus edge cases",
 					"snippet": "const trapFocusEdgeCases = () => {\n    const toggle = useToggle();\n\n    return (\n        <Example>\n            <Example.Item title=\"Radio should be navigatable with arrow keys\">\n                <Button onClick={toggle.activate}>Open modal</Button>\n                <Modal active={toggle.active} onClose={toggle.deactivate}>\n                    <View gap={2}>\n                        <Button onClick={() => {}}>Action 1</Button>\n                        <Radio name=\"radio\" value=\"1\">\n                            Option 1\n                        </Radio>\n                        <Radio name=\"radio\" value=\"2\">\n                            Option 2\n                        </Radio>\n                        <Button onClick={() => {}}>Action 2</Button>\n                    </View>\n                </Modal>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import {\n    Button,\n    Dismissible,\n    DropdownMenu,\n    Example,\n    Modal,\n    Placeholder,\n    Radio,\n    Switch,\n    TextField,\n    View,\n} from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Modal/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Modal",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Modal/Modal.tsx",
-				"actualName": "Modal",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Component position on the screen",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<\"bottom\" | \"center\" | \"start\" | \"end\" | \"full-screen\">"
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size, literal css value",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Component padding, unit token multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Remove overflow from the component content",
+						"name": "overflow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"visible\"", "value": [{ "value": "\"visible\"" }] }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is closed",
+						"name": "onClose",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((args: { reason: CloseReason | \"drag\"; }) => void)" }
+					},
+					"transparentOverlay": {
+						"defaultValue": null,
+						"description": "Make the overlay transparent",
+						"name": "transparentOverlay",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"blurredOverlay": {
+						"defaultValue": null,
+						"description": "Make the overlay blurred",
+						"name": "blurredOverlay",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableSwipeGesture": {
+						"defaultValue": null,
+						"description": "Disable swipe gesture to close the component on touch devices",
+						"name": "disableSwipeGesture",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable closing the component on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Focus the first focusable element in the component when it is opened, when false, focus will be set on the component content container",
+						"name": "autoFocus",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element, useful when there is no visible title",
+						"name": "ariaLabel",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"overlayClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the overlay element",
+						"name": "overlayClassName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "(Attributes<\"div\"> & { ref?: RefObject<HTMLDivElement | null>; })"
+						}
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the visibility of the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the component is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"containerRef": {
+						"defaultValue": null,
+						"description": "Element to render the component in",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"onAfterOpen": {
+						"defaultValue": null,
+						"description": "Callback after the component open transition is complete",
+						"name": "onAfterOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onAfterClose": {
+						"defaultValue": null,
+						"description": "Callback after the component close transition is complete",
+						"name": "onAfterClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					}
+				},
+				"exportName": "Modal"
 			}
 		},
 		"components-numberfield": {
@@ -1030,54 +5840,450 @@
 			"path": "./src/components/NumberField/tests/NumberField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-numberfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => {\n    return (\n        <Example>\n            <Example.Item title=\"variant: outline\">\n                <NumberField\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"variant: faded\">\n                <NumberField\n                    variant=\"faded\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"variant: headless\">\n                <NumberField\n                    variant=\"headless\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-numberfield--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: small\">\n                <NumberField\n                    size=\"small\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    suffix=\"m2\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: medium\">\n                <NumberField\n                    size=\"medium\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: large\">\n                <NumberField\n                    size=\"large\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: xlarge\">\n                <NumberField\n                    size=\"xlarge\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-numberfield--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <NumberField\n    name=\"test-name\"\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    disabled\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-numberfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <NumberField\n    name=\"test-name\"\n    defaultValue={2}\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-numberfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <NumberField\n    name=\"test-name\"\n    value={2}\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "minMax",
+					"id": "components-numberfield--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <NumberField\n        name=\"test-name\"\n        defaultValue={6}\n        min={5}\n        max={10}\n        increaseAriaLabel=\"Increase\"\n        decreaseAriaLabel=\"Decrease\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-numberfield--step",
 					"name": "step",
 					"snippet": "const step = () => (\n    <NumberField\n        name=\"test-name\"\n        defaultValue={6}\n        step={0.5}\n        increaseAriaLabel=\"Increase\"\n        decreaseAriaLabel=\"Decrease\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-numberfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <NumberField\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n            increaseAriaLabel=\"Increase\"\n            decreaseAriaLabel=\"Decrease\"\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-numberfield--form-control",
+					"name": "test: FormControl",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"FormControl\">\n            <FormControl>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"FormControl, disabled\">\n            <FormControl disabled>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"FormControl, error\">\n            <FormControl hasError>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "valueChanges",
+					"id": "components-numberfield--value-changes",
+					"name": "test: keyboard",
 					"snippet": "const valueChanges = () => (\n    <Example>\n        <Example.Item title=\"keyboard\">\n            <NumberField\n                name=\"name\"\n                increaseAriaLabel=\"Increase\"\n                decreaseAriaLabel=\"Decrease\"\n                inputAttributes={{ \"aria-label\": \"Label\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, FormControl, NumberField } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/NumberField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "NumberField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/NumberField/NumberField.tsx",
-				"actualName": "NumberField",
+				"methods": [],
+				"props": {
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component value is changed",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<number, ChangeEvent<HTMLInputElement>>" }
+					},
+					"increaseAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the increase button",
+						"name": "increaseAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"decreaseAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the decrease button",
+						"name": "decreaseAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum value supported in the form field",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum value supported in the form field",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"step": {
+						"defaultValue": null,
+						"description": "Step at which the value will increase or decrease when clicking the button controls",
+						"name": "step",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the form field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the form field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1087,34 +6293,166 @@
 			"path": "./src/components/Pagination/tests/Pagination.stories.tsx",
 			"stories": [
 				{
+					"id": "components-pagination--truncate",
 					"name": "truncate",
 					"snippet": "const truncate = () => {\n    return (\n        <Example>\n            <Example.Item title=\"start\">\n                <Pagination\n                    total={10}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"middle\">\n                <Pagination\n                    total={10}\n                    defaultPage={5}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"end\">\n                <Pagination\n                    total={10}\n                    defaultPage={10}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"no truncation\">\n                <Pagination\n                    total={4}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "render",
+					"id": "components-pagination--render",
+					"name": "rendering",
 					"snippet": "const render = () => (\n    <div data-testid=\"root\">\n        <Pagination\n            total={10}\n            previousAriaLabel=\"Previous\"\n            nextAriaLabel=\"Next\"\n            pageAriaLabel={(args) => `Page ${args.page}`}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "defaultPage",
+					"id": "components-pagination--default-page",
+					"name": "defaultPage, uncontrolled",
 					"snippet": "const defaultPage = () => <div data-testid=\"root\">\n    <Pagination\n        total={10}\n        defaultPage={2}\n        onChange={fn()}\n        previousAriaLabel=\"Previous\"\n        nextAriaLabel=\"Next\" />\n</div>;"
 				},
 				{
-					"name": "page",
+					"id": "components-pagination--page",
+					"name": "page, controlled",
 					"snippet": "const page = () => <div data-testid=\"root\">\n    <Pagination\n        total={10}\n        page={2}\n        onChange={fn()}\n        previousAriaLabel=\"Previous\"\n        nextAriaLabel=\"Next\" />\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "components-pagination--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Pagination\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            total={10}\n            previousAriaLabel=\"Previous\"\n            nextAriaLabel=\"Next\"\n        />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Pagination } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Pagination/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Pagination",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Pagination/Pagination.tsx",
-				"actualName": "Pagination",
+				"methods": [],
+				"props": {
+					"total": {
+						"defaultValue": null,
+						"description": "Total number of pages available",
+						"name": "total",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "number" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the current page changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { page: number; }) => void)" }
+					},
+					"pageAriaLabel": {
+						"defaultValue": null,
+						"description": "Function to dynamically get an aria-label for each page",
+						"name": "pageAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { page: number; }) => string)" }
+					},
+					"previousAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the previous page button",
+						"name": "previousAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"nextAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the next page button",
+						"name": "nextAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"page": {
+						"defaultValue": null,
+						"description": "Currently selected page number, starts with 1, enables controlled mode",
+						"name": "page",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultPage": {
+						"defaultValue": null,
+						"description": "Default selected page number, starts with 1, enables uncontrolled mode",
+						"name": "defaultPage",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1124,54 +6462,229 @@
 			"path": "./src/components/PinField/tests/PinField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-pinfield--base",
 					"name": "base",
 					"snippet": "const base = () => <PinField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-pinfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <PinField name=\"pin\" variant=\"faded\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-pinfield--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <PinField name=\"pin\" size=\"small\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <PinField name=\"pin\" size=\"medium\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <PinField name=\"pin\" size=\"large\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <PinField name=\"pin\" size=\"xlarge\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: responsive, s: medium, m+: xlarge\">\n            <PinField\n                name=\"pin\"\n                size={{ s: \"medium\", m: \"xlarge\" }}\n                inputAttributes={{ \"aria-label\": \"Pin\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-pinfield--value-length",
 					"name": "valueLength",
 					"snippet": "const valueLength = () => (\n    <PinField name=\"test-name\" valueLength={6} inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-pinfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <PinField\n    name=\"test-name\"\n    onChange={fn()}\n    defaultValue=\"12\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-pinfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <PinField\n    name=\"test-name\"\n    onChange={fn()}\n    value=\"12\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-pinfield--pattern",
 					"name": "pattern",
 					"snippet": "const pattern = () => <PinField\n    name=\"test-name\"\n    pattern=\"alphabetic\"\n    defaultValue=\"ab\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-pinfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <PinField\n            name=\"test-name\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ \"aria-label\": \"Label\", id: \"test-input-id\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-pinfield--form-control",
+					"name": "test: with FormControl",
 					"snippet": "const formControl = () => (\n    <FormControl>\n        <FormControl.Label>Label</FormControl.Label>\n        <PinField name=\"test-name\" />\n    </FormControl>\n);"
 				},
 				{
-					"name": "keyboard",
+					"id": "components-pinfield--keyboard",
+					"name": "test: keyboard navigation",
 					"snippet": "const keyboard = () => <PinField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				}
 			],
 			"import": "import { Example, FormControl, PinField } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/PinField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "PinField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/PinField/PinField.tsx",
-				"actualName": "PinField",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"valueLength": {
+						"defaultValue": null,
+						"description": "Amount of characters in the pin",
+						"name": "valueLength",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"pattern": {
+						"defaultValue": null,
+						"description": "Character pattern used in the input value",
+						"name": "pattern",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"numeric\" | \"alphabetic\" | \"alphanumeric\"",
+							"value": [
+								{ "value": "\"numeric\"" },
+								{ "value": "\"alphabetic\"" },
+								{ "value": "\"alphanumeric\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Input fields render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\"",
+							"value": [{ "value": "\"outline\"" }, { "value": "\"faded\"" }]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the input element, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1181,75 +6694,514 @@
 			"path": "./src/components/Popover/tests/Popover.stories.tsx",
 			"stories": [
 				{
+					"id": "components-popover--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: bottom\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"bottom-start\" />\n                <Demo position=\"bottom\" />\n                <Demo position=\"bottom-end\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: top\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"top-start\" />\n                <Demo position=\"top\" />\n                <Demo position=\"top-end\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: start\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"start-top\" />\n                <Demo position=\"start\" />\n                <Demo position=\"start-bottom\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: end\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"end-top\" />\n                <Demo position=\"end\" />\n                <Demo position=\"end-bottom\" defaultActive />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "widthNumber",
+					"id": "components-popover--width-number",
+					"name": "width: px",
 					"snippet": "const widthNumber = () => <Demo width=\"400px\" defaultActive />;"
 				},
 				{
-					"name": "widthFull",
+					"id": "components-popover--width-full",
+					"name": "width: 100%",
 					"snippet": "const widthFull = () => <Demo width=\"100%\" defaultActive />;"
 				},
 				{
+					"id": "components-popover--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 0\">\n            <Demo padding={0} />\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <Demo padding={6} defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-popover--elevation",
 					"name": "elevation",
 					"snippet": "const elevation = () => (\n    <Example>\n        <Example.Item title=\"elevation: raised\">\n            <Demo elevation=\"raised\" defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-popover--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <Popover onOpen={fn()} onClose={fn()} defaultActive>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "active",
+					"id": "components-popover--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <Popover onOpen={fn()} onClose={fn()} active>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "components-popover--active-false",
+					"name": "active false, controlled",
 					"snippet": "const activeFalse = () => <Popover onOpen={fn()} onClose={fn()} active={false}>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "dismissible",
+					"id": "components-popover--dismissible",
+					"name": "dismissible, onClose, className, attributes, closeAriaLabel",
 					"snippet": "const dismissible = () => <Popover onClose={fn()} defaultActive>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>\n        <Popover.Dismissible\n            closeAriaLabel=\"Close\"\n            attributes={{ \"data-testid\": \"test-id\" }}\n            className=\"test-classname\">Content\n                            </Popover.Dismissible>\n    </Popover.Content>\n</Popover>;"
 				},
 				{
+					"id": "components-popover--auto-focus",
 					"name": "autoFocus",
 					"snippet": "const autoFocus = () => (\n    <Example>\n        <Example.Item title=\"autoFocus=false\">\n            <Demo autoFocus={false} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-popover--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Popover active>\n            <Popover.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </Popover.Trigger>\n            <Popover.Content className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n                Content\n            </Popover.Content>\n        </Popover>\n    </div>\n);"
 				},
 				{
-					"name": "testNested",
+					"id": "components-popover--test-nested",
+					"name": "test: nested",
 					"snippet": "const testNested = () => (\n    <Popover position=\"bottom\">\n        <Popover.Trigger>\n            {(attributes) => <Button attributes={attributes}>Open</Button>}\n        </Popover.Trigger>\n        <Popover.Content>\n            <View gap={2} align=\"start\">\n                Popover content\n                <Popover>\n                    <Popover.Trigger>\n                        {(attributes) => <Button attributes={attributes}>Open</Button>}\n                    </Popover.Trigger>\n                    <Popover.Content>Hello</Popover.Content>\n                </Popover>\n            </View>\n        </Popover.Content>\n    </Popover>\n);"
 				},
 				{
-					"name": "testWithTooltip",
+					"id": "components-popover--test-with-tooltip",
+					"name": "test: with tooltip",
 					"snippet": "const testWithTooltip = () => (\n    <View paddingTop={10}>\n        <Tooltip position=\"top\" text=\"Hello\">\n            {(tooltipAttributes) => (\n                <Popover position=\"bottom\">\n                    <Popover.Trigger>\n                        {(attributes) => (\n                            <Button\n                                attributes={{\n                                    ...attributes,\n                                    ...tooltipAttributes,\n                                }}\n                            >\n                                Open\n                            </Button>\n                        )}\n                    </Popover.Trigger>\n                    <Popover.Content>\n                        <View gap={2} align=\"start\">\n                            Popover content\n                            <Button onClick={() => {}}>Button</Button>\n                        </View>\n                    </Popover.Content>\n                </Popover>\n            )}\n        </Tooltip>\n    </View>\n);"
 				},
 				{
-					"name": "testContentEditable",
+					"id": "components-popover--test-content-editable",
+					"name": "test: contenteditable",
 					"snippet": "const testContentEditable = () => {\n    const [active, setActive] = useState(false);\n\n    return (\n        <Popover>\n            <Popover.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </Popover.Trigger>\n            <Popover.Content>\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={() => {}}>Hello</Button>\n                    </View.Item>\n\n                    <ScrollArea height=\"100px\">\n                        <div\n                            style={{ height: \"200px\" }}\n                            contentEditable\n                            tabIndex={0}\n                            onInput={(e) => {\n                                setActive(e.currentTarget.innerText.startsWith(\"@\"));\n                            }}\n                            onKeyDown={(e) => {\n                                console.log(e.key);\n                                if (e.key === \"Enter\" && active) {\n                                    e.preventDefault();\n                                    e.currentTarget.innerText = \"@hello\";\n                                    setActive(false);\n                                }\n                            }}\n                        />\n                    </ScrollArea>\n\n                    <Popover\n                        active={active}\n                        onClose={() => setActive(false)}\n                        originCoordinates={{ x: 300, y: 300 }}\n                        trapFocusMode=\"selection-menu\"\n                    >\n                        <Popover.Content>\n                            <View gap={4}>\n                                <MenuItem onClick={() => {}}>Action</MenuItem>\n                                <MenuItem onClick={() => {}}>Close</MenuItem>\n                            </View>\n                        </Popover.Content>\n                    </Popover>\n                </View>\n            </Popover.Content>\n        </Popover>\n    );\n};"
 				},
 				{
-					"name": "variant",
+					"id": "components-popover--variant",
+					"name": "variant [deprecated]",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: headless\">\n            <Popover variant=\"headless\" defaultActive position=\"bottom-start\">\n                <Popover.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </Popover.Trigger>\n                <Popover.Content>\n                    <View\n                        height=\"100px\"\n                        width=\"100px\"\n                        borderColor=\"primary\"\n                        borderRadius=\"medium\"\n                        backgroundColor=\"primary-faded\"\n                    />\n                </Popover.Content>\n            </Popover>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, MenuItem, Popover, ScrollArea, Tooltip, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Popover/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Popover",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Popover/Popover.tsx",
-				"actualName": "Popover",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Automatically focus the first focusable element in the content, when false the content container will be focused instead",
+						"name": "autoFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | TrapMode" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Content element padding, unit token multiplier",
+						"name": "padding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "@deprecated use Flyout utility instead, will be removed in v4",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"elevated\" | \"headless\"",
+							"value": [{ "value": "\"elevated\"" }, { "value": "\"headless\"" }]
+						}
+					}
+				},
+				"exportName": "Popover"
 			}
 		},
 		"components-progress": {
@@ -1258,38 +7210,177 @@
 			"path": "./src/components/Progress/tests/Progress.stories.tsx",
 			"stories": [
 				{
+					"id": "components-progress--value",
 					"name": "value",
 					"snippet": "const value = () => (\n    <Example>\n        <Example.Item title=\"value: 50\">\n            <Progress value={50} ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"value: 20, min: 0, max: 40\">\n            <Progress value={20} min={0} max={40} ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"value: 50, min: 0, max: 40\">\n            <Progress value={50} min={0} max={40} ariaLabel=\"rating value\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small, value: 50\">\n            <Progress value={50} size=\"small\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"size: medium, value: 50\">\n            <Progress value={50} size=\"medium\" ariaLabel=\"rating value\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: critical, value: 50\">\n            <Progress value={50} color=\"critical\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: warning, value: 50\">\n            <Progress value={50} color=\"warning\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive, value: 50\">\n            <Progress value={50} color=\"positive\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: media, value: 50\">\n            <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                <Progress value={50} color=\"media\" ariaLabel=\"rating value\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--duration",
 					"name": "duration",
 					"snippet": "const duration = () => {\n    const [active, setActive] = React.useState(false);\n\n    const handleChange = () => {\n        setActive((state) => !state);\n    };\n\n    return (\n        <Example>\n            <Example.Item title=\"duration: 2000\">\n                <View gap={3}>\n                    <View.Item>\n                        <Button onClick={handleChange}>Change</Button>\n                    </View.Item>\n\n                    <Progress value={active ? 100 : 0} duration={2000} ariaLabel=\"rating value\" />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "render",
+					"id": "components-progress--render",
+					"name": "rendering",
 					"snippet": "const render = () => <Progress value={75} min={50} max={100} ariaLabel=\"progress\" />;"
 				},
 				{
-					"name": "className",
+					"id": "components-progress--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Progress className=\"test-classname\" attributes={{ id: \"test-id\" }} ariaLabel=\"progress\" />\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, Progress, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Progress/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Progress",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Progress/Progress.tsx",
-				"actualName": "Progress",
+				"methods": [],
+				"props": {
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the progress bar controlling the size of the fill",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Lower value boundary of the progress bar",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Upper value boundary of the progress bar",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"warning\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"duration": {
+						"defaultValue": null,
+						"description": "Duration of the progress bar animation in milliseconds",
+						"name": "duration",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1299,30 +7390,135 @@
 			"path": "./src/components/ProgressIndicator/tests/ProgressIndicator.stories.tsx",
 			"stories": [
 				{
+					"id": "components-progressindicator--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const [activeIndex, setActiveIndex] = React.useState(0);\n    const total = 10;\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <View gap={4}>\n                    <View direction=\"row\" gap={2} align=\"center\">\n                        <Button\n                            onClick={() => {\n                                setActiveIndex((prev) => Math.max(0, prev - 1));\n                            }}\n                        >\n                            Previous\n                        </Button>\n                        <Button\n                            onClick={() => {\n                                setActiveIndex((prev) => Math.min(total - 1, prev + 1));\n                            }}\n                        >\n                            Next\n                        </Button>\n                        <Text weight=\"medium\">Index: {activeIndex}</Text>\n                    </View>\n\n                    <View borderRadius=\"medium\" overflow=\"hidden\" width=\"300px\">\n                        <Scrim\n                            position=\"bottom\"\n                            backgroundSlot={<View aspectRatio={16 / 9} backgroundColor=\"neutral-faded\" />}\n                        >\n                            <View align=\"center\">\n                                <ProgressIndicator total={total} activeIndex={activeIndex} color=\"media\" />\n                            </View>\n                        </Scrim>\n                    </View>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-progressindicator--color",
 					"name": "color",
 					"snippet": "const color = () => {\n    return (\n        <Example>\n            <Example.Item title=\"color: primary\">\n                <ProgressIndicator total={10} activeIndex={5} color=\"primary\" />\n            </Example.Item>\n            <Example.Item title=\"color: media\">\n                <View borderRadius=\"medium\" overflow=\"hidden\" width=\"300px\">\n                    <Scrim\n                        position=\"bottom\"\n                        backgroundSlot={<View aspectRatio={16 / 9} backgroundColor=\"neutral-faded\" />}\n                    >\n                        <View align=\"center\">\n                            <ProgressIndicator total={10} activeIndex={5} color=\"media\" />\n                        </View>\n                    </Scrim>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-progressindicator--aria-label",
 					"name": "ariaLabel",
 					"snippet": "const ariaLabel = () => <ProgressIndicator total={10} className=\"test-classname\" ariaLabel=\"Progress\" />;"
 				},
 				{
-					"name": "className",
+					"id": "components-progressindicator--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ProgressIndicator total={10} className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, ProgressIndicator, Scrim, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ProgressIndicator/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ProgressIndicator",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ProgressIndicator/ProgressIndicator.tsx",
-				"actualName": "ProgressIndicator",
+				"methods": [],
+				"props": {
+					"total": {
+						"defaultValue": null,
+						"description": "Total amount of progress indicator dots",
+						"name": "total",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "number" }
+					},
+					"activeIndex": {
+						"defaultValue": null,
+						"description": "Index of the active progress indicator dot",
+						"name": "activeIndex",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\"",
+							"value": [{ "value": "\"media\"" }, { "value": "\"primary\"" }]
+						}
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1332,50 +7528,203 @@
 			"path": "./src/components/Radio/tests/Radio.stories.tsx",
 			"stories": [
 				{
+					"id": "components-radio--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"small\" defaultChecked>\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"medium\">\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"large\">\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: responsive, s: small, m: large\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size={{ s: \"small\", m: \"large\" }}>\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-radio--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Radio name=\"error\" value=\"dog\" hasError>\n                Radio\n            </Radio>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-radio--render",
+					"name": "name, value",
 					"snippet": "const render = () => (\n    <Radio name=\"test-name\" value=\"test-value\">\n        Content\n    </Radio>\n);"
 				},
 				{
-					"name": "checked",
+					"id": "components-radio--checked",
+					"name": "checked, controlled",
 					"snippet": "const checked = () => <Radio name=\"test-name\" value=\"test-value\" checked onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "checkedFalse",
+					"id": "components-radio--checked-false",
+					"name": "checked false, controlled",
 					"snippet": "const checkedFalse = () => <Radio name=\"test-name\" value=\"test-value\" checked={false} onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-radio--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Radio name=\"test-name\" value=\"test-value\" defaultChecked onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "defaultCheckedFalse",
+					"id": "components-radio--default-checked-false",
+					"name": "defaultChecked false, uncontrolled",
 					"snippet": "const defaultCheckedFalse = () => <Radio name=\"test-name\" value=\"test-value\" onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
+					"id": "components-radio--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Radio name=\"test-name\" value=\"test-value\" disabled>\n        Content\n    </Radio>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-radio--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Radio className=\"test-classname\" attributes={{ id: \"test-id\" }} value=\"value\">\n            Content\n        </Radio>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Radio, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Radio/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Radio",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Radio/Radio.tsx",
-				"actualName": "Radio",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the form field from the form submission",
+						"name": "disabled",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Indicate that the form field has an error",
+						"name": "hasError",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element",
+						"name": "value",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the input is focused",
+						"name": "onFocus",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the input is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "",
+						"name": "checked",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultChecked",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1385,26 +7734,169 @@
 			"path": "./src/components/RadioGroup/tests/RadioGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "value",
+					"id": "components-radiogroup--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <RadioGroup name=\"test-name\" value=\"1\" onChange={fn()}>\n    {/* checked should be ignored */}\n    <Radio value=\"1\" checked={false}>Content\n                    </Radio>\n    <Radio value=\"2\">Content 2</Radio>\n</RadioGroup>;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-radiogroup--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <RadioGroup name=\"test-name\" defaultValue=\"1\" onChange={fn()}>\n    {/* checked should be ignored */}\n    <Radio value=\"1\" checked={false}>Content\n                    </Radio>\n    <Radio value=\"2\">Content 2</Radio>\n</RadioGroup>;"
 				},
 				{
+					"id": "components-radiogroup--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <RadioGroup name=\"test-name\" disabled>\n        <Radio value=\"test-value\">Content</Radio>\n    </RadioGroup>\n);"
 				}
 			],
 			"import": "import { Radio, RadioGroup } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/RadioGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "RadioGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/RadioGroup/RadioGroup.tsx",
-				"actualName": "RadioGroup",
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the radio group",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the form field from the form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Indicate that the form field has an error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the input element, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1414,39 +7906,131 @@
 			"path": "./src/components/Resizable/tests/Resizable.stories.tsx",
 			"stories": [
 				{
+					"id": "components-resizable--direction",
 					"name": "direction",
 					"snippet": "const direction = () => {\n    return (\n        <Example>\n            <Example.Item title=\"row\">\n                <Resizable height=\"200px\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n            <Example.Item title=\"column\">\n                <Resizable height=\"400px\" direction=\"column\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n\n            {/* Test that page doesn't scroll on dragging */}\n            <div style={{ height: 2000 }} />\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-resizable--children",
 					"name": "children",
 					"snippet": "const children = () => {\n    return (\n        <Example>\n            <Example.Item title=\"render props, row\">\n                <Resizable height=\"200px\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n            <Example.Item title=\"render props, column\">\n                <Resizable height=\"400px\" direction=\"column\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-resizable--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"bordered, row\">\n            <Resizable height=\"200px\" variant=\"bordered\">\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n            </Resizable>\n        </Example.Item>\n        <Example.Item title=\"bordered, column\">\n            <Resizable height=\"400px\" direction=\"column\" variant=\"bordered\">\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n            </Resizable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "components-resizable--size",
+					"name": "minSize, maxSize, defaultSize",
 					"snippet": "const size = () => (\n    <Resizable className=\"test-classname\" attributes={{ id: \"test-id\" }} height=\"200px\">\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n        <Resizable.Handle />\n        <Resizable.Item minSize=\"200px\" maxSize=\"500px\" defaultSize=\"300px\">\n            <Panel />\n        </Resizable.Item>\n    </Resizable>\n);"
 				},
 				{
-					"name": "layout",
+					"id": "components-resizable--layout",
+					"name": "height, gap",
 					"snippet": "const layout = () => (\n    <Resizable height=\"100px\" gap={8}>\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n        <Resizable.Handle />\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n    </Resizable>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-resizable--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Resizable className=\"test-classname\" attributes={{ id: \"test-id\" }} height=\"200px\">\n            <Resizable.Item>\n                <Panel />\n            </Resizable.Item>\n            <Resizable.Handle />\n            <Resizable.Item>\n                <Panel />\n            </Resizable.Item>\n        </Resizable>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, Resizable, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Resizable/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Resizable",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Resizable/Resizable.tsx",
-				"actualName": "Resizable",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Resizable/Resizable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"bordered\" | \"borderless\"",
+							"value": [{ "value": "\"bordered\"" }, { "value": "\"borderless\"" }]
+						}
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Component content direction with the resize handle rendered in between the chidlren",
+						"name": "direction",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Resizable/Resizable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between children, base unit token number multiplier",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					}
+				},
+				"exportName": "Resizable"
 			}
 		},
 		"components-scrim": {
@@ -1455,26 +8039,101 @@
 			"path": "./src/components/Scrim/tests/Scrim.stories.tsx",
 			"stories": [
 				{
+					"id": "components-scrim--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: center\">\n            <Scrim backgroundSlot={<Placeholder h={200} />}>Scrim</Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <Scrim position=\"bottom\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: top\">\n            <Scrim position=\"top\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: start\">\n            <Scrim position=\"start\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <Scrim position=\"end\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-scrim--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Scrim className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Scrim>\n    </div>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "components-scrim--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"without backgroundSlot, size is based on the parent component\">\n            <div style={{ height: 300, position: \"relative\" }}>\n                <Scrim>Text</Scrim>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Placeholder, Scrim } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Scrim/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Scrim",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Scrim/Scrim.tsx",
-				"actualName": "Scrim",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"backgroundSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting background content behind the scrim",
+						"name": "backgroundSlot",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Component content position",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"bottom\" | \"start\" | \"end\" | \"full\"",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"full\"" }
+							]
+						}
+					},
+					"scrimClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the scrim element",
+						"name": "scrimClassName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1484,79 +8143,398 @@
 			"path": "./src/components/Select/tests/Select.stories.tsx",
 			"stories": [
 				{
-					"name": "nativeRender",
+					"id": "components-select--native-render",
+					"name": "native rendering, options, name, id",
 					"snippet": "const nativeRender = () => (\n    <Example>\n        <Example.Item title=\"native with options prop\">\n            <Select\n                name=\"animal\"\n                id=\"animal-1\"\n                placeholder=\"Select an animal\"\n                options={[\n                    { label: \"Dog\", value: \"dog\" },\n                    { label: \"Turtle\", value: \"turtle\" },\n                ]}\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            />\n        </Example.Item>\n        <Example.Item title=\"native with option tags\">\n            <Select\n                name=\"animal\"\n                id=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "customRender",
+					"id": "components-select--custom-render",
+					"name": "custom rendering, name, id, option groups",
 					"snippet": "const customRender = () => (\n    <Example>\n        <Example.Item title=\"custom with options\">\n            <Select.Custom\n                name=\"animal\"\n                id=\"animal-1\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"native with option tags\">\n            <Select.Custom\n                name=\"animal-2\"\n                id=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Group label=\"Birds\">\n                    <Select.Option value=\"pigeon\">Pigeon</Select.Option>\n                    <Select.Option value=\"parrot\">Parrot</Select.Option>\n                </Select.Group>\n                <Select.Group label=\"Sea Mammals\">\n                    <Select.Option value=\"whale\">Whale</Select.Option>\n                    <Select.Option value=\"dolphin\">Dolphin</Select.Option>\n                </Select.Group>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "nativeHandlers",
+					"id": "components-select--native-handlers",
+					"name": "native, controlled, uncontrolled, onFocus, onBlur, onChange",
 					"snippet": "const nativeHandlers = () => <Example>\n    <Example.Item title=\"native, uncontrolled, onChange\">\n        <Select\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n    <Example.Item title=\"native, controlled, onChange\">\n        <Select\n            name=\"animal-2\"\n            placeholder=\"Select an animal\"\n            value=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n    <Example.Item title=\"native, onFocus, onBlur, onClick\">\n        <Select\n            name=\"animal-3\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onFocus={fn()}\n            onBlur={fn()}\n            onClick={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "customHandlers",
+					"id": "components-select--custom-handlers",
+					"name": "custom, controlled, uncontrolled, onFocus, onBlur, onChange",
 					"snippet": "const customHandlers = () => <Example>\n    <Example.Item title=\"custom, uncontrolled, onChange\">\n        <Select.Custom\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n    <Example.Item title=\"custom, controlled, onChange\">\n        <Select.Custom\n            name=\"animal-2\"\n            placeholder=\"Select an animal\"\n            value=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n    <Example.Item title=\"native, onFocus, onBlur, onClick\">\n        <Select.Custom\n            name=\"animal-3\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onFocus={fn()}\n            onBlur={fn()}\n            onClick={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "triggerOnly",
+					"id": "components-select--trigger-only",
+					"name": "trigger only, onClick",
 					"snippet": "const triggerOnly = (args) => {\n    const toggle = useToggle();\n    const [value, setValue] = React.useState(\"Dog\");\n\n    const handleClick: SelectProps[\"onClick\"] = (e) => {\n        args.handleClick(e);\n        toggle.toggle();\n    };\n\n    return (\n        <Example>\n            <Example.Item title=\"trigger only, onClick\">\n                <Select\n                    name=\"animal\"\n                    placeholder=\"Select an animal\"\n                    onClick={handleClick}\n                    value=\"dog\"\n                    inputAttributes={{\n                        \"aria-label\": \"Select an animal\",\n                    }}\n                >\n                    {value}\n                </Select>\n                <Modal\n                    active={toggle.active}\n                    onClose={toggle.deactivate}\n                    position=\"bottom\"\n                    padding={2}\n                    attributes={{ \"aria-label\": \"Select an animal\" }}\n                >\n                    <div role=\"listbox\" aria-label=\"Select an animal\">\n                        <MenuItem\n                            roundedCorners\n                            onClick={() => {\n                                setValue(\"Dog\");\n                                toggle.deactivate();\n                            }}\n                            attributes={{\n                                role: \"option\",\n                            }}\n                        >\n                            Dog\n                        </MenuItem>\n                        <MenuItem\n                            roundedCorners\n                            attributes={{\n                                role: \"option\",\n                            }}\n                            onClick={() => {\n                                setValue(\"Turtle\");\n                                toggle.deactivate();\n                            }}\n                        >\n                            Turtle\n                        </MenuItem>\n                    </div>\n                </Modal>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-select--multiple",
 					"name": "multiple",
 					"snippet": "const multiple = () => <Example>\n    <Example.Item title=\"multiple\">\n        <Select.Custom\n            multiple\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue={[\"dog\"]}\n            onChange={fn()}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-select--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded, native\">\n            <Select\n                variant=\"faded\"\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n\n        <Example.Item title=\"variant: faded, custom\">\n            <Select.Custom\n                variant=\"faded\"\n                name=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless, native\">\n            <Select\n                variant=\"headless\"\n                name=\"animal-3\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless, custom\">\n            <Select.Custom\n                variant=\"headless\"\n                name=\"animal-4\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <Select.Custom size=\"small\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <Select.Custom size=\"medium\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <Select.Custom size=\"large\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: xlarge\">\n            <Select.Custom size=\"xlarge\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "startSlot",
+					"id": "components-select--start-slot",
+					"name": "icon,startSlot",
 					"snippet": "const startSlot = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Select.Custom name=\"animal\" placeholder=\"Select an animal\" icon={IconZap}>\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n\n        <Example.Item title=\"startSlot\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                startSlot={<Placeholder h={20} />}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--render-value",
 					"name": "renderValue",
 					"snippet": "const renderValue = () => {\n    const options = [\n        {\n            value: \"1\",\n            label: \"Title 1\",\n            subtitle: \"Subtitle 1\",\n        },\n        {\n            value: \"2\",\n            label: \"Title 2\",\n            subtitle: \"Subtitle 2\",\n        },\n    ];\n\n    return (\n        <Example>\n            <Example.Item title=\"default renderer, single\">\n                <Select.Custom name=\"animal\" defaultValue=\"1\" placeholder=\"Nothing selected\">\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"default renderer, multiple\">\n                <Select.Custom name=\"animal\" defaultValue={[\"1\"]} multiple placeholder=\"Nothing selected\">\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"renderValue, single\">\n                <Select.Custom\n                    name=\"animal\"\n                    defaultValue=\"1\"\n                    placeholder=\"Nothing selected\"\n                    renderValue={(args) => <Badge>Title {args.value}</Badge>}\n                >\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"renderValue, multiple\">\n                <Select.Custom\n                    name=\"animal\"\n                    defaultValue={[\"1\"]}\n                    multiple\n                    placeholder=\"Nothing selected\"\n                    renderValue={(args) => <Badge>Titles {args.value.join(\", \")}</Badge>}\n                >\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-select--error",
 					"name": "error",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Select.Custom name=\"animal\" placeholder=\"Select an animal\" hasError>\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, native\">\n            <Select\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                disabled\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n        <Example.Item title=\"disabled, custom\">\n            <Select.Custom\n                name=\"animal-2\"\n                placeholder=\"Select an animal\"\n                disabled\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-select--class-name",
+					"name": "className, attributes, inputAttributes",
 					"snippet": "const className = () => (\n    <Example>\n        <Example.Item title=\"native, className, attributes, inputAttributes\">\n            <Select\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                className=\"native-class\"\n                attributes={{ id: \"test-id\" }}\n                inputAttributes={{ \"aria-label\": \"test-label\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n        <Example.Item title=\"custom, className, attributes, inputAttributes\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                className=\"custom-class\"\n                attributes={{ id: \"test-id\" }}\n                inputAttributes={{ \"aria-label\": \"test-label\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "fallback",
+					"id": "components-select--fallback",
+					"name": "test: fallbackAdjustLayout",
 					"snippet": "const fallback = () => (\n    <Example>\n        <Example.Item title=\"fallback\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                {[...Array(100)].map((_, index) => (\n                    <Select.Option key={index} value={`item-${index}`}>\n                        Item {index + 1}\n                    </Select.Option>\n                ))}\n            </Select.Custom>\n            <div style={{ height: \"1000px\" }}></div>\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                {[...Array(100)].map((_, index) => (\n                    <Select.Option key={index} value={`item-${index}`}>\n                        Item {index + 1}\n                    </Select.Option>\n                ))}\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-select--form-control",
+					"name": "test: with FormControl",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"FormControl\">\n            <FormControl hasError>\n                <FormControl.Label>Animal</FormControl.Label>\n                <Select.Custom name=\"animal\" placeholder=\"Select an animal\">\n                    <Select.Option value=\"dog\">Dog</Select.Option>\n                    <Select.Option value=\"turtle\">Turtle</Select.Option>\n                </Select.Custom>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "components-select--test-composition",
+					"name": "test: composition",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item title=\"custom with options\">\n            <Select.Custom\n                name=\"animal\"\n                id=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Group>\n                    <Select.Option value=\"dog\">Dog</Select.Option>\n                    <Select.Option value=\"turtle\">Turtle</Select.Option>\n                </Select.Group>\n                <Select.Group>Hello</Select.Group>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Badge, Example, FormControl, MenuItem, Modal, Placeholder, Select, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Select/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Select",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Select/Select.tsx",
-				"actualName": "Select",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the select user interaction and form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value selected",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon to display in the select start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the select value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when the trigger is clicked",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"options": {
+						"defaultValue": null,
+						"description": "@deprecated Use <option /> children instead",
+						"name": "options",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NativeOption[]" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the input is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLSelectElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the input is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLSelectElement, Element>) => void)" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"select\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"renderValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "renderValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "undefined" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLSelectElement>>" }
+					}
+				},
+				"exportName": "Select"
 			}
 		},
 		"components-skeleton": {
@@ -1565,26 +8543,87 @@
 			"path": "./src/components/Skeleton/tests/Skeleton.stories.tsx",
 			"stories": [
 				{
+					"id": "components-skeleton--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"text\">\n            <Skeleton />\n        </Example.Item>\n\n        <Example.Item title=\"view, rectangle\">\n            <Skeleton width=\"100px\" height=\"100px\" />\n        </Example.Item>\n\n        <Example.Item title=\"view, circle\">\n            <Skeleton width=\"100px\" height=\"100px\" borderRadius=\"circular\" />\n        </Example.Item>\n\n        <Example.Item title=\"view, rectangle, responsive\">\n            <Skeleton width={{ s: \"100px\", m: \"200px\" }} height={{ s: \"100px\", m: \"200px\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-skeleton--radius",
 					"name": "radius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius=small\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"small\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=medium\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"medium\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=large\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"large\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=circular\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"circular\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-skeleton--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Skeleton className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Skeleton } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Skeleton/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Skeleton",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Skeleton/Skeleton.tsx",
-				"actualName": "Skeleton",
+				"methods": [],
+				"props": {
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width style, literal string value or a base unit token number multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Radius>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Skeleton/Skeleton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Skeleton/Skeleton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1594,66 +8633,421 @@
 			"path": "./src/components/Slider/tests/Slider.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "components-slider--base",
+					"name": "name, minName, maxName, range",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"single, name\">\n            <Slider name=\"slider-single\" defaultValue={30} />\n        </Example.Item>\n        <Example.Item title=\"range, name\">\n            <Slider range name=\"slider-range\" defaultMinValue={30} defaultMaxValue={85} />\n        </Example.Item>\n        <Example.Item title=\"range, minName, maxName\">\n            <Slider\n                range\n                minName=\"slider-min\"\n                maxName=\"slider-max\"\n                defaultMinValue={30}\n                defaultMaxValue={85}\n            />\n        </Example.Item>\n        <div style={{ height: 2000 }} />\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--orientation",
 					"name": "orientation",
 					"snippet": "const orientation = () => (\n    <Example>\n        <Example.Item title=\"orientation: vertical\">\n            <View height=\"200px\">\n                <Slider\n                    range\n                    name=\"slider\"\n                    defaultMinValue={30}\n                    defaultMaxValue={85}\n                    orientation=\"vertical\"\n                />\n            </View>\n        </Example.Item>\n        <View height=\"2000px\" />\n    </Example>\n);"
 				},
 				{
-					"name": "minMax",
+					"id": "components-slider--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <Example>\n        <Example.Item title=\"min, max\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={60} />\n        </Example.Item>\n        <Example.Item title=\"min, max, value < min\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={30} />\n        </Example.Item>\n        <Example.Item title=\"min, max, value > max\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={80} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--step",
 					"name": "step",
 					"snippet": "const step = () => (\n    <Example>\n        <Example.Item title=\"step: 5\">\n            <Slider name=\"slider\" defaultValue={30} step={5} />\n        </Example.Item>\n\n        <Example.Item title=\"step: 5, defaultValue: 31, rounded down to 30\">\n            <Slider name=\"slider\" defaultValue={31} step={5} />\n        </Example.Item>\n\n        <Example.Item title=\"step: 0.01, float\">\n            <Slider name=\"slider\" defaultValue={30} step={0.01} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <Slider name=\"slider\" defaultValue={30} disabled />\n        </Example.Item>\n\n        <Example.Item title=\"disabled, range\">\n            <Slider name=\"slider\" range defaultMinValue={30} defaultMaxValue={80} disabled />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--render-value",
 					"name": "renderValue",
 					"snippet": "const renderValue = () => (\n    <Example>\n        <Example.Item title=\"renderValue: $\">\n            <Slider name=\"name\" defaultValue={50} renderValue={(args) => `$${args.value}`} />\n        </Example.Item>\n        <Example.Item title=\"renderValue: false\">\n            <Slider name=\"name\" defaultValue={50} renderValue={false} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-slider--default-value",
+					"name": "defaultValue, onChange, onChangeCommit",
 					"snippet": "const defaultValue = () => <View paddingTop={10}>\n    <Slider name=\"test-name\" defaultValue={50} onChange={fn()} onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "value",
+					"id": "components-slider--value",
+					"name": "value, onChange, onChangeCommit",
 					"snippet": "const value = () => <View paddingTop={10}>\n    <Slider name=\"test-name\" value={50} onChange={fn()} onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "rangeDefaultValue",
+					"id": "components-slider--range-default-value",
+					"name": "range, defaultValue, onChange, onChangeCommit",
 					"snippet": "const rangeDefaultValue = () => <View paddingTop={10}>\n    <Slider\n        range\n        name=\"test-name\"\n        defaultMinValue={50}\n        defaultMaxValue={70}\n        onChange={fn()}\n        onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "rangeValue",
+					"id": "components-slider--range-value",
+					"name": "range, value, onChange, onChangeCommit, minName, maxName",
 					"snippet": "const rangeValue = () => <View paddingTop={10}>\n    <Slider\n        range\n        minName=\"test-name-min\"\n        maxName=\"test-name-max\"\n        minValue={50}\n        maxValue={70}\n        onChange={fn()}\n        onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "className",
+					"id": "components-slider--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Slider name=\"name\" className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				},
 				{
-					"name": "testForm",
+					"id": "components-slider--test-form",
+					"name": "test: form onChange",
 					"snippet": "const testForm = (args) => {\n    const formRef = React.useRef<HTMLFormElement>(null);\n    const [data, setData] = React.useState<[string, FormDataEntryValue][]>([]);\n\n    const handleChange = (e: React.FormEvent<HTMLFormElement>) => {\n        const formData = new FormData(e.currentTarget);\n        const nextState = [...formData.entries()];\n\n        args.handleFormChange({ formData: nextState });\n        setData(nextState);\n    };\n\n    return (\n        <View paddingTop={10} gap={4}>\n            <form onChange={handleChange} ref={formRef}>\n                <Slider\n                    range\n                    minName=\"slider-min\"\n                    maxName=\"slider-max\"\n                    defaultMinValue={30}\n                    defaultMaxValue={50}\n                />\n            </form>\n\n            {data.map((v) => v.join(\": \")).join(\", \")}\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testSwipe",
+					"id": "components-slider--test-swipe",
+					"name": "test: prevents parent swipe",
 					"snippet": "const testSwipe = () => {\n    const toggle = useToggle(true);\n\n    return (\n        <Modal active={toggle.active} onClose={toggle.deactivate} position=\"end\">\n            <View gap={4}>\n                <Modal.Title>Modal</Modal.Title>\n                <Slider name=\"slider\" defaultValue={30} />\n            </View>\n        </Modal>\n    );\n};"
 				}
 			],
 			"import": "import { Example, Modal, Slider, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Slider/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Slider",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Slider/Slider.tsx",
-				"actualName": "Slider",
+				"methods": [],
+				"props": {
+					"step": {
+						"defaultValue": null,
+						"description": "Step of the slider",
+						"name": "step",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the slider user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum value of the slider",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum value of the slider",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"orientation": {
+						"defaultValue": null,
+						"description": "Orientation of the slider",
+						"name": "orientation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"vertical\" | \"horizontal\"",
+							"value": [{ "value": "\"vertical\"" }, { "value": "\"horizontal\"" }]
+						}
+					},
+					"renderValue": {
+						"defaultValue": null,
+						"description": "Render a custom value in the thumb tooltip",
+						"name": "renderValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | ((args: { value: number; }) => string)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the slider, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the slider, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"range": {
+						"defaultValue": null,
+						"description": "Enables range slider with two thumbs",
+						"name": "range",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the slider input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"minName": {
+						"defaultValue": null,
+						"description": "Name of the slider min value input element, overrides the name",
+						"name": "minName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"maxName": {
+						"defaultValue": null,
+						"description": "Name of the slider max value input element, overrides the name",
+						"name": "maxName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the slider value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: SingleChangeArgs) => void) | ((args: RangeChangeArgs) => void) | ((args: RangeChangeArgs) => void)"
+						}
+					},
+					"onChangeCommit": {
+						"defaultValue": null,
+						"description": "Callback when the user commits the change by releasing the thumb\nCallback when the user commits the change by releasing the thumbs",
+						"name": "onChangeCommit",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: SingleChangeArgs) => void) | ((args: RangeChangeArgs) => void) | ((args: RangeChangeArgs) => void)"
+						}
+					},
+					"minValue": {
+						"defaultValue": null,
+						"description": "Minimum value of the slider",
+						"name": "minValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"maxValue": {
+						"defaultValue": null,
+						"description": "Maximum value of the slider",
+						"name": "maxValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultMinValue": {
+						"defaultValue": null,
+						"description": "Default minimum value of the slider, enables uncontrolled mode",
+						"name": "defaultMinValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultMaxValue": {
+						"defaultValue": null,
+						"description": "Default maximum value of the slider, enables uncontrolled mode",
+						"name": "defaultMaxValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1663,35 +9057,137 @@
 			"path": "./src/components/Stepper/tests/Stepper.stories.tsx",
 			"stories": [
 				{
+					"id": "components-stepper--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example>\n        <Example.Item title=\"direction: row\">\n            <Stepper activeId=\"1\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <Stepper activeId=\"1\" direction=\"column\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-stepper--label-display",
 					"name": "labelDisplay",
 					"snippet": "const labelDisplay = () => (\n    <Example>\n        <Example.Item title=\"direction: row, labels hidden\">\n            <Stepper activeId=\"1\" labelDisplay=\"hidden\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: column, labels hiden\">\n            <Stepper activeId=\"1\" direction=\"column\" labelDisplay=\"hidden\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: row, labels hidden on s\">\n            <Stepper activeId=\"1\" labelDisplay={{ s: \"hidden\", m: \"inline\" }}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-stepper--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 6, direction: row\">\n            <Stepper activeId=\"1\" gap={6}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"gap: 6, direction: column\">\n            <Stepper activeId=\"1\" direction=\"column\" gap={6}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap\", \"[s] 2\", \"[m+] 5\"]}>\n            <Stepper activeId=\"1\" gap={{ s: 2, m: 5 }}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-stepper--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Stepper className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Stepper.Item attributes={{ id: \"test-item-id\" }} className=\"test-item-classname\" />\n        </Stepper>\n    </div>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-stepper--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"multiline subtitle\",\n                \"should wrap the text correctly\",\n                \"should display the connector correctly\",\n            ]}\n        >\n            <Demo\n                activeId={0}\n                subtitle=\"It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, Placeholder, Stepper, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Stepper/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Stepper",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Stepper/Stepper.tsx",
-				"actualName": "Stepper",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"activeId": {
+						"defaultValue": null,
+						"description": "Id of the item to display as active",
+						"name": "activeId",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string | number" }
+					},
+					"labelDisplay": {
+						"defaultValue": null,
+						"description": "Display variant for the item label",
+						"name": "labelDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"hidden\" | \"inline\">" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Direction of the stepper",
+						"name": "direction",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between items (default: 3)",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
+				"exportName": "Stepper"
 			}
 		},
 		"components-switch": {
@@ -1700,38 +9196,236 @@
 			"path": "./src/components/Switch/tests/Switch.stories.tsx",
 			"stories": [
 				{
-					"name": "size",
+					"id": "components-switch--size",
+					"name": "Size",
 					"snippet": "const size = () => (\n\t<Example>\n\t\t<Example.Item title=\"size: medium\">\n\t\t\t<Switch name=\"active\" size=\"medium\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: small\">\n\t\t\t<Switch name=\"active\" size=\"small\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: large\">\n\t\t\t<Switch name=\"active\" size=\"large\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: responsive, s: small, m: large\">\n\t\t\t<Switch\n\t\t\t\tname=\"active\"\n\t\t\t\tsize={{ s: \"small\", m: \"large\" }}\n\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t/>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "label",
+					"id": "components-switch--label",
+					"name": "Label",
 					"snippet": "const label = () => (\n\t<Example>\n\t\t<Example.Item title=\"size: medium\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch reversed name=\"active\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: small\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" size=\"small\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch\n\t\t\t\t\treversed\n\t\t\t\t\tname=\"active\"\n\t\t\t\t\tsize=\"small\"\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t\t>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\n\t\t<Example.Item title=\"size: large\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" size=\"large\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch\n\t\t\t\t\treversed\n\t\t\t\t\tname=\"active\"\n\t\t\t\t\tsize=\"large\"\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t\t>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-switch--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Switch name=\"test-name\" defaultChecked onChange={fn()}>Label\n            </Switch>;"
 				},
 				{
-					"name": "checked",
+					"id": "components-switch--checked",
+					"name": "checked, uncontrolled",
 					"snippet": "const checked = () => <Switch name=\"test-name\" checked onChange={fn()}>Label\n            </Switch>;"
 				},
 				{
+					"id": "components-switch--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, unselected\">\n            <Switch name=\"active\" disabled inputAttributes={{ \"aria-label\": \"test switch\" }} />\n        </Example.Item>\n        <Example.Item title=\"disabled, selected\">\n            <Switch\n                name=\"active\"\n                disabled\n                defaultChecked\n                inputAttributes={{ \"aria-label\": \"test switch\" }}\n            />\n        </Example.Item>\n        <Example.Item title=\"disabled, with label\">\n            <Switch name=\"active\" disabled>\n                Switch\n            </Switch>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-switch--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Switch\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ \"aria-label\": \"test select\", id: \"test-input-id\" }}\n            name=\"name\"\n        >\n            Label\n        </Switch>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Switch, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Switch/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Switch",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Switch/Switch.tsx",
-				"actualName": "Switch",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the switch",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the switch input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the switch user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"reversed": {
+						"defaultValue": null,
+						"description": "Reverse the children position",
+						"name": "reversed",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the switch value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the switch is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the switch is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default value of the switch, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Value of the switch, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1741,51 +9435,112 @@
 			"path": "./src/components/Table/tests/Table.stories.tsx",
 			"stories": [
 				{
-					"name": "layout",
+					"id": "components-table--layout",
+					"name": "base",
 					"snippet": "const layout = () => (\n    <Example>\n        <Example.Item title=\"base\">\n            <Table>\n                <Table.Head>\n                    <Table.Row>\n                        <Table.Heading>Column 1</Table.Heading>\n                        <Table.Heading>Column 2</Table.Heading>\n                    </Table.Row>\n                </Table.Head>\n                <Table.Body>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell>Cell 2</Table.Cell>\n                    </Table.Row>\n                </Table.Body>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"colspan: 2 for col 2, rowspan: 2 for cell 3\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading colSpan={2}>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                    <Table.Cell rowSpan={2}>Cell 3</Table.Cell>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"align: center for heading 1, align: end for heading 2\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading align=\"center\">Column 1</Table.Heading>\n                    <Table.Heading align=\"end\">Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"valign: center for cell 2, valign: end for cell 3\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>\n                        <View height={15} backgroundColor=\"neutral-faded\" />\n                    </Table.Cell>\n                    <Table.Cell verticalAlign=\"center\">Cell 2</Table.Cell>\n                    <Table.Cell verticalAlign=\"end\">Cell 3</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"width: 40%, minWidth: 200px for col 1\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"40%\" minWidth=\"200px\">\n                        Column 1\n                    </Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-table--border",
 					"name": "border",
 					"snippet": "const border = () => (\n    <Example>\n        <Example.Item title=\"border: true\">\n            <Table border>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"columnBorder: true\">\n            <Table columnBorder>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"columnBorder: true, border: true\">\n            <Table columnBorder border>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-table--rows",
 					"name": "rows",
 					"snippet": "const rows = () => (\n    <Example>\n        <Example.Item title=\"highlighted for row 2\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row highlighted>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"clickable row 2, focus ring\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row onClick={() => {}}>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-table--render",
+					"name": "rendering",
 					"snippet": "const render = () => (\n    <Table>\n        <Table.Head>\n            <Table.Row>\n                <Table.Heading>Heading</Table.Heading>\n                <Table.Heading>Heading</Table.Heading>\n            </Table.Row>\n        </Table.Head>\n        <Table.Body>\n            <Table.Row>\n                <Table.Cell>Content</Table.Cell>\n                <Table.Cell>Content</Table.Cell>\n            </Table.Row>\n        </Table.Body>\n    </Table>\n);"
 				},
 				{
-					"name": "tbody",
+					"id": "components-table--tbody",
+					"name": "tbody rendering",
 					"snippet": "const tbody = () => (\n    <Table>\n        <Table.Row>\n            <Table.Heading>Heading</Table.Heading>\n            <Table.Heading>Heading</Table.Heading>\n        </Table.Row>\n    </Table>\n);"
 				},
 				{
-					"name": "tabIndex",
+					"id": "components-table--tab-index",
+					"name": "adds tabIndex for clickable rows",
 					"snippet": "const tabIndex = () => (\n    <Table>\n        <Table.Row>\n            <Table.Cell />\n        </Table.Row>\n        <Table.Row onClick={() => {}}>\n            <Table.Cell />\n        </Table.Row>\n        <Table.Row attributes={{ onClick: () => {} }}>\n            <Table.Cell />\n        </Table.Row>\n    </Table>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-table--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Table className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Table.Row attributes={{ id: \"test-row-id\" }}>\n                <Table.Cell attributes={{ id: \"test-cell-id\" }}></Table.Cell>\n            </Table.Row>\n        </Table>\n    </div>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-table--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"scroll fade\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"500px\">Column 1</Table.Heading>\n                    <Table.Heading width=\"500px\">Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"card with highlighted heading\">\n            <Card elevated padding={0}>\n                <Table>\n                    <Table.Row highlighted>\n                        <Table.Heading width=\"50%\" minWidth=\"200px\">\n                            Column 1\n                        </Table.Heading>\n                        <Table.Heading colSpan={2} align=\"end\">\n                            Column 2\n                        </Table.Heading>\n                    </Table.Row>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell align=\"center\">Cell 2</Table.Cell>\n                        <Table.Cell align=\"end\">Cell 3</Table.Cell>\n                    </Table.Row>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell align=\"center\">Cell 2</Table.Cell>\n                        <Table.Cell align=\"end\">Cell 3</Table.Cell>\n                    </Table.Row>\n                </Table>\n            </Card>\n        </Example.Item>\n        <Example.Item title=\"width: auto, nowrap\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"50%\">Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                    <Table.Heading>Column 3</Table.Heading>\n                    <Table.Heading width=\"auto\">Long heading title</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                    <Table.Cell>Cell 3</Table.Cell>\n                    <Table.Cell>Cell 4</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "examples",
+					"id": "components-table--examples",
+					"name": "test: selectable",
 					"snippet": "const examples = () => (\n    <Example>\n        <Example.Item title=\"selectable\">\n            <SelectionDemo />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Card, Checkbox, Example, Table, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Table/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Table",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Table/Table.tsx",
-				"actualName": "Table",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"border": {
+						"defaultValue": null,
+						"description": "Add border around the table",
+						"name": "border",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"columnBorder": {
+						"defaultValue": null,
+						"description": "Add border between the table columns",
+						"name": "columnBorder",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
+				"exportName": "Table"
 			}
 		},
 		"components-tabs": {
@@ -1794,71 +9549,196 @@
 			"path": "./src/components/Tabs/tests/Tabs.stories.tsx",
 			"stories": [
 				{
+					"id": "components-tabs--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Tabs>\n        <Tabs.List>\n            <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n            <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n        </Tabs.List>\n\n        <Tabs.Panel value=\"1\">\n            <View padding={4}>Content 1</View>\n        </Tabs.Panel>\n        <Tabs.Panel value=\"2\">\n            <View padding={4}>Content 2</View>\n        </Tabs.Panel>\n    </Tabs>\n);"
 				},
 				{
+					"id": "components-tabs--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Tabs defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills\">\n            <Tabs variant=\"pills\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills-elevated\">\n            <Tabs variant=\"pills-elevated\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: borderless\">\n            <Tabs variant=\"borderless\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"variant: default, size: large\">\n            <Tabs size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills, size: large\">\n            <Tabs variant=\"pills\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills-elevated, size: large\">\n            <Tabs variant=\"pills-elevated\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: borderless, size: large\">\n            <Tabs variant=\"borderless\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example>\n        <Example.Item title=\"direction: column, variant: underline\">\n            <Tabs direction=\"column\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: pills\">\n            <Tabs direction=\"column\" variant=\"pills\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: pills-elevated\">\n            <Tabs direction=\"column\" variant=\"pills-elevated\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: borderless\">\n            <Tabs direction=\"column\" variant=\"borderless\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Tabs>\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"1\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"icon only\">\n            <Tabs variant=\"pills-elevated\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap} attributes={{ \"aria-label\": \"Tab 1\" }} />\n                    <Tabs.Item value=\"1\" icon={IconZap} attributes={{ \"aria-label\": \"Tab 2\" }} />\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "equalWidth",
+					"id": "components-tabs--equal-width",
+					"name": "itemWidth",
 					"snippet": "const equalWidth = () => (\n    <Example>\n        <Example.Item title=\"equal width items\">\n            <Tabs onChange={console.log} itemWidth=\"equal\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"1\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                    <Tabs.Item value=\"2\" icon={IconZap}>\n                        Very long item 3\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--href",
 					"name": "href",
 					"snippet": "const href = () => (\n    <Example>\n        <Example.Item title=\"href, no onChange\">\n            <Tabs value=\"2\">\n                <Tabs.List>\n                    <Tabs.Item value=\"1\" href=\"#item-1\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"2\" href=\"#item-2\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                    <Tabs.Item value=\"3\" href=\"#item-3\" icon={IconZap}>\n                        Very long item 3\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "disabled",
+					"id": "components-tabs--disabled",
+					"name": "item, disabled",
 					"snippet": "const disabled = () => {\n    return (\n        <Example>\n            <Example.Item title=\"disabled\">\n                <Tabs defaultValue=\"1\">\n                    <Tabs.List>\n                        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"2\" disabled icon={IconZap}>\n                            Item 2\n                        </Tabs.Item>\n                        <Tabs.Item value=\"3\">Item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"1\">\n                        <View padding={4}>Content 1</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <View padding={4}>Content 2</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"3\">\n                        <View padding={4}>Content 3</View>\n                    </Tabs.Panel>\n                </Tabs>\n            </Example.Item>\n\n            <Example.Item title=\"disabled, href\">\n                <Tabs defaultValue=\"1\">\n                    <Tabs.List>\n                        <Tabs.Item href=\"#item1\" value=\"1\">\n                            Item 1\n                        </Tabs.Item>\n                        <Tabs.Item href=\"#item2\" value=\"2\" disabled icon={IconZap}>\n                            Item 2\n                        </Tabs.Item>\n                        <Tabs.Item href=\"#item3\" value=\"3\">\n                            Item 3\n                        </Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"1\">\n                        <View padding={4}>Content 1</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <View padding={4}>Content 2</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"3\">\n                        <View padding={4}>Content 3</View>\n                    </Tabs.Panel>\n                </Tabs>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-tabs--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <Tabs defaultValue=\"2\" onChange={fn()}>\n    <Tabs.List>\n        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n        <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n    </Tabs.List>\n    <Tabs.Panel value=\"1\">Content 1</Tabs.Panel>\n    <Tabs.Panel value=\"2\">Content 2</Tabs.Panel>\n</Tabs>;"
 				},
 				{
-					"name": "value",
+					"id": "components-tabs--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <Tabs value=\"2\" onChange={fn()}>\n    <Tabs.List>\n        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n        <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n    </Tabs.List>\n    <Tabs.Panel value=\"1\">Content 1</Tabs.Panel>\n    <Tabs.Panel value=\"2\">Content 2</Tabs.Panel>\n</Tabs>;"
 				},
 				{
-					"name": "className",
+					"id": "components-tabs--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Tabs>\n            <Tabs.List attributes={{ id: \"test-list-id\" }} className=\"test-list-classname\">\n                <Tabs.Item attributes={{ id: \"test-item-id\" }} value=\"1\">\n                    Item\n                </Tabs.Item>\n            </Tabs.List>\n\n            <Tabs.Panel\n                attributes={{ \"data-testid\": \"test-panel-id\" }}\n                className=\"test-panel-classname\"\n                value=\"1\"\n            />\n        </Tabs>\n    </div>\n);"
 				},
 				{
-					"name": "testFocusableContent",
+					"id": "components-tabs--test-focusable-content",
+					"name": "test: focusable content",
 					"snippet": "const testFocusableContent = () => (\n    <Example>\n        <Example.Item title=\"panels without focusable content\">\n            <Tabs>\n                <View gap={4}>\n                    <Tabs.List>\n                        <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                        <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"0\">Tab 1</Tabs.Panel>\n                    <Tabs.Panel value=\"1\">Tab 2</Tabs.Panel>\n                    <Tabs.Panel value=\"2\">Tab 3</Tabs.Panel>\n                </View>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"panels with focusable content\">\n            <Tabs>\n                <View gap={4}>\n                    <Tabs.List>\n                        <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                        <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"0\">\n                        <Button onClick={() => {}}>Tab 1 action</Button>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"1\">\n                        <Button onClick={() => {}}>Tab 2 action</Button>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <Button onClick={() => {}}>Tab 3 action</Button>\n                    </Tabs.Panel>\n                </View>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "components-tabs--test-composition",
+					"name": "test: composition",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item title=\"Viewport overflow\">\n            <Tabs>\n                <Tabs.List>\n                    {[...Array(8)].map((_, i) => (\n                        <Tabs.Item value={`${i}`} key={i} icon={IconZap}>\n                            Very long item {i}\n                        </Tabs.Item>\n                    ))}\n                </Tabs.List>\n\n                {[...Array(8)].map((_, i) => (\n                    <Tabs.Panel value={`${i}`} key={i}>\n                        Tab {i}\n                    </Tabs.Panel>\n                ))}\n            </Tabs>\n        </Example.Item>\n        <Example.Item>\n            <Tabs onChange={console.log} variant=\"pills-elevated\" name=\"hey\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">\n                        <View borderColor=\"neutral-faded\" padding={5}>\n                            Item 3\n                        </View>\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"Custom non-interactive list children\">\n            <Tabs direction=\"column\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <View height={6} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testEdgeCaseDom",
+					"id": "components-tabs--test-edge-case-dom",
+					"name": "test: scroll subscription",
 					"snippet": "const testEdgeCaseDom = () => {\n    const [activeItem, setActiveItem] = React.useState(\"1\");\n    const sectionsRef = React.useRef(null);\n\n    return (\n        <Example>\n            <Example.Item title=\"active item changes on scroll\">\n                <View justify=\"center\" align=\"center\" padding={10}>\n                    <View width={60} gap={2}>\n                        <Tabs value={activeItem} onChange={(args) => setActiveItem(args.value)}>\n                            <Tabs.List>\n                                <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                                <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n                                <Tabs.Item value=\"3\">Item 3</Tabs.Item>\n                                <Tabs.Item value=\"4\">Item 4</Tabs.Item>\n                            </Tabs.List>\n                        </Tabs>\n\n                        <ScrollArea\n                            attributes={{ ref: sectionsRef }}\n                            height={70}\n                            onScroll={(args) => {\n                                setActiveItem(Math.min(4, Math.floor(args.y * 10) + 1).toString());\n                            }}\n                        >\n                            <View gap={4}>\n                                <View gap={2}>\n                                    <Text>Section 1</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View grow height=\"100px\" backgroundColor=\"neutral-faded\" key={i} />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 2</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 3</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 4</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n                            </View>\n                        </ScrollArea>\n                    </View>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Example, ScrollArea, Tabs, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Tabs/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Tabs",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Tabs/Tabs.tsx",
-				"actualName": "Tabs",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Direction of the tab buttons",
+						"name": "direction",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"itemWidth": {
+						"defaultValue": null,
+						"description": "Equal width for the tab buttons",
+						"name": "itemWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"equal\"", "value": [{ "value": "\"equal\"" }] }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Render variant for component",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"bordered\" | \"borderless\" | \"pills\" | \"pills-elevated\"",
+							"value": [
+								{ "value": "\"bordered\"" },
+								{ "value": "\"borderless\"" },
+								{ "value": "\"pills\"" },
+								{ "value": "\"pills-elevated\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"large\" | \"medium\"",
+							"value": [{ "value": "\"large\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the tab buttons group when used as a form control",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the active tab value changes",
+						"name": "onChange",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((args: { value: string; name?: string; }) => void)" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the active tab, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the active tab, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "Tabs"
 			}
 		},
 		"components-textarea": {
@@ -1867,71 +9747,315 @@
 			"path": "./src/components/TextArea/tests/TextArea.stories.tsx",
 			"stories": [
 				{
-					"name": "variants",
+					"id": "components-textarea--variants",
+					"name": "variant",
 					"snippet": "const variants = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <TextArea variant=\"faded\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless\">\n            <TextArea variant=\"headless\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: medium\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"medium\" />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"large\" />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"xlarge\" />\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] large\", \"[m+] medium\"]}>\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size={{ s: \"xlarge\", m: \"medium\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--resize",
 					"name": "resize",
 					"snippet": "const resize = () => (\n    <Example>\n        <Example.Item title=\"resize: none\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" resize=\"none\" />\n        </Example.Item>\n        <Example.Item title=\"resize: auto\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" resize=\"auto\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-textarea--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" hasError />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner\">\n            <View gap={2}>\n                <Text variant=\"featured-2\">What problem are you trying to solve?</Text>\n                <TextArea.Aligner>\n                    <TextArea\n                        variant=\"headless\"\n                        placeholder=\"Try something like 'I have a job'\"\n                        name=\"description\"\n                    />\n                </TextArea.Aligner>\n                <View.Item>\n                    <Button>Next</Button>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-textarea--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"long value without breaks\">\n            <TextArea\n                name=\"hey\"\n                defaultValue={`<div style=\"position:relative;width:100%;padding-top:calc(150% + 72px)\">\n<iframe src=\"nskjdfdsdkjfsjkdfhbsjlhdfbsjlhfbs;jhbsdljfhsbljhfsbljhfbsjlfdhbsljhfbsdljhfbsljhfbslufbhsdlfds\" />\n</div>`}\n                resize=\"auto\"\n                placeholder=\"Placeholder\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-textarea--render",
+					"name": "base",
 					"snippet": "const render = () => <TextArea name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-textarea--placeholder",
 					"name": "placeholder",
 					"snippet": "const placeholder = () => (\n    <TextArea\n        name=\"test-name\"\n        placeholder=\"Placeholder\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-textarea--id",
 					"name": "id",
 					"snippet": "const id = () => (\n    <TextArea name=\"test-name\" id=\"test-id\" inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
+					"id": "components-textarea--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <TextArea name=\"test-name\" disabled inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-textarea--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <TextArea\n    name=\"test-name\"\n    defaultValue=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-textarea--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <TextArea\n    name=\"test-name\"\n    value=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-textarea--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <TextArea\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-textarea--form-control",
+					"name": "test: form control",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"with helper\">\n            <FormControl>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextArea name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n        <Example.Item title=\"with error\">\n            <FormControl hasError>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextArea name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, FormControl, Text, TextArea, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/TextArea/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "TextArea",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/TextArea/TextArea.tsx",
-				"actualName": "TextArea",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text area",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text area input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text area user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text area value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLTextAreaElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text area is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLTextAreaElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text area is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLTextAreaElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"textarea\">" }
+					},
+					"resize": {
+						"defaultValue": null,
+						"description": "Enable or disable the text area resizing, supports auto-sizing",
+						"name": "resize",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"none\" | \"auto\"",
+							"value": [{ "value": "\"none\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "TextArea"
 			}
 		},
 		"components-textfield": {
@@ -1940,71 +10064,445 @@
 			"path": "./src/components/TextField/tests/TextField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-textfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <TextField variant=\"faded\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless\">\n            <TextField variant=\"headless\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded\">\n            <TextField\n                rounded\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                icon={IconZap}\n                prefix=\"+31\"\n                endSlot={<Button rounded size=\"small\" icon={IconZap} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"rounded, variant: faded\">\n            <View direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <TextField\n                        rounded\n                        variant=\"faded\"\n                        name=\"Name\"\n                        placeholder=\"Enter your name\"\n                        startSlot={\n                            <Badge rounded size=\"small\">\n                                Hello\n                            </Badge>\n                        }\n                    />\n                </View.Item>\n                <Button rounded>Submit</Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-textfield--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" hasError />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "attachments",
+					"id": "components-textfield--attachments",
+					"name": "icon, endIcon, suffix, prefix, startSlot, endSlot, startSlotPadding, endSlotPadding",
 					"snippet": "const attachments = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" value=\"Reshaped\" icon={IconZap} />\n        </Example.Item>\n        <Example.Item title=\"endIcon\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" value=\"Reshaped\" endIcon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title={[\"startSlot\", \"vertical and horizontal padding aligned\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title={[\"endSlot\", \"vertical and horizontal padding aligned\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                endSlot={\n                    <Button\n                        icon={IconZap}\n                        size=\"small\"\n                        onClick={() => {}}\n                        attributes={{ \"aria-label\": \"Action\" }}\n                    />\n                }\n            />\n        </Example.Item>\n\n        <Example.Item title=\"paddingSlotStart=4, paddingSlotEnd=2\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlotPadding={4}\n                endSlotPadding={2}\n                startSlot={<Placeholder h={20} />}\n                endSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"with all affixes\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                endIcon={IconZap}\n                icon={IconZap}\n                prefix=\"Estimated value\"\n                suffix=\"m2\"\n                startSlot={<Placeholder h={20} />}\n                endSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"multiline wrap\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlot={[...Array(10).keys()].map((i) => (\n                    <Badge size=\"small\" key={i}>\n                        Item {i + 1}\n                    </Badge>\n                ))}\n                multiline\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"small\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"medium\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"large\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"xlarge\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] xlarge\", \"[m+] medium\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                size={{ s: \"xlarge\", m: \"medium\" }}\n                icon={IconZap}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner\">\n            <View gap={2}>\n                <Text variant=\"featured-2\">What problem are you trying to solve?</Text>\n                <TextField.Aligner>\n                    <TextField\n                        variant=\"headless\"\n                        placeholder=\"Try something like 'I have a job'\"\n                        name=\"description\"\n                    />\n                </TextField.Aligner>\n                <View.Item>\n                    <Button>Next</Button>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-textfield--render",
+					"name": "base",
 					"snippet": "const render = () => <TextField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-textfield--placeholder",
 					"name": "placeholder",
 					"snippet": "const placeholder = () => (\n    <TextField\n        name=\"test-name\"\n        placeholder=\"Placeholder\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-textfield--id",
 					"name": "id",
 					"snippet": "const id = () => (\n    <TextField name=\"test-name\" id=\"test-id\" inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
+					"id": "components-textfield--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <TextField name=\"test-name\" disabled inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-textfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <TextField\n    name=\"test-name\"\n    defaultValue=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-textfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <TextField\n    name=\"test-name\"\n    value=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-textfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <TextField\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-textfield--form-control",
+					"name": "test: form control",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"with helper\">\n            <FormControl>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextField name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n        <Example.Item title=\"with error\">\n            <FormControl hasError>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextField name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Badge, Button, Example, FormControl, Placeholder, Text, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/TextField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "TextField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/TextField/TextField.tsx",
-				"actualName": "TextField",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"multiline": {
+						"defaultValue": null,
+						"description": "Enable multiline text field wrapping",
+						"name": "multiline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to be fully rounded",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content after the text field value",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text field value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the text field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the text field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "TextField"
 			}
 		},
 		"components-timeline": {
@@ -2013,27 +10511,71 @@
 			"path": "./src/components/Timeline/tests/Timeline.stories.tsx",
 			"stories": [
 				{
+					"id": "components-timeline--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"children passed directly\">\n            <Timeline>\n                <Placeholder />\n                <Placeholder />\n                <Placeholder />\n            </Timeline>\n        </Example.Item>\n        <Example.Item title=\"children wrapped with Timeline.Item\">\n            <Timeline>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "marker",
+					"id": "components-timeline--marker",
+					"name": "markerSlot",
 					"snippet": "const marker = () => (\n    <Example>\n        <Example.Item title=\"slot\">\n            <Timeline>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n\n        <Example.Item title=\"null marker\">\n            <Timeline>\n                <Timeline.Item markerSlot={null}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={null}>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-timeline--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Timeline className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Timeline.Item className=\"test-item-classname\" attributes={{ id: \"test-item-id\" }}>\n                Content\n            </Timeline.Item>\n            <Timeline.Item>Content</Timeline.Item>\n        </Timeline>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Placeholder, Timeline } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Timeline/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Timeline",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Timeline/Timeline.tsx",
-				"actualName": "Timeline",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"ul\">" }
+					}
+				},
+				"exportName": "Timeline"
 			}
 		},
 		"components-toast": {
@@ -2041,32 +10583,54 @@
 			"name": "Toast",
 			"path": "./src/components/Toast/tests/Toast.stories.tsx",
 			"stories": [
-				{ "name": "size", "snippet": "const size = () => <Size />;" },
 				{
+					"id": "components-toast--size",
+					"name": "size",
+					"snippet": "const size = () => <Size />;"
+				},
+				{
+					"id": "components-toast--position",
 					"name": "position",
 					"snippet": "const position = () => <Position />;"
 				},
-				{ "name": "color", "snippet": "const color = () => <Color />;" },
-				{ "name": "timeout", "snippet": "const timeout = () => <Timeout />;" },
 				{
-					"name": "regionOptions",
+					"id": "components-toast--color",
+					"name": "color",
+					"snippet": "const color = () => <Color />;"
+				},
+				{
+					"id": "components-toast--timeout",
+					"name": "timeout",
+					"snippet": "const timeout = () => <Timeout />;"
+				},
+				{
+					"id": "components-toast--region-options",
+					"name": "expanded",
 					"snippet": "const regionOptions = () => <Expanded />;"
 				},
-				{ "name": "slots", "snippet": "const slots = () => <Slots />;" },
 				{
+					"id": "components-toast--slots",
+					"name": "slots",
+					"snippet": "const slots = () => <Slots />;"
+				},
+				{
+					"id": "components-toast--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const toast = useToast();\n\n    return (\n        <Button\n            onClick={() => {\n                const id = toast.show({\n                    title: \"Title\",\n                    text: \"Text\",\n                    children: \"Children\",\n                    startSlot: \"Slot\",\n                    actionsSlot: (\n                        <Button attributes={{ \"data-testid\": \"trigger-id\" }} onClick={() => toast.hide(id)}>\n                            Trigger\n                        </Button>\n                    ),\n                });\n            }}\n        >\n            Show toast\n        </Button>\n    );\n};"
 				},
 				{
-					"name": "nested",
+					"id": "components-toast--nested",
+					"name": "ToastProvider",
 					"snippet": "const nested = () => {\n    return (\n        <div data-testid=\"test-container-id\">\n            <ToastProvider>\n                <NestedDemo />\n            </ToastProvider>\n        </div>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-toast--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => {\n    const toast = useToast();\n\n    return (\n        <Button\n            onClick={() => {\n                const id = toast.show({\n                    text: \"Content\",\n                    attributes: { \"data-testid\": \"test-id\" },\n                    className: \"test-classname\",\n                });\n            }}\n        >\n            Show toast\n        </Button>\n    );\n};"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-toast--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"Multiline, should support dynamic height\">\n            <Multiline />\n        </Example.Item>\n        <Example.Item title=\"Nested ToastProvider\">\n            <ToastProvider>\n                <Nested />\n            </ToastProvider>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
@@ -2083,30 +10647,601 @@
 			"path": "./src/components/ToggleButton/tests/ToggleButton.stories.tsx",
 			"stories": [
 				{
+					"id": "components-togglebutton--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"outline\">\n            <ToggleButton>Button</ToggleButton>\n        </Example.Item>\n        <Example.Item title=\"ghost\">\n            <ToggleButton variant=\"ghost\">Button</ToggleButton>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-togglebutton--selected-color",
 					"name": "selectedColor",
 					"snippet": "const selectedColor = () => (\n    <Example>\n        <Example.Item title=\"selectedColor: primary\">\n            <ToggleButton selectedColor=\"primary\" defaultChecked>\n                Button\n            </ToggleButton>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onChange",
+					"id": "components-togglebutton--on-change",
+					"name": "checked, defaultChecked, onChange",
 					"snippet": "const onChange = () => <Example>\n    <Example.Item title=\"defaultChecked, onChange\">\n        <ToggleButton defaultChecked onChange={fn()} value=\"1\">Button\n                                </ToggleButton>\n    </Example.Item>\n    <Example.Item title=\"checked, onChange\">\n        <ToggleButton checked onChange={fn()} value=\"2\">Button\n                                </ToggleButton>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-togglebutton--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <ToggleButton onClick={fn()}>Button</ToggleButton>;"
 				}
 			],
 			"import": "import { Example, ToggleButton } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ToggleButton/ToggleButton.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "ToggleButton",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ToggleButton/ToggleButton.tsx",
-				"actualName": "ToggleButton",
+				"methods": [],
+				"props": {
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loading": {
+						"defaultValue": null,
+						"description": "Show loading state",
+						"name": "loading",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loadingAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the loading indicator",
+						"name": "loadingAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Make the component take the full width of the parent element",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"ghost\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"ghost\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"selectedColor": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme when selected",
+						"name": "selectedColor",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the toggle button, enables controlled mode for the ToggleButtonGroup",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the toggle button value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { checked: boolean; value: string; event: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>; }) => void)"
+						}
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default value of the toggle button, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Value of the toggle button, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2116,34 +11251,194 @@
 			"path": "./src/components/ToggleButtonGroup/tests/ToggleButtonGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "single",
+					"id": "components-togglebuttongroup--single",
+					"name": "checked, defaultChecked, onChange",
 					"snippet": "const single = () => <Example>\n    <Example.Item title=\"single, uncontrolled, onChange\">\n        <ToggleButtonGroup onChange={fn()}>\n            <ToggleButton value=\"1\" onChange={fn()}>Button\n                                    </ToggleButton>\n            <ToggleButton value=\"2\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n    <Example.Item title=\"single, controlled, onChange\">\n        <ToggleButtonGroup onChange={fn()} value={[]}>\n            <ToggleButton value=\"3\" onChange={fn()}>Button\n                                    </ToggleButton>\n            <ToggleButton value=\"4\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "multiple",
+					"id": "components-togglebuttongroup--multiple",
+					"name": "selectionMode, checked, defaultChecked, onChange",
 					"snippet": "const multiple = () => <Example>\n    <Example.Item title=\"multiple, uncontrolled, onChange\">\n        <ToggleButtonGroup onChange={fn()} selectionMode=\"multiple\">\n            <ToggleButton value=\"1\">Button</ToggleButton>\n            <ToggleButton value=\"2\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n    <Example.Item title=\"multiple, controlled, onChange\">\n        <ToggleButtonGroup onChange={fn()} value={[]} selectionMode=\"multiple\">\n            <ToggleButton value=\"3\">Button</ToggleButton>\n            <ToggleButton value=\"4\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "selectedColor",
+					"id": "components-togglebuttongroup--selected-color",
+					"name": "color,selectedColor",
 					"snippet": "const selectedColor = () => (\n    <Example>\n        <Example.Item title=\"selectedColor: primary\">\n            <ToggleButtonGroup selectedColor=\"primary\" defaultValue={[\"2\"]}>\n                <ToggleButton value=\"1\">Button</ToggleButton>\n                <ToggleButton value=\"2\">Button</ToggleButton>\n                <ToggleButton value=\"3\">Button</ToggleButton>\n            </ToggleButtonGroup>\n        </Example.Item>\n        <Example.Item title=\"color: primary, selectedColor: critical\">\n            <ToggleButtonGroup color=\"primary\" selectedColor=\"critical\" defaultValue={[\"2\"]}>\n                <ToggleButton value=\"1\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n                <ToggleButton value=\"2\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n                <ToggleButton value=\"3\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n            </ToggleButtonGroup>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-togglebuttongroup--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ToggleButtonGroup className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <ToggleButton>Button 1</ToggleButton>\n            <ToggleButton>Button 1</ToggleButton>\n        </ToggleButtonGroup>\n    </div>\n);"
 				},
 				{
-					"name": "testIcon",
+					"id": "components-togglebuttongroup--test-icon",
+					"name": "test: icon only",
 					"snippet": "const testIcon = () => (\n    <Example>\n        <Example.Item title=\"icon only\">\n            <ToggleButtonGroup selectedColor=\"primary\">\n                <ToggleButton value=\"1\" icon={IconPlus} />\n                <ToggleButton value=\"2\" icon={IconMinus} />\n                <ToggleButton value=\"3\" icon={IconCheckmark} />\n            </ToggleButtonGroup>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, ToggleButton, ToggleButtonGroup } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ToggleButtonGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ToggleButtonGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx",
-				"actualName": "ToggleButtonGroup",
+				"methods": [],
+				"props": {
+					"selectionMode": {
+						"defaultValue": { "value": "\"single\"" },
+						"description": "Selection mode for the toggle button group",
+						"name": "selectionMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"single\" | \"multiple\"",
+							"value": [{ "value": "\"single\"" }, { "value": "\"multiple\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme applied to each button",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"selectedColor": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme for the selected button",
+						"name": "selectedColor",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the toggle button group value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { value: string[]; event: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>; }) => void)"
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting child Button components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Selected values in the group, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default selected values in the group, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2153,30 +11448,269 @@
 			"path": "./src/components/Tooltip/tests/Tooltip.stories.tsx",
 			"stories": [
 				{
+					"id": "components-tooltip--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: bottom-start\">\n            <View direction=\"row\" gap={2}>\n                <Demo position=\"bottom-start\" text=\"Tooltip 1\" />\n                <Demo position=\"bottom-start\" text=\"Tooltip 2\" />\n                <Demo position=\"bottom-start\" text=\"Tooltip 3\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: bottom\">\n            <Demo position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"position: bottom-end\">\n            <Demo position=\"bottom-end\" />\n        </Example.Item>\n        <Example.Item title=\"position: top-start\">\n            <Demo position=\"top-start\" />\n        </Example.Item>\n        <Example.Item title=\"position: top\">\n            <Demo position=\"top\" />\n        </Example.Item>\n        <Example.Item title=\"position: top-end\">\n            <Demo position=\"top-end\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: start\">\n            <View align=\"end\">\n                <Demo position=\"start\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: start-top\">\n            <View align=\"end\">\n                <Demo position=\"start-top\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: start-bottom\">\n            <View align=\"end\">\n                <Demo position=\"start-bottom\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <Demo position=\"end\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: end-top\">\n            <Demo position=\"end-top\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: end-bottom\">\n            <Demo position=\"end-bottom\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tooltip--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: inverted\">\n            <Demo color=\"inverted\" position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"color: dark\">\n            <Demo color=\"dark\" position=\"bottom\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-tooltip--default-active",
+					"name": "uncontrolled",
 					"snippet": "const defaultActive = () => <Tooltip text=\"Content\" onOpen={fn()} onClose={fn()}>\n    {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n</Tooltip>;"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-tooltip--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"responsive visibility\">\n            <DemoResponsive text=\"Responsive\" />\n        </Example.Item>\n\n        <Example.Item title=\"without text\">\n            <Tooltip>{() => <Button>Button</Button>}</Tooltip>\n        </Example.Item>\n\n        <Example.Item title=\"tooltip with popover\">\n            <Tooltip text=\"Tooltip\" position=\"top\">\n                {(attributes) => (\n                    <Popover position=\"bottom\">\n                        <Popover.Trigger>\n                            {(popoverAttributes) => (\n                                <Button attributes={{ ...attributes, ...popoverAttributes }}>Action</Button>\n                            )}\n                        </Popover.Trigger>\n                        <Popover.Content>Popover</Popover.Content>\n                    </Popover>\n                )}\n            </Tooltip>\n        </Example.Item>\n\n        <Example.Item title=\"nested popovers inside a tooltip\">\n            <View direction=\"row\" gap={2}>\n                <Tooltip position=\"top\" text=\"Hello\">\n                    {(tooltipAttributes) => (\n                        <Popover position=\"bottom\" width=\"300px\">\n                            <Popover.Trigger>\n                                {(attributes) => (\n                                    <Button attributes={{ ...tooltipAttributes, ...attributes }}>\n                                        Tooltip with popover\n                                    </Button>\n                                )}\n                            </Popover.Trigger>\n                            <Popover.Content>\n                                <View gap={2} align=\"center\" direction=\"row\" justify=\"space-between\">\n                                    Popover content\n                                    <Popover position=\"bottom\" width=\"300px\">\n                                        <Popover.Trigger>\n                                            {(attributes) => <Button attributes={attributes}>Open</Button>}\n                                        </Popover.Trigger>\n                                        <Popover.Content>\n                                            <Popover.Dismissible align=\"center\" closeAriaLabel=\"Close\">\n                                                Another popover content\n                                            </Popover.Dismissible>\n                                        </Popover.Content>\n                                    </Popover>\n                                </View>\n                            </Popover.Content>\n                        </Popover>\n                    )}\n                </Tooltip>\n                <Tooltip position=\"top\" text=\"Hello\">\n                    {(tooltipAttributes) => <Button attributes={tooltipAttributes}>Just a tooltip</Button>}\n                </Tooltip>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, Popover, Tooltip, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Tooltip/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Tooltip",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Tooltip/Tooltip.tsx",
-				"actualName": "Tooltip",
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the flyout content interactivity",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"contentAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the content element",
+						"name": "contentAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"contentClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the content element",
+						"name": "contentClassName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "(attributes: TriggerAttributes) => ReactNode" }
+					},
+					"text": {
+						"defaultValue": null,
+						"description": "Text content for the tooltip",
+						"name": "text",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"inverted\"" },
+						"description": "Color of the tooltip",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"dark\" | \"inverted\"",
+							"value": [{ "value": "\"dark\"" }, { "value": "\"inverted\"" }]
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2186,51 +11720,191 @@
 			"path": "./src/components/Accordion/tests/Accordion.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-accordion--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Accordion defaultActive>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--icon-size",
 					"name": "iconSize",
 					"snippet": "const iconSize = () => (\n    <Accordion iconSize={6}>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--icon-position",
 					"name": "iconPosition",
 					"snippet": "const iconPosition = () => (\n    <Accordion iconPosition=\"start\">\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Accordion defaultActive gap={4}>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <Placeholder />\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--on-toggle",
 					"name": "onToggle",
 					"snippet": "const onToggle = () => <Accordion onToggle={fn()}>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
+					"id": "utility-components-accordion--active",
 					"name": "active",
 					"snippet": "const active = () => <Accordion onToggle={fn()} active>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
+					"id": "utility-components-accordion--default-active",
 					"name": "defaultActive",
 					"snippet": "const defaultActive = () => <Accordion onToggle={fn()} defaultActive>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
-					"name": "renderProps",
+					"id": "utility-components-accordion--render-props",
+					"name": "children: render props",
 					"snippet": "const renderProps = () => <Accordion onToggle={fn()}>\n    <Accordion.Trigger>\n        {(attributes, { active }) => (\n            <Button attributes={{ ...attributes, \"data-active\": active }}>Trigger</Button>\n        )}\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-accordion--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Accordion className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Accordion.Trigger>\n                <Placeholder>Trigger</Placeholder>\n            </Accordion.Trigger>\n            <Accordion.Content>\n                <View paddingTop={2}>\n                    <Placeholder />\n                </View>\n            </Accordion.Content>\n        </Accordion>\n    </div>\n);"
 				}
 			],
 			"import": "import { Accordion, Button, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Accordion/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Accordion",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Accordion/Accordion.tsx",
-				"actualName": "Accordion",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"iconSize": {
+						"defaultValue": null,
+						"description": "Expand / collapse icon size in units",
+						"name": "iconSize",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"iconPosition": {
+						"defaultValue": null,
+						"description": "Position of the expand / collapse icon",
+						"name": "iconPosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"start\" | \"end\"",
+							"value": [{ "value": "\"start\"" }, { "value": "\"end\"" }]
+						}
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between the trigger and the content",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the trigger and the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onToggle": {
+						"defaultValue": null,
+						"description": "Callback when the accordion is expanded or collapsed",
+						"name": "onToggle",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((active: boolean) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control whether the accordion is expanded or collapsed, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control whether the accordion is expanded or collapsed by default, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Accordion"
 			}
 		},
 		"utility-components-actionable": {
@@ -2239,54 +11913,456 @@
 			"path": "./src/components/Actionable/tests/Actionable.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "utility-components-actionable--base",
+					"name": "href, onClick",
 					"snippet": "const base = () => <Example>\n    <Example.Item title=\"span\">\n        <Actionable>Span</Actionable>\n    </Example.Item>\n    <Example.Item title=\"onClick\">\n        <Actionable onClick={fn()}>Button</Actionable>\n    </Example.Item>\n    <Example.Item title=\"href\">\n        <Actionable href=\"https://reshaped.so\" attributes={{ target: \"_blank\" }}>Link\n                            </Actionable>\n    </Example.Item>\n    <Example.Item title=\"attributes.href\">\n        <Actionable attributes={{ href: \"https://reshaped.so\" }}>Link with attributes</Actionable>\n    </Example.Item>\n    <Example.Item title=\"href, onClick\">\n        <Actionable\n            onClick={(e) => {\n                e.preventDefault();\n                args.handleSecondClick(e);\n            }}\n            href=\"https://reshaped.so\">Link with onClick\n                            </Actionable>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "utility-components-actionable--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, button\">\n            <Actionable disabled onClick={() => {}}>\n                Button\n            </Actionable>\n        </Example.Item>\n        <Example.Item title=\"disabled, link\">\n            <Actionable disabled href=\"https://reshaped.so\">\n                Link\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--full-width",
 					"name": "fullWidth",
 					"snippet": "const fullWidth = () => (\n    <Example>\n        <Example.Item title=\"fullWidth\">\n            <Actionable fullWidth href=\"https://reshaped.so\">\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--inset-focus",
 					"name": "insetFocus",
 					"snippet": "const insetFocus = () => (\n    <Example>\n        <Example.Item title=\"insetFocus\">\n            <Actionable insetFocus onClick={() => {}}>\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--disable-focus-ring",
 					"name": "disableFocusRing",
 					"snippet": "const disableFocusRing = () => (\n    <Example>\n        <Example.Item title=\"disableFocusRing\">\n            <Actionable disableFocusRing onClick={() => {}}>\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--border-radius",
 					"name": "borderRadius",
 					"snippet": "const borderRadius = () => (\n    <Example>\n        <Example.Item title=\"borderRadius: inherit\">\n            <Actionable borderRadius=\"inherit\" onClick={() => {}}>\n                <View borderRadius=\"large\">Actionable</View>\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--type",
 					"name": "type",
 					"snippet": "const type = (args) => (\n    <Example>\n        <Example.Item title=\"type: submit\">\n            <form\n                onSubmit={(e) => {\n                    e.preventDefault();\n                    args.handleSubmit();\n                }}\n            >\n                <Actionable onClick={() => {}} type=\"submit\">\n                    Submit\n                </Actionable>\n            </form>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "as",
+					"id": "utility-components-actionable--as",
+					"name": "as, render",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"as: span\">\n            <Actionable onClick={() => {}} as=\"span\">\n                Trigger\n            </Actionable>\n        </Example.Item>\n        <Example.Item title=\"render, disabled\">\n            <Actionable disabled onClick={() => {}} render={(props) => <section {...props} />}>\n                Trigger\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--stop-propagation",
 					"name": "stopPropagation",
 					"snippet": "const stopPropagation = () => <div onClick={fn()}>\n    <Actionable stopPropagation onClick={() => {}}>Trigger\n                    </Actionable>\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-actionable--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Actionable className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Actionable>\n    </div>\n);"
 				}
 			],
 			"import": "import { Actionable, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Actionable/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Actionable",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Actionable/Actionable.tsx",
-				"actualName": "Actionable",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"touchHitbox": {
+						"defaultValue": null,
+						"description": "Enable a minimum required touch hitbox",
+						"name": "touchHitbox",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Take up the full width of its parent",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"insetFocus": {
+						"defaultValue": null,
+						"description": "Enable a focus ring inside the element bounds",
+						"name": "insetFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableFocusRing": {
+						"defaultValue": null,
+						"description": "Don't show a focus ring on focus, can be used when it is within a container with a focus ring",
+						"name": "disableFocusRing",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Apply the focus ring to the child and rely on its border radius",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"inherit\"", "value": [{ "value": "\"inherit\"" }] }
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2296,30 +12372,149 @@
 			"path": "./src/components/Container/tests/Container.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-container--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: default\">\n            <Container>\n                <Placeholder />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"padding: 0\">\n            <Container padding={0}>\n                <Placeholder />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "utility-components-container--size",
+					"name": "width, height, maxHeight",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"width: 200px, height: 200px\">\n            <Container width=\"200px\" height=\"200px\">\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width: 200px, height: 200px, maxHeight: 100px\">\n            <Container width=\"200px\" height=\"200px\" maxHeight=\"100px\">\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width, height: [s] 100px, [m+] 200px\">\n            <Container width={{ s: \"100px\", m: \"200px\" }} height={{ s: \"100px\", m: \"200px\" }}>\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width, height: [s] 100px, [m+] 200px, maxHeight: [s] 50px, [m+]: 100px\">\n            <Container\n                width={{ s: \"100px\", m: \"200px\" }}\n                height={{ s: \"100px\", m: \"200px\" }}\n                maxHeight={{ s: \"50px\", m: \"100px\" }}\n            >\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "flex",
+					"id": "utility-components-container--flex",
+					"name": "align, justify",
 					"snippet": "const flex = () => (\n    <Example>\n        <Example.Item title=\"align: center, justify: center\">\n            <Container align=\"center\" justify=\"center\" height=\"200px\">\n                <Placeholder />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-container--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Container className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </Container>\n    </div>\n);"
 				}
 			],
 			"import": "import { Container, Example, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Container/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Container",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Container/Container.tsx",
-				"actualName": "Container",
+				"methods": [],
+				"props": {
+					"align": {
+						"defaultValue": null,
+						"description": "Flex align-items for the content",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Flex justify-content for the content",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier\nComponent height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" },
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height style, literal string value or a base unit token number multiplier\nComponent max height, literal css value or unit token multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" },
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Component inline padding",
+						"name": "padding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Component width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2329,34 +12524,157 @@
 			"path": "./src/components/Dismissible/tests/Dismissible.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-dismissible--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Dismissible closeAriaLabel=\"Close banner\" onClose={() => {}}>\n                <Placeholder />\n            </Dismissible>\n        </Example.Item>\n        <Example.Item title=\"variant: media\">\n            <View width=\"300px\">\n                <Dismissible variant=\"media\" closeAriaLabel=\"Close banner\" onClose={() => {}}>\n                    <View aspectRatio={16 / 9}>\n                        <Image\n                            height=\"100%\"\n                            src=\"https://images.unsplash.com/photo-1607030529528-ca6923e27f77?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1867&q=80)\"\n                        />\n                    </View>\n                </Dismissible>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-dismissible--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: center\">\n            <Dismissible align=\"center\" closeAriaLabel=\"Close\" onClose={() => {}}>\n                <Placeholder />\n            </Dismissible>\n        </Example.Item>\n\n        <Example.Item title=\"align: center, variant: media\">\n            <Dismissible align=\"center\" closeAriaLabel=\"Close\" variant=\"media\" onClose={() => {}}>\n                <View aspectRatio={16 / 9}>\n                    <Image\n                        height=\"100%\"\n                        src=\"https://images.unsplash.com/photo-1607030529528-ca6923e27f77?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1867&q=80)\"\n                    />\n                </View>\n            </Dismissible>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-dismissible--hide-close-button",
 					"name": "hideCloseButton",
 					"snippet": "const hideCloseButton = () => (\n    <Example>\n        <Example.Item title=\"hide close button\">\n            <div id=\"root\">\n                <Dismissible hideCloseButton>\n                    <Placeholder />\n                </Dismissible>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "closeAriaLabel",
+					"id": "utility-components-dismissible--close-aria-label",
+					"name": "onClose, closeAriaLabel",
 					"snippet": "const closeAriaLabel = () => <Dismissible closeAriaLabel=\"Close\" onClose={fn()}>\n    <Placeholder />\n</Dismissible>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-dismissible--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Dismissible\n            closeAriaLabel=\"Close\"\n            onClose={() => {}}\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n        >\n            <Placeholder />\n        </Dismissible>\n    </div>\n);"
 				}
 			],
 			"import": "import { Dismissible, Example, Image, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Dismissible/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Dismissible",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Dismissible/Dismissible.tsx",
-				"actualName": "Dismissible",
+				"methods": [],
+				"props": {
+					"hideCloseButton": {
+						"defaultValue": null,
+						"description": "Hide the close button\nShow the close button",
+						"name": "hideCloseButton",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"closeAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the close button",
+						"name": "closeAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"media\"", "value": [{ "value": "\"media\"" }] }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Close button alignment",
+						"name": "align",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"center\"",
+							"value": [{ "value": "\"top\"" }, { "value": "\"center\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is dismissed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2366,135 +12684,577 @@
 			"path": "./src/components/Flyout/tests/Flyout.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-flyout--position",
 					"name": "position",
 					"snippet": "const position = () => {\n    return (\n        <View gap={4} padding={50} align=\"center\" justify=\"center\" height=\"100vh\" width=\"120%\">\n            <View gap={4} direction=\"row\">\n                <Demo position=\"top-start\" defaultActive />\n                <Demo position=\"top\" />\n                <Demo position=\"top-end\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"end-top\" />\n                <Demo position=\"end\" />\n                <Demo position=\"end-bottom\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"start-top\" />\n                <Demo position=\"start\" />\n                <Demo position=\"start-bottom\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"bottom-start\" />\n                <Demo position=\"bottom\" />\n                <Demo position=\"bottom-end\" />\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "defaultActive",
+					"id": "utility-components-flyout--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <Flyout onOpen={fn()} onClose={fn()} defaultActive>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "active",
+					"id": "utility-components-flyout--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <Flyout onOpen={fn()} onClose={fn()} active>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "utility-components-flyout--active-false",
+					"name": "active: false, controlled",
 					"snippet": "const activeFalse = () => <Flyout onOpen={fn()} onClose={fn()} active={false}>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "modes",
+					"id": "utility-components-flyout--modes",
+					"name": "triggerType, trapFocusMode",
 					"snippet": "const modes = () => {\n    return (\n        <Example>\n            <Example.Item title=\"triggerType: click\">\n                <View direction=\"row\" gap={4}>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"dialog\" text=\"dialog\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"action-menu\" text=\"action-menu\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"action-bar\" text=\"action-bar\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"content-menu\" text=\"content-menu\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode={false} text=\"false\">\n                        {modeContent}\n                    </Demo>\n                </View>\n            </Example.Item>\n\n            <Example.Item title=\"triggerType: hover\">\n                <View direction=\"row\" gap={4}>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"dialog\" triggerType=\"hover\" text=\"dialog\">\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"action-menu\"\n                        triggerType=\"hover\"\n                        text=\"action-menu\"\n                    >\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"action-bar\"\n                        triggerType=\"hover\"\n                        text=\"action-bar\"\n                    >\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"content-menu\"\n                        triggerType=\"hover\"\n                        text=\"content-menu\"\n                    >\n                        {modeContent}\n                    </Demo>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "positionFallbacks",
+					"id": "utility-components-flyout--position-fallbacks",
+					"name": "fallbackPositions",
 					"snippet": "const positionFallbacks = () => {\n    return (\n        <Example>\n            <Example.Item title=\"position: top, default fallbacks\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" />\n                </View>\n            </Example.Item>\n            <Example.Item title=\"position: top, fallbackPositions: [start]\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" fallbackPositions={[\"start\"]} contentHeight={200} defaultActive />\n                </View>\n            </Example.Item>\n            <Example.Item title=\"position: top, fallbackPositions: false\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" fallbackPositions={false} contentHeight={400} />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--fallback-adjust-layout",
 					"name": "fallbackAdjustLayout",
 					"snippet": "const fallbackAdjustLayout = () => {\n    return (\n        <Demo\n            contentHeight={false}\n            position=\"bottom-start\"\n            width=\"200px\"\n            fallbackAdjustLayout\n            defaultActive\n        >\n            <div style={{ height: \"600px\" }}>Content</div>\n        </Demo>\n    );\n};"
 				},
 				{
-					"name": "fallbackAdjustLayoutShift",
+					"id": "utility-components-flyout--fallback-adjust-layout-shift",
+					"name": "fallbackAdjustLayout, shift",
 					"snippet": "const fallbackAdjustLayoutShift = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={10}>\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    attributes={{ ref: containerRef }}\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls containerRef={containerRef} />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <FallbackAdjustLayoutControls />\n            <div style={{ height: \"100vh\", width: \"250%\" }} />\n        </View>\n    );\n};"
 				},
 				{
-					"name": "fallbackAdjustLayoutSize",
+					"id": "utility-components-flyout--fallback-adjust-layout-size",
+					"name": "fallbackAdjustLayout, size",
 					"snippet": "const fallbackAdjustLayoutSize = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={10}>\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls large />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    attributes={{ ref: containerRef }}\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls containerRef={containerRef} large />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <FallbackAdjustLayoutControls large />\n            <div style={{ height: \"100vh\", width: \"250%\" }} />\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--origin-coordinates",
 					"name": "originCoordinates",
 					"snippet": "const originCoordinates = () => {\n    return (\n        <View gap={4} direction=\"row\">\n            <Demo position=\"bottom-start\" originCoordinates={{ x: 150, y: 150 }} defaultActive />\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--width",
 					"name": "width",
 					"snippet": "const width = () => (\n    <Example>\n        <Example.Item title=\"width: 300px\">\n            <Demo width=\"300px\" position=\"bottom\" />\n        </Example.Item>\n\n        <Example.Item title=\"width: trigger\">\n            <Demo width=\"trigger\" contentWidth={false} defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-flyout--content-gap",
 					"name": "contentGap",
 					"snippet": "const contentGap = () => <Demo contentGap={10} defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--content-shift",
 					"name": "contentShift",
 					"snippet": "const contentShift = () => <Demo contentShift={10} defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-content-hover",
 					"name": "disableContentHover",
 					"snippet": "const disableContentHover = () => <Demo triggerType=\"hover\" disableContentHover />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-close-on-outside-click",
 					"name": "disableCloseOnOutsideClick",
 					"snippet": "const disableCloseOnOutsideClick = () => <Demo disableCloseOnOutsideClick />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-hide-animation",
 					"name": "disableHideAnimation",
 					"snippet": "const disableHideAnimation = () => <Demo disableHideAnimation defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Flyout disabled>\n        <Flyout.Trigger>\n            {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n        </Flyout.Trigger>\n        <Flyout.Content>\n            <Content />\n        </Flyout.Content>\n    </Flyout>\n);"
 				},
 				{
+					"id": "utility-components-flyout--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const portalRef = React.useRef<HTMLDivElement>(null);\n    const portalRef2 = React.useRef<HTMLDivElement>(null);\n    const portalRef3 = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={4} direction=\"row\">\n            <View\n                grow\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef, \"data-testid\": \"container\" }}\n                justify=\"end\"\n                align=\"start\"\n                padding={4}\n            >\n                <Demo containerRef={portalRef} position=\"bottom-start\" defaultActive />\n            </View>\n            <View\n                grow\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef2 }}\n                justify=\"start\"\n                align=\"end\"\n                padding={4}\n            >\n                <Demo containerRef={portalRef2} position=\"top-end\" />\n            </View>\n            <View\n                width={50}\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef3 }}\n                padding={4}\n                overflow=\"auto\"\n            >\n                <View height={120} width=\"120%\" justify=\"center\" align=\"center\">\n                    <Demo containerRef={portalRef3} position=\"bottom-end\" />\n                </View>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--initial-focus-ref",
 					"name": "initialFocusRef",
 					"snippet": "const initialFocusRef = () => {\n    const initialFocusRef = React.useRef<HTMLInputElement>(null);\n\n    return (\n        <Demo initialFocusRef={initialFocusRef}>\n            <View gap={4}>\n                <Button onClick={() => {}}>Action 1</Button>\n                <TextField name=\"foo\" inputAttributes={{ ref: initialFocusRef }} />\n            </View>\n        </Demo>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--instance-ref",
 					"name": "instanceRef",
 					"snippet": "const instanceRef = () => {\n    const flyoutRef = React.useRef<FlyoutInstance>(null);\n\n    return (\n        <View direction=\"row\" gap={4}>\n            <Demo\n                instanceRef={flyoutRef}\n                disableCloseOnOutsideClick\n                onOpen={fn()}\n                onClose={fn()} />\n            <Button onClick={() => flyoutRef.current?.open()}>Open</Button>\n            <Button onClick={() => flyoutRef.current?.close()}>Close</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "contentAttributes",
+					"id": "utility-components-flyout--content-attributes",
+					"name": "content: className, attributes",
 					"snippet": "const contentAttributes = () => {\n    return (\n        <Flyout position=\"bottom\" defaultActive>\n            <Flyout.Trigger>\n                {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n            </Flyout.Trigger>\n            <Flyout.Content attributes={{ \"data-testid\": \"test-id\" }} className=\"test-classname\">\n                <Content />\n            </Flyout.Content>\n        </Flyout>\n    );\n};"
 				},
 				{
-					"name": "testShadowDom",
+					"id": "utility-components-flyout--test-shadow-dom",
+					"name": "test: shadow dom",
 					"snippet": "const testShadowDom = () => <custom-element-flyout />;"
 				},
 				{
-					"name": "testInsideFixed",
+					"id": "utility-components-flyout--test-inside-fixed",
+					"name": "test: inside position fixed",
 					"snippet": "const testInsideFixed = () => (\n    <React.Fragment>\n        <View\n            position=\"fixed\"\n            insetBottom={2}\n            insetStart={2}\n            insetEnd={2}\n            backgroundColor=\"elevation-overlay\"\n            borderColor=\"neutral-faded\"\n            borderRadius=\"small\"\n            padding={4}\n            zIndex={10}\n            attributes={{ \"data-testid\": \"container\" }}\n            height={20}\n        >\n            <Demo defaultActive position=\"top-start\" />\n        </View>\n        <View paddingTop={18} gap={4}>\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n        </View>\n    </React.Fragment>\n);"
 				},
 				{
-					"name": "testInsideSticky",
+					"id": "utility-components-flyout--test-inside-sticky",
+					"name": "test: inside position sticky",
 					"snippet": "const testInsideSticky = () => (\n    <React.Fragment>\n        <View\n            position=\"sticky\"\n            insetTop={4}\n            insetStart={0}\n            insetEnd={0}\n            backgroundColor=\"elevation-overlay\"\n            borderColor=\"neutral-faded\"\n            borderRadius=\"small\"\n            padding={4}\n            zIndex={10}\n            attributes={{ \"data-testid\": \"container\" }}\n        >\n            <Demo defaultActive />\n        </View>\n        <View gap={4} paddingTop={2}>\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n        </View>\n    </React.Fragment>\n);"
 				},
 				{
-					"name": "testInsideScrollable",
+					"id": "utility-components-flyout--test-inside-scrollable",
+					"name": "test: inside scrollable",
 					"snippet": "const testInsideScrollable = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View padding={20}>\n            <View height={30} overflow=\"auto\" backgroundColor=\"neutral-faded\" borderRadius=\"small\">\n                <View height={50} attributes={{ ref: containerRef }} padding={20} paddingBottom={30}>\n                    <Demo position=\"bottom\" />\n                </View>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testInsideModal",
+					"id": "utility-components-flyout--test-inside-modal",
+					"name": "test: inside modal",
 					"snippet": "const testInsideModal = () => {\n    return (\n        <Modal active position=\"end\">\n            <View gap={4} align=\"start\">\n                <Modal.Title>Title</Modal.Title>\n                <Demo position=\"bottom-start\" />\n                <View height={300} width={25} backgroundColor=\"neutral-faded\" />\n                <Demo position=\"start\" />\n                <View height={300} width={25} backgroundColor=\"neutral-faded\" />\n                <Demo position=\"bottom-start\" />\n            </View>\n        </Modal>\n    );\n};"
 				},
 				{
-					"name": "testDynamicBounds",
+					"id": "utility-components-flyout--test-dynamic-bounds",
+					"name": "test: auto position update",
 					"snippet": "const testDynamicBounds = () => {\n    const [left, setLeft] = React.useState(50);\n    const [top, setTop] = React.useState(50);\n    const [size, setSize] = React.useState<\"medium\" | \"large\">(\"medium\");\n    const flyoutRef = React.useRef<FlyoutInstance>(null);\n\n    React.useEffect(() => {\n        flyoutRef.current?.updatePosition();\n    }, [left, top]);\n\n    return (\n        <View gap={4}>\n            <View direction=\"row\" gap={2}>\n                <Button onClick={() => setLeft((prev) => prev - 10)}>Left</Button>\n                <Button onClick={() => setLeft((prev) => prev + 10)}>Right</Button>\n                <Button onClick={() => setTop((prev) => prev - 10)}>Up</Button>\n                <Button onClick={() => setTop((prev) => prev + 10)}>Down</Button>\n                <Button\n                    onClick={() => {\n                        setLeft(50);\n                        setTop(50);\n                    }}\n                >\n                    Center\n                </Button>\n                <Button onClick={() => setSize(\"large\")}>Large button</Button>\n                <Button onClick={() => setSize(\"medium\")}>Small button</Button>\n            </View>\n            <View height={100}>\n                <Flyout\n                    position=\"bottom\"\n                    instanceRef={flyoutRef}\n                    disableCloseOnOutsideClick\n                    defaultActive\n                >\n                    <Flyout.Trigger>\n                        {(attributes) => (\n                            <div style={{ position: \"absolute\", left: `${left}%`, top: `${top}%` }}>\n                                <Button color=\"primary\" attributes={attributes} size={size}>\n                                    Open\n                                </Button>\n                            </div>\n                        )}\n                    </Flyout.Trigger>\n                    <Flyout.Content>\n                        <Content />\n                    </Flyout.Content>\n                </Flyout>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testScopedTheming",
+					"id": "utility-components-flyout--test-scoped-theming",
+					"name": "test: content uses scope theme",
 					"snippet": "const testScopedTheming = () => (\n    <View gap={3} align=\"start\">\n        <Button color=\"primary\">Slate button</Button>\n        <Theme name=\"reshaped\">\n            <Flyout triggerType=\"click\" active position=\"bottom-start\">\n                <Flyout.Trigger>\n                    {(attributes) => (\n                        <Button color=\"primary\" attributes={attributes}>\n                            Reshaped button\n                        </Button>\n                    )}\n                </Flyout.Trigger>\n                <Flyout.Content>\n                    <Content>\n                        <View gap={1}>\n                            <View.Item>Portal content, rendered in body</View.Item>\n                            <Button color=\"primary\">Reshaped button</Button>\n                        </View>\n                    </Content>\n                </Flyout.Content>\n            </Flyout>\n        </Theme>\n    </View>\n);"
 				},
 				{
-					"name": "testWithoutFocusable",
+					"id": "utility-components-flyout--test-without-focusable",
+					"name": "test: without focusable content",
 					"snippet": "const testWithoutFocusable = () => <Demo position=\"bottom-start\" />;"
 				},
 				{
-					"name": "testChangeSize",
+					"id": "utility-components-flyout--test-change-size",
+					"name": "test: size updates",
 					"snippet": "const testChangeSize = () => {\n    const [position, setPosition] = React.useState<FlyoutProps[\"position\"]>(\"bottom-start\");\n    const [updatedHeight, setUpdatedHeight] = React.useState(false);\n\n    return (\n        <>\n            <View direction=\"row\" gap={4} align=\"center\">\n                <Select\n                    name=\"position\"\n                    options={[\n                        \"bottom-start\",\n                        \"bottom\",\n                        \"bottom-end\",\n                        \"top-start\",\n                        \"top\",\n                        \"top-end\",\n                        \"start-top\",\n                        \"start\",\n                        \"start-bottom\",\n                        \"end-top\",\n                        \"end\",\n                        \"end-bottom\",\n                    ].map((p) => ({ label: p, value: p }))}\n                    onChange={(args) => setPosition(args.value as FlyoutProps[\"position\"])}\n                    value={position}\n                />\n                <Switch name=\"height\" onChange={(args) => setUpdatedHeight(args.checked)}>\n                    Change height\n                </Switch>\n            </View>\n            <div\n                style={{\n                    position: \"fixed\",\n                    top: \"50%\",\n                    left: \"50%\",\n                    transform: \"translate(-50%, -50%)\",\n                }}\n            >\n                <Demo position={position} disableCloseOnOutsideClick active contentHeight={false}>\n                    <View\n                        backgroundColor=\"neutral-faded\"\n                        borderRadius=\"small\"\n                        height={updatedHeight ? 50 : 25}\n                        attributes={{ style: { transition: \"0.2s ease-in-out\" } }}\n                    />\n                </Demo>\n            </div>\n        </>\n    );\n};"
 				}
 			],
 			"import": "import {\n    Button,\n    Example,\n    Flyout,\n    Modal,\n    Reshaped,\n    Select,\n    Switch,\n    TextField,\n    Theme,\n    View,\n} from \"reshaped\";\nimport React from \"react\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Flyout/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Flyout",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Flyout/Flyout.tsx",
-				"actualName": "Flyout",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"groupTimeouts": {
+						"defaultValue": null,
+						"description": "Removes the content display delay if another flyout is already active",
+						"name": "groupTimeouts",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | TrapMode" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the flyout content interactivity",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Automatically focus the first focusable element in the content, when false the content container will be focused instead",
+						"name": "autoFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the content element",
+						"name": "contentClassName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"contentAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the content element",
+						"name": "contentAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Flyout"
 			}
 		},
 		"utility-components-formcontrol": {
@@ -2503,43 +13263,147 @@
 			"path": "./src/components/FormControl/tests/FormControl.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-formcontrol--status",
 					"name": "status",
 					"snippet": "const status = () => (\n    <Example>\n        <Example.Item title=\"status: default\">\n            <FormControl>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"status: error\">\n            <FormControl hasError>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: medium\">\n            <FormControl size=\"medium\">\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <FormControl size=\"large\">\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" size=\"large\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <FormControl disabled>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--required",
 					"name": "required",
 					"snippet": "const required = () => (\n    <Example>\n        <Example.Item title=\"required\">\n            <FormControl required>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "utility-components-formcontrol--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"horizontal\">\n            <FormControl>\n                <View direction=\"row\" gap={10} align=\"center\">\n                    <View width=\"100px\">\n                        <FormControl.Label>Label</FormControl.Label>\n                    </View>\n                    <View.Item grow>\n                        <TextField name=\"name\" placeholder=\"Enter value\" />\n                    </View.Item>\n                </View>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-formcontrol--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <FormControl id=\"test-id\" hasError>\n        <FormControl.Label>Label</FormControl.Label>\n        <TextField name=\"name\" />\n        <FormControl.Helper>Caption</FormControl.Helper>\n        <FormControl.Error>Error</FormControl.Error>\n    </FormControl>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--group",
 					"name": "group",
 					"snippet": "const group = () => (\n    <FormControl group>\n        <FormControl.Label>Label</FormControl.Label>\n        <RadioGroup name=\"name\">\n            <View gap={2}>\n                <Radio value=\"1\">One</Radio>\n                <Radio value=\"2\">Two</Radio>\n            </View>\n        </RadioGroup>\n    </FormControl>\n);"
 				}
 			],
 			"import": "import { Example, FormControl, Radio, RadioGroup, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/FormControl/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "FormControl",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/FormControl/FormControl.tsx",
-				"actualName": "FormControl",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size, to be used together with the other form component sizes",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"large\" | \"medium\"",
+							"value": [{ "value": "\"large\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"required": {
+						"defaultValue": null,
+						"description": "Change component to show a required indicator",
+						"name": "required",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Apply disabled styles",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"group": {
+						"defaultValue": null,
+						"description": "Apply semantic html markup when used for displaying multiple form fields together with a single label",
+						"name": "group",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Custom id for the form control",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "FormControl"
 			}
 		},
 		"utility-components-grid": {
@@ -2548,43 +13412,421 @@
 			"path": "./src/components/Grid/tests/Grid.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "utility-components-grid--base",
+					"name": "gap, columnGap, rowGap, align, justify, maxWidth, width, height",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"gap: 2\">\n            <Grid gap={2} columns={2}>\n                {[1, 2].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"columnGap: 2, rowGap: 4\">\n            <Grid columnGap={2} rowGap={4} columns={2}>\n                {[1, 2, 3, 4].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"align: center\">\n            <Grid gap={2} columns={2} align=\"center\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={8}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"justify: center\">\n            <Grid gap={2} columns=\"200px 200px\" justify=\"center\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"maxWidth: 400px\">\n            <Grid gap={2} columns=\"200px 200px\" maxWidth=\"400px\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"width: 400px, height: 200px\">\n            <Grid gap={2} columns={2} width=\"400px\" height=\"200px\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "layout",
+					"id": "utility-components-grid--layout",
+					"name": "rows, columns",
 					"snippet": "const layout = () => (\n    <Example>\n        <Example.Item title=\"simple: 2 rows, 3 columns\">\n            <Grid gap={4} columns={3} rows={2}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"columns template, 1fr 2fr 1fr\">\n            <Grid gap={4} columns=\"1fr 2fr 1fr\" rows={2}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"rows template, 1fr 2fr\">\n            <Grid gap={4} columns={3} rows=\"1fr 2fr\">\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"responsive\">\n            <Grid gap={4} columns={{ s: 3, m: \"1fr 2fr 1fr\" }} rows={{ s: 2, m: \"1fr 2fr\" }}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemLayout",
+					"id": "utility-components-grid--item-layout",
+					"name": "colStart, colEnd, rowStart, rowEnd",
 					"snippet": "const itemLayout = () => (\n    <Example>\n        <Example.Item title=\"column, start 1, end 3\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item colStart={1} colEnd={3}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"column, start 1, span 2\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item colStart={1} colSpan={2}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"row, start 1, end 3\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowEnd={3}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"row, start 1, span 2\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowSpan={2}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"responsive\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowSpan={{ s: 1, m: 2 }} colStart={1} colSpan={{ s: 1, m: 2 }}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-grid--areas",
 					"name": "areas",
 					"snippet": "const areas = () => (\n    <Example>\n        <Example.Item title=\"simple: 2 rows, 3 columns\">\n            <Grid gap={4} rows={2} areas={[\"a .\", \"a b\"]}>\n                {[\"a\", \"b\"].map((area) => (\n                    <Grid.Item area={area} key={area}>\n                        <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                            {area}\n                        </View>\n                    </Grid.Item>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "auto",
+					"id": "utility-components-grid--auto",
+					"name": "autoFlow, autoColumns, autoRows",
 					"snippet": "const auto = () => (\n    <Example>\n        <Example.Item title=\"auto flow: column\">\n            <Grid gap={4} autoFlow=\"column\" rows={2} columns={2}>\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"auto rows\">\n            <Grid gap={4} autoRows=\"100px\" columns={2}>\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"auto columns\">\n            <Grid gap={4} autoColumns=\"100px\" autoFlow=\"column\">\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-grid--as",
 					"name": "as",
 					"snippet": "const as = () => (\n    <Grid as=\"ul\">\n        <Grid.Item as=\"li\">Content</Grid.Item>\n    </Grid>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-grid--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Grid className=\"test-class\" attributes={{ id: \"test-id\" }}>\n            <Grid.Item className=\"test-item-class\" attributes={{ id: \"test-item-id\" }}>\n                Content\n            </Grid.Item>\n        </Grid>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Grid, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Grid/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Grid",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Grid/Grid.tsx",
-				"actualName": "Grid",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between grid items",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"columnGap": {
+						"defaultValue": null,
+						"description": "Horizontal gap between grid items",
+						"name": "columnGap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"rowGap": {
+						"defaultValue": null,
+						"description": "Vertical gap between grid items",
+						"name": "rowGap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Align grid items vertically",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Justify grid items horizontally",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"rows": {
+						"defaultValue": null,
+						"description": "Grid template rows",
+						"name": "rows",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<number | \"inherit\" | \"none\" | \"auto\" | (string & {}) | \"-moz-initial\" | \"initial\" | \"revert\" | \"revert-layer\" | \"unset\" | \"max-content\" | \"min-content\" | \"subgrid\">"
+						}
+					},
+					"columns": {
+						"defaultValue": null,
+						"description": "Grid template columns",
+						"name": "columns",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<number | \"inherit\" | \"none\" | \"auto\" | (string & {}) | \"-moz-initial\" | \"initial\" | \"revert\" | \"revert-layer\" | \"unset\" | \"max-content\" | \"min-content\" | \"subgrid\">"
+						}
+					},
+					"areas": {
+						"defaultValue": null,
+						"description": "Grid areas for template syntax",
+						"name": "areas",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string[]>" }
+					},
+					"autoFlow": {
+						"defaultValue": null,
+						"description": "Grid auto flow",
+						"name": "autoFlow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoFlow>" }
+					},
+					"autoColumns": {
+						"defaultValue": null,
+						"description": "Grid auto columns",
+						"name": "autoColumns",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoColumns<0 | (string & {})>>" }
+					},
+					"autoRows": {
+						"defaultValue": null,
+						"description": "Grid auto rows",
+						"name": "autoRows",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoRows<0 | (string & {})>>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Maximum width of the grid container, literal css value or unit token multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width of the grid container, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height of the grid container, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Custom root element html tag",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					}
+				},
+				"exportName": "Grid"
 			}
 		},
 		"utility-components-hidden": {
@@ -2593,22 +13835,261 @@
 			"path": "./src/components/Hidden/tests/Hidden.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-hidden--visibility",
 					"name": "visibility",
 					"snippet": "const visibility = () => (\n    <Example>\n        <Example.Item title=\"hide: always\">\n            <Hidden hide={true}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on s\">\n            <Hidden hide={{ s: false, m: true }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on l/xl\">\n            <Hidden hide={{ s: true, l: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on m/l/xl\">\n            <Hidden hide={{ s: true, m: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on m\">\n            <Hidden hide={{ s: true, m: false, l: true }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on s/xl\">\n            <Hidden hide={{ s: false, m: true, xl: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"hide: always, visibility\">\n            <Hidden hide visibility>\n                Content\n            </Hidden>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-hidden--as",
 					"name": "as",
 					"snippet": "const as = () => <Hidden as=\"span\">Content</Hidden>;"
 				}
 			],
 			"import": "import { Example, Hidden } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Hidden/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Hidden",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Hidden/Hidden.tsx",
-				"actualName": "Hidden",
+				"methods": [],
+				"props": {
+					"hide": {
+						"defaultValue": null,
+						"description": "Pick at which viewport sizes to hide the children",
+						"name": "hide",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"visibility": {
+						"defaultValue": null,
+						"description": "Use visibility hidden instead of display none",
+						"name": "visibility",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Custom root element html tag",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2618,22 +14099,39 @@
 			"path": "./src/components/HiddenVisually/tests/HiddenVisually.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-hiddenvisually--visibility",
 					"name": "visibility",
 					"snippet": "const visibility = () => (\n    <Example>\n        <Example.Item title=\"pronounced by screen readers\">\n            <HiddenVisually>Screen-reader only</HiddenVisually>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-hiddenvisually--children",
 					"name": "children",
 					"snippet": "const children = () => <HiddenVisually>Content</HiddenVisually>;"
 				}
 			],
 			"import": "import { Example, HiddenVisually } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/HiddenVisually/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "HiddenVisually",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/HiddenVisually/HiddenVisually.tsx",
-				"actualName": "HiddenVisually",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/HiddenVisually/HiddenVisually.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2643,34 +14141,115 @@
 			"path": "./src/components/Icon/tests/Icon.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-icon--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: 4\">\n            <Icon svg={IconZap} size={4} />\n        </Example.Item>\n        <Example.Item title=\"size: 8\">\n            <Icon svg={IconZap} size={8} />\n        </Example.Item>\n        <Example.Item title=\"size: 100%\">\n            <View width={25} height={25}>\n                <Icon svg={IconZap} size=\"100%\" />\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive size\", \"[s] 5\", \"[m]: 10\"]}>\n            <Icon svg={IconZap} size={{ s: 5, m: 10 }} />\n        </Example.Item>\n        <Example.Item title=\"size: inherit from font\">\n            <Text variant=\"title-6\">\n                <View direction=\"row\" align=\"center\" gap={2}>\n                    <Icon svg={IconZap} />\n                    <View.Item>Reshaped</View.Item>\n                </View>\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-icon--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <Icon svg={IconZap} color=\"neutral\" />\n        </Example.Item>\n        <Example.Item title=\"color: neutral-faded\">\n            <Icon svg={IconZap} color=\"neutral-faded\" />\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <Icon svg={IconZap} color=\"primary\" />\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Icon svg={IconZap} color=\"critical\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Icon svg={IconZap} color=\"positive\" />\n        </Example.Item>\n        <Example.Item title=\"color: disabled\">\n            <Icon svg={IconZap} color=\"disabled\" />\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <div style={{ color: \"tomato\" }}>\n                <Icon svg={IconZap} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "autoWidth",
+					"id": "utility-components-icon--auto-width",
+					"name": "autoWidth, blank",
 					"snippet": "const autoWidth = () => (\n    <Example>\n        <Example.Item title=\"square boundaries\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={IconMic} size={10} />\n            </div>\n        </Example.Item>\n        <Example.Item title=\"auto width boundaries\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={IconMic} size={10} autoWidth />\n            </div>\n        </Example.Item>\n        <Example.Item title=\"blank\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={null} size={10} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-icon--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Icon svg={IconZap} className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				},
 				{
-					"name": "render",
+					"id": "utility-components-icon--render",
+					"name": "test: hidden from sr",
 					"snippet": "const render = () => (\n    <div data-testid=\"root\">\n        <Icon svg={IconZap} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Icon, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Icon/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Icon",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Icon/Icon.tsx",
-				"actualName": "Icon",
+				"methods": [],
+				"props": {
+					"svg": {
+						"defaultValue": null,
+						"description": "Icon svg component or node",
+						"name": "svg",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Icon size, literal css value or unit token multiplier",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Icon color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"warning\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"autoWidth": {
+						"defaultValue": null,
+						"description": "Use the width of the svg asset instead of providing a square bounding box",
+						"name": "autoWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2680,54 +14259,230 @@
 			"path": "./src/components/Image/tests/Image.stories.tsx",
 			"stories": [
 				{
-					"name": "src",
+					"id": "utility-components-image--src",
+					"name": "src, alt",
 					"snippet": "const src = () => (\n    <Example>\n        <Example.Item title=\"src, alt\">\n            <Image src={imgUrl} alt=\"Image alt\" />\n        </Example.Item>\n\n        <Example.Item title=\"src\">\n            <Image src={imgUrl} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "utility-components-image--size",
+					"name": "width, height, maxWidth, aspectRatio",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"width: 200px\">\n            <Image src={imgUrl} width=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"height: 200px\">\n            <Image src={imgUrl} height=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"maxWidth: 200px\">\n            <Image src={imgUrl} maxWidth=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"aspectRatio: 1/1\">\n            <Image src={imgUrl} aspectRatio={1 / 1} width=\"300px\" />\n        </Example.Item>\n        <Example.Item title={[\"responsive width\", \"[s] 200px\", \"[m+] 300px\"]}>\n            <Image src={imgUrl} width={{ s: \"200px\", m: \"300px\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "radius",
+					"id": "utility-components-image--radius",
+					"name": "borderRadius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius: small\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"small\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"radius: medium\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"medium\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"radius: large\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--display-mode",
 					"name": "displayMode",
 					"snippet": "const displayMode = () => (\n    <Example>\n        <Example.Item title=\"mode: cover\">\n            <Image src={imgUrl} height=\"200px\" width=\"100%\" displayMode=\"cover\" />\n        </Example.Item>\n        <Example.Item title=\"mode: contain\">\n            <Image src={imgUrl} height=\"200px\" width=\"100%\" displayMode=\"contain\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--on-load",
 					"name": "onLoad",
 					"snippet": "const onLoad = () => <Image src={imgUrl} alt=\"photo\" onLoad={fn()} />;"
 				},
 				{
+					"id": "utility-components-image--on-error",
 					"name": "onError",
 					"snippet": "const onError = () => <Image src=\"/invalid.png\" alt=\"photo\" onError={fn()} />;"
 				},
 				{
+					"id": "utility-components-image--fallback",
 					"name": "fallback",
 					"snippet": "const fallback = () => (\n    <Example>\n        <Example.Item title=\"fallback, background, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"fallback, image, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback={imgUrl} />\n                </View>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"fallback, icon, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback={<Icon svg={IconZap} size={10} />} />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"fallback, icon, no url\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image fallback={<Icon svg={IconZap} size={10} />} />\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--render-image",
 					"name": "renderImage",
 					"snippet": "const renderImage = () => (\n    <Example>\n        <Example.Item title=\"renderImage\">\n            <Image\n                src={imgUrl}\n                alt=\"Amsterdam canal\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image\" />}\n            />\n        </Example.Item>\n        <Example.Item title=\"renderImage, fallback\">\n            <Image\n                src=\"error\"\n                fallback={imgUrl}\n                alt=\"Amsterdam canal 2\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image-fallback\" />}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "imageAttributes",
+					"id": "utility-components-image--image-attributes",
+					"name": "className, attributes,imageAttributes",
 					"snippet": "const imageAttributes = () => (\n    <div data-testid=\"root\">\n        <Image\n            src={imgUrl}\n            alt=\"photo\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            imageAttributes={{ \"data-testid\": \"test-img-id\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "ratio",
+					"id": "utility-components-image--ratio",
+					"name": "test: aspectRatio",
 					"snippet": "const ratio = () => (\n    <Example>\n        <Example.Item title=\"ratio: 16/9\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"ratio: 16/9, displayMode: contain\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} displayMode=\"contain\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Icon, Image, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Image/Image.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Image",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Image/Image.tsx",
-				"actualName": "Image",
+				"methods": [],
+				"props": {
+					"src": {
+						"defaultValue": null,
+						"description": "Image URL",
+						"name": "src",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"alt": {
+						"defaultValue": null,
+						"description": "Image alt text",
+						"name": "alt",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Image width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Image height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Image max width, literal css value or unit token multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"aspectRatio": {
+						"defaultValue": null,
+						"description": "Image aspect ratio, width / height",
+						"name": "aspectRatio",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Image border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"large\" | \"medium\"",
+							"value": [
+								{ "value": "\"small\"" },
+								{ "value": "\"large\"" },
+								{ "value": "\"medium\"" }
+							]
+						}
+					},
+					"displayMode": {
+						"defaultValue": null,
+						"description": "Image display mode for controlling how it fits into the provided boundaries",
+						"name": "displayMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"cover\" | \"contain\"",
+							"value": [{ "value": "\"cover\"" }, { "value": "\"contain\"" }]
+						}
+					},
+					"onLoad": {
+						"defaultValue": null,
+						"description": "Image on load event",
+						"name": "onLoad",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: SyntheticEvent<Element, Event>) => void)" }
+					},
+					"onError": {
+						"defaultValue": null,
+						"description": "Image on error event",
+						"name": "onError",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: SyntheticEvent<Element, Event>) => void)" }
+					},
+					"fallback": {
+						"defaultValue": null,
+						"description": "Image fallback content if the image fails to load or was not provided",
+						"name": "fallback",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"renderImage": {
+						"defaultValue": null,
+						"description": "Image render function, can be used for integrating with Image component in 3rd party frameworks",
+						"name": "renderImage",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Omit<Attributes<\"img\">, \"src\" | \"alt\"> & { src: string; alt: string; }) => ReactNode)"
+						}
+					},
+					"imageAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the image element",
+						"name": "imageAttributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"img\">" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(Attributes<\"div\"> & Attributes<\"img\">)" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2737,46 +14492,229 @@
 			"path": "./src/components/Overlay/tests/Overlay.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-overlay--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate}>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--transparent",
 					"name": "transparent",
 					"snippet": "const transparent = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate} transparent>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--blurred",
 					"name": "blurred",
 					"snippet": "const blurred = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate} blurred>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "renderProps",
+					"id": "utility-components-overlay--render-props",
+					"name": "children, render props",
 					"snippet": "const renderProps = () => (\n    <Overlay active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        {(args) => (args.active ? \"Opened\" : \"Closed\")}\n    </Overlay>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "utility-components-overlay--handlers",
+					"name": "onOpen, onClose, onAfterOpen, onAfterClose",
 					"snippet": "const handlers = () => {\n    const overlayToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => overlayToggle.toggle()}>Open overlay</Button>\n            <Overlay\n                active={overlayToggle.active}\n                onClose={(closeArgs) => {\n                    overlayToggle.deactivate();\n                    args.handleClose(closeArgs);\n                }}\n                onOpen={fn()}\n                onAfterOpen={fn()}\n                onAfterClose={fn()}>Content\n                                </Overlay>\n        </>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--disable-close-on-click",
 					"name": "disableCloseOnClick",
 					"snippet": "const disableCloseOnClick = (args) => (\n    <Overlay\n        active\n        disableCloseOnClick\n        onClose={(closeArgs) => {\n            args.handleClose(closeArgs);\n        }}\n    >\n        Content\n    </Overlay>\n);"
 				},
 				{
+					"id": "utility-components-overlay--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <>\n            <div ref={containerRef} data-testid=\"test-id\" style={{ height: 200 }} />\n            <Overlay active containerRef={containerRef}>\n                Content\n            </Overlay>\n        </>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-overlay--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <Overlay active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        Content\n    </Overlay>\n);"
 				}
 			],
 			"import": "import { Button, Example, Overlay } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Overlay/index.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Overlay",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Overlay/Overlay.tsx",
-				"actualName": "Overlay",
+				"methods": [],
+				"props": {
+					"transparent": {
+						"defaultValue": null,
+						"description": "Make the overlay transparent",
+						"name": "transparent",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number | boolean" }
+					},
+					"blurred": {
+						"defaultValue": null,
+						"description": "Make the overlay blurred",
+						"name": "blurred",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Control the overflow of the component content",
+						"name": "overflow",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"auto\"",
+							"value": [{ "value": "\"hidden\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, render function receives the state of the component as an argument",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode | ((props: { active: boolean; }) => ReactNode)" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the visibility of the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason: CloseReason; }) => void)" }
+					},
+					"onAfterClose": {
+						"defaultValue": null,
+						"description": "Callback after the component close transition is complete",
+						"name": "onAfterClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the component is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onAfterOpen": {
+						"defaultValue": null,
+						"description": "Callback after the component open transition is complete",
+						"name": "onAfterOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"disableCloseOnClick": {
+						"defaultValue": null,
+						"description": "Disable closing the component on outside click",
+						"name": "disableCloseOnClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": null,
+						"description": "Element to render the component in",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2786,42 +14724,213 @@
 			"path": "./src/components/Reshaped/tests/Reshaped.stories.tsx",
 			"stories": [
 				{
-					"name": "rtl",
+					"id": "utility-components-reshaped--rtl",
+					"name": "defaultRTL",
 					"snippet": "const rtl = () => (\n    <Reshaped defaultRTL theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				},
 				{
-					"name": "controlledMode",
+					"id": "utility-components-reshaped--controlled-mode",
+					"name": "colorMode, controlled",
 					"snippet": "const controlledMode = () => {\n    const [mode, setMode] = useState<G.ColorMode>(\"dark\");\n\n    return (\n        <Reshaped theme=\"reshaped\" colorMode={mode}>\n            <Button\n                onClick={() => {\n                    setMode(mode === \"dark\" ? \"light\" : \"dark\");\n                }}\n            >\n                Toggle color mode\n            </Button>\n        </Reshaped>\n    );\n};"
 				},
 				{
-					"name": "lightMode",
+					"id": "utility-components-reshaped--light-mode",
+					"name": "defaultColorMode=light",
 					"snippet": "const lightMode = () => <Reshaped theme=\"reshaped\">Hello</Reshaped>;"
 				},
 				{
-					"name": "darkMode",
+					"id": "utility-components-reshaped--dark-mode",
+					"name": "defaultColorMode=dark",
 					"snippet": "const darkMode = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				},
 				{
+					"id": "utility-components-reshaped--scoped",
 					"name": "scoped",
 					"snippet": "const scoped = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\" scoped>\n        Hello\n    </Reshaped>\n);"
 				},
 				{
-					"name": "testScoped",
+					"id": "utility-components-reshaped--test-scoped",
+					"name": "test: scoped switch",
 					"snippet": "const testScoped = () => (\n    <Reshaped theme=\"reshaped\">\n        <Reshaped theme=\"slate\" scoped>\n            <ScopedComponent />\n        </Reshaped>\n    </Reshaped>\n);"
 				},
 				{
-					"name": "keyboardMode",
+					"id": "utility-components-reshaped--keyboard-mode",
+					"name": "test: keyboard mode",
 					"snippet": "const keyboardMode = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				}
 			],
 			"import": "import { Button, Reshaped } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Reshaped/Reshaped.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Reshaped",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Reshaped/Reshaped.tsx",
-				"actualName": "Reshaped",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"theme": {
+						"defaultValue": null,
+						"description": "Theme of the application, enables controlled mode",
+						"name": "theme",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NonNullable<Theme>" }
+					},
+					"defaultTheme": {
+						"defaultValue": null,
+						"description": "Default theme of the application, enables uncontrolled mode",
+						"name": "defaultTheme",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NonNullable<Theme>" }
+					},
+					"defaultRTL": {
+						"defaultValue": null,
+						"description": "Default content direction of the application",
+						"name": "defaultRTL",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode of the application, enables controlled mode",
+						"name": "colorMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode",
+							"value": [{ "value": "\"light\"" }, { "value": "\"dark\"" }]
+						}
+					},
+					"defaultColorMode": {
+						"defaultValue": null,
+						"description": "Default color mode of the application, enables uncontrolled mode",
+						"name": "defaultColorMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode",
+							"value": [{ "value": "\"light\"" }, { "value": "\"dark\"" }]
+						}
+					},
+					"defaultViewport": {
+						"defaultValue": null,
+						"description": "Default viewport size of the application",
+						"name": "defaultViewport",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Viewport",
+							"value": [
+								{ "value": "\"s\"" },
+								{ "value": "\"m\"" },
+								{ "value": "\"l\"" },
+								{ "value": "\"xl\"" }
+							]
+						}
+					},
+					"toastOptions": {
+						"defaultValue": null,
+						"description": "Global options for the ToastProvider",
+						"name": "toastOptions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "Partial<Record<Position, { width?: string; expanded?: boolean; }>> | undefined"
+						}
+					},
+					"scoped": {
+						"defaultValue": null,
+						"description": "Enable scoped mode for applications not using Reshaped provider at the application root",
+						"name": "scoped",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2831,42 +14940,150 @@
 			"path": "./src/components/ScrollArea/tests/ScrollArea.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-scrollarea--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"vertical scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"horizontal scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\" height=\"100px\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"horizontal and vertical scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-scrollarea--scrollbar-display",
 					"name": "scrollbarDisplay",
 					"snippet": "const scrollbarDisplay = () => (\n    <Example>\n        <Example.Item title=\"scrollbarDisplay: hover\">\n            <ScrollArea height=\"100px\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"scrollbarDisplay: hidden\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"hidden\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"scrollbarDisplay: visible\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "height",
+					"id": "utility-components-scrollarea--height",
+					"name": "height, maxHeight",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"height: 80px\">\n            <ScrollArea height=\"80px\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"responsive height: s 80px, m: 120px\">\n            <ScrollArea height={{ s: \"80px\", m: \"120px\" }}>\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"maxHeight: 80px\">\n            <ScrollArea maxHeight=\"80px\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"responsive max height: s 80px, m: 200px\">\n            <ScrollArea maxHeight={{ s: \"80px\", m: \"200px\" }}>\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onScroll",
+					"id": "utility-components-scrollarea--on-scroll",
+					"name": "ref, onScroll",
 					"snippet": "const onScroll = () => {\n    const ref = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={4}>\n            <View.Item>\n                <Button onClick={() => ref.current?.scrollBy({ top: 50, left: 50 })}>Scroll</Button>\n            </View.Item>\n            <ScrollArea height=\"100px\" ref={ref} scrollbarDisplay=\"visible\" onScroll={fn()}>\n                <View backgroundColor=\"neutral-faded\" padding={4} width=\"1000px\" height=\"200px\">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                                            has been the industry's standard dummy text ever since the 1500s, when an unknown\n                                            printer took a galley of type and scrambled it to make a type specimen book. It has\n                                            survived not only five centuries, but also the leap into electronic typesetting,\n                                            remaining essentially unchanged. It was popularised in the 1960s with the release of\n                                            Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                                            publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                                        </View>\n            </ScrollArea>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-scrollarea--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ScrollArea className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </ScrollArea>\n    </div>\n);"
 				},
 				{
-					"name": "testNested",
+					"id": "utility-components-scrollarea--test-nested",
+					"name": "test: nested",
 					"snippet": "const testNested = () => (\n    <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n        <View padding={4} paddingInline={16}>\n            <ScrollArea height=\"200px\" scrollbarDisplay=\"visible\">\n                {Array(20)\n                    .fill(\"\")\n                    .map((_, index) => {\n                        return <div key={index}>Item {index + 1}</div>;\n                    })}\n            </ScrollArea>\n        </View>\n    </ScrollArea>\n);"
 				},
 				{
-					"name": "testDynamicHeight",
+					"id": "utility-components-scrollarea--test-dynamic-height",
+					"name": "test: dynamic height change",
 					"snippet": "const testDynamicHeight = () => {\n    const [count, setCount] = React.useState(10);\n\n    return (\n        <View gap={4}>\n            <View.Item>\n                <Button onClick={() => setCount((prev) => prev + 10)}>Add more items</Button>\n            </View.Item>\n\n            <ScrollArea height=\"200px\" scrollbarDisplay=\"visible\">\n                <View gap={2}>\n                    {new Array(count).fill(\"\").map((_, i) => (\n                        <View.Item key={i}>Item {i + 1}</View.Item>\n                    ))}\n                </View>\n            </ScrollArea>\n        </View>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Example, ScrollArea, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ScrollArea/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ScrollArea",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ScrollArea/ScrollArea.tsx",
-				"actualName": "ScrollArea",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"scrollbarDisplay": {
+						"defaultValue": null,
+						"description": "Scrollbar visibility behavior based on the user interaction",
+						"name": "scrollbarDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"hover\" | \"visible\"",
+							"value": [
+								{ "value": "\"hidden\"" },
+								{ "value": "\"hover\"" },
+								{ "value": "\"visible\"" }
+							]
+						}
+					},
+					"onScroll": {
+						"defaultValue": null,
+						"description": "Callback when the scroll area is scrolled",
+						"name": "onScroll",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: Coordinates) => void)" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height of the scroll area, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height of the scroll area, literal css value or unit token multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2876,54 +15093,387 @@
 			"path": "./src/components/Text/tests/Text.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-text--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: title-1\">\n            <Text variant=\"title-1\">Title 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-2\">\n            <Text variant=\"title-2\">Title 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-3\">\n            <Text variant=\"title-3\">Title 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-4\">\n            <Text variant=\"title-4\">Title 4</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-5\">\n            <Text variant=\"title-5\">Title 5</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-6\">\n            <Text variant=\"title-6\">Title 6</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-1\">\n            <Text variant=\"featured-1\">Featured 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-2\">\n            <Text variant=\"featured-2\">Featured 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-3\">\n            <Text variant=\"featured-3\">Featured 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-1\">\n            <Text variant=\"body-1\">Body 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-2\">\n            <Text variant=\"body-2\">Body 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-3\">\n            <Text variant=\"body-3\">Body 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: caption-1\">\n            <Text variant=\"caption-1\">Caption 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: caption-2\">\n            <Text variant=\"caption-2\">Caption 2</Text>\n        </Example.Item>\n        <Example.Item title={[\"responsive variant\", \"[s] body-3\", \"[m+] title-4\"]}>\n            <Text variant={{ s: \"body-3\", m: \"title-4\" }}>Responsive</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--weight",
 					"name": "weight",
 					"snippet": "const weight = () => (\n    <Example>\n        <Example.Item title=\"weight: regular\">\n            <Text weight=\"regular\">Regular</Text>\n        </Example.Item>\n        <Example.Item title=\"weight: medium\">\n            <Text weight=\"medium\">Medium</Text>\n        </Example.Item>\n        <Example.Item title=\"weight: bold\">\n            <Text weight=\"bold\">Bold</Text>\n        </Example.Item>\n        <Example.Item title={[\"responsive\", \"[s] weight: regular\", \"[m+] bold\"]}>\n            <Text weight={{ s: \"regular\", m: \"bold\" }}>Responsive</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: inherit\">\n            <Text>Neutral</Text>\n        </Example.Item>\n        <Example.Item title=\"color: neutral-faded\">\n            <Text color=\"neutral-faded\">Faded</Text>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Text color=\"positive\">Positive</Text>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <Text color=\"warning\">Warning</Text>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Text color=\"critical\">Critical</Text>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <Text color=\"primary\">Primary</Text>\n        </Example.Item>\n        <Example.Item title=\"color: disabled\">\n            <Text color=\"disabled\" attributes={{ \"aria-disabled\": true }}>\n                Disabled\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--decoration",
 					"name": "decoration",
 					"snippet": "const decoration = () => (\n    <Example>\n        <Example.Item title=\"decoration: line-through\">\n            <Text decoration=\"line-through\">Line through</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--wrap",
 					"name": "wrap",
 					"snippet": "const wrap = () => (\n    <Example>\n        <Example.Item title=\"wrap: balance\">\n            <Text wrap=\"balance\" variant=\"title-3\">\n                The design system you want to build\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "mono",
+					"id": "utility-components-text--mono",
+					"name": "monospace",
 					"snippet": "const mono = () => (\n    <Example>\n        <Example.Item title=\"monospace\">\n            <Text monospace>Content</Text>\n        </Example.Item>\n        <Example.Item title=\"monospace, variant, weight\">\n            <Text monospace variant=\"title-1\" weight=\"regular\">\n                Content\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--max-lines",
 					"name": "maxLines",
 					"snippet": "const maxLines = () => (\n    <Example>\n        <Example.Item title=\"maxLines: 2\">\n            <Text maxLines={2}>\n                There are many variations of passages of Lorem Ipsum available, but the majority have\n                suffered alteration in some form, by injected humour, or randomised words which don't look\n                even slightly believable. If you are going to use a passage of Lorem Ipsum, you need to be\n                sure there isn't anything embarrassing hidden in the middle of text. All the Lorem Ipsum\n                generators on the Internet tend to repeat predefined chunks as necessary, making this the\n                first true generator on the Internet. It uses a dictionary of over 200 Latin words,\n                combined with a handful of model sentence structures, to generate Lorem Ipsum which looks\n                reasonable. The generated Lorem Ipsum is therefore always free from repetition, injected\n                humour, or non-characteristic words etc.\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: start\">\n            <Text align=\"start\">Text content</Text>\n        </Example.Item>\n        <Example.Item title=\"align: center\">\n            <Text align=\"center\">Text content</Text>\n        </Example.Item>\n        <Example.Item title=\"align: end\">\n            <Text align=\"end\">Text content</Text>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive alignment\", \"[s]: center\", \"[m+] start\"]}>\n            <Text align={{ s: \"center\", m: \"start\" }}>Text content</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "asProp",
+					"id": "utility-components-text--as-prop",
+					"name": "as",
 					"snippet": "const asProp = () => (\n    <>\n        <Text as=\"h1\">Content</Text>\n        <Text variant=\"title-3\">Content</Text>\n        <Text variant={{ s: \"title-3\", m: \"title-4\" }}>Content</Text>\n    </>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-text--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Text className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Text>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Text/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Text",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Text/Text.tsx",
-				"actualName": "Text",
+				"methods": [],
+				"props": {
+					"variant": {
+						"defaultValue": null,
+						"description": "Text render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Variant>" }
+					},
+					"weight": {
+						"defaultValue": null,
+						"description": "Text font weight",
+						"name": "weight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"medium\" | \"bold\" | \"regular\">" }
+					},
+					"monospace": {
+						"defaultValue": null,
+						"description": "Render monospace font",
+						"name": "monospace",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Text color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"warning\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Text alignment",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"center\" | \"start\" | \"end\">" }
+					},
+					"wrap": {
+						"defaultValue": null,
+						"description": "CSS wrapping style",
+						"name": "wrap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"balance\"", "value": [{ "value": "\"balance\"" }] }
+					},
+					"decoration": {
+						"defaultValue": null,
+						"description": "CSS text decoration style",
+						"name": "decoration",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"line-through\"",
+							"value": [{ "value": "\"line-through\"" }]
+						}
+					},
+					"maxLines": {
+						"defaultValue": null,
+						"description": "Maximum number of lines to render, used for text truncation",
+						"name": "maxLines",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different html tag",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2933,46 +15483,114 @@
 			"path": "./src/components/Theme/tests/Theme.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-theme--scoped",
 					"name": "scoped",
 					"snippet": "const scoped = () => (\n    <Example>\n        <Example.Item title=\"scoped, single\">\n            <Theme name=\"reshaped\">\n                <Card attributes={{ \"data-testid\": \"test-id\" }}>\n                    <Button color=\"primary\">Action</Button>\n                </Card>\n            </Theme>\n        </Example.Item>\n\n        <Example.Item title=\"scoped, multiple\">\n            <Theme name={[\"reshaped\", \"figma\"]}>\n                <Card attributes={{ \"data-testid\": \"test-id-multi\" }}>\n                    <View direction=\"row\" gap={4}>\n                        <Button color=\"primary\">Action</Button>\n\n                        <Popover>\n                            <Popover.Trigger>\n                                {(attributes) => <Button attributes={attributes}>Popover</Button>}\n                            </Popover.Trigger>\n                            <Popover.Content>Content</Popover.Content>\n                        </Popover>\n                    </View>\n                </Card>\n            </Theme>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-theme--light",
 					"name": "light",
 					"snippet": "const light = () => (\n    <Theme name=\"reshaped\" colorMode=\"light\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--dark",
 					"name": "dark",
 					"snippet": "const dark = () => (\n    <Theme name=\"reshaped\" colorMode=\"dark\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--inherited",
 					"name": "inherited",
 					"snippet": "const inherited = () => (\n    <Theme name=\"reshaped\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--inverted",
 					"name": "inverted",
 					"snippet": "const inverted = () => (\n    <Theme name=\"reshaped\" colorMode=\"inverted\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--controlled",
 					"name": "controlled",
 					"snippet": "const controlled = () => {\n    const Internal = () => {\n        const { setTheme, theme } = useTheme();\n\n        return (\n            <Button color=\"primary\" onClick={() => setTheme(\"slate\")}>\n                Switch to slate\n            </Button>\n        );\n    };\n\n    return (\n        <div data-testid=\"root\">\n            <Theme name=\"reshaped\">\n                <Internal />\n            </Theme>\n        </div>\n    );\n};"
 				},
 				{
+					"id": "utility-components-theme--uncontrolled",
 					"name": "uncontrolled",
 					"snippet": "const uncontrolled = () => {\n    const Internal = () => {\n        const { setTheme } = useTheme();\n\n        return (\n            <Button color=\"primary\" onClick={() => setTheme(\"slate\")}>\n                Switch to slate\n            </Button>\n        );\n    };\n\n    return (\n        <div data-testid=\"root\">\n            <Theme defaultName=\"reshaped\">\n                <Internal />\n            </Theme>\n        </div>\n    );\n};"
 				},
 				{
-					"name": "disabledTransition",
+					"id": "utility-components-theme--disabled-transition",
+					"name": "disabled transitions",
 					"snippet": "const disabledTransition = () => {\n    const { invertColorMode } = useTheme();\n\n    return (\n        <Example>\n            <Example.Item title=\"should have no transitions while switching color mode\">\n                <View gap={3}>\n                    <Button onClick={invertColorMode}>Invert mode</Button>\n\n                    <MenuItem selected>Test transition</MenuItem>\n\n                    <Card>Default card</Card>\n\n                    <Theme colorMode=\"inverted\">\n                        <Card>Inverted card</Card>\n                    </Theme>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Card, Example, MenuItem, Popover, Theme, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Theme/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Theme",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Theme/Theme.tsx",
-				"actualName": "Theme",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the theme to use, enables controlled mode",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"defaultName": {
+						"defaultValue": null,
+						"description": "Default name of the theme to use, enables uncontrolled mode",
+						"name": "defaultName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode to use",
+						"name": "colorMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode | \"inverted\"",
+							"value": [
+								{ "value": "\"light\"" },
+								{ "value": "\"dark\"" },
+								{ "value": "\"inverted\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2982,147 +15600,880 @@
 			"path": "./src/components/View/tests/View.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-view--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example title=\"Border is used to highlight the padding value\">\n        <Example.Item title=\"padding: 4\">\n            <View padding={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <View padding={6} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: 0\">\n            <View padding={0} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: vertical 2, horizontal 4\">\n            <View paddingInline={4} paddingBlock={2} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingTop: 4\">\n            <View paddingTop={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingBottom: 4\">\n            <View paddingBottom={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingStart: 4\">\n            <View paddingStart={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingEnd: 4\">\n            <View paddingEnd={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive padding:\",\n                \"[s] vertical 2, horizontal 4\",\n                \"[m+] vertical 4, horizontal 8\",\n            ]}\n        >\n            <View paddingInline={{ s: 4, m: 8 }} paddingBlock={{ s: 2, m: 4 }} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"responsive padding:\", \"[s] top 2, bottom 4\", \"[m+] top 4, bottom 0, start: 8\"]}\n        >\n            <View\n                paddingTop={{ s: 2, m: 4 }}\n                paddingBottom={{ s: 4, m: 0 }}\n                paddingStart={{ s: 0, m: 8 }}\n                borderColor=\"neutral\"\n            >\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"nested padding, child view should have no horizontal padding\">\n            <View paddingStart={4} borderColor=\"neutral\">\n                <View borderColor=\"primary\" paddingBlock={4}>\n                    <Placeholder />\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example title=\"Item 1 is another component, Item 2 is View.Item, Item 3 is text\">\n        <Example.Item title=\"direction: column as default\">\n            <View gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <View gap={3} direction=\"column\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column-reverse\">\n            <View gap={3} direction=\"column-reverse\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row\">\n            <View gap={3} direction=\"row\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row-reverse\">\n            <View gap={3} direction=\"row-reverse\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"responsive direction\", \"[s] column-reverse\", \"[m] row-reverse\", \"[l+] row\"]}\n        >\n            <View direction={{ s: \"column-reverse\", m: \"row-reverse\", l: \"row\" }} gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 4, direction: row\">\n            <View direction=\"row\" gap={4} divided>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n                <Placeholder>Item 3</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 0, direction: row\">\n            <View direction=\"row\" gap={0}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap, direction: row\", \"[s] 4\", \"[m+] 8\"]}>\n            <View direction=\"row\" gap={{ s: 4, m: 8 }}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 4, direction: column\">\n            <View gap={4}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 0, direction: column\">\n            <View gap={0}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap, direction: column\", \"[s] 4\", \"[m+] 8\"]}>\n            <View gap={{ s: 4, m: 8 }}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--divided",
 					"name": "divided",
 					"snippet": "const divided = () => (\n    <Example>\n        <Example.Item title=\"direction: row\">\n            <View divided direction=\"row\" gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <View divided gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive divided\", \"[s] direction: row\", \"[m+] direction: column\"]}>\n            <View divided direction={{ s: \"row\", m: \"column\" }} gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row, columns\">\n            <View divided gap={3} direction=\"row\">\n                <View.Item columns={2}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={8}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={2}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"with React.Fragment\">\n            <View direction=\"row\" gap={4} divided>\n                <Placeholder>Item 1</Placeholder>\n                <>\n                    <Placeholder>Item 2</Placeholder>\n                    <Placeholder>Item 3</Placeholder>\n                </>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example title=\"Removes side borders and border radius when applied\">\n        <Example.Item title=\"bleed: 4\">\n            <View bleed={4} padding={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive bleed\", \"[s] 4\", \"[m+] 0\"]}>\n            <View bleed={{ s: 4, m: 0 }} padding={4} borderRadius=\"small\" borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--wrap",
 					"name": "wrap",
 					"snippet": "const wrap = () => (\n    <Example>\n        <Example.Item title=\"wrap: false\">\n            <View direction=\"row\" wrap={false} gap={3}>\n                <Placeholder w={600} h={100} />\n                <Placeholder w={600} h={100} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: start, direction: row\">\n            <View align=\"start\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: center, direction: row\">\n            <View align=\"center\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: end, direction: row\">\n            <View align=\"end\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"align: stretch, direction: row\",\n                \"2nd item is stretched based on the 1st item height\",\n            ]}\n        >\n            <View align=\"stretch\" direction=\"row\" gap={3}>\n                <Placeholder h={100} />\n                <Placeholder h=\"auto\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: baseline, direction: row\">\n            <View align=\"baseline\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Text variant=\"title-6\">Content</Text>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"align: start, direction: column\">\n            <View align=\"start\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: center, direction: column\">\n            <View align=\"center\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: end, direction: row\">\n            <View align=\"end\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"align: stretch, direction: column\",\n                \"1st item uses its own width, 2nd item is stretched to full width\",\n            ]}\n        >\n            <View align=\"stretch\" direction=\"column\" gap={3}>\n                <Placeholder w={100} />\n                <Placeholder w=\"auto\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--justify",
 					"name": "justify",
 					"snippet": "const justify = () => (\n    <Example>\n        <Example.Item title=\"justify: start, direction: row\">\n            <View justify=\"start\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: center, direction: row\">\n            <View justify=\"center\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: end, direction: row\">\n            <View justify=\"end\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: space-between, direction: row\">\n            <View justify=\"space-between\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"justify: start, direction: column, height: 200px\">\n            <View height=\"200px\" justify=\"start\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: center, direction: column, height: 200px\">\n            <View height=\"200px\" justify=\"center\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: end, direction: column, height: 200px\">\n            <View justify=\"end\" height=\"200px\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: space-between, direction: column, height: 200px\">\n            <View justify=\"space-between\" height=\"200px\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--text-align",
 					"name": "textAlign",
 					"snippet": "const textAlign = () => (\n    <Example>\n        <Example.Item title=\"textAlign: start\">\n            <View textAlign=\"start\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: center\">\n            <View textAlign=\"center\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: end\">\n            <View textAlign=\"end\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: [s] start, [m+] end\">\n            <View textAlign={{ s: \"start\", m: \"end\" }}>Content</View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"height: 100px, width: 100px\">\n            <View backgroundColor=\"neutral-faded\" height=\"100px\" width=\"100px\" />\n        </Example.Item>\n        <Example.Item title=\"height: 25, width: 25\">\n            <View backgroundColor=\"neutral-faded\" height={25} width={25} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive height and width\",\n                \"[s] height: 25, width: 25\",\n                \"[m+] height: 200px, width: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                height={{ s: 25, m: \"200px\" }}\n                width={{ s: 25, m: \"200px\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "ratio",
+					"id": "utility-components-view--ratio",
+					"name": "aspectRatio",
 					"snippet": "const ratio = () => (\n    <Example>\n        <Example.Item title=\"ratio: 16 / 9\">\n            <View backgroundColor=\"neutral-faded\" aspectRatio={16 / 9} width=\"200px\" />\n        </Example.Item>\n        <Example.Item title={[\"responsive ratio\", \"[s] 1/1\", \"[m+] 16/9\"]}>\n            <View backgroundColor=\"neutral-faded\" aspectRatio={{ s: 1, m: 16 / 9 }} width=\"200px\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "maxSize",
+					"id": "utility-components-view--max-size",
+					"name": "width, height, maxWidth, maxHeight",
 					"snippet": "const maxSize = () => (\n    <Example>\n        <Example.Item title=\"maxHeight: 150px, maxWidth: 150px, height: 300px\">\n            <View backgroundColor=\"neutral-faded\" maxHeight=\"150px\" maxWidth=\"150px\" height=\"300px\" />\n        </Example.Item>\n        <Example.Item title=\"maxHeight: 25, maxWidth: 25, height: 50\">\n            <View backgroundColor=\"neutral-faded\" maxHeight={25} maxWidth={25} height={50} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive maxHeight and maxWidth, height: 300\",\n                \"[s] maxHeight: 25, maxWidth: 25\",\n                \"[m+] maxHeight: 200px, maxWidth: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                maxHeight={{ s: 25, m: \"200px\" }}\n                maxWidth={{ s: 25, m: \"200px\" }}\n                height=\"300px\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "minSize",
+					"id": "utility-components-view--min-size",
+					"name": "width, height, minWidth, minHeight",
 					"snippet": "const minSize = () => (\n    <Example>\n        <Example.Item title=\"minHeight: 150px, minWidth: 150px, height: 50px, width: 50px\">\n            <View\n                backgroundColor=\"neutral-faded\"\n                minHeight=\"150px\"\n                minWidth=\"150px\"\n                height=\"50px\"\n                width=\"50px\"\n            />\n        </Example.Item>\n        <Example.Item title=\"minHeight: 25, minWidth: 25, height: 5, width: 5\">\n            <View backgroundColor=\"neutral-faded\" minHeight={25} minWidth={25} height={5} width={5} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive minHeight and minWidth, height: 50px, width: 50px\",\n                \"[s] minHeight: 25, minWidth: 25\",\n                \"[m+] minHeight: 200px, minWidth: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                minHeight={{ s: 25, m: \"200px\" }}\n                minWidth={{ s: 25, m: \"200px\" }}\n                height=\"50px\"\n                width=\"50px\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "background",
+					"id": "utility-components-view--background",
+					"name": "backgroundColor",
 					"snippet": "const background = () => (\n    <Example title=\"border is used to highlight the backround value when it's similar to the page background, text color changes based on the background\">\n        <Example.Item title=\"bg: page\">\n            <View backgroundColor=\"page\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: page-faded\">\n            <View backgroundColor=\"page-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: disabled\">\n            <View backgroundColor=\"disabled\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: disabled-faded\">\n            <View backgroundColor=\"disabled-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-base\">\n            <View backgroundColor=\"elevation-base\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-raised\">\n            <View backgroundColor=\"elevation-raised\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-overlay\">\n            <View backgroundColor=\"elevation-overlay\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: neutral\">\n            <View backgroundColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: neutral-faded\">\n            <View backgroundColor=\"neutral-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: primary\">\n            <View backgroundColor=\"primary\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: primary-faded\">\n            <View backgroundColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: critical\">\n            <View backgroundColor=\"critical\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: critical-faded\">\n            <View backgroundColor=\"critical-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: warning\">\n            <View backgroundColor=\"warning\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: warning-faded\">\n            <View backgroundColor=\"warning-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: positive\">\n            <View backgroundColor=\"positive\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: positive-faded\">\n            <View backgroundColor=\"positive-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--border-color",
 					"name": "borderColor",
 					"snippet": "const borderColor = () => (\n    <Example>\n        <Example.Item title=\"border: neutral\">\n            <View borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: neutral-faded\">\n            <View borderColor=\"neutral-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: primary\">\n            <View borderColor=\"primary\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: primary-faded\">\n            <View borderColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: critical\">\n            <View borderColor=\"critical\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: critical-faded\">\n            <View borderColor=\"critical-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: warning\">\n            <View borderColor=\"warning\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: warning-faded\">\n            <View borderColor=\"warning-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: positive\">\n            <View borderColor=\"positive\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: positive-faded\">\n            <View borderColor=\"positive-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: transparent, background: primary-faded\">\n            <View borderColor=\"transparent\" backgroundColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive\", \"[s] primary\", \"[m+] neutral\"]}>\n            <View borderColor={{ s: \"primary\", m: \"neutral\" }} padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--border",
 					"name": "border",
 					"snippet": "const border = () => (\n    <Example>\n        <Example.Item title=\"border: true\">\n            <View border borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderTop: true\">\n            <View borderTop borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderBottom: true\">\n            <View borderBottom borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderStart: true\">\n            <View borderStart borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderEnd: true\">\n            <View borderEnd borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderInline: true\">\n            <View borderInline borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderBlock: true\">\n            <View borderBlock borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderTop: true, borderStart: true, \">\n            <View borderColor=\"neutral\" borderTop borderStart padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"responsive\",\n                \"[s] borderTop: true, borderStart: true\",\n                \"[m+] borderBottom: true, borderEnd: true\",\n            ]}\n        >\n            <View\n                borderColor=\"neutral\"\n                borderTop={{ s: true, m: false }}\n                borderStart={{ s: true, m: false }}\n                borderBottom={{ s: false, m: true }}\n                borderEnd={{ s: false, m: true }}\n                padding={4}\n            >\n                Content\n            </View>\n        </Example.Item>\n\n        <div style={{ height: 100 }} />\n    </Example>\n);"
 				},
 				{
-					"name": "radius",
+					"id": "utility-components-view--radius",
+					"name": "borderRadius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius: small\">\n            <View borderRadius=\"small\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: medium\">\n            <View borderRadius=\"medium\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: large\">\n            <View borderRadius=\"large\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: circular\">\n            <View borderRadius=\"circular\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--shadow",
 					"name": "shadow",
 					"snippet": "const shadow = () => (\n    <Example>\n        <Example.Item title=\"shadow: raised, radius: medium\">\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                shadow=\"raised\"\n                borderRadius=\"medium\"\n                backgroundColor=\"elevation-raised\"\n            />\n        </Example.Item>\n        <Example.Item title=\"shadow: overlay, radius: medium\">\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                shadow=\"overlay\"\n                borderRadius=\"medium\"\n                backgroundColor=\"elevation-overlay\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--overflow",
 					"name": "overflow",
 					"snippet": "const overflow = () => (\n    <Example>\n        <Example.Item\n            title={[\"overflow: hidden, radius: medium\", \"child background should have radius\"]}\n        >\n            <View height=\"100px\" width=\"100px\" shadow=\"raised\" borderRadius=\"medium\" overflow=\"hidden\">\n                <View backgroundColor=\"primary\" height=\"100%\" width=\"100%\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positioning",
+					"id": "utility-components-view--positioning",
+					"name": "position",
 					"snippet": "const positioning = () => (\n    <Example>\n        <Example.Item title=\"position: relative + absolute\">\n            <View borderColor=\"neutral\" position=\"relative\">\n                <Placeholder />\n                <View\n                    position=\"absolute\"\n                    insetTop={0}\n                    insetEnd={0}\n                    backgroundColor=\"critical\"\n                    zIndex={5}\n                    height={10}\n                    width={10}\n                />\n                <View\n                    position=\"absolute\"\n                    insetTop={0}\n                    insetEnd={0}\n                    backgroundColor=\"primary\"\n                    height={15}\n                    width={15}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: sticky\">\n            <div style={{ overflow: \"auto\", height: 100 }} tabIndex={0}>\n                <View position=\"sticky\" borderColor=\"primary\" insetTop={0}>\n                    Content\n                </View>\n                <Placeholder h={1000} />\n            </div>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive\", \"[s] position: absolute\", \"[m+]: position: relative\"]}>\n            <div style={{ overflow: \"auto\", height: 100, position: \"relative\" }} tabIndex={0}>\n                <View position={{ s: \"absolute\", m: \"relative\" }} borderColor=\"primary\" insetTop={0}>\n                    Content\n                </View>\n                <Placeholder h={1000} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--inset",
 					"name": "inset",
 					"snippet": "const inset = () => (\n    <Example>\n        <Example.Item title=\"inset: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" inset={4} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetTop: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" insetTop={4} height={10} width={10} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetStart: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetStart={4}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetEnd: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" insetEnd={4} height={10} width={10} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetBottom: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetBottom={4}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"responsive, [s] insetBottom: 4 [m+] insetEnd: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetBottom={{ s: 4, m: \"auto\" }}\n                    insetEnd={{ s: \"auto\", m: 4 }}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--animated",
 					"name": "animated",
 					"snippet": "const animated = () => {\n    const [background, setBackground] = React.useState<ViewProps[\"backgroundColor\"]>(\"neutral\");\n\n    return (\n        <View gap={3} align=\"start\">\n            <Button\n                onClick={() => setBackground((prev) => (prev === \"neutral\" ? \"primary\" : \"neutral\"))}\n            >\n                Change background\n            </Button>\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                backgroundColor={background}\n                align=\"center\"\n                justify=\"center\"\n                animated\n            >\n                Content\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "itemGapBefore",
+					"id": "utility-components-view--item-gap-before",
+					"name": "item, gapBefore",
 					"snippet": "const itemGapBefore = () => (\n    <Example>\n        <Example.Item title={[\"gap: 4, 3rd item gapBefore: 10, direction: row\", \"increased gap\"]}>\n            <View direction=\"row\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={10}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 4, direction: row\", \"reduced gap\"]}>\n            <View direction=\"row\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={4}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 0, direction: row\", \"removed gap\"]}>\n            <View direction=\"row\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={0}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"gap: 4, direction: row, 2nd item gap: auto\">\n            <View direction=\"row\" gap={4}>\n                <Placeholder w={200} />\n                <View.Item gapBefore=\"auto\">\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"gap: 4, 3rd item gapBefore: 10, direction: column\", \"increased gap\"]}>\n            <View direction=\"column\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={10}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 4, direction: column\", \"reduced gap\"]}>\n            <View direction=\"column\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={4}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 0, direction: column\", \"removed gap\"]}>\n            <View direction=\"column\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={0}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"gap: 4, direction: column, height: 200px, 2nd item gap: auto\">\n            <View height=\"200px\" gap={4}>\n                <Placeholder />\n                <View.Item gapBefore=\"auto\">\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"responsive item gap\",\n                \"gap: 4, direction: row\",\n                \"[s] 3rd item gapBefore: 10\",\n                \"[m+] 3rd item gapBefore: 0\",\n            ]}\n        >\n            <View direction=\"row\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={{ s: 10, m: 0 }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemGrow",
+					"id": "utility-components-view--item-grow",
+					"name": "item, grow",
 					"snippet": "const itemGrow = () => (\n    <Example>\n        <Example.Item title=\"direction: row, 2nd item grow\">\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column, height: 200px, 2nd item grow\">\n            <View direction=\"column\" gap={3} height=\"200px\">\n                <Placeholder />\n                <View.Item grow>\n                    <Placeholder h=\"100%\" />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row, 2nd item grow, applied to View\">\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View grow>\n                    <Placeholder />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive item grow, direction: row\",\n                \"[s] 2nd item grow\",\n                \"[m+] 2nd item doesn't grow\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View.Item grow={{ s: true, m: false }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive item grow, direction: column, height: 200px\",\n                \"[s] 2nd item grow\",\n                \"[m+] 2nd item doesn't grow\",\n            ]}\n        >\n            <View direction=\"column\" gap={3} height=\"200px\">\n                <Placeholder />\n                <View.Item grow={{ s: true, m: false }}>\n                    <Placeholder h=\"100%\" />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemColumns",
+					"id": "utility-components-view--item-columns",
+					"name": "item, columns",
 					"snippet": "const itemColumns = () => (\n    <Example>\n        <Example.Item title=\"columns 6, 6, gap: 0\">\n            <View direction=\"row\">\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 3, 9, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={3}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, 9, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive columns\", \"[s] columns 6, 6, 12, gap: 4\", \"[m+]: 4, 4, 4\"]}>\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={{ s: 6, m: 4 }}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 6, m: 4 }}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 12, m: 4 }}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, 9, gap: 4, 2nd item gapBefore: 20\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6} gapBefore={20}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemOrder",
+					"id": "utility-components-view--item-order",
+					"name": "item, order",
 					"snippet": "const itemOrder = () => (\n    <Example>\n        <Example.Item title=\"order: 1 3 2\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={4}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={4} order={1}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={4}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive order\", \"[s] 1 2 3\", \"[m+] 1 3 2\"]}>\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={4}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={4} order={{ s: 0, m: 1 }}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={4}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive order\",\n                \"[s]: 1 3 2, 2 is full width on second row\",\n                \"[m+]: 1 2 3, 2 has grow in the center of the first row\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <View.Item columns={{ s: 6, m: \"auto\" }}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item\n                    grow={{ s: false, m: true }}\n                    order={{ s: 1, m: 0 }}\n                    columns={{ s: 12, m: \"auto\" }}\n                >\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 6, m: \"auto\" }}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "hiddenItem",
+					"id": "utility-components-view--hidden-item",
+					"name": "composition, Hidden item",
 					"snippet": "const hiddenItem = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"[s] 2nd item: visible, grow, 3rd item: !grow\",\n                \"[m+] 2nd item: hidden, 2nd item divider: hidden, 3rd item: grow\",\n            ]}\n        >\n            <View direction=\"row\" divided gap={3}>\n                <Placeholder />\n                <Hidden hide={{ s: false, m: true }}>\n                    <View.Item grow key=\"3\">\n                        <Placeholder />\n                    </View.Item>\n                </Hidden>\n                <View.Item grow={{ s: false, m: true }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"[s] 2nd item: visible, grow, 3rd item: !grow\",\n                \"[m+] 2nd item: hidden, 2nd item: grow doesn't push 3rd item, 3rd item: grow\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Placeholder />\n                <Hidden hide={{ s: false, m: true }}>\n                    <View.Item grow>\n                        <Placeholder />\n                    </View.Item>\n                </Hidden>\n                <View.Item grow={{ s: false, m: true }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "keys",
+					"id": "utility-components-view--keys",
+					"name": "item, key",
 					"snippet": "const keys = () => {\n    const toggle = useToggle();\n\n    return (\n        <View gap={2}>\n            <Button onClick={() => toggle.toggle()}>Toggle</Button>\n            <View.Item>Item 1</View.Item>\n            {toggle.active && <KeyItem>Item 2</KeyItem>}\n            <KeyItem>Item 3</KeyItem>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "nestedGaps",
+					"id": "utility-components-view--nested-gaps",
+					"name": "composition, nested gap",
 					"snippet": "const nestedGaps = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"direction: column, gap: 10\",\n                \"Child 1: direction: column, gap: 2\",\n                \"Child 2: direction column, gap: 6\",\n                \"Child 3: gapBefore: 0\",\n                \"Child 3 view: direction: row, gap: 2\",\n            ]}\n        >\n            <View gap={10}>\n                <View gap={2}>\n                    <Placeholder>Child 1</Placeholder>\n                    <Placeholder>Child 1</Placeholder>\n                </View>\n\n                <View gap={6}>\n                    <Placeholder>Child 2</Placeholder>\n                    <Placeholder>Child 2</Placeholder>\n                </View>\n\n                <View.Item gapBefore={0}>\n                    <View direction=\"row\" gap={2}>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "utility-components-view--test-composition",
+					"name": "composition, edge cases",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item>\n            <View direction=\"row\" align=\"center\" gap={4} padding={4}>\n                <View width=\"80px\" height=\"60px\" backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n\n                <View direction=\"row\" align=\"center\" gap={1} grow>\n                    <View.Item shrink>\n                        <Text>Text (like Jeff's Puzzles)</Text>\n                    </View.Item>\n\n                    <View minWidth=\"auto\" grow>\n                        <Button size=\"small\" color=\"neutral\" icon={IconPlus} />\n                    </View>\n                </View>\n\n                <Button color=\"primary\" rounded>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"View.Item, MenuItem, Aspect ratio\",\n                \"ratio should increase height on viewport change\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <View.Item>\n                    <Placeholder />\n                </View.Item>\n                <MenuItem selected roundedCorners>\n                    Menu\n                </MenuItem>\n                <View.Item grow>\n                    <View aspectRatio={16 / 9}>\n                        <Placeholder h=\"100%\" />\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"Scrollable tabs inside View.Item with grow\">\n            <View direction=\"row\" align=\"center\" gap={3}>\n                <Placeholder />\n                <View.Item grow>\n                    <View padding={0} align=\"center\">\n                        <Tabs variant=\"pills\">\n                            <Tabs.List>\n                                <Tabs.Item value=\"1\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"2\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"3\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"4\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"5\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"6\">Very long item</Tabs.Item>\n                            </Tabs.List>\n                            {[1, 2, 3, 5, 6].map((i) => (\n                                <Tabs.Panel key={i} value={i.toString()} />\n                            ))}\n                        </Tabs>\n                    </View>\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"2nd item has grow, Avatar stays circle\">\n            <View direction=\"row\" gap={3}>\n                <Avatar initials=\"DB\" />\n                <View.Item grow>\n                    Veggies sunt bona vobis, proinde vos postulo esse magis grape pea sprouts horseradish\n                    courgette maize spinach prairie turnip jícama coriander quandong gourd broccoli seakale\n                    gumbo. Parsley corn lentil zucchini radicchio maize burdock avocado sea lettuce.\n                    Garbanzo tigernut earthnut pea fennel.\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"item gapBefore from parent doesn't affect the child view\",\n                \"columns should take full width\",\n            ]}\n        >\n            <View>\n                <View.Item gapBefore={20}>\n                    <View direction=\"row\" gap={4}>\n                        <View.Item columns={6}>\n                            <Placeholder />\n                        </View.Item>\n                        <View.Item columns={6}>\n                            <Placeholder />\n                        </View.Item>\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"View becomes flexbox if there is a child with grow\">\n            <View height=\"300px\" borderColor=\"neutral-faded\">\n                <View height=\"50px\" />\n                <View grow backgroundColor=\"neutral-faded\" padding={4}>\n                    Grow\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "asProp",
+					"id": "utility-components-view--as-prop",
+					"name": "as",
 					"snippet": "const asProp = () => (\n    <View as=\"ul\">\n        <View.Item as=\"li\">Content</View.Item>\n    </View>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-view--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <View className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </View>\n    </div>\n);"
 				},
 				{
-					"name": "itemClassName",
+					"id": "utility-components-view--item-class-name",
+					"name": "item className, attributes",
 					"snippet": "const itemClassName = () => (\n    <div data-testid=\"root\">\n        <View.Item className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </View.Item>\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Button, Example, Hidden, MenuItem, Placeholder, Tabs, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/View/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "View",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/View/View.tsx",
-				"actualName": "View",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"divided": {
+						"defaultValue": null,
+						"description": "Render a divider between each child",
+						"name": "divided",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Flex direction for the content",
+						"name": "direction",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Direction>" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between children, base unit token number multiplier",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"wrap": {
+						"defaultValue": null,
+						"description": "Flex wrap for the content",
+						"name": "wrap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Flex align-items for the content",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Flex justify-content for the content",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width style, literal string value or a base unit token number multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"aspectRatio": {
+						"defaultValue": null,
+						"description": "Aspect ratio style, represented as width / height",
+						"name": "aspectRatio",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height style, literal string value or a base unit token number multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Maximum width style, literal string value or a base unit token number multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"minHeight": {
+						"defaultValue": null,
+						"description": "Minimum height style, literal string value or a base unit token number multiplier",
+						"name": "minHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"minWidth": {
+						"defaultValue": null,
+						"description": "Minimum width style, literal string value or a base unit token number multiplier",
+						"name": "minWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Padding style for all sides, base unit token number multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingTop": {
+						"defaultValue": null,
+						"description": "Padding top, base unit token number multiplier",
+						"name": "paddingTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingBottom": {
+						"defaultValue": null,
+						"description": "Padding bottom, base unit token number multiplier",
+						"name": "paddingBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingStart": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "paddingStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingEnd": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "paddingEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingInline": {
+						"defaultValue": null,
+						"description": "Padding inline, base unit token number multiplier",
+						"name": "paddingInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingBlock": {
+						"defaultValue": null,
+						"description": "Padding block, base unit token number multiplier",
+						"name": "paddingBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margin and remove side borders, base unit token number multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"textAlign": {
+						"defaultValue": null,
+						"description": "Text align for the content",
+						"name": "textAlign",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<TextAlign>" }
+					},
+					"backgroundColor": {
+						"defaultValue": null,
+						"description": "Background color, based on the color tokens",
+						"name": "backgroundColor",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"critical-faded\" | \"warning\" | \"warning-faded\" | \"positive-faded\" | \"primary-faded\" | \"elevation-base\" | \"elevation-raised\" | \"elevation-overlay\" | \"page\" | \"page-faded\" | \"disabled-faded\" | \"brand\" | \"white\" | \"black\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"critical-faded\"" },
+								{ "value": "\"warning\"" },
+								{ "value": "\"warning-faded\"" },
+								{ "value": "\"positive-faded\"" },
+								{ "value": "\"primary-faded\"" },
+								{ "value": "\"elevation-base\"" },
+								{ "value": "\"elevation-raised\"" },
+								{ "value": "\"elevation-overlay\"" },
+								{ "value": "\"page\"" },
+								{ "value": "\"page-faded\"" },
+								{ "value": "\"disabled-faded\"" },
+								{ "value": "\"brand\"" },
+								{ "value": "\"white\"" },
+								{ "value": "\"black\"" }
+							]
+						}
+					},
+					"borderColor": {
+						"defaultValue": null,
+						"description": "Border color, based on the color tokens",
+						"name": "borderColor",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<BorderColor>" }
+					},
+					"border": {
+						"defaultValue": null,
+						"description": "Add border to all sides",
+						"name": "border",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderTop": {
+						"defaultValue": null,
+						"description": "Add border to the top side",
+						"name": "borderTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderBottom": {
+						"defaultValue": null,
+						"description": "Add border to the bottom side",
+						"name": "borderBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderStart": {
+						"defaultValue": null,
+						"description": "Add border to the inline start side",
+						"name": "borderStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderEnd": {
+						"defaultValue": null,
+						"description": "Add border to the inline end side",
+						"name": "borderEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderInline": {
+						"defaultValue": null,
+						"description": "Add border to the inline direction",
+						"name": "borderInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderBlock": {
+						"defaultValue": null,
+						"description": "Add border to the block direction",
+						"name": "borderBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Radius>" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Position style",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Position>" }
+					},
+					"inset": {
+						"defaultValue": null,
+						"description": "Inset style, base unit token number multiplier when used as a number",
+						"name": "inset",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetStart": {
+						"defaultValue": null,
+						"description": "Inset start, base unit token number multiplier when used as a number",
+						"name": "insetStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetEnd": {
+						"defaultValue": null,
+						"description": "Inset end, base unit token number multiplier when used as a number",
+						"name": "insetEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetTop": {
+						"defaultValue": null,
+						"description": "Inset top, base unit token number multiplier when used as a number",
+						"name": "insetTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetBottom": {
+						"defaultValue": null,
+						"description": "Inset bottom, base unit token number multiplier when used as a number",
+						"name": "insetBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"zIndex": {
+						"defaultValue": null,
+						"description": "z-index style",
+						"name": "zIndex",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"shadow": {
+						"defaultValue": null,
+						"description": "Shadow style, based on the shadow tokens",
+						"name": "shadow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Overflow style",
+						"name": "overflow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"auto\"",
+							"value": [{ "value": "\"hidden\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"animated": {
+						"defaultValue": null,
+						"description": "Add transition for the properties",
+						"name": "animated",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					},
+					"grow": {
+						"defaultValue": null,
+						"description": "Apply flex-grow, using it on View.Item applies additional styles on the parent View",
+						"name": "grow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"shrink": {
+						"defaultValue": null,
+						"description": "Apply flex-shrink",
+						"name": "shrink",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "View"
 			}
 		},
 		"hooks-useelementid": {
@@ -3131,7 +16482,8 @@
 			"path": "./src/hooks/tests/useElementId.stories.tsx",
 			"stories": [
 				{
-					"name": "id",
+					"id": "hooks-useelementid--id",
+					"name": "passed id",
 					"snippet": "const id = () => {\n    return <Component id=\"hey\" />;\n};"
 				}
 			],
@@ -3148,6 +16500,7 @@
 			"path": "./src/hooks/tests/useHandlerRef.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usehandlerref--base",
 					"name": "base",
 					"snippet": "const base = (args) => {\n    const [count, setCount] = React.useState(0);\n\n    // Creating a new handler on each render\n    const handleEffect = () => {\n        args.handleEffect(0);\n    };\n\n    return (\n        <View gap={4}>\n            <Button onClick={() => setCount((prev) => prev + 1)}>Increase count</Button>\n            <Component onEffect={handleEffect} count={count} />\n        </View>\n    );\n};"
 				}
@@ -3165,43 +16518,53 @@
 			"path": "./src/hooks/tests/useHotkeys.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usehotkeys--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const { checkHotkeyState } = useHotkeys({\n        \"shift + b + n\": () => console.log(\"pressed\"),\n        \"c + v\": () => console.log(\"c + v\"),\n        \"Meta + k\": () => console.log(\"meta + k\"),\n        \"Meta + f\": () => console.log(\"meta + f\"),\n        \"Meta + v\": () => console.log(\"meta + v\"),\n        \"Meta + b\": () => console.log(\"meta + b\"),\n        \"control + enter\": () => console.log(\"control + enter\"),\n        \"meta + enter\": () => console.log(\"meta + enter\"),\n        \"mod + enter\": () => console.log(\"mod + enter\"),\n        \"mod + ArrowRight\": () => console.log(\"right\"),\n        \"mod + ArrowUp\": () => console.log(\"top\"),\n        \"shift + ArrowRight\": () => console.log(\"right\"),\n        \"shift + ArrowUp\": () => console.log(\"top\"),\n        \"alt+shift+n\": () => console.log(\"alt+shift+n\"),\n        \"shift+alt+n\": () => console.log(\"shift+alt+n\"),\n        \"alt+shiftLeft+n\": () => console.log(\"alt+shiftLeft+n\"),\n    });\n    const active = checkHotkeyState(\"shift + b + n\");\n    const shiftActive = checkHotkeyState(\"shift\");\n    const bActive = checkHotkeyState(\"b\");\n    const nActive = checkHotkeyState(\"n\");\n\n    return (\n        <View\n            animated\n            gap={2}\n            direction=\"row\"\n            backgroundColor={active ? \"positive-faded\" : undefined}\n            padding={2}\n            borderRadius=\"small\"\n        >\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={shiftActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={shiftActive ? undefined : \"raised\"}\n            >\n                Shift\n            </View>\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={bActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={bActive ? undefined : \"raised\"}\n            >\n                b\n            </View>\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={nActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={nActive ? undefined : \"raised\"}\n            >\n                n\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "singleKey",
+					"id": "hooks-usehotkeys--single-key",
+					"name": "single key",
 					"snippet": "const singleKey = (args) => <Component hotkeys={{ a: args.handleHotkey }} />;"
 				},
 				{
-					"name": "modKey",
+					"id": "hooks-usehotkeys--mod-key",
+					"name": "mod key",
 					"snippet": "const modKey = (args) => <Component hotkeys={{ mod: args.handleHotkey }} />;"
 				},
 				{
-					"name": "modKeyHold",
+					"id": "hooks-usehotkeys--mod-key-hold",
+					"name": "mod key on hold",
 					"snippet": "const modKeyHold = (args) => <Component hotkeys={{ \"Meta + b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyList",
+					"id": "hooks-usehotkeys--key-list",
+					"name": "key list",
 					"snippet": "const keyList = (args) => <Component hotkeys={{ \"a,b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombination",
+					"id": "hooks-usehotkeys--key-combination",
+					"name": "key combination",
 					"snippet": "const keyCombination = (args) => <Component hotkeys={{ \"a+b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationFormat",
+					"id": "hooks-usehotkeys--key-combination-format",
+					"name": "key combination without formatting",
 					"snippet": "const keyCombinationFormat = (args) => <Component hotkeys={{ \"A  + b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationOrder",
+					"id": "hooks-usehotkeys--key-combination-order",
+					"name": "key combination without order",
 					"snippet": "const keyCombinationOrder = (args) => <Component hotkeys={{ \"b+a\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationMoreThanRequired",
+					"id": "hooks-usehotkeys--key-combination-more-than-required",
+					"name": "key combination, more keys pressed",
 					"snippet": "const keyCombinationMoreThanRequired = (args) => <Component hotkeys={{ \"z + x\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "optionModified",
+					"id": "hooks-usehotkeys--option-modified",
+					"name": "modified with alt/option",
 					"snippet": "const optionModified = (args) => (\n    <Component hotkeys={{ \"alt+n\": args.handleHotkeyModified, \"alt+shift\": args.handleHotkey }} />\n);"
 				}
 			],
@@ -3218,22 +16581,27 @@
 			"path": "./src/hooks/tests/useKeyboardArrowNavigation.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usekeyboardarrownavigation--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "horizontal",
+					"id": "hooks-usekeyboardarrownavigation--horizontal",
+					"name": "orientation: horizontal",
 					"snippet": "const horizontal = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, orientation: \"horizontal\" });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "vertical",
+					"id": "hooks-usekeyboardarrownavigation--vertical",
+					"name": "orientation: vertical",
 					"snippet": "const vertical = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, orientation: \"vertical\" });\n\n    return (\n        <View gap={2} direction=\"column\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-usekeyboardarrownavigation--circular",
 					"name": "circular",
 					"snippet": "const circular = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, circular: true });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-usekeyboardarrownavigation--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, disabled: true });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				}
@@ -3249,7 +16617,13 @@
 			"id": "hooks-usekeyboardmode",
 			"name": "useKeyboardMode",
 			"path": "./src/hooks/tests/useKeyboardMode.stories.tsx",
-			"stories": [{ "name": "base", "snippet": "const base = () => <Component />;" }],
+			"stories": [
+				{
+					"id": "hooks-usekeyboardmode--base",
+					"name": "base",
+					"snippet": "const base = () => <Component />;"
+				}
+			],
 			"import": "import { Button, View } from \"reshaped\";",
 			"jsDocTags": {},
 			"error": {
@@ -3263,19 +16637,23 @@
 			"path": "./src/hooks/tests/useOnClickOutside.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-useonclickoutside--base",
 					"name": "base",
 					"snippet": "const base = (args) => {\n    const ref = React.useRef(null);\n    const [target, setTarget] = React.useState<\"inside\" | \"outside\" | null>(null);\n\n    useOnClickOutside([ref], () => {\n        args.handleOutsideClick();\n        setTarget(\"outside\");\n    });\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }} onClick={() => setTarget(\"inside\")}>\n                Trigger\n            </Button>\n            {target && `Clicked ${target}`}\n        </View>\n    );\n};"
 				},
 				{
-					"name": "refs",
+					"id": "hooks-useonclickoutside--refs",
+					"name": "multiple refs",
 					"snippet": "const refs = (args) => {\n    const ref = React.useRef(null);\n    const ref2 = React.useRef(null);\n\n    useOnClickOutside([ref, ref2], () => {\n        args.handleOutsideClick();\n    });\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }}>Trigger</Button>\n            <Button attributes={{ ref: ref2 }}>Trigger 2</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-useonclickoutside--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = (args) => {\n    const ref = React.useRef(null);\n\n    useOnClickOutside(\n        [ref],\n        () => {\n            args.handleOutsideClick();\n        },\n        {\n            disabled: true,\n        }\n    );\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }}>Trigger</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "deps",
+					"id": "hooks-useonclickoutside--deps",
+					"name": "test: handler uses latest state",
 					"snippet": "const deps = (args) => {\n    const ref = React.useRef(null);\n    const [count, setCount] = React.useState(0);\n\n    useOnClickOutside([ref], () => {\n        args.handleOutsideClick({ count });\n    });\n\n    return (\n        <Button attributes={{ ref }} onClick={() => setCount((prev) => prev + 1)}>\n            Trigger\n        </Button>\n    );\n};"
 				}
 			],
@@ -3290,7 +16668,13 @@
 			"id": "hooks-usertl",
 			"name": "useRTL",
 			"path": "./src/hooks/tests/useRTL.stories.tsx",
-			"stories": [{ "name": "setRTL", "snippet": "const setRTL = () => <Component />;" }],
+			"stories": [
+				{
+					"id": "hooks-usertl--set-rtl",
+					"name": "setRTL",
+					"snippet": "const setRTL = () => <Component />;"
+				}
+			],
 			"import": "",
 			"jsDocTags": {},
 			"error": {
@@ -3304,10 +16688,12 @@
 			"path": "./src/hooks/tests/useResponsiveClientValue.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-useresponsiveclientvalue--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const value = useResponsiveClientValue<ViewProps[\"backgroundColor\"]>({\n        s: \"neutral\",\n        m: \"critical\",\n        l: \"positive\",\n    });\n\n    return <View width={25} height={25} backgroundColor={value} />;\n};"
 				},
 				{
+					"id": "hooks-useresponsiveclientvalue--boolean",
 					"name": "boolean",
 					"snippet": "const boolean = () => {\n    const value = useResponsiveClientValue<boolean>({\n        s: true,\n        l: false,\n    });\n\n    return <div>{value?.toString()}</div>;\n};"
 				}
@@ -3325,19 +16711,23 @@
 			"path": "./src/hooks/tests/useScrollLock.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usescrolllock--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock();\n\n    return (\n        <React.Fragment>\n            <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n            <div style={{ height: \"150vh\" }} />\n        </React.Fragment>\n    );\n};"
 				},
 				{
-					"name": "origin",
+					"id": "hooks-usescrolllock--origin",
+					"name": "originRef",
 					"snippet": "const origin = () => {\n    const originRef = React.useRef<HTMLDivElement>(null);\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock({ originRef });\n\n    return (\n        <View overflow=\"auto\" height={25} attributes={{ ref: originRef, \"data-testid\": \"root\" }}>\n            <View height={50} padding={4} backgroundColor=\"neutral-faded\" borderRadius=\"medium\">\n                <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "container",
+					"id": "hooks-usescrolllock--container",
+					"name": "containerRef",
 					"snippet": "const container = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock({ containerRef });\n\n    return (\n        <View height={25} attributes={{ ref: containerRef, \"data-testid\": \"root\" }}>\n            <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testContainerAsync",
+					"id": "hooks-usescrolllock--test-container-async",
+					"name": "test: containerRef locked count",
 					"snippet": "const testContainerAsync = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const globalLock = useScrollLock();\n    const scopedLock = useScrollLock({ containerRef });\n\n    return (\n        <Example>\n            <Example.Item title=\"calling regular lock and lock with a container only requires a single unlock to remove overflow\">\n                <View attributes={{ ref: containerRef }} gap={4} direction=\"row\">\n                    <Button\n                        onClick={globalLock.scrollLocked ? globalLock.unlockScroll : globalLock.lockScroll}\n                    >\n                        Toggle\n                    </Button>\n                    <Button\n                        onClick={scopedLock.scrollLocked ? scopedLock.unlockScroll : scopedLock.lockScroll}\n                    >\n                        Toggle\n                    </Button>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
@@ -3354,14 +16744,17 @@
 			"path": "./src/hooks/tests/useToggle.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usetoggle--toggle",
 					"name": "toggle",
 					"snippet": "const toggle = () => {\n    const { toggle, active } = useToggle();\n\n    return (\n        <Button onClick={() => toggle()} attributes={{ \"data-active\": active }}>\n            {active ? \"Deactivate\" : \"Activate\"}\n        </Button>\n    );\n};"
 				},
 				{
+					"id": "hooks-usetoggle--activate",
 					"name": "activate",
 					"snippet": "const activate = () => {\n    const { activate, active } = useToggle();\n\n    return (\n        <React.Fragment>\n            <Button onClick={activate} attributes={{ \"data-active\": active }}>\n                Activate\n            </Button>\n        </React.Fragment>\n    );\n};"
 				},
 				{
+					"id": "hooks-usetoggle--deactivate",
 					"name": "deactivate",
 					"snippet": "const deactivate = () => {\n    const { deactivate, active } = useToggle(true);\n\n    return (\n        <Button onClick={deactivate} attributes={{ \"data-active\": active }}>\n            Deactivate\n        </Button>\n    );\n};"
 				}
@@ -3379,39 +16772,48 @@
 			"path": "./src/utilities/a11y/tests/TrapFocus.stories.tsx",
 			"stories": [
 				{
-					"name": "modeDialog",
+					"id": "utilities-trapfocus--mode-dialog",
+					"name": "mode: dialog",
 					"snippet": "const modeDialog = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, { mode: \"dialog\" });\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\"mode: dialog\", \"tab navigation, always stays inside until released\"]}\n            >\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View.Item>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeActionMenu",
+					"id": "utilities-trapfocus--mode-action-menu",
+					"name": "mode: action-menu",
 					"snippet": "const modeActionMenu = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"action-menu\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: action-menu\",\n                    \"up/down arrow navigation, tab and shift+tab release the focus and follows natural tab order\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeActionBar",
+					"id": "utilities-trapfocus--mode-action-bar",
+					"name": "mode: action-bar",
 					"snippet": "const modeActionBar = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"action-bar\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: action-bar\",\n                    \"left/right arrow navigation, tab and shift+tab release the focus and follows natural tab order\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeContentMenu",
+					"id": "utilities-trapfocus--mode-content-menu",
+					"name": "mode: content-menu",
 					"snippet": "const modeContentMenu = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"content-menu\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: content-menu\",\n                    \"tab navigation, tabbing outside the content will trigger the release\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utilities-trapfocus--include-trigger",
 					"name": "includeTrigger",
 					"snippet": "const includeTrigger = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n            includeTrigger: true,\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utilities-trapfocus--initial-focus-el",
 					"name": "initialFocusEl",
 					"snippet": "const initialFocusEl = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const initialFocusRef = React.useRef<HTMLButtonElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n            initialFocusEl: initialFocusRef.current,\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View\n                            gap={4}\n                            direction=\"row\"\n                            padding={4}\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            attributes={{ ref: rootRef }}\n                        >\n                            <Button onClick={() => {}}>Action 1</Button>\n                            <Button onClick={() => {}} attributes={{ ref: initialFocusRef }}>\n                                Action 2\n                            </Button>\n                            <Button onClick={() => {}}>Action 3</Button>\n                            <Button onClick={trapToggle.deactivate}>Release</Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "focusableElements",
+					"id": "utilities-trapfocus--focusable-elements",
+					"name": "test: focusable elements",
 					"snippet": "const focusableElements = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current);\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title=\"test with all types of focusable elements\">\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={trapToggle.activate}>Activate</Button>\n                    </View.Item>\n\n                    {trapToggle.active && (\n                        <View\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            padding={4}\n                            gap={4}\n                            attributes={{ ref: rootRef }}\n                            align=\"start\"\n                        >\n                            <Link href=\"#\" attributes={{ \"data-testid\": \"test-link\" }}>\n                                Link\n                            </Link>\n\n                            <TextField\n                                name=\"input\"\n                                placeholder=\"Input\"\n                                inputAttributes={{ \"data-testid\": \"test-text-field\" }}\n                            />\n\n                            <TextArea name=\"textarea\" inputAttributes={{ \"data-testid\": \"test-text-area\" }} />\n\n                            <Select\n                                name=\"select\"\n                                options={[\n                                    { label: \"Option 1\", value: \"1\" },\n                                    { label: \"Option 2\", value: \"2\" },\n                                ]}\n                                inputAttributes={{ \"data-testid\": \"test-select\" }}\n                            />\n\n                            <RadioGroup name=\"radio\">\n                                <Radio value=\"1\" inputAttributes={{ \"data-testid\": \"test-radio-1\" }}>\n                                    Option 1\n                                </Radio>\n                                <Radio value=\"2\" inputAttributes={{ \"data-testid\": \"test-radio-2\" }}>\n                                    Option 2\n                                </Radio>\n                            </RadioGroup>\n\n                            <Editor />\n\n                            <div tabIndex={0} role=\"button\" data-testid=\"test-tabindex\">\n                                div with tabIndex\n                            </div>\n\n                            <div style={{ display: \"none\" }}>\n                                <Button onClick={() => {}} attributes={{ \"data-testid\": \"test-hidden-button\" }}>\n                                    Hidden\n                                </Button>\n                            </div>\n\n                            <Button\n                                onClick={() => {}}\n                                attributes={{ tabIndex: -1, \"data-testid\": \"test-button-negative-tabindex\" }}\n                            >\n                                Excluded\n                            </Button>\n\n                            <input type=\"hidden\" data-testid=\"test-input-hidden\" />\n\n                            <Button\n                                onClick={trapToggle.deactivate}\n                                attributes={{ \"data-testid\": \"test-button\" }}\n                            >\n                                Release button\n                            </Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "nested",
+					"id": "utilities-trapfocus--nested",
+					"name": "test: nested",
 					"snippet": "const nested = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const innerRootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n    const innerTrapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    React.useEffect(() => {\n        if (!innerTrapToggle.active) return;\n        if (!innerRootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(innerRootRef.current, {\n            mode: \"dialog\",\n        });\n\n        return () => trapFocus.release();\n    }, [innerTrapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"nested, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View gap={4}>\n                            <View\n                                gap={4}\n                                direction=\"row\"\n                                padding={4}\n                                backgroundColor=\"neutral-faded\"\n                                borderRadius=\"medium\"\n                                attributes={{ ref: rootRef }}\n                            >\n                                <Button onClick={() => {}}>Action</Button>\n                                <Button onClick={innerTrapToggle.activate}>Inner trap focus</Button>\n                                <Button onClick={trapToggle.deactivate}>Release</Button>\n                            </View>\n\n                            {innerTrapToggle.active && (\n                                <View\n                                    gap={4}\n                                    direction=\"row\"\n                                    padding={4}\n                                    backgroundColor=\"neutral-faded\"\n                                    borderRadius=\"medium\"\n                                    attributes={{ ref: innerRootRef }}\n                                >\n                                    <Button onClick={() => {}}>Action</Button>\n                                    <Button onClick={innerTrapToggle.deactivate}>Release</Button>\n                                </View>\n                            )}\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "mutationObserver",
+					"id": "utilities-trapfocus--mutation-observer",
+					"name": "test: mutation observer",
 					"snippet": "const mutationObserver = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n    const [mutated, setMutated] = React.useState(false);\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n        });\n\n        setTimeout(() => {\n            setMutated(true);\n        }, 50);\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View\n                            gap={4}\n                            direction=\"row\"\n                            padding={4}\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            attributes={{ ref: rootRef }}\n                        >\n                            {!mutated && (\n                                <>\n                                    <Button onClick={() => {}}>Action 1</Button>\n                                    <Button onClick={() => {}}>Action 2</Button>\n                                </>\n                            )}\n                            <Button onClick={() => {}}>Action 3</Button>\n                            <Button onClick={trapToggle.deactivate}>Release</Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
@@ -3428,15 +16830,35 @@
 			"path": "./src/components/_private/Portal/tests/Portal.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "internal-portal--base",
+					"name": "Base",
 					"snippet": "const base = () => {\n\tconst ref = React.useRef<HTMLDivElement>(null);\n\tconst [mounted, setMounted] = React.useState(false);\n\n\tReact.useEffect(() => {\n\t\tsetMounted(true);\n\t}, []);\n\n\treturn (\n\t\t<>\n\t\t\t<div style={{ border: \"2px solid #333\", padding: 16 }}>\n\t\t\t\tApp\n\t\t\t\t{mounted && <Portal targetRef={ref}>Ported to green</Portal>}\n\t\t\t</div>\n\t\t\t<div ref={ref} style={{ border: \"2px solid green\", padding: 16 }} />\n\t\t</>\n\t);\n};"
 				}
 			],
 			"import": "import { Portal } from \"reshaped\";",
 			"jsDocTags": {},
-			"error": {
-				"name": "No component definition found",
-				"message": "File: /Users/shilman/projects/design-systems/reshaped/src/components/_private/Portal/index.ts\nError:\nNo suitable component definition found.\nYou can debug your component file in this playground: https://react-docgen.dev/playground\nCode:\nimport Portal, { PortalScope } from \"./Portal\";\n\nconst PortalRoot = Portal as typeof Portal & {\n\tScope: typeof PortalScope;\n};\n\nPortalRoot.Scope = PortalScope;\n\nexport default PortalRoot;\nexport type { Props as PortalProps } from \"./Portal.types\";\n\n\nFile: /Users/shilman/projects/design-systems/reshaped/src/components/_private/Portal/Portal.types.ts\nError:\nNo suitable component definition found.\nYou can debug your component file in this playground: https://react-docgen.dev/playground\nCode:\nimport React from \"react\";\n\nexport type Props = {\n\tchildren?: React.ReactNode;\n\ttargetRef?: React.RefObject<HTMLElement | ShadowRoot | null>;\n};\n\nexport type ScopeProps<T extends HTMLElement> = {\n\tchildren: (ref: React.RefObject<T | null>) => React.ReactNode;\n};\n\nexport type Context = {\n\tscopeRef: React.RefObject<HTMLElement | null>;\n};\n"
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/_private/Portal/index.ts",
+				"description": "",
+				"displayName": "Portal",
+				"methods": [],
+				"props": {
+					"targetRef": {
+						"defaultValue": null,
+						"description": "",
+						"name": "targetRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/_private/Portal/Portal.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | ShadowRoot | null>" }
+					}
+				},
+				"exportName": "Portal"
 			}
 		},
 		"internal-usedrag": {
@@ -3444,24 +16866,33 @@
 			"name": "useDrag",
 			"path": "./src/hooks/tests/useDrag.stories.tsx",
 			"stories": [
-				{ "name": "base", "snippet": "const base = () => <Example />;" },
 				{
-					"name": "mouseEvents",
+					"id": "internal-usedrag--base",
+					"name": "base",
+					"snippet": "const base = () => <Example />;"
+				},
+				{
+					"id": "internal-usedrag--mouse-events",
+					"name": "onDrag, mouse events",
 					"snippet": "const mouseEvents = () => {\n    return <Demo onDrag={fn()} />;\n};"
 				},
 				{
-					"name": "touchEvents",
+					"id": "internal-usedrag--touch-events",
+					"name": "onDrag, touch events",
 					"snippet": "const touchEvents = () => {\n    return <Demo onDrag={fn()} />;\n};"
 				},
 				{
-					"name": "orientationHorizontal",
+					"id": "internal-usedrag--orientation-horizontal",
+					"name": "orientation horizontal",
 					"snippet": "const orientationHorizontal = () => {\n    return <Demo onDrag={fn()} orientation=\"horizontal\" />;\n};"
 				},
 				{
-					"name": "orientationVertical",
+					"id": "internal-usedrag--orientation-vertical",
+					"name": "orientation vertical",
 					"snippet": "const orientationVertical = () => {\n    return <Demo onDrag={fn()} orientation=\"vertical\" />;\n};"
 				},
 				{
+					"id": "internal-usedrag--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => {\n    return <Demo onDrag={fn()} disabled />;\n};"
 				}
@@ -3479,7 +16910,8 @@
 			"path": "./src/tests/ShadowDOM.stories.tsx",
 			"stories": [
 				{
-					"name": "behavior",
+					"id": "internal-shadowdom--behavior",
+					"name": "Behavior",
 					"snippet": "const behavior = () => (\n\t<Example>\n\t\t<Example.Item title=\"base\">\n\t\t\t<Component />\n\t\t</Example.Item>\n\t</Example>\n);"
 				}
 			],
@@ -3496,30 +16928,94 @@
 			"path": "./src/tests/themes.stories.tsx",
 			"stories": [
 				{
-					"name": "test",
+					"id": "internal-themes--test",
+					"name": "Test",
 					"snippet": "const test = () => {\n\tconst { colorMode } = useTheme();\n\tconst [activeColor, setColor] = useState(colors[0]);\n\tconst [theme, setTheme] = useState(\"\");\n\tconst [algo, setAlgo] = useState<\"wcag\" | \"apca\">(\"wcag\");\n\n\tuseLayoutEffect(() => {\n\t\tsetTheme(\n\t\t\tgetThemeCSS(\n\t\t\t\t\"test\",\n\t\t\t\t{\n\t\t\t\t\tcolor: generateThemeColors({\n\t\t\t\t\t\tprimary: activeColor === colors[0] ? undefined : activeColor,\n\t\t\t\t\t}),\n\t\t\t\t},\n\t\t\t\t{\n\t\t\t\t\tcolorContrastAlgorithm: algo,\n\t\t\t\t}\n\t\t\t)\n\t\t);\n\t}, [activeColor, algo]);\n\n\treturn (\n\t\t<>\n\t\t\t<style>{theme}</style>\n\t\t\t<Theme name=\"test\">\n\t\t\t\t<View gap={4}>\n\t\t\t\t\t<View direction=\"row\" align=\"center\" gap={4}>\n\t\t\t\t\t\t{colors.map((color) => {\n\t\t\t\t\t\t\tconst hex = colorMode === \"dark\" && color === \"#000000\" ? \"#ffffff\" : color;\n\n\t\t\t\t\t\t\treturn (\n\t\t\t\t\t\t\t\t<Actionable key={color} onClick={() => setColor(color)} borderRadius=\"inherit\">\n\t\t\t\t\t\t\t\t\t<View\n\t\t\t\t\t\t\t\t\t\twidth={5}\n\t\t\t\t\t\t\t\t\t\theight={5}\n\t\t\t\t\t\t\t\t\t\tborderRadius=\"circular\"\n\t\t\t\t\t\t\t\t\t\tattributes={{\n\t\t\t\t\t\t\t\t\t\t\tstyle: {\n\t\t\t\t\t\t\t\t\t\t\t\ttransition: `box-shadow var(--rs-duration-fast) var(--rs-easing-standard)`,\n\t\t\t\t\t\t\t\t\t\t\t\tbackground: hex,\n\t\t\t\t\t\t\t\t\t\t\t\tboxShadow:\n\t\t\t\t\t\t\t\t\t\t\t\t\tcolor === activeColor\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t? `0 0 0 3px var(--rs-color-background-elevation-base), 0 0 0 5px ${hex}`\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t: undefined,\n\t\t\t\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t\t\t\t}}\n\t\t\t\t\t\t\t\t\t/>\n\t\t\t\t\t\t\t\t</Actionable>\n\t\t\t\t\t\t\t);\n\t\t\t\t\t\t})}\n\t\t\t\t\t\t<View.Item gapBefore=\"auto\">\n\t\t\t\t\t\t\t<Switch name=\"algo\" onChange={(args) => setAlgo(args.checked ? \"apca\" : \"wcag\")}>\n\t\t\t\t\t\t\t\tUse APCA\n\t\t\t\t\t\t\t</Switch>\n\t\t\t\t\t\t</View.Item>\n\t\t\t\t\t</View>\n\n\t\t\t\t\t<ThemePlayground />\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</>\n\t);\n};"
 				},
 				{
-					"name": "base",
+					"id": "internal-themes--base",
+					"name": "Base",
 					"snippet": "const base = () => (\n\t<Example>\n\t\t<Example.Item title=\"custom runtime theme\">\n\t\t\t<style>{css}</style>\n\t\t\t<Theme name=\"green\">\n\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"on colors generation\">\n\t\t\t<style>{css2}</style>\n\t\t\t<Theme name=\"peach\">\n\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "generation",
+					"id": "internal-themes--generation",
+					"name": "Generation",
 					"snippet": "const generation = () => (\n\t<div>\n\t\t<style>{cssGenerated}</style>\n\t\t<Theme name=\"generated\">{componentExamples}</Theme>\n\t</div>\n);"
 				},
 				{
-					"name": "onColors",
+					"id": "internal-themes--on-colors",
+					"name": "On Colors",
 					"snippet": "const onColors = () => (\n\t<Example>\n\t\t<Example.Item title=\"custom on color values\">\n\t\t\t<style>{onColorsCss}</style>\n\t\t\t<Theme name=\"on-color\">\n\t\t\t\t<View gap={2} direction=\"row\">\n\t\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t\t\t<Button color=\"critical\">Critical button</Button>\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"custom on color values, apca\">\n\t\t\t<style>{onColorsCssApca}</style>\n\t\t\t<Theme name=\"on-color-apca\">\n\t\t\t\t<View gap={2} direction=\"row\">\n\t\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t\t\t<Button color=\"critical\">Critical button</Button>\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t</Example>\n);"
 				}
 			],
 			"import": "import {\n    Actionable,\n    Alert,\n    Avatar,\n    Badge,\n    Button,\n    Card,\n    DropdownMenu,\n    Example,\n    Link,\n    Switch,\n    Text,\n    TextField,\n    Theme,\n    ThemePlayground,\n    View,\n} from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Theme/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Theme",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Theme/Theme.tsx",
-				"actualName": "Theme",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the theme to use, enables controlled mode",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"defaultName": {
+						"defaultValue": null,
+						"description": "Default name of the theme to use, enables uncontrolled mode",
+						"name": "defaultName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode to use",
+						"name": "colorMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode | \"inverted\"",
+							"value": [
+								{ "value": "\"light\"" },
+								{ "value": "\"dark\"" },
+								{ "value": "\"inverted\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -3529,7 +17025,8 @@
 			"path": "./src/Sandbox.stories.tsx",
 			"stories": [
 				{
-					"name": "preview",
+					"id": "sandbox--preview",
+					"name": "Preview",
 					"snippet": "const preview = () => {\n\treturn (\n\t\t<Preview>\n\t\t\t<Component />\n\t\t</Preview>\n\t);\n};"
 				}
 			],
@@ -3540,5 +17037,6 @@
 				"message": "We could not detect the component from your story file. Specify meta.component.\n   7 | import MenuItem from \"components/MenuItem\";\n   8 |\n>  9 | export default {\n     | ^\n  10 | \ttitle: \"Sandbox\",\n  11 | \tchromatic: { disableSnapshot: true },\n  12 | };\n\n./src/Sandbox.stories.tsx:\nimport View from \"components/View\";\nimport Image from \"components/Image\";\nimport React from \"react\";\nimport Select from \"components/Select\";\nimport useToggle from \"hooks/useToggle\";\nimport Modal from \"components/Modal\";\nimport MenuItem from \"components/MenuItem\";\n\nexport default {\n\ttitle: \"Sandbox\",\n\tchromatic: { disableSnapshot: true },\n};\n\nconst Preview: React.FC<{ children: React.ReactNode }> = (props) => {\n\treturn (\n\t\t<View padding={20} gap={6}>\n\t\t\t<View position=\"absolute\" insetTop={0} insetStart={0}>\n\t\t\t\t<Image src=\"./logo.svg\" />\n\t\t\t</View>\n\n\t\t\t{props.children}\n\t\t</View>\n\t);\n};\n\nexport const preview = () => {\n\treturn (\n\t\t<Preview>\n\t\t\t<Component />\n\t\t</Preview>\n\t);\n};\n\nconst Component = () => {\n\tconst toggle = useToggle();\n\tconst [value, setValue] = React.useState(\"Dog\");\n\n\tconst handleClick = () => {\n\t\ttoggle.toggle();\n\t};\n\n\treturn (\n\t\t<>\n\t\t\t<Select name=\"animal\" placeholder=\"Select an animal\" onClick={handleClick}>\n\t\t\t\t{value}\n\t\t\t</Select>\n\t\t\t<Modal active={toggle.active} onClose={toggle.deactivate} position=\"bottom\" padding={2}>\n\t\t\t\t<MenuItem\n\t\t\t\t\troundedCorners\n\t\t\t\t\tonClick={() => {\n\t\t\t\t\t\tsetValue(\"Dog\");\n\t\t\t\t\t\ttoggle.deactivate();\n\t\t\t\t\t}}\n\t\t\t\t\tattributes={{\n\t\t\t\t\t\trole: \"option\",\n\t\t\t\t\t}}\n\t\t\t\t>\n\t\t\t\t\tDog\n\t\t\t\t</MenuItem>\n\t\t\t\t<MenuItem\n\t\t\t\t\troundedCorners\n\t\t\t\t\tattributes={{\n\t\t\t\t\t\trole: \"option\",\n\t\t\t\t\t}}\n\t\t\t\t\tonClick={() => {\n\t\t\t\t\t\tsetValue(\"Turtle\");\n\t\t\t\t\t\ttoggle.deactivate();\n\t\t\t\t\t}}\n\t\t\t\t>\n\t\t\t\t\tTurtle\n\t\t\t\t</MenuItem>\n\t\t\t</Modal>\n\t\t</>\n\t);\n};\n"
 			}
 		}
-	}
+	},
+	"meta": { "docgen": "react-docgen-typescript", "durationMs": 2919 }
 }

--- a/eval/tasks/902-create-component-composite-reshaped/manifests/components.json
+++ b/eval/tasks/902-create-component-composite-reshaped/manifests/components.json
@@ -7,46 +7,201 @@
 			"path": "./src/components/ActionBar/tests/ActionBar.stories.tsx",
 			"stories": [
 				{
-					"name": "positionRelative",
+					"id": "components-actionbar--position-relative",
+					"name": "position, positionType: relative",
 					"snippet": "const positionRelative = () => (\n    <Example>\n        <Example.Item title=\"position: top\">\n            <ActionBar position=\"top\">\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <ActionBar position=\"bottom\">\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positionAbsolute",
+					"id": "components-actionbar--position-absolute",
+					"name": "position, positionType: absolute",
 					"snippet": "const positionAbsolute = () => (\n    <Example>\n        <Example.Item title=\"position: top-start\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top-start\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: top\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: top-end\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top-end\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom-start\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom-start\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom-end\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positionFixed",
+					"id": "components-actionbar--position-fixed",
+					"name": "position, positionType: fixed",
 					"snippet": "const positionFixed = () => (\n    <>\n        <ActionBar padding={2} position=\"top-start\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"top\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"top-end\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom-start\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom-end\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <div style={{ height: 2000 }} />\n    </>\n);"
 				},
 				{
+					"id": "components-actionbar--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated, position: top\">\n            <ActionBar position=\"top\" elevated>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"elevated, position: bottom\">\n            <ActionBar elevated>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"auto elevated, position: bottom\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-actionbar--offset",
 					"name": "offset",
 					"snippet": "const offset = () => (\n    <Example>\n        <Example.Item title=\"offset 2, position: top\">\n            <Fixtures.Container>\n                <ActionBar position=\"top\" positionType=\"absolute\" offset={2}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"offset 2, position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\" offset={2}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"offset s: 2, m: 4, position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\" offset={{ s: 2, m: 4 }}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-actionbar--active",
 					"name": "active",
 					"snippet": "const active = () => {\n    const barToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => barToggle.toggle()}>Toggle</Button>\n            <ActionBar active={barToggle.active} positionType=\"fixed\" position=\"top-end\">\n                <Fixtures.Actions />\n            </ActionBar>\n        </>\n    );\n};"
 				},
 				{
-					"name": "padding",
+					"id": "components-actionbar--padding",
+					"name": "padding, paddingBlock, paddingInline",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 6\">\n            <ActionBar padding={6}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"paddingBlock: 2, paddingInline: 4\">\n            <ActionBar paddingBlock={2} paddingInline={4}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"padding: [s] 4, [m+] 6\">\n            <ActionBar padding={{ s: 4, m: 6 }}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-actionbar--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ActionBar className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </ActionBar>\n    </div>\n);"
 				}
 			],
 			"import": "import { ActionBar, Button, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ActionBar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ActionBar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ActionBar/ActionBar.tsx",
-				"actualName": "ActionBar",
+				"methods": [],
+				"props": {
+					"paddingBlock": {
+						"defaultValue": null,
+						"description": "Padding block, base unit token number multiplier",
+						"name": "paddingBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingInline": {
+						"defaultValue": null,
+						"description": "Padding inline, base unit token number multiplier",
+						"name": "paddingInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Padding style for all sides, base unit token number multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Show or hide the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"offset": {
+						"defaultValue": null,
+						"description": "Offset from the container bounds",
+						"name": "offset",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"position": {
+						"defaultValue": { "value": "\"bottom\"" },
+						"description": "Position based on the container bounds",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"top-end\" | \"top-start\" | \"bottom\" | \"bottom-start\" | \"bottom-end\"",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" }
+							]
+						}
+					},
+					"positionType": {
+						"defaultValue": null,
+						"description": "CSS position style",
+						"name": "positionType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"relative\" | \"absolute\" | \"fixed\">" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Display above the content with elevated shadow and background",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -56,30 +211,138 @@
 			"path": "./src/components/Alert/tests/Alert.stories.tsx",
 			"stories": [
 				{
+					"id": "components-alert--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        {([\"neutral\", \"primary\", \"critical\", \"positive\", \"warning\"] as const).map((color) => (\n            <Example.Item title={`color: ${color}`} key={color}>\n                <Alert\n                    color={color}\n                    title=\"Alert title goes here\"\n                    icon={IconZap}\n                    actionsSlot={\n                        <>\n                            <Link\n                                variant=\"plain\"\n                                color={color === \"neutral\" ? \"primary\" : color}\n                                onClick={() => {}}\n                            >\n                                View now\n                            </Link>\n                            <Link\n                                variant=\"plain\"\n                                color={color === \"neutral\" ? \"primary\" : color}\n                                onClick={() => {}}\n                            >\n                                Dismiss\n                            </Link>\n                        </>\n                    }\n                >\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard\n                </Alert>\n            </Example.Item>\n        ))}\n    </Example>\n);"
 				},
 				{
+					"id": "components-alert--inline",
 					"name": "inline",
 					"snippet": "const inline = () => (\n    <Example>\n        <Example.Item title=\"inline: true\">\n            <Alert\n                inline\n                title=\"Alert title goes here\"\n                icon={IconZap}\n                actionsSlot={\n                    <>\n                        <Link variant=\"plain\" onClick={() => {}}>\n                            View now\n                        </Link>\n                        <Link variant=\"plain\" onClick={() => {}}>\n                            Dismiss\n                        </Link>\n                    </>\n                }\n            >\n                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has\n                been the industry's standard\n            </Alert>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-alert--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4\">\n            <Alert bleed={4} icon={IconZap}>\n                Content\n            </Alert>\n        </Example.Item>\n        <Example.Item title=\"bleed: [s] 4, [m+] 0\">\n            <Alert bleed={{ s: 4, m: 0 }} icon={IconZap}>\n                Content\n            </Alert>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-alert--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Alert className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </Alert>\n    </div>\n);"
 				}
 			],
 			"import": "import { Alert, Example, Link, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Alert/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Alert",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Alert/Alert.tsx",
-				"actualName": "Alert",
+				"methods": [],
+				"props": {
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"title": {
+						"defaultValue": null,
+						"description": "Title slot",
+						"name": "title",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Slot for rendering the main content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"actionsSlot": {
+						"defaultValue": null,
+						"description": "Actions slot, usually used for Buttons and Links, automatically adds a gap between the actions",
+						"name": "actionsSlot",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Color scheme of the alert elements",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"inline": {
+						"defaultValue": null,
+						"description": "Display action to the right of the content",
+						"name": "inline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margin and remove side borders, base unit token number multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -89,35 +352,573 @@
 			"path": "./src/components/Autocomplete/tests/Autocomplete.stories.tsx",
 			"stories": [
 				{
-					"name": "active",
+					"id": "components-autocomplete--active",
+					"name": "active, onOpen, onClose",
 					"snippet": "const active = (args) => {\n    const toggle = useToggle(true);\n\n    return (\n        <Example>\n            <Example.Item title=\"active, onOpen, onClose\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete\n                        name=\"fruit\"\n                        placeholder=\"Pick your food\"\n                        active={toggle.active}\n                        onOpen={() => {\n                            args.handleOpen();\n                            toggle.activate();\n                        }}\n                        onClose={() => {\n                            args.handleClose();\n                            toggle.deactivate();\n                        }}\n                        onChange={(args) => console.log(args)}\n                    >\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "base",
+					"id": "components-autocomplete--base",
+					"name": "onInput, onItemSelect, onBackspace",
 					"snippet": "const base = () => {\n    const [value, setValue] = React.useState(\"\");\n\n    return (\n        <Example>\n            <Example.Item title=\"Base\">\n                <FormControl>\n                    <FormControl.Label>Food</FormControl.Label>\n                    <Autocomplete\n                        name=\"fruit\"\n                        placeholder=\"Pick your food\"\n                        value={value}\n                        onChange={(args) => setValue(args.value)}\n                        onBackspace={fn()}\n                        onItemSelect={fn()}>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "itemData",
+					"id": "components-autocomplete--item-data",
+					"name": "item data",
 					"snippet": "const itemData = () => {\n    return (\n        <Example>\n            <Example.Item title=\"item data\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete name=\"fruit\" placeholder=\"Pick your food\" onItemSelect={fn()} active>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v} data={i === 1 ? { foo: true } : undefined}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "itemDisabled",
+					"id": "components-autocomplete--item-disabled",
+					"name": "item disabled",
 					"snippet": "const itemDisabled = () => {\n    return (\n        <Example>\n            <Example.Item title=\"item disabled\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete name=\"fruit\" placeholder=\"Pick your food\" active>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v} disabled={i === 1}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "multiselect",
+					"id": "components-autocomplete--multiselect",
+					"name": "test: multiselect",
 					"snippet": "const multiselect = () => {\n    const options = [\n        \"Pizza\",\n        \"Pie\",\n        \"Ice-cream\",\n        \"Fries\",\n        \"Salad\",\n        \"Option 4\",\n        \"Option 5\",\n        \"Option 6\",\n    ];\n\n    const inputRef = React.useRef<HTMLInputElement>(null);\n    const [values, setValues] = React.useState<string[]>([\n        \"Option 4\",\n        \"Option 5\",\n        \"Option 6\",\n        \"Pizza\",\n        \"Ice-cream\",\n    ]);\n    const [query, setQuery] = React.useState(\"\");\n\n    const handleDismiss = (dismissedValue: string) => {\n        const nextValues = values.filter((value) => value !== dismissedValue);\n        setValues(nextValues);\n        inputRef.current?.focus();\n    };\n\n    const valuesNode = values.map((value) => (\n        <Badge dismissAriaLabel=\"Dismiss value\" onDismiss={() => handleDismiss(value)} key={value}>\n            {value}\n        </Badge>\n    ));\n\n    return (\n        <FormControl>\n            <FormControl.Label>Food</FormControl.Label>\n            <Autocomplete\n                name=\"fruit\"\n                value={query}\n                placeholder=\"Pick your food\"\n                startSlot={valuesNode}\n                multiline\n                inputAttributes={{ ref: inputRef }}\n                onChange={(args) => setQuery(args.value)}\n                onBackspace={() => {\n                    if (query.length === 0) {\n                        setValues((prev) => prev.slice(0, -1));\n                    }\n                }}\n                onItemSelect={(args) => {\n                    setQuery(\"\");\n                    setValues((prev) => [...prev, args.value]);\n                }}\n            >\n                {options.map((v) => {\n                    if (!v.toLowerCase().includes(query.toLowerCase())) return;\n                    if (values.includes(v)) return;\n\n                    return (\n                        <Autocomplete.Item key={v} value={v}>\n                            {v}\n                        </Autocomplete.Item>\n                    );\n                })}\n            </Autocomplete>\n        </FormControl>\n    );\n};"
 				}
 			],
 			"import": "import { Autocomplete, Badge, Example, FormControl } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Autocomplete/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Autocomplete",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Autocomplete/Autocomplete.tsx",
-				"actualName": "Autocomplete",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"multiline": {
+						"defaultValue": null,
+						"description": "Enable multiline text field wrapping",
+						"name": "multiline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to be fully rounded",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content after the text field value",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text field value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the text field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the text field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"onInput": {
+						"defaultValue": null,
+						"description": "Callback for when value changes from user input",
+						"name": "onInput",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onItemSelect": {
+						"defaultValue": null,
+						"description": "Callback for when an item is selected in the dropdown",
+						"name": "onItemSelect",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: SelectArgs) => void)" }
+					},
+					"onBackspace": {
+						"defaultValue": null,
+						"description": "Callback for when the backspace key is pressed while the input is focused",
+						"name": "onBackspace",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onEnter": {
+						"defaultValue": null,
+						"description": "Callback for when the enter key is pressed while the input is focused",
+						"name": "onEnter",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Slot for rendering the Autocomplete.Item components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					}
+				},
+				"exportName": "Autocomplete"
 			}
 		},
 		"components-avatar": {
@@ -126,46 +927,230 @@
 			"path": "./src/components/Avatar/tests/Avatar.stories.tsx",
 			"stories": [
 				{
-					"name": "src",
+					"id": "components-avatar--src",
+					"name": "src, alt",
 					"snippet": "const src = () => (\n    <Example>\n        <Example.Item title=\"src, alt\">\n            <Avatar\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n                alt=\"Amsterdam canal\"\n                size={12}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"src\">\n            <Avatar src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "initials",
+					"id": "components-avatar--initials",
+					"name": "initials, icon",
 					"snippet": "const initials = () => (\n    <Example>\n        <Example.Item title=\"initials\">\n            <Avatar initials=\"RS\" />\n        </Example.Item>\n\n        <Example.Item title=\"icon\">\n            <Avatar icon={IconZap} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-avatar--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: 6\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={6} icon={IconZap} />\n                <Avatar size={6} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: 15\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={15} icon={IconZap} />\n                <Avatar size={15} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: 40\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={40} icon={IconZap} />\n                <Avatar size={40} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] 10\", \"[m+] 20\"]}>\n            <View direction=\"row\" gap={3}>\n                <Avatar size={{ s: 10, m: 20 }} icon={IconZap} />\n                <Avatar size={{ s: 10, m: 20 }} icon={IconZap} squared />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-avatar--squared",
 					"name": "squared",
 					"snippet": "const squared = () => (\n    <Example>\n        <Example.Item title=\"squared, with image\">\n            <Avatar\n                squared\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n            />\n        </Example.Item>\n        <Example.Item title=\"squared, with initials\">\n            <Avatar squared initials=\"RS\" />\n        </Example.Item>\n        <Example.Item title=\"squared, with initials\">\n            <Avatar squared icon={IconZap} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "colors",
+					"id": "components-avatar--colors",
+					"name": "color, variant",
 					"snippet": "const colors = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"neutral\" icon={IconZap} />\n                <Avatar color=\"neutral\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"primary\" icon={IconZap} />\n                <Avatar color=\"primary\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"positive\" icon={IconZap} />\n                <Avatar color=\"positive\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"warning\" icon={IconZap} />\n                <Avatar color=\"warning\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"critical\" icon={IconZap} />\n                <Avatar color=\"critical\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "fallback",
+					"id": "components-avatar--fallback",
+					"name": "test: fallback",
 					"snippet": "const fallback = (args) => {\n    const [error, setError] = useState(false);\n\n    return (\n        <Avatar\n            src={error ? undefined : \"/foo\"}\n            icon={IconZap}\n            imageAttributes={{\n                onError: () => {\n                    setError(true);\n                    args.handleError();\n                },\n            }}\n        />\n    );\n};"
 				},
 				{
+					"id": "components-avatar--render-image",
 					"name": "renderImage",
 					"snippet": "const renderImage = () => (\n    <Example>\n        <Example.Item title=\"renderImage\">\n            <Avatar\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n                alt=\"Amsterdam canal\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image\" />}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-avatar--class-name",
+					"name": "className, attributes, imageAttributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Avatar\n            src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            imageAttributes={{ id: \"test-image-id\", alt: \"test image\" }}\n        />\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Avatar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Avatar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Avatar/Avatar.tsx",
-				"actualName": "Avatar",
+				"methods": [],
+				"props": {
+					"src": {
+						"defaultValue": null,
+						"description": "Image URL",
+						"name": "src",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"alt": {
+						"defaultValue": null,
+						"description": "Image alt text",
+						"name": "alt",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"imageAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the image element",
+						"name": "imageAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"img\">" }
+					},
+					"renderImage": {
+						"defaultValue": null,
+						"description": "Render prop for the image element, useful for integrating with the Image component from third party frameworks",
+						"name": "renderImage",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Omit<Attributes<\"img\">, \"src\" | \"alt\"> & { src: string; alt: string; }) => ReactNode)"
+						}
+					},
+					"initials": {
+						"defaultValue": null,
+						"description": "Initials to display if no image is provided",
+						"name": "initials",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon, used when no image is provided",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"squared": {
+						"defaultValue": null,
+						"description": "Change the shape to rounded square",
+						"name": "squared",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"faded\"",
+							"value": [{ "value": "\"solid\"" }, { "value": "\"faded\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "12" },
+						"description": "Size of the component, base unit token number multiplier",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -175,63 +1160,273 @@
 			"path": "./src/components/Badge/tests/Badge.stories.tsx",
 			"stories": [
 				{
+					"id": "components-badge--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Badge>Badge</Badge>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <Badge variant=\"faded\">Badge</Badge>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <Badge variant=\"outline\">Badge</Badge>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"primary\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"primary\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"primary\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: positive, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"positive\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"positive\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"positive\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: critical, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"critical\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"critical\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"critical\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: warning, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"warning\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"warning\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"warning\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"small\">Badge</Badge>\n                <Badge rounded size=\"small\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge>Badge</Badge>\n                <Badge rounded>Badge</Badge>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"large\">Badge</Badge>\n                <Badge rounded size=\"large\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={3} direction=\"row\">\n                <Badge icon={IconCheckmark} endIcon={IconChevronRight} size=\"small\">\n                    Badge\n                </Badge>\n                <Badge icon={IconCheckmark} size=\"small\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={3} direction=\"row\">\n                <Badge icon={IconCheckmark} endIcon={IconChevronRight}>\n                    Badge\n                </Badge>\n                <Badge icon={IconCheckmark} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"large\" icon={IconCheckmark} endIcon={IconChevronRight}>\n                    Badge\n                </Badge>\n\n                <Badge icon={IconCheckmark} size=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onDismiss",
+					"id": "components-badge--on-dismiss",
+					"name": "onDismiss, dismissAriaLabel",
 					"snippet": "const onDismiss = () => <Example>\n    <Example.Item title=\"onDismiss\">\n        <Badge onDismiss={fn()} dismissAriaLabel=\"Dismiss\">Badge\n                            </Badge>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-badge--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded>Badge</Badge>\n                <Badge rounded variant=\"faded\">\n                    Badge\n                </Badge>\n                <Badge rounded variant=\"outline\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"rounded, all sizes, color: critical\", \"one character, renders as circle\"]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Badge rounded color=\"critical\" size=\"small\">\n                    2\n                </Badge>\n                <Badge rounded color=\"critical\">\n                    2\n                </Badge>\n                <Badge rounded color=\"critical\" size=\"large\">\n                    2\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--empty",
 					"name": "empty",
 					"snippet": "const empty = () => (\n    <Example>\n        <Example.Item title=\"empty, not rounded, all sizes, color: critical\">\n            <View direction=\"row\" gap={3}>\n                <Badge size=\"small\" color=\"critical\" />\n                <Badge color=\"critical\" />\n                <Badge size=\"large\" color=\"critical\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"empty, rounded, all sizes, color: critical\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded size=\"small\" color=\"critical\" />\n                <Badge rounded color=\"critical\" />\n                <Badge rounded size=\"large\" color=\"critical\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"empty, rounded, all sizes, color: neutral\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded size=\"small\" color=\"neutral\" />\n                <Badge rounded />\n                <Badge rounded size=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--highlighted",
 					"name": "highlighted",
 					"snippet": "const highlighted = () => (\n    <Example>\n        <Example.Item title=\"highlighted, color: neutral\">\n            <View gap={3} direction=\"row\">\n                <Badge highlighted>Badge</Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--container",
 					"name": "container",
 					"snippet": "const container = () => {\n    const [hidden, setHidden] = React.useState(false);\n\n    return (\n        <Example title={<Button onClick={() => setHidden(!hidden)}>Toggle badges</Button>}>\n            <Example.Item title=\"position: top-end\">\n                <Badge.Container>\n                    <Badge color=\"primary\" hidden={hidden}>\n                        5\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: bottom-end\">\n                <Badge.Container position=\"bottom-end\">\n                    <Badge color=\"primary\" hidden={hidden}>\n                        5\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: top-end, rounded, multiple digits\">\n                <Badge.Container>\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        123\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: top-end, rounded, empty\">\n                <Badge.Container>\n                    <Badge color=\"primary\" rounded hidden={hidden} />\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: top-end, overlap\", \"should cover the circular avatar\"]}>\n                <Badge.Container overlap>\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        2\n                    </Badge>\n                    <Avatar initials=\"A\" />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: bottom-end, overlap\", \"should cover the circular avatar\"]}>\n                <Badge.Container overlap position=\"bottom-end\">\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        2\n                    </Badge>\n                    <Avatar initials=\"A\" />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: top-end, overlap\", \"should cover the icon\"]}>\n                <Badge.Container overlap position=\"top-end\">\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden} />\n                    <Icon svg={IconCheckmark} size={5} />\n                </Badge.Container>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-badge--href",
 					"name": "href",
 					"snippet": "const href = () => (\n    <Badge href=\"https://reshaped.so\" dismissAriaLabel=\"Dismiss\">\n        Badge\n    </Badge>\n);"
 				},
 				{
+					"id": "components-badge--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Badge onClick={fn()}>Badge</Badge>;"
 				},
 				{
-					"name": "className",
+					"id": "components-badge--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Badge color=\"primary\" className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Badge, Button, Example, Icon, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Badge/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Badge",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Badge/Badge.tsx",
-				"actualName": "Badge",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"large\" | \"medium\"",
+							"value": [
+								{ "value": "\"small\"" },
+								{ "value": "\"large\"" },
+								{ "value": "\"medium\"" }
+							]
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "highlighted",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hidden": {
+						"defaultValue": null,
+						"description": "Transition the component to hidden state",
+						"name": "hidden",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting text or other content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"onDismiss": {
+						"defaultValue": null,
+						"description": "Callback triggered when the dismiss button is pressed",
+						"name": "onDismiss",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"dismissAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the dismiss button",
+						"name": "dismissAriaLabel",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "Badge"
 			}
 		},
 		"components-breadcrumbs": {
@@ -240,51 +1435,185 @@
 			"path": "./src/components/Breadcrumbs/tests/Breadcrumbs.stories.tsx",
 			"stories": [
 				{
+					"id": "components-breadcrumbs--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <Breadcrumbs ariaLabel=\"breadcrumb neutral\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"color: primary\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb primary\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "item",
+					"id": "components-breadcrumbs--item",
+					"name": "item, disabled",
 					"snippet": "const item = () => (\n    <Example>\n        <Example.Item title=\"disabled item\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb disabled\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}} disabled>\n                    Disabled item 2\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "icon",
+					"id": "components-breadcrumbs--icon",
+					"name": "item, icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"item with icon\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb with icon\">\n                <Breadcrumbs.Item icon={IconZap} onClick={() => {}}>\n                    Item 1\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "slots",
+					"id": "components-breadcrumbs--slots",
+					"name": "separator, children",
 					"snippet": "const slots = () => (\n    <Example>\n        <Example.Item title=\"slot: separator\">\n            <Breadcrumbs color=\"primary\" separator=\"/\" ariaLabel=\"breadcrumb with separator\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"custom child content\">\n            <Breadcrumbs ariaLabel=\"breadcrumb with custom children\">\n                <Breadcrumbs.Item onClick={() => {}}>\n                    <Badge>Item 1</Badge>\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>\n                    <Badge>Item 2</Badge>\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-breadcrumbs--collapsed",
 					"name": "collapsed",
 					"snippet": "const collapsed = () => (\n    <Example>\n        <Example.Item title=\"collapsed, 3 items shown by default\">\n            <Breadcrumbs\n                defaultVisibleItems={3}\n                ariaLabel=\"breadcrumbs one\"\n                expandAriaLabel=\"Expand items\"\n            >\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"collapsed, 4 items shown by default\">\n            <Breadcrumbs\n                defaultVisibleItems={4}\n                ariaLabel=\"breadcrumb two\"\n                expandAriaLabel=\"Expand items\"\n            >\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"collapsed, 3 items shown by default, not expandable\">\n            <Breadcrumbs defaultVisibleItems={3} ariaLabel=\"breadcrumb three\" disableExpand>\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "multiline",
+					"id": "components-breadcrumbs--multiline",
+					"name": "composition, multiline",
 					"snippet": "const multiline = () => (\n    <Example>\n        <Example.Item title=\"wraps content when multiline\">\n            <Breadcrumbs ariaLabel=\"breadcrumb multiline\">\n                {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((i) => (\n                    <Breadcrumbs.Item onClick={() => {}} key={i}>\n                        Item {i}\n                    </Breadcrumbs.Item>\n                ))}\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onClick",
+					"id": "components-breadcrumbs--on-click",
+					"name": "item, onClick, disabled",
 					"snippet": "const onClick = () => <Breadcrumbs>\n    <Breadcrumbs.Item onClick={fn()}>Trigger</Breadcrumbs.Item>\n    <Breadcrumbs.Item onClick={fn()} disabled>Trigger\n                    </Breadcrumbs.Item>\n</Breadcrumbs>;"
 				},
 				{
-					"name": "href",
+					"id": "components-breadcrumbs--href",
+					"name": "item, href",
 					"snippet": "const href = () => (\n    <Breadcrumbs>\n        <Breadcrumbs.Item href=\"https://reshaped.so\">Trigger</Breadcrumbs.Item>\n    </Breadcrumbs>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-breadcrumbs--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Breadcrumbs className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Breadcrumbs.Item>Trigger</Breadcrumbs.Item>\n        </Breadcrumbs>\n    </div>\n);"
 				}
 			],
 			"import": "import { Badge, Breadcrumbs, Example } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Breadcrumbs/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Breadcrumbs",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Breadcrumbs/Breadcrumbs.tsx",
-				"actualName": "Breadcrumbs",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children to position items",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ReactElement<unknown, string | JSXElementConstructor<any>>[]"
+						}
+					},
+					"separator": {
+						"defaultValue": null,
+						"description": "Node for defining custom separator between items",
+						"name": "separator",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"neutral\"",
+							"value": [{ "value": "\"primary\"" }, { "value": "\"neutral\"" }]
+						}
+					},
+					"defaultVisibleItems": {
+						"defaultValue": null,
+						"description": "Number of items to show by default, others will be hidden and can be expanded",
+						"name": "defaultVisibleItems",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"expandAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the expand button",
+						"name": "expandAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disableExpand": {
+						"defaultValue": null,
+						"description": "Turn expand button into static text and disable the expand functionality",
+						"name": "disableExpand",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the component",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"nav\">" }
+					}
+				},
+				"exportName": "Breadcrumbs"
 			}
 		},
 		"components-button": {
@@ -293,87 +1622,599 @@
 			"path": "./src/components/Button/tests/Button.stories.tsx",
 			"stories": [
 				{
-					"name": "variantAndColor",
+					"id": "components-button--variant-and-color",
+					"name": "variant, color",
 					"snippet": "const variantAndColor = () => (\n    <Example>\n        <Example.Item title=\"variant: solid\">\n            <View gap={4} direction=\"row\">\n                <Button onClick={() => {}}>Button</Button>\n                <Button onClick={() => {}} color=\"primary\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"faded\">\n                    Button\n                </Button>\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"outline\">\n                    Button\n                </Button>\n\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: ghost\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"ghost\">\n                    Button\n                </Button>\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: media\">\n            <View backgroundColor=\"primary\" borderRadius=\"medium\" padding={4} direction=\"row\" gap={4}>\n                <Button onClick={() => {}} color=\"media\">\n                    Button\n                </Button>\n\n                <Button onClick={() => {}} color=\"media\" variant=\"faded\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Button onClick={() => {}} icon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"endIcon\">\n            <Button onClick={() => {}} endIcon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"icon, endIcon\">\n            <Button onClick={() => {}} icon={IconZap} endIcon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"icon only\">\n            <Button onClick={() => {}} icon={IconZap} attributes={{ \"aria-label\": \"Action\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"small\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"small\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Button icon={IconZap}>Button</Button>\n                <Button variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"large\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"large\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"xlarge\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"xlarge\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"xlarge\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large, [m+] medium\">\n            <Button size={{ s: \"large\", m: \"medium\" }} icon={IconZap}>\n                Responsive\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated, color: neutral\">\n            <View direction=\"row\" gap={4}>\n                <Button elevated onClick={() => {}}>\n                    Button\n                </Button>\n                <Button elevated variant=\"outline\" onClick={() => {}}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"elevated, color\">\n            <View direction=\"row\" gap={4}>\n                <Button elevated color=\"primary\">\n                    Button\n                </Button>\n                <Button elevated variant=\"outline\" color=\"primary\">\n                    Button\n                </Button>\n                <View backgroundColor=\"primary\" padding={4} borderRadius=\"medium\">\n                    <Button color=\"media\" elevated>\n                        Button\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded, size: small, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, size: medium, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, size: large, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, icon only, all sizes\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"small\" icon={IconZap} />\n                <Button rounded icon={IconZap} />\n                <Button rounded size=\"large\" icon={IconZap} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--full-width",
 					"name": "fullWidth",
 					"snippet": "const fullWidth = () => (\n    <Example>\n        <Example.Item title=\"fullWidth, all variants\">\n            <View gap={3}>\n                <Button fullWidth>Neutral</Button>\n                <Button fullWidth variant=\"faded\">\n                    Faded\n                </Button>\n                <Button fullWidth variant=\"outline\">\n                    Outline\n                </Button>\n                <Button fullWidth variant=\"ghost\">\n                    Ghost\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive fullWidth\", \"[s] true\", \"[m+] false\"]}>\n            <Button fullWidth={{ s: true, m: false }}>Button</Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--loading",
 					"name": "loading",
 					"snippet": "const loading = () => (\n    <Example>\n        <Example.Item title=\"loading, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"loading, color critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"loading, color positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"loading, color: media\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n\n                <div style={{ position: \"absolute\", top: 16, left: 16 }}>\n                    <View gap={3} direction=\"row\">\n                        <Button color=\"media\" loading loadingAriaLabel=\"Loading\">\n                            Button\n                        </Button>\n                        <Button color=\"media\" variant=\"faded\" loading loadingAriaLabel=\"Loading\">\n                            Button\n                        </Button>\n                    </View>\n                </div>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"loading, long button text\", \"button size should stay the same\"]}>\n            <Button loading loadingAriaLabel=\"Loading\" color=\"primary\">\n                Long button text\n            </Button>\n        </Example.Item>\n\n        <Example.Item title={[\"loading, icon only\", \"button keep square 1/1 ratio\"]}>\n            <Button icon={IconZap} rounded loading loadingAriaLabel=\"Loading\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--highlighted",
 					"name": "highlighted",
 					"snippet": "const highlighted = () => (\n    <Example>\n        <Example.Item title=\"highlighted, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"highlighted, color: critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted color=\"critical\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"highlighted, color: positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted color=\"positive\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled icon={IconZap} onClick={() => {}}>\n                    Button\n                </Button>\n                <Button disabled variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"disabled, color: critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled color=\"critical\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"disabled, color: positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled color=\"positive\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"disabled, color: media\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n\n                <div style={{ position: \"absolute\", top: 16, left: 16 }}>\n                    <View gap={3} direction=\"row\">\n                        <Button color=\"media\" disabled>\n                            Button\n                        </Button>\n                        <Button color=\"media\" variant=\"faded\" disabled>\n                            Button\n                        </Button>\n                    </View>\n                </div>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner: all\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>Content</View.Item>\n                <Button.Aligner>\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: top\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"top\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: top and end\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side={[\"top\", \"end\"]}>\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: bottom\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2} align=\"end\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"bottom\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: start\">\n            <View padding={4} borderColor=\"neutral-faded\" gap={2} align=\"start\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"start\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: end\">\n            <View padding={4} borderColor=\"neutral-faded\" gap={2} align=\"end\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"end\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "components-button--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"slot gap\">\n            <Button variant=\"outline\">\n                <Avatar size={6} initials=\"RS\" />\n                Label\n                <Hotkey>B</Hotkey>\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--href",
 					"name": "href",
 					"snippet": "const href = () => <Button href=\"https://reshaped.so\">Trigger</Button>;"
 				},
 				{
+					"id": "components-button--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Button onClick={fn()}>Trigger</Button>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-button--href-on-click",
+					"name": "href, onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <Button\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </Button>\n);"
 				},
 				{
+					"id": "components-button--as",
 					"name": "as",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"as: span\">\n            <Button onClick={() => {}} as=\"span\">\n                Trigger\n            </Button>\n        </Example.Item>\n        <Example.Item title=\"render, disabled\">\n            <Button\n                disabled\n                onClick={() => {}}\n                render={(props) => <section {...props} />}\n                attributes={{ \"data-testid\": \"render-el\" }}\n            >\n                Trigger\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-button--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Button className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Button>\n    </div>\n);"
 				},
 				{
+					"id": "components-button--group",
 					"name": "group",
 					"snippet": "const group = () => (\n    <Example>\n        <Example.Item title=\"with icon\">\n            <Button.Group>\n                <Button rounded>Submit</Button>\n                <Button rounded icon={IconZap} />\n            </Button.Group>\n        </Example.Item>\n        <Example.Item title=\"variant: solid\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\", \"media\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color}>One</Button>\n                        <Button color={color}>Two</Button>\n                        <Button color={color}>Three</Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"outline\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"outline\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"outline\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\", \"media\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"faded\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"faded\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"faded\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"variant: ghost\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"ghost\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"ghost\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"ghost\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "groupClassName",
+					"id": "components-button--group-class-name",
+					"name": "group className, attributes",
 					"snippet": "const groupClassName = () => (\n    <div data-testid=\"root\">\n        <Button.Group className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Button>Trigger</Button>\n        </Button.Group>\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Button, Example, Hotkey, Image, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Button/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Button",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Button/Button.tsx",
-				"actualName": "Button",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"ghost\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"ghost\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loading": {
+						"defaultValue": null,
+						"description": "Show loading state",
+						"name": "loading",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loadingAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the loading indicator",
+						"name": "loadingAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Make the component take the full width of the parent element",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "highlighted",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Button"
 			}
 		},
 		"components-calendar": {
@@ -382,54 +2223,363 @@
 			"path": "./src/components/Calendar/tests/Calendar.stories.tsx",
 			"stories": [
 				{
+					"id": "components-calendar--default-month",
 					"name": "defaultMonth",
 					"snippet": "const defaultMonth = () => (\n    <Example>\n        <Example.Item title=\"defaultMonth: 2020 January\">\n            <Calendar defaultMonth={new Date(2020, 0)} range />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "uncontrolled",
+					"id": "components-calendar--uncontrolled",
+					"name": "defaultValue, range",
 					"snippet": "const uncontrolled = () => <Example>\n    <Example.Item title=\"defaultValue\">\n        <Calendar\n            defaultMonth={new Date(2020, 0)}\n            defaultValue={new Date(2020, 0, 10)}\n            onChange={fn()} />\n    </Example.Item>\n    <Example.Item title=\"defaultValue, range\">\n        <Calendar\n            range\n            defaultMonth={new Date(2020, 0)}\n            defaultValue={{ start: new Date(2020, 0, 10), end: new Date(2020, 0, 15) }}\n            onChange={fn()} />\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "controlled",
+					"id": "components-calendar--controlled",
+					"name": "value, range",
 					"snippet": "const controlled = () => <Example>\n    <Example.Item title=\"value\">\n        <Calendar\n            defaultMonth={new Date(2020, 0)}\n            value={new Date(2020, 0, 10)}\n            onChange={fn()} />\n    </Example.Item>\n    <Example.Item title=\"defaultValue, range\">\n        <Calendar\n            range\n            defaultMonth={new Date(2020, 0)}\n            value={{ start: new Date(2020, 0, 10), end: new Date(2020, 0, 15) }}\n            onChange={fn()} />\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-calendar--selected-dates",
 					"name": "selectedDates",
 					"snippet": "const selectedDates = () => (\n    <Example>\n        <Example.Item title=\"selectedDates: [4,8]\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                value={null}\n                selectedDates={[new Date(2020, 0, 4), new Date(2020, 0, 8)]}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "minMax",
+					"id": "components-calendar--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <Example>\n        <Example.Item title=\"min: 4, max: 20\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                min={new Date(2020, 0, 4)}\n                max={new Date(2020, 0, 20)}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-calendar--first-week-day",
 					"name": "firstWeekDay",
 					"snippet": "const firstWeekDay = () => (\n    <Example>\n        <Example.Item title=\"firstWeekDay: 3 (Wed)\">\n            <Calendar defaultMonth={new Date(2020, 0)} firstWeekDay={3} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "translation",
+					"id": "components-calendar--translation",
+					"name": "render functions",
 					"snippet": "const translation = () => (\n    <Example>\n        <Example.Item title=\"translated to NL\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                renderMonthLabel={({ date }) => date.toLocaleDateString(\"nl\", { month: \"short\" })}\n                renderSelectedMonthLabel={({ date }) =>\n                    date.toLocaleDateString(\"nl\", { month: \"long\", year: \"numeric\" })\n                }\n                renderWeekDay={({ date }) => date.toLocaleDateString(\"nl\", { weekday: \"short\" })}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "ariaLabels",
+					"id": "components-calendar--aria-labels",
+					"name": "aria labels",
 					"snippet": "const ariaLabels = () => (\n    <Example>\n        <Example.Item title=\"aria labels\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                nextYearAriaLabel=\"Test next year\"\n                nextMonthAriaLabel=\"Test next month\"\n                renderDateAriaLabel={() => \"Test date\"}\n                renderMonthAriaLabel={() => \"Test month\"}\n                previousYearAriaLabel=\"Test previous year\"\n                previousMonthAriaLabel=\"Test previous month\"\n                monthSelectionAriaLabel=\"Test month selection\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "monthSelection",
+					"id": "components-calendar--month-selection",
+					"name": "test: month selection",
 					"snippet": "const monthSelection = () => (\n    <Example>\n        <Example.Item title=\"month selection\">\n            <Calendar defaultMonth={new Date(2020, 1)} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "keyboardNavigation",
+					"id": "components-calendar--keyboard-navigation",
+					"name": "test: keyboard navigation",
 					"snippet": "const keyboardNavigation = () => (\n    <Example>\n        <Example.Item title=\"keyboard navigation\">\n            <Calendar defaultMonth={new Date(2020, 0)} />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Calendar, Example } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Calendar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Calendar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Calendar/Calendar.tsx",
-				"actualName": "Calendar",
+				"methods": [],
+				"props": {
+					"range": {
+						"defaultValue": null,
+						"description": "Disable range selection\nEnable range selection",
+						"name": "range",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Current selected date value, enables controlled mode\nCurrent selected range value, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date | RangeValue | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default selected date value, enables uncontrolled mode\nDefault selected range value, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date | RangeValue" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when date selection changes\nCallback when range selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { value: Date; }) => void) | ((args: { value: Date; }) => void) | ((args: { value: RangeValue; }) => void) | ((args: { value: RangeValue; }) => void)"
+						}
+					},
+					"defaultMonth": {
+						"defaultValue": { "value": "Date.now()" },
+						"description": "Default month to display",
+						"name": "defaultMonth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum date that can be selected",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum date that can be selected",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"firstWeekDay": {
+						"defaultValue": { "value": "1, Monday" },
+						"description": "First day of the week",
+						"name": "firstWeekDay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"selectedDates": {
+						"defaultValue": null,
+						"description": "Dates that are selected",
+						"name": "selectedDates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date[]" }
+					},
+					"renderWeekDay": {
+						"defaultValue": null,
+						"description": "Render a custom weekday label, can be used for localization",
+						"name": "renderWeekDay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { weekDay: number; date: Date; }) => string)" }
+					},
+					"renderSelectedMonthLabel": {
+						"defaultValue": null,
+						"description": "Render a custom month label, can be used for localization",
+						"name": "renderSelectedMonthLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { date: Date; }) => string)" }
+					},
+					"renderMonthLabel": {
+						"defaultValue": null,
+						"description": "Render a custom month label, can be used for localization",
+						"name": "renderMonthLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { month: number; date: Date; }) => string)" }
+					},
+					"previousMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the previous month button",
+						"name": "previousMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"nextMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "",
+						"name": "nextMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"previousYearAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the previous year button",
+						"name": "previousYearAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"nextYearAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the next year button",
+						"name": "nextYearAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"monthSelectionAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the month selection button",
+						"name": "monthSelectionAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"renderDateAriaLabel": {
+						"defaultValue": null,
+						"description": "Dynamic aria label applied to each date cell based on the arguments",
+						"name": "renderDateAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { date: Date; }) => string)" }
+					},
+					"renderMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "Dynamic aria label applied to each month element based on the arguments",
+						"name": "renderMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { month: number; }) => string)" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -439,50 +2589,356 @@
 			"path": "./src/components/Card/tests/Card.stories.tsx",
 			"stories": [
 				{
+					"id": "components-card--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: default\">\n            <Card>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title=\"padding: 2\">\n            <Card padding={2}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title=\"padding: 0\">\n            <Card padding={0}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive padding\", \"[s] 4\", \"[m+] 8\"]}>\n            <Card padding={{ s: 4, m: 8 }}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--selected",
 					"name": "selected",
 					"snippet": "const selected = () => (\n    <Example>\n        <Example.Item title=\"selected\">\n            <Card selected>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated\">\n            <Card elevated>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4\">\n            <Card bleed={4}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n        <Example.Item title={[\"responsive bleed\", \"[s] 4\", \"[m+] 0\"]}>\n            <Card bleed={{ s: 4, m: 0 }}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--height",
 					"name": "height",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"height: 200px\">\n            <Card height=\"200px\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Card onClick={fn()}>Trigger</Card>;"
 				},
 				{
+					"id": "components-card--href",
 					"name": "href",
 					"snippet": "const href = () => <Card href=\"https://reshaped.so\">Trigger</Card>;"
 				},
 				{
+					"id": "components-card--as",
 					"name": "as",
 					"snippet": "const as = () => <Card as=\"span\" attributes={{ \"data-testid\": \"root\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-card--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Card className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Card, Example, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Card/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Card",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Card/Card.tsx",
-				"actualName": "Card",
+				"methods": [],
+				"props": {
+					"padding": {
+						"defaultValue": null,
+						"description": "Component padding, base unit multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Remove side borders and apply negative margins, base unit multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"selected": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "selected",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when the component is clicked, turns component into a button",
+						"name": "onClick",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL to navigate to when the component is clicked, turns component into a link",
+						"name": "href",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"as": {
+						"defaultValue": { "value": "\"div\"" },
+						"description": "Custom component tag name",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(Attributes<keyof IntrinsicElements> & (Attributes))" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -492,56 +2948,181 @@
 			"path": "./src/components/Carousel/tests/Carousel.stories.tsx",
 			"stories": [
 				{
+					"id": "components-carousel--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Carousel attributes={{ \"data-testid\": \"test-id\" }} visibleItems={3}>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n    </Carousel>\n);"
 				},
 				{
+					"id": "components-carousel--visible-items",
 					"name": "visibleItems",
 					"snippet": "const visibleItems = () => (\n    <Example>\n        <Example.Item title=\"visibleItems: 3\">\n            <Carousel visibleItems={3}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive visibleItems\", \"s: 2, m+ 3\"]}>\n            <Carousel visibleItems={{ s: 2, m: 3 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title=\"visibleItems: auto\">\n            <Carousel>\n                <Placeholder h={100} />\n                <Placeholder h={100} w={200} />\n                <Placeholder h={100} w={300} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 2, visibleItems 3\">\n            <Carousel visibleItems={3} gap={2}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"gap: responsive, visibleItems: 3\", \"s: 2, l: 8\"]}>\n            <Carousel visibleItems={3} gap={{ s: 2, l: 8 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4, visibleItems: 3\">\n            <Carousel visibleItems={3} bleed={4}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive bleed, visibleItems: 3\", \"[s] 4, [l+] 0\"]}>\n            <Carousel visibleItems={3} bleed={{ s: 4, l: 0 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--navigation-display",
 					"name": "navigationDisplay",
 					"snippet": "const navigationDisplay = () => (\n    <Example>\n        <Example.Item title=\"navigationDisplay: hidden\">\n            <Carousel\n                visibleItems={3}\n                navigationDisplay=\"hidden\"\n                attributes={{ \"data-testid\": \"test-id\" }}\n            >\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "instanceRef",
+					"id": "components-carousel--instance-ref",
+					"name": "instanceRef, onChange",
 					"snippet": "const instanceRef = (args) => {\n    const carouselRef = React.useRef<CarouselInstanceRef>(null);\n    const [index, setIndex] = React.useState(0);\n\n    return (\n        <Example>\n            <Example.Item title=\"instanceRef, onChange\">\n                <View gap={3}>\n                    <View gap={3} direction=\"row\" align=\"center\">\n                        <Button onClick={() => carouselRef.current?.navigateBack()}>Back</Button>\n                        <Button onClick={() => carouselRef.current?.navigateForward()}>Forward</Button>\n                        <Button onClick={() => carouselRef.current?.navigateTo(3)}>To 3</Button>\n                        <View.Item>Index: {index}</View.Item>\n                    </View>\n                    <Carousel\n                        visibleItems={2}\n                        instanceRef={carouselRef}\n                        navigationDisplay=\"hidden\"\n                        onChange={(changeArgs) => {\n                            args.handleChange(changeArgs);\n                            setIndex(changeArgs.index);\n                        }}\n                    >\n                        <Placeholder h={100}>Item 0</Placeholder>\n                        <Placeholder h={100}>Item 1</Placeholder>\n                        <Placeholder h={100}>Item 2</Placeholder>\n                        <Placeholder h={100}>Item 3</Placeholder>\n                        <Placeholder h={100}>Item 4</Placeholder>\n                        <Placeholder h={100}>Item 5</Placeholder>\n                    </Carousel>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-carousel--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Carousel visibleItems={2} className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder h={100}>Item 0</Placeholder>\n            <Placeholder h={100}>Item 1</Placeholder>\n            <Placeholder h={100}>Item 2</Placeholder>\n            <Placeholder h={100}>Item 3</Placeholder>\n            <Placeholder h={100}>Item 4</Placeholder>\n            <Placeholder h={100}>Item 5</Placeholder>\n        </Carousel>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Carousel, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Carousel/index.ts",
 				"description": "",
-				"methods": [
-					{
-						"name": "navigateTo",
-						"docblock": null,
-						"modifiers": [],
-						"params": [
+				"displayName": "Carousel",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, each child is rendered as a carousel item",
+						"name": "children",
+						"declarations": [
 							{
-								"name": "index",
-								"optional": false,
-								"type": { "name": "number" }
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
 							}
 						],
-						"returns": null
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"visibleItems": {
+						"defaultValue": null,
+						"description": "Number of items visible at once in the container",
+						"name": "visibleItems",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between items in the container, base unit multiplier",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margins, base unit multiplier, can be used to make sure the items don't get clipped when scrolling",
+						"name": "bleed",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"navigationDisplay": {
+						"defaultValue": null,
+						"description": "Hide navigation controls",
+						"name": "navigationDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"hidden\"", "value": [{ "value": "\"hidden\"" }] }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the carousel methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the first visible carousel index changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { index: number; }) => void)" }
+					},
+					"onScroll": {
+						"defaultValue": null,
+						"description": "Callback when the carousel scrolls",
+						"name": "onScroll",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: UIEvent<HTMLUListElement, UIEvent>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
 					}
-				],
-				"displayName": "Carousel",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Carousel/Carousel.tsx",
-				"actualName": "Carousel",
+				},
 				"exportName": "default"
 			}
 		},
@@ -551,46 +3132,259 @@
 			"path": "./src/components/Checkbox/tests/Checkbox.stories.tsx",
 			"stories": [
 				{
-					"name": "render",
+					"id": "components-checkbox--render",
+					"name": "name, value",
 					"snippet": "const render = () => (\n    <Checkbox name=\"test-name\" value=\"test-value\">\n        Content\n    </Checkbox>\n);"
 				},
 				{
+					"id": "components-checkbox--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"small\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"small\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"medium\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"medium\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"large\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"large\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: responsive, s: small, m: large\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size={{ s: \"small\", m: \"large\" }} defaultChecked>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-checkbox--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Checkbox name=\"animal\" value=\"dog\" hasError>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-checkbox--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n        <Example.Item title=\"disabled, checked\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled checked>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n        <Example.Item title=\"disabled, indeterminate\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled indeterminate>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "checked",
+					"id": "components-checkbox--checked",
+					"name": "checked, controlled",
 					"snippet": "const checked = () => <Checkbox name=\"test-name\" value=\"test-value\" checked onChange={fn()}>Content\n            </Checkbox>;"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-checkbox--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Checkbox name=\"test-name\" value=\"test-value\" defaultChecked onChange={fn()}>Content\n            </Checkbox>;"
 				},
 				{
+					"id": "components-checkbox--indeterminate",
 					"name": "indeterminate",
 					"snippet": "const indeterminate = () => (\n    <Checkbox name=\"test-name\" value=\"test-value\" indeterminate>\n        Content\n    </Checkbox>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-checkbox--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Checkbox className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Checkbox>\n    </div>\n);"
 				}
 			],
 			"import": "import { Checkbox, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Checkbox/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Checkbox",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Checkbox/Checkbox.tsx",
-				"actualName": "Checkbox",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the label",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Component name attribute",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the component",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Component value used for form submission",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"indeterminate": {
+						"defaultValue": null,
+						"description": "Show a indeterminate state, used for \"select all\" checkboxes with some of the individual checkboxes selected",
+						"name": "indeterminate",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the component is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the component is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Component checked state, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default checked state, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -600,26 +3394,143 @@
 			"path": "./src/components/CheckboxGroup/tests/CheckboxGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "value",
+					"id": "components-checkboxgroup--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <View gap={2}>\n    <CheckboxGroup name=\"test-name\" value={[\"1\"]} onChange={fn()}>\n        {/* checked should be ignored */}\n        <Checkbox value=\"1\" checked={false}>Content\n                            </Checkbox>\n        <Checkbox value=\"2\">Content 2</Checkbox>\n    </CheckboxGroup>\n</View>;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-checkboxgroup--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <View gap={2}>\n    <CheckboxGroup name=\"test-name\" defaultValue={[\"1\"]} onChange={fn()}>\n        {/* checked should be ignored */}\n        <Checkbox value=\"1\" checked={false}>Content\n                            </Checkbox>\n        <Checkbox value=\"2\">Content 2</Checkbox>\n    </CheckboxGroup>\n</View>;"
 				},
 				{
+					"id": "components-checkboxgroup--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <CheckboxGroup name=\"test-name\" disabled>\n        <Checkbox value=\"test-value\">Item 1</Checkbox>\n        <Checkbox value=\"test-value-2\">Item 2</Checkbox>\n    </CheckboxGroup>\n);"
 				}
 			],
 			"import": "import { Checkbox, CheckboxGroup, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/CheckboxGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "CheckboxGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/CheckboxGroup/CheckboxGroup.tsx",
-				"actualName": "CheckboxGroup",
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Component id attribute",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting checkboxes or custom layout components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the component from form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Component name attribute",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string[], ChangeEvent<HTMLInputElement>>" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Component value, enables controlled mode\nComponent value, enables uncontrolled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -629,23 +3540,346 @@
 			"path": "./src/components/ContextMenu/tests/ContextMenu.stories.tsx",
 			"stories": [
 				{
+					"id": "components-contextmenu--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"base\">\n            <div style={{ height: 200, overflow: \"auto\" }}>\n                <ContextMenu>\n                    <View height=\"400px\" backgroundColor=\"neutral-faded\" borderRadius=\"medium\" />\n\n                    <ContextMenu.Content>\n                        <ContextMenu.Item>Item 1</ContextMenu.Item>\n                        <ContextMenu.Item>Item 2</ContextMenu.Item>\n                    </ContextMenu.Content>\n                </ContextMenu>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "components-contextmenu--handlers",
+					"name": "handleOpen, handleClose",
 					"snippet": "const handlers = () => <div style={{ height: 200, overflow: \"auto\" }} data-testid=\"scroll\">\n    <ContextMenu onOpen={fn()} onClose={fn()}>\n        <View\n            height=\"400px\"\n            backgroundColor=\"neutral-faded\"\n            borderRadius=\"medium\"\n            attributes={{ \"data-testid\": \"root\" }} />\n        <ContextMenu.Content>\n            <ContextMenu.Item>Item</ContextMenu.Item>\n        </ContextMenu.Content>\n    </ContextMenu>\n</div>;"
 				}
 			],
 			"import": "import { ContextMenu, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ContextMenu/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ContextMenu",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ContextMenu/ContextMenu.tsx",
-				"actualName": "ContextMenu",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/DropdownMenu/DropdownMenu.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | \"action-menu\" | \"selection-menu\"" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					}
+				},
+				"exportName": "ContextMenu"
 			}
 		},
 		"components-divider": {
@@ -654,30 +3888,118 @@
 			"path": "./src/components/Divider/tests/Divider.stories.tsx",
 			"stories": [
 				{
-					"name": "rendering",
+					"id": "components-divider--rendering",
+					"name": "base",
 					"snippet": "const rendering = () => (\n    <Example>\n        <Example.Item title=\"default rendering\">\n            <Divider />\n        </Example.Item>\n\n        <Example.Item title={[\"blank rendering\", \"box should overlap with divider\"]}>\n            <View width=\"40px\" height=\"10px\" backgroundColor=\"primary\" />\n            <Divider blank />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-divider--vertical",
 					"name": "vertical",
 					"snippet": "const vertical = () => (\n    <Example>\n        <Example.Item title=\"vertical\">\n            <View gap={3} direction=\"row\" align=\"stretch\">\n                <Placeholder />\n                <View.Item>\n                    <Divider vertical />\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive vertical\", \"[s] true\", \"[m+]: false\"]}>\n            <View gap={3} direction={{ s: \"row\", m: \"column\" }} align=\"stretch\">\n                <Placeholder />\n                <View.Item>\n                    <Divider vertical={{ s: true, m: false }} />\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "label",
+					"id": "components-divider--label",
+					"name": "children, contentPosition",
 					"snippet": "const label = () => {\n    return (\n        <Example>\n            <Example.Item title=\"alignment\">\n                <View gap={4}>\n                    <Divider>Centered label</Divider>\n                    <Divider contentPosition=\"start\">Start label</Divider>\n                    <Divider contentPosition=\"end\">End label</Divider>\n                </View>\n            </Example.Item>\n\n            <Example.Item title=\"responsive\">\n                <View gap={3} direction={{ s: \"column\", m: \"row\" }} align=\"stretch\">\n                    <Placeholder />\n                    <View.Item>\n                        <Divider vertical={{ s: false, m: true }}>or pick second option</Divider>\n                    </View.Item>\n                    <Placeholder />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-divider--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Divider className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Divider, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Divider/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Divider",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Divider/Divider.tsx",
-				"actualName": "Divider",
+				"methods": [],
+				"props": {
+					"blank": {
+						"defaultValue": null,
+						"description": "Change component to take no space, useful for using it as a border in components like Tabs",
+						"name": "blank",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"vertical": {
+						"defaultValue": null,
+						"description": "Change component to render vertically",
+						"name": "vertical",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"contentPosition": {
+						"defaultValue": null,
+						"description": "Position for rendering children",
+						"name": "contentPosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"center\" | \"start\" | \"end\"",
+							"value": [{ "value": "\"center\"" }, { "value": "\"start\"" }, { "value": "\"end\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting text labels or custom components as a part of divider",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"hr\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -687,51 +4009,415 @@
 			"path": "./src/components/DropdownMenu/tests/DropdownMenu.stories.tsx",
 			"stories": [
 				{
+					"id": "components-dropdownmenu--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: default\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <DropdownMenu position=\"end\">\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n\n        <Example.Item title={[\"position: top-start\", \"should change to top-start to fit viewport\"]}>\n            <DropdownMenu position=\"top-end\">\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n        <div style={{ height: 2000 }} />\n    </Example>\n);"
 				},
 				{
+					"id": "components-dropdownmenu--sections",
 					"name": "sections",
 					"snippet": "const sections = () => (\n    <Example>\n        <Example.Item title=\"2 sections\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Section>\n                        <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                    </DropdownMenu.Section>\n\n                    <DropdownMenu.Section>\n                        <DropdownMenu.Item>Item 3</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 4</DropdownMenu.Item>\n                    </DropdownMenu.Section>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-dropdownmenu--submenu",
 					"name": "submenu",
 					"snippet": "const submenu = () => (\n    <Example>\n        <Example.Item title=\"submenu\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item onClick={() => {}}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger>Item 2</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger>Item 3</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2-1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2-2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger disabled>Item 4, disabled</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 3-1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 3-2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-dropdownmenu--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <DropdownMenu onOpen={fn()} onClose={fn()} defaultActive>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "active",
+					"id": "components-dropdownmenu--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <DropdownMenu onOpen={fn()} onClose={fn()} active>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "components-dropdownmenu--active-false",
+					"name": "active false, controlled",
 					"snippet": "const activeFalse = () => <DropdownMenu onOpen={fn()} onClose={fn()} active={false}>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "className",
+					"id": "components-dropdownmenu--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <DropdownMenu active>\n            <DropdownMenu.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </DropdownMenu.Trigger>\n            <DropdownMenu.Content className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n                <DropdownMenu.Item>Item</DropdownMenu.Item>\n            </DropdownMenu.Content>\n        </DropdownMenu>\n    </div>\n);"
 				},
 				{
-					"name": "testScroll",
+					"id": "components-dropdownmenu--test-scroll",
+					"name": "test: scroll",
 					"snippet": "const testScroll = () => (\n    <Example>\n        <Example.Item title=\"Scrolls on page mount to the dropdown\">\n            <div style={{ height: 1000 }} />\n            <DropdownMenu position=\"end\" key=\"scroll\" defaultActive>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testTheme",
+					"id": "components-dropdownmenu--test-theme",
+					"name": "test: theme",
 					"snippet": "const testTheme = () => (\n    <Example>\n        <Example.Item title=\"switch color mode while dropdown is active and check that it still works\">\n            <ThemeSwitching />\n        </Example.Item>\n        <Example.Item title=\"dropdown inherits multiple themes\">\n            <ThemeMultiple />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, DropdownMenu, Example, Theme, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/DropdownMenu/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "DropdownMenu",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/DropdownMenu/DropdownMenu.tsx",
-				"actualName": "DropdownMenu",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/DropdownMenu/DropdownMenu.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | \"action-menu\" | \"selection-menu\"" }
+					}
+				},
+				"exportName": "DropdownMenu"
 			}
 		},
 		"components-fileupload": {
@@ -740,35 +4426,165 @@
 			"path": "./src/components/FileUpload/tests/FileUpload.stories.tsx",
 			"stories": [
 				{
+					"id": "components-fileupload--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"Base upload with previews\">\n            <Demo />\n        </Example.Item>\n        <Example.Item title=\"With trigger\">\n            <FileUpload name=\"file\">\n                <div>\n                    Drop files to attach, or{\" \"}\n                    <FileUpload.Trigger>\n                        <Link variant=\"plain\">browse</Link>\n                    </FileUpload.Trigger>\n                </div>\n            </FileUpload>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "inline",
+					"id": "components-fileupload--inline",
+					"name": "inline, variant, render props",
 					"snippet": "const inline = () => {\n    return (\n        <Example>\n            <Example.Item title=\"inline\">\n                <FileUpload name=\"file\" inline onChange={console.log}>\n                    <View padding={2} paddingInline={3}>\n                        Upload\n                    </View>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"variant headless\">\n                <FileUpload name=\"file2\" variant=\"headless\" onChange={console.log}>\n                    <Button variant=\"outline\" fullWidth>\n                        Upload\n                    </Button>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"variant headless, inline\">\n                <FileUpload name=\"file2\" variant=\"headless\" inline onChange={console.log}>\n                    <Button>Upload</Button>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"inline, render props\">\n                <FileUpload name=\"file3\" variant=\"headless\" inline onChange={console.log}>\n                    {(props) => <Button highlighted={props.highlighted}>Upload</Button>}\n                </FileUpload>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-fileupload--height",
 					"name": "height",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"Custom height\">\n            <FileUpload name=\"file\" height=\"300px\">\n                <View gap={3}>\n                    <Icon svg={IconMic} size={8} />\n                    Drop files to attach\n                </View>\n            </FileUpload>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onChange",
+					"id": "components-fileupload--on-change",
+					"name": "name, onChange",
 					"snippet": "const onChange = () => <div data-testid=\"root\">\n    <FileUpload name=\"test-name\" onChange={fn()}>Content\n                    </FileUpload>\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "components-fileupload--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <FileUpload\n            name=\"name\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ id: \"test-input-id\" }}\n        >\n            Content\n        </FileUpload>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, FileUpload, Icon, Image, Link, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/FileUpload/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "FileUpload",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/FileUpload/FileUpload.tsx",
-				"actualName": "FileUpload",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, can be a render function that receives component state",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode | ((props: { highlighted?: boolean; }) => ReactNode)" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component value is changed",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ChangeHandler<File[], ChangeEvent<HTMLInputElement> | DragEvent<HTMLDivElement>>"
+						}
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Component height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component variant, headless variant is useful for rendering custom triggers like a Button",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"headless\"",
+							"value": [{ "value": "\"outline\"" }, { "value": "\"headless\"" }]
+						}
+					},
+					"inline": {
+						"defaultValue": null,
+						"description": "Change component to render inline making it more compact",
+						"name": "inline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					}
+				},
+				"exportName": "FileUpload"
 			}
 		},
 		"components-hotkey": {
@@ -777,22 +4593,78 @@
 			"path": "./src/components/Hotkey/tests/Hotkey.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "components-hotkey--base",
+					"name": "Base",
 					"snippet": "const base = () => (\n\t<Example>\n\t\t<Example.Item title=\"Base\">\n\t\t\t<Demo />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"Active\">\n\t\t\t<Hotkey active>⌘K</Hotkey>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"Inside input slot\">\n\t\t\t<View width=\"300px\">\n\t\t\t\t<TextField\n\t\t\t\t\tname=\"hey\"\n\t\t\t\t\tendSlot={<Demo />}\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"hotkey test\" }}\n\t\t\t\t/>\n\t\t\t</View>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-hotkey--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Hotkey className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            ⌘K\n        </Hotkey>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Hotkey, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Hotkey/Hotkey.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Hotkey",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Hotkey/Hotkey.tsx",
-				"actualName": "Hotkey",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Highlight the component, can be used to show when hotkey is pressed",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -802,54 +4674,241 @@
 			"path": "./src/components/Link/tests/Link.stories.tsx",
 			"stories": [
 				{
+					"id": "components-link--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: underline\">\n            <Link href=\"http://reshaped.so\" attributes={{ target: \"_blank\" }}>\n                Reshaped\n            </Link>\n        </Example.Item>\n        <Example.Item title=\"variant: plain\">\n            <Link onClick={() => {}} variant=\"plain\">\n                Link\n            </Link>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary\">\n            <Link color=\"primary\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Link color=\"critical\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Link color=\"positive\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <Link color=\"warning\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <Link color=\"inherit\">Link</Link>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon, variant: underline\">\n            <Link icon={IconZap}>Link</Link>\n        </Example.Item>\n        <Example.Item title=\"icon, variant: plain\">\n            <Link icon={IconZap} variant=\"plain\">\n                Link\n            </Link>\n        </Example.Item>\n        <Example.Item\n            title={[\"icon, variant: underline\", \"should inherit display-1 size from the parent\"]}\n        >\n            <Text variant=\"title-3\">\n                <Link icon={IconZap} variant=\"underline\">\n                    Instant delivery\n                </Link>\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--href",
 					"name": "href",
 					"snippet": "const href = () => <Link href=\"https://reshaped.so\">Trigger</Link>;"
 				},
 				{
+					"id": "components-link--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Link onClick={fn()}>Trigger</Link>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-link--href-on-click",
+					"name": "href + onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <Link\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </Link>\n);"
 				},
 				{
+					"id": "components-link--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Link disabled onClick={() => {}}>\n        Trigger\n    </Link>\n);"
 				},
 				{
+					"id": "components-link--render",
 					"name": "render",
 					"snippet": "const render = () => <Link render={(props) => <section {...props} />}>Trigger</Link>;"
 				},
 				{
-					"name": "className",
+					"id": "components-link--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Link className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Link>\n    </div>\n);"
 				},
 				{
-					"name": "testMultilineInText",
+					"id": "components-link--test-multiline-in-text",
+					"name": "test: multiline",
 					"snippet": "const testMultilineInText = () => (\n    <Example>\n        <Example.Item title=\"should wrap inside the text\">\n            <div>\n                Someone asked me to write this text that is boring to ready for everyone and to add&nbsp;\n                <Link href=\"/\">this very very long link</Link> to it.\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Link, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Link/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Link",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Link/Link.tsx",
-				"actualName": "Link",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon at the start position",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"primary\"" },
+						"description": "Link color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"inherit\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"inherit\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"underline\"" },
+						"description": "Link render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"plain\" | \"underline\"",
+							"value": [{ "value": "\"plain\"" }, { "value": "\"underline\"" }]
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -859,30 +4918,110 @@
 			"path": "./src/components/Loader/tests/Loader.stories.tsx",
 			"stories": [
 				{
+					"id": "components-loader--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: medium\">\n                <Loader size=\"medium\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title=\"size: small\">\n                <Loader size=\"small\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title=\"size: large\">\n                <Loader size=\"large\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title={[\"responsive size\", \"[s] small\", \"[m+] medium\"]}>\n                <Loader size={{ s: \"small\", m: \"medium\" }} ariaLabel=\"Loading\" />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-loader--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary\">\n            <Loader ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Loader color=\"critical\" ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Loader color=\"positive\" ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <Loader color=\"inherit\" ariaLabel=\"Loading\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-loader--aria-label",
 					"name": "ariaLabel",
 					"snippet": "const ariaLabel = () => <Loader ariaLabel=\"Loading\" attributes={{ \"data-testid\": \"root\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-loader--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Loader className=\"test-classname\" attributes={{ id: \"test-id\" }} ariaLabel=\"Loading\" />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Loader } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Loader/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Loader",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Loader/Loader.tsx",
-				"actualName": "Loader",
+				"methods": [],
+				"props": {
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"inherit\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -892,67 +5031,504 @@
 			"path": "./src/components/MenuItem/tests/MenuItem.stories.tsx",
 			"stories": [
 				{
+					"id": "components-menuitem--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <MenuItem size=\"small\" icon={IconZap} onClick={() => {}} endSlot={<Hotkey>⌘K</Hotkey>}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <MenuItem icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <MenuItem size=\"large\" icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title={[\"responsive size\", \"[s] small\", \"[m] medium\", \"[l+] large\"]}>\n            <MenuItem size={{ s: \"small\", m: \"medium\", l: \"large\" }} icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <MenuItem color=\"neutral\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <MenuItem color=\"primary\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <MenuItem color=\"critical\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--selected",
 					"name": "selected",
 					"snippet": "const selected = () => (\n    <Example>\n        <Example.Item title=\"selected, color: neutral\">\n            <MenuItem color=\"neutral\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"selected, color: primary\">\n            <MenuItem color=\"primary\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"selected, color: critical\">\n            <MenuItem color=\"critical\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--rounded-corners",
 					"name": "roundedCorners",
 					"snippet": "const roundedCorners = () => (\n    <Example>\n        <Example.Item title=\"roundedCorners\">\n            <MenuItem roundedCorners selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive roundedCorners\", \"[s]: false\", \"[m+]: true\"]}>\n            <MenuItem roundedCorners={{ s: false, m: true }} selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "slots",
+					"id": "components-menuitem--slots",
+					"name": "startSlot, endSlot",
 					"snippet": "const slots = () => (\n    <Example>\n        <Example.Item title=\"startSlot, endSlot, selected\">\n            <MenuItem startSlot={<Placeholder h={20} />} endSlot={<Placeholder h={20} />} selected>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem size=\"small\" selected onClick={() => {}}>\n                        Menu item\n                    </MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem selected>Menu item</MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem size=\"large\" selected>\n                        Menu item\n                    </MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--href",
 					"name": "href",
 					"snippet": "const href = () => <MenuItem href=\"https://reshaped.so\">Trigger</MenuItem>;"
 				},
 				{
+					"id": "components-menuitem--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <MenuItem onClick={fn()}>Trigger</MenuItem>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-menuitem--href-on-click",
+					"name": "href + onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <MenuItem\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </MenuItem>\n);"
 				},
 				{
+					"id": "components-menuitem--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <MenuItem disabled onClick={() => {}}>\n        Trigger\n    </MenuItem>\n);"
 				},
 				{
-					"name": "as",
+					"id": "components-menuitem--as",
+					"name": "as, render",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"render, disabled\">\n            <MenuItem\n                disabled\n                onClick={() => {}}\n                render={(props) => <section {...props} />}\n                attributes={{ \"data-testid\": \"render-el\" }}\n            >\n                Trigger\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-menuitem--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <MenuItem className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </MenuItem>\n    </div>\n);"
 				},
 				{
-					"name": "alignerClassName",
+					"id": "components-menuitem--aligner-class-name",
+					"name": "aligner, className, attributes",
 					"snippet": "const alignerClassName = () => (\n    <div data-testid=\"root\">\n        <MenuItem.Aligner className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <MenuItem>Trigger</MenuItem>\n        </MenuItem.Aligner>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Hotkey, MenuItem, Placeholder, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/MenuItem/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "MenuItem",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/MenuItem/MenuItem.tsx",
-				"actualName": "MenuItem",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content\nNode for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"neutral\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"neutral\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content at the start side of the component",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content at the end side of the component",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component as hovered or focused. For example, when displaying currently focused item in Autocomplete",
+						"name": "highlighted",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"selected": {
+						"defaultValue": null,
+						"description": "Highlight the component as selected",
+						"name": "selected",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"roundedCorners": {
+						"defaultValue": null,
+						"description": "Round the corners of the component",
+						"name": "roundedCorners",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					}
+				},
+				"exportName": "MenuItem"
 			}
 		},
 		"components-modal": {
@@ -961,67 +5537,301 @@
 			"path": "./src/components/Modal/tests/Modal.stories.tsx",
 			"stories": [
 				{
+					"id": "components-modal--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title={[\"responsive position\", \"[s] full-screen\", \"[m] center\", \"[l] end\"]}>\n            <Demo position={{ s: \"full-screen\", m: \"center\", l: \"end\" }} />\n        </Example.Item>\n        <Example.Item title=\"position: center\">\n            <Demo position=\"center\" />\n        </Example.Item>\n        <Example.Item title=\"position: bottom\">\n            <Demo position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"position: start\">\n            <Demo position=\"start\" />\n        </Example.Item>\n        <Example.Item title=\"position: end\">\n            <Demo position=\"end\" />\n        </Example.Item>\n        <Example.Item title=\"position: full-screen\">\n            <Demo position=\"full-screen\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: default\">\n                <Demo />\n            </Example.Item>\n            <Example.Item title=\"size: 300px\">\n                <Demo size=\"300px\" />\n            </Example.Item>\n            <Example.Item\n                title={[\"size: 800px\", \"should have max width of 100% minus gaps on the sides\"]}\n            >\n                <Demo size=\"800px\" />\n            </Example.Item>\n            <Example.Item\n                title={[\n                    \"responsive size, responsive position\",\n                    \"[s] auto\",\n                    \"[m+] 600px\",\n                    \"bottom position changes height instead of width\",\n                ]}\n            >\n                <Demo\n                    position={{ s: \"bottom\", m: \"center\", l: \"end\" }}\n                    size={{ s: \"auto\", m: \"600px\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-modal--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 0\">\n            <Demo padding={0} />\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <Demo padding={6} />\n        </Example.Item>\n        <Example.Item title={[\"responsive padding\", \"[s] 2\", \"[m+]: 6\"]}>\n            <Demo padding={{ s: 2, m: 6 }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--overflow",
 					"name": "overflow",
 					"snippet": "const overflow = () => (\n    <Example>\n        <Example.Item title=\"default overflow\">\n            <Demo>\n                <div\n                    style={{\n                        position: \"absolute\",\n                        top: -32,\n                        left: -32,\n                        height: 100,\n                        width: 100,\n                        background: \"tomato\",\n                    }}\n                />\n            </Demo>\n        </Example.Item>\n\n        <Example.Item title=\"overflow: visible\">\n            <Demo overflow=\"visible\">\n                <div\n                    style={{\n                        position: \"absolute\",\n                        top: -32,\n                        left: -32,\n                        height: 100,\n                        width: 100,\n                        background: \"tomato\",\n                    }}\n                />\n            </Demo>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--composition",
 					"name": "composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"title, subtitle, dismissible\">\n            <Demo title=\"Modal title\" subtitle=\"Modal subtitle\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--overlay",
 					"name": "overlay",
 					"snippet": "const overlay = () => (\n    <Example>\n        <Example.Item title=\"transparentOverlay, doesn't lock scroll\">\n            <Demo transparentOverlay />\n        </Example.Item>\n        <Example.Item title=\"blurredOverlay\">\n            <Demo blurredOverlay />\n        </Example.Item>\n        <View height=\"1000px\" />\n    </Example>\n);"
 				},
 				{
-					"name": "flags",
+					"id": "components-modal--flags",
+					"name": "disableCloseOnOutsideClick",
 					"snippet": "const flags = () => {\n    return (\n        <Example>\n            <Example.Item title=\"disableCloseOnOutsideClick\">\n                <Demo disableCloseOnOutsideClick onClose={fn()} active />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-modal--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const containerRef2 = React.useRef<HTMLDivElement>(null);\n    const toggle = useToggle();\n    const toggle2 = useToggle();\n\n    return (\n        <Example>\n            <Example.Item title={[\"in scrollable container\", \"scroll and then open\"]}>\n                <View\n                    attributes={{ ref: containerRef2 }}\n                    borderRadius=\"medium\"\n                    height=\"400px\"\n                    overflow=\"auto\"\n                    backgroundColor=\"neutral-faded\"\n                    padding={4}\n                >\n                    <View gap={4} align=\"start\">\n                        <Button onClick={toggle2.activate}>Open modal</Button>\n                        <View height=\"500px\" backgroundColor=\"primary\" width=\"500px\" borderRadius=\"medium\" />\n                    </View>\n                    <Modal\n                        containerRef={containerRef2}\n                        active={toggle2.active}\n                        onClose={toggle2.deactivate}\n                        position=\"end\"\n                    >\n                        <Placeholder />\n                    </Modal>\n                </View>\n            </Example.Item>\n            <Example.Item title=\"in static container\">\n                <View\n                    attributes={{ ref: containerRef }}\n                    borderRadius=\"medium\"\n                    height=\"400px\"\n                    overflow=\"hidden\"\n                    backgroundColor=\"neutral-faded\"\n                    padding={4}\n                >\n                    <Button onClick={toggle.activate}>Open modal</Button>\n                    <Modal\n                        containerRef={containerRef}\n                        active={toggle.active}\n                        onClose={toggle.deactivate}\n                        position=\"end\"\n                    >\n                        <Placeholder />\n                    </Modal>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "renderProps",
+					"id": "components-modal--render-props",
+					"name": "children, render props",
 					"snippet": "const renderProps = () => (\n    <Modal active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        <Modal.Title>Title</Modal.Title>\n        Content\n    </Modal>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "components-modal--handlers",
+					"name": "onOpen, onClose, onAfterOpen, onAfterClose",
 					"snippet": "const handlers = () => {\n    const overlayToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => overlayToggle.toggle()}>Open overlay</Button>\n            <Modal\n                active={overlayToggle.active}\n                onClose={(closeArgs) => {\n                    overlayToggle.deactivate();\n                    args.handleClose(closeArgs);\n                }}\n                onOpen={fn()}\n                onAfterOpen={fn()}\n                onAfterClose={fn()}>\n                <Modal.Title>Title</Modal.Title>Content\n                                </Modal>\n        </>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-modal--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <Modal active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        <Modal.Title>Title</Modal.Title>\n        Content\n    </Modal>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-modal--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => {\n    const menuModalToggle = useToggle();\n    const menuModalToggleInner = useToggle();\n    const scrollModalToggle = useToggle();\n    const inputRef = React.useRef<HTMLInputElement>(null);\n\n    return (\n        <Example>\n            <Example.Item title=\"Scrolls with long content on touch devices\">\n                <Demo position=\"center\">\n                    <Button onClick={() => {}}>Action</Button>\n                    <View height=\"2000px\" backgroundColor=\"primary-faded\" />\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"keyboard focus stays on the modal first\">\n                <Demo title=\"Modal title\" autoFocus={false} />\n            </Example.Item>\n            <Example.Item title=\"trap focus works with custom children components\">\n                <Demo title=\"Modal title\">\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <Switch name=\"switch\" />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"focus moves to the input\">\n                <Demo\n                    title=\"Modal title\"\n                    onOpen={() => {\n                        inputRef.current?.focus();\n                    }}\n                >\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <TextField name=\"name\" inputAttributes={{ ref: inputRef }} />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"Focus moves to the input with autoFocus\">\n                <Demo title=\"Modal title\">\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <TextField\n                            name=\"name\"\n                            placeholder=\"autofocus\"\n                            inputAttributes={{ autoFocus: true }}\n                        />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"scrollable area in modal ignores swipe-to-close\">\n                <View gap={3} direction=\"row\">\n                    <Button onClick={scrollModalToggle.activate}>Open</Button>\n                    <Modal\n                        active={scrollModalToggle.active}\n                        onClose={scrollModalToggle.deactivate}\n                        size=\"300px\"\n                        position=\"bottom\"\n                    >\n                        <View\n                            height=\"1000px\"\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            padding={4}\n                        >\n                            Content\n                        </View>\n                    </Modal>\n                </View>\n            </Example.Item>\n            <Example.Item\n                title={[\n                    \"trap focus works correctly when it was already trapped\",\n                    \"focus return back to the dropdown trigger on modal close\",\n                    \"closing dropdown inside the modal doesn't close the modal\",\n                ]}\n            >\n                <DropdownMenu>\n                    <DropdownMenu.Trigger>\n                        {(attributes) => <Button attributes={attributes}>Open menu</Button>}\n                    </DropdownMenu.Trigger>\n                    <DropdownMenu.Content>\n                        <DropdownMenu.Item onClick={menuModalToggle.activate}>Open dialog</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                    </DropdownMenu.Content>\n                </DropdownMenu>\n                <Modal active={menuModalToggle.active} onClose={menuModalToggle.deactivate}>\n                    <View gap={3}>\n                        <DropdownMenu>\n                            <DropdownMenu.Trigger>\n                                {(attributes) => <Button attributes={attributes}>Open menu</Button>}\n                            </DropdownMenu.Trigger>\n                            <DropdownMenu.Content>\n                                <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                                <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                            </DropdownMenu.Content>\n                        </DropdownMenu>\n                        <Button onClick={menuModalToggleInner.activate}>Open dialog</Button>\n                        <Button onClick={menuModalToggle.deactivate}>Close</Button>\n                        <Modal active={menuModalToggleInner.active} onClose={menuModalToggleInner.deactivate}>\n                            <Button onClick={menuModalToggleInner.deactivate}>Close</Button>\n                        </Modal>\n                    </View>\n                </Modal>\n            </Example.Item>\n\n            <Example.Item title=\"disableSwipeGesture\">\n                <Demo disableSwipeGesture position=\"start\" />\n            </Example.Item>\n\n            <Example.Item title=\"scroll locks on open\">\n                <Demo />\n                <View height=\"1000px\" />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "trapFocusEdgeCases",
+					"id": "components-modal--trap-focus-edge-cases",
+					"name": "test: trap focus edge cases",
 					"snippet": "const trapFocusEdgeCases = () => {\n    const toggle = useToggle();\n\n    return (\n        <Example>\n            <Example.Item title=\"Radio should be navigatable with arrow keys\">\n                <Button onClick={toggle.activate}>Open modal</Button>\n                <Modal active={toggle.active} onClose={toggle.deactivate}>\n                    <View gap={2}>\n                        <Button onClick={() => {}}>Action 1</Button>\n                        <Radio name=\"radio\" value=\"1\">\n                            Option 1\n                        </Radio>\n                        <Radio name=\"radio\" value=\"2\">\n                            Option 2\n                        </Radio>\n                        <Button onClick={() => {}}>Action 2</Button>\n                    </View>\n                </Modal>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import {\n    Button,\n    Dismissible,\n    DropdownMenu,\n    Example,\n    Modal,\n    Placeholder,\n    Radio,\n    Switch,\n    TextField,\n    View,\n} from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Modal/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Modal",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Modal/Modal.tsx",
-				"actualName": "Modal",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Component position on the screen",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<\"bottom\" | \"center\" | \"start\" | \"end\" | \"full-screen\">"
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size, literal css value",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Component padding, unit token multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Remove overflow from the component content",
+						"name": "overflow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"visible\"", "value": [{ "value": "\"visible\"" }] }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is closed",
+						"name": "onClose",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((args: { reason: CloseReason | \"drag\"; }) => void)" }
+					},
+					"transparentOverlay": {
+						"defaultValue": null,
+						"description": "Make the overlay transparent",
+						"name": "transparentOverlay",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"blurredOverlay": {
+						"defaultValue": null,
+						"description": "Make the overlay blurred",
+						"name": "blurredOverlay",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableSwipeGesture": {
+						"defaultValue": null,
+						"description": "Disable swipe gesture to close the component on touch devices",
+						"name": "disableSwipeGesture",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable closing the component on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Focus the first focusable element in the component when it is opened, when false, focus will be set on the component content container",
+						"name": "autoFocus",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element, useful when there is no visible title",
+						"name": "ariaLabel",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"overlayClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the overlay element",
+						"name": "overlayClassName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "(Attributes<\"div\"> & { ref?: RefObject<HTMLDivElement | null>; })"
+						}
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the visibility of the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the component is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"containerRef": {
+						"defaultValue": null,
+						"description": "Element to render the component in",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"onAfterOpen": {
+						"defaultValue": null,
+						"description": "Callback after the component open transition is complete",
+						"name": "onAfterOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onAfterClose": {
+						"defaultValue": null,
+						"description": "Callback after the component close transition is complete",
+						"name": "onAfterClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					}
+				},
+				"exportName": "Modal"
 			}
 		},
 		"components-numberfield": {
@@ -1030,54 +5840,450 @@
 			"path": "./src/components/NumberField/tests/NumberField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-numberfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => {\n    return (\n        <Example>\n            <Example.Item title=\"variant: outline\">\n                <NumberField\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"variant: faded\">\n                <NumberField\n                    variant=\"faded\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"variant: headless\">\n                <NumberField\n                    variant=\"headless\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-numberfield--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: small\">\n                <NumberField\n                    size=\"small\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    suffix=\"m2\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: medium\">\n                <NumberField\n                    size=\"medium\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: large\">\n                <NumberField\n                    size=\"large\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: xlarge\">\n                <NumberField\n                    size=\"xlarge\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-numberfield--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <NumberField\n    name=\"test-name\"\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    disabled\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-numberfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <NumberField\n    name=\"test-name\"\n    defaultValue={2}\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-numberfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <NumberField\n    name=\"test-name\"\n    value={2}\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "minMax",
+					"id": "components-numberfield--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <NumberField\n        name=\"test-name\"\n        defaultValue={6}\n        min={5}\n        max={10}\n        increaseAriaLabel=\"Increase\"\n        decreaseAriaLabel=\"Decrease\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-numberfield--step",
 					"name": "step",
 					"snippet": "const step = () => (\n    <NumberField\n        name=\"test-name\"\n        defaultValue={6}\n        step={0.5}\n        increaseAriaLabel=\"Increase\"\n        decreaseAriaLabel=\"Decrease\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-numberfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <NumberField\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n            increaseAriaLabel=\"Increase\"\n            decreaseAriaLabel=\"Decrease\"\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-numberfield--form-control",
+					"name": "test: FormControl",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"FormControl\">\n            <FormControl>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"FormControl, disabled\">\n            <FormControl disabled>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"FormControl, error\">\n            <FormControl hasError>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "valueChanges",
+					"id": "components-numberfield--value-changes",
+					"name": "test: keyboard",
 					"snippet": "const valueChanges = () => (\n    <Example>\n        <Example.Item title=\"keyboard\">\n            <NumberField\n                name=\"name\"\n                increaseAriaLabel=\"Increase\"\n                decreaseAriaLabel=\"Decrease\"\n                inputAttributes={{ \"aria-label\": \"Label\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, FormControl, NumberField } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/NumberField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "NumberField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/NumberField/NumberField.tsx",
-				"actualName": "NumberField",
+				"methods": [],
+				"props": {
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component value is changed",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<number, ChangeEvent<HTMLInputElement>>" }
+					},
+					"increaseAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the increase button",
+						"name": "increaseAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"decreaseAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the decrease button",
+						"name": "decreaseAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum value supported in the form field",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum value supported in the form field",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"step": {
+						"defaultValue": null,
+						"description": "Step at which the value will increase or decrease when clicking the button controls",
+						"name": "step",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the form field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the form field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1087,34 +6293,166 @@
 			"path": "./src/components/Pagination/tests/Pagination.stories.tsx",
 			"stories": [
 				{
+					"id": "components-pagination--truncate",
 					"name": "truncate",
 					"snippet": "const truncate = () => {\n    return (\n        <Example>\n            <Example.Item title=\"start\">\n                <Pagination\n                    total={10}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"middle\">\n                <Pagination\n                    total={10}\n                    defaultPage={5}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"end\">\n                <Pagination\n                    total={10}\n                    defaultPage={10}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"no truncation\">\n                <Pagination\n                    total={4}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "render",
+					"id": "components-pagination--render",
+					"name": "rendering",
 					"snippet": "const render = () => (\n    <div data-testid=\"root\">\n        <Pagination\n            total={10}\n            previousAriaLabel=\"Previous\"\n            nextAriaLabel=\"Next\"\n            pageAriaLabel={(args) => `Page ${args.page}`}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "defaultPage",
+					"id": "components-pagination--default-page",
+					"name": "defaultPage, uncontrolled",
 					"snippet": "const defaultPage = () => <div data-testid=\"root\">\n    <Pagination\n        total={10}\n        defaultPage={2}\n        onChange={fn()}\n        previousAriaLabel=\"Previous\"\n        nextAriaLabel=\"Next\" />\n</div>;"
 				},
 				{
-					"name": "page",
+					"id": "components-pagination--page",
+					"name": "page, controlled",
 					"snippet": "const page = () => <div data-testid=\"root\">\n    <Pagination\n        total={10}\n        page={2}\n        onChange={fn()}\n        previousAriaLabel=\"Previous\"\n        nextAriaLabel=\"Next\" />\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "components-pagination--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Pagination\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            total={10}\n            previousAriaLabel=\"Previous\"\n            nextAriaLabel=\"Next\"\n        />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Pagination } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Pagination/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Pagination",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Pagination/Pagination.tsx",
-				"actualName": "Pagination",
+				"methods": [],
+				"props": {
+					"total": {
+						"defaultValue": null,
+						"description": "Total number of pages available",
+						"name": "total",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "number" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the current page changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { page: number; }) => void)" }
+					},
+					"pageAriaLabel": {
+						"defaultValue": null,
+						"description": "Function to dynamically get an aria-label for each page",
+						"name": "pageAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { page: number; }) => string)" }
+					},
+					"previousAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the previous page button",
+						"name": "previousAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"nextAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the next page button",
+						"name": "nextAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"page": {
+						"defaultValue": null,
+						"description": "Currently selected page number, starts with 1, enables controlled mode",
+						"name": "page",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultPage": {
+						"defaultValue": null,
+						"description": "Default selected page number, starts with 1, enables uncontrolled mode",
+						"name": "defaultPage",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1124,54 +6462,229 @@
 			"path": "./src/components/PinField/tests/PinField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-pinfield--base",
 					"name": "base",
 					"snippet": "const base = () => <PinField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-pinfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <PinField name=\"pin\" variant=\"faded\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-pinfield--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <PinField name=\"pin\" size=\"small\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <PinField name=\"pin\" size=\"medium\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <PinField name=\"pin\" size=\"large\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <PinField name=\"pin\" size=\"xlarge\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: responsive, s: medium, m+: xlarge\">\n            <PinField\n                name=\"pin\"\n                size={{ s: \"medium\", m: \"xlarge\" }}\n                inputAttributes={{ \"aria-label\": \"Pin\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-pinfield--value-length",
 					"name": "valueLength",
 					"snippet": "const valueLength = () => (\n    <PinField name=\"test-name\" valueLength={6} inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-pinfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <PinField\n    name=\"test-name\"\n    onChange={fn()}\n    defaultValue=\"12\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-pinfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <PinField\n    name=\"test-name\"\n    onChange={fn()}\n    value=\"12\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-pinfield--pattern",
 					"name": "pattern",
 					"snippet": "const pattern = () => <PinField\n    name=\"test-name\"\n    pattern=\"alphabetic\"\n    defaultValue=\"ab\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-pinfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <PinField\n            name=\"test-name\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ \"aria-label\": \"Label\", id: \"test-input-id\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-pinfield--form-control",
+					"name": "test: with FormControl",
 					"snippet": "const formControl = () => (\n    <FormControl>\n        <FormControl.Label>Label</FormControl.Label>\n        <PinField name=\"test-name\" />\n    </FormControl>\n);"
 				},
 				{
-					"name": "keyboard",
+					"id": "components-pinfield--keyboard",
+					"name": "test: keyboard navigation",
 					"snippet": "const keyboard = () => <PinField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				}
 			],
 			"import": "import { Example, FormControl, PinField } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/PinField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "PinField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/PinField/PinField.tsx",
-				"actualName": "PinField",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"valueLength": {
+						"defaultValue": null,
+						"description": "Amount of characters in the pin",
+						"name": "valueLength",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"pattern": {
+						"defaultValue": null,
+						"description": "Character pattern used in the input value",
+						"name": "pattern",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"numeric\" | \"alphabetic\" | \"alphanumeric\"",
+							"value": [
+								{ "value": "\"numeric\"" },
+								{ "value": "\"alphabetic\"" },
+								{ "value": "\"alphanumeric\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Input fields render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\"",
+							"value": [{ "value": "\"outline\"" }, { "value": "\"faded\"" }]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the input element, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1181,75 +6694,514 @@
 			"path": "./src/components/Popover/tests/Popover.stories.tsx",
 			"stories": [
 				{
+					"id": "components-popover--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: bottom\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"bottom-start\" />\n                <Demo position=\"bottom\" />\n                <Demo position=\"bottom-end\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: top\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"top-start\" />\n                <Demo position=\"top\" />\n                <Demo position=\"top-end\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: start\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"start-top\" />\n                <Demo position=\"start\" />\n                <Demo position=\"start-bottom\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: end\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"end-top\" />\n                <Demo position=\"end\" />\n                <Demo position=\"end-bottom\" defaultActive />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "widthNumber",
+					"id": "components-popover--width-number",
+					"name": "width: px",
 					"snippet": "const widthNumber = () => <Demo width=\"400px\" defaultActive />;"
 				},
 				{
-					"name": "widthFull",
+					"id": "components-popover--width-full",
+					"name": "width: 100%",
 					"snippet": "const widthFull = () => <Demo width=\"100%\" defaultActive />;"
 				},
 				{
+					"id": "components-popover--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 0\">\n            <Demo padding={0} />\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <Demo padding={6} defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-popover--elevation",
 					"name": "elevation",
 					"snippet": "const elevation = () => (\n    <Example>\n        <Example.Item title=\"elevation: raised\">\n            <Demo elevation=\"raised\" defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-popover--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <Popover onOpen={fn()} onClose={fn()} defaultActive>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "active",
+					"id": "components-popover--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <Popover onOpen={fn()} onClose={fn()} active>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "components-popover--active-false",
+					"name": "active false, controlled",
 					"snippet": "const activeFalse = () => <Popover onOpen={fn()} onClose={fn()} active={false}>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "dismissible",
+					"id": "components-popover--dismissible",
+					"name": "dismissible, onClose, className, attributes, closeAriaLabel",
 					"snippet": "const dismissible = () => <Popover onClose={fn()} defaultActive>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>\n        <Popover.Dismissible\n            closeAriaLabel=\"Close\"\n            attributes={{ \"data-testid\": \"test-id\" }}\n            className=\"test-classname\">Content\n                            </Popover.Dismissible>\n    </Popover.Content>\n</Popover>;"
 				},
 				{
+					"id": "components-popover--auto-focus",
 					"name": "autoFocus",
 					"snippet": "const autoFocus = () => (\n    <Example>\n        <Example.Item title=\"autoFocus=false\">\n            <Demo autoFocus={false} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-popover--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Popover active>\n            <Popover.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </Popover.Trigger>\n            <Popover.Content className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n                Content\n            </Popover.Content>\n        </Popover>\n    </div>\n);"
 				},
 				{
-					"name": "testNested",
+					"id": "components-popover--test-nested",
+					"name": "test: nested",
 					"snippet": "const testNested = () => (\n    <Popover position=\"bottom\">\n        <Popover.Trigger>\n            {(attributes) => <Button attributes={attributes}>Open</Button>}\n        </Popover.Trigger>\n        <Popover.Content>\n            <View gap={2} align=\"start\">\n                Popover content\n                <Popover>\n                    <Popover.Trigger>\n                        {(attributes) => <Button attributes={attributes}>Open</Button>}\n                    </Popover.Trigger>\n                    <Popover.Content>Hello</Popover.Content>\n                </Popover>\n            </View>\n        </Popover.Content>\n    </Popover>\n);"
 				},
 				{
-					"name": "testWithTooltip",
+					"id": "components-popover--test-with-tooltip",
+					"name": "test: with tooltip",
 					"snippet": "const testWithTooltip = () => (\n    <View paddingTop={10}>\n        <Tooltip position=\"top\" text=\"Hello\">\n            {(tooltipAttributes) => (\n                <Popover position=\"bottom\">\n                    <Popover.Trigger>\n                        {(attributes) => (\n                            <Button\n                                attributes={{\n                                    ...attributes,\n                                    ...tooltipAttributes,\n                                }}\n                            >\n                                Open\n                            </Button>\n                        )}\n                    </Popover.Trigger>\n                    <Popover.Content>\n                        <View gap={2} align=\"start\">\n                            Popover content\n                            <Button onClick={() => {}}>Button</Button>\n                        </View>\n                    </Popover.Content>\n                </Popover>\n            )}\n        </Tooltip>\n    </View>\n);"
 				},
 				{
-					"name": "testContentEditable",
+					"id": "components-popover--test-content-editable",
+					"name": "test: contenteditable",
 					"snippet": "const testContentEditable = () => {\n    const [active, setActive] = useState(false);\n\n    return (\n        <Popover>\n            <Popover.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </Popover.Trigger>\n            <Popover.Content>\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={() => {}}>Hello</Button>\n                    </View.Item>\n\n                    <ScrollArea height=\"100px\">\n                        <div\n                            style={{ height: \"200px\" }}\n                            contentEditable\n                            tabIndex={0}\n                            onInput={(e) => {\n                                setActive(e.currentTarget.innerText.startsWith(\"@\"));\n                            }}\n                            onKeyDown={(e) => {\n                                console.log(e.key);\n                                if (e.key === \"Enter\" && active) {\n                                    e.preventDefault();\n                                    e.currentTarget.innerText = \"@hello\";\n                                    setActive(false);\n                                }\n                            }}\n                        />\n                    </ScrollArea>\n\n                    <Popover\n                        active={active}\n                        onClose={() => setActive(false)}\n                        originCoordinates={{ x: 300, y: 300 }}\n                        trapFocusMode=\"selection-menu\"\n                    >\n                        <Popover.Content>\n                            <View gap={4}>\n                                <MenuItem onClick={() => {}}>Action</MenuItem>\n                                <MenuItem onClick={() => {}}>Close</MenuItem>\n                            </View>\n                        </Popover.Content>\n                    </Popover>\n                </View>\n            </Popover.Content>\n        </Popover>\n    );\n};"
 				},
 				{
-					"name": "variant",
+					"id": "components-popover--variant",
+					"name": "variant [deprecated]",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: headless\">\n            <Popover variant=\"headless\" defaultActive position=\"bottom-start\">\n                <Popover.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </Popover.Trigger>\n                <Popover.Content>\n                    <View\n                        height=\"100px\"\n                        width=\"100px\"\n                        borderColor=\"primary\"\n                        borderRadius=\"medium\"\n                        backgroundColor=\"primary-faded\"\n                    />\n                </Popover.Content>\n            </Popover>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, MenuItem, Popover, ScrollArea, Tooltip, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Popover/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Popover",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Popover/Popover.tsx",
-				"actualName": "Popover",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Automatically focus the first focusable element in the content, when false the content container will be focused instead",
+						"name": "autoFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | TrapMode" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Content element padding, unit token multiplier",
+						"name": "padding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "@deprecated use Flyout utility instead, will be removed in v4",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"elevated\" | \"headless\"",
+							"value": [{ "value": "\"elevated\"" }, { "value": "\"headless\"" }]
+						}
+					}
+				},
+				"exportName": "Popover"
 			}
 		},
 		"components-progress": {
@@ -1258,38 +7210,177 @@
 			"path": "./src/components/Progress/tests/Progress.stories.tsx",
 			"stories": [
 				{
+					"id": "components-progress--value",
 					"name": "value",
 					"snippet": "const value = () => (\n    <Example>\n        <Example.Item title=\"value: 50\">\n            <Progress value={50} ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"value: 20, min: 0, max: 40\">\n            <Progress value={20} min={0} max={40} ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"value: 50, min: 0, max: 40\">\n            <Progress value={50} min={0} max={40} ariaLabel=\"rating value\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small, value: 50\">\n            <Progress value={50} size=\"small\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"size: medium, value: 50\">\n            <Progress value={50} size=\"medium\" ariaLabel=\"rating value\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: critical, value: 50\">\n            <Progress value={50} color=\"critical\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: warning, value: 50\">\n            <Progress value={50} color=\"warning\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive, value: 50\">\n            <Progress value={50} color=\"positive\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: media, value: 50\">\n            <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                <Progress value={50} color=\"media\" ariaLabel=\"rating value\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--duration",
 					"name": "duration",
 					"snippet": "const duration = () => {\n    const [active, setActive] = React.useState(false);\n\n    const handleChange = () => {\n        setActive((state) => !state);\n    };\n\n    return (\n        <Example>\n            <Example.Item title=\"duration: 2000\">\n                <View gap={3}>\n                    <View.Item>\n                        <Button onClick={handleChange}>Change</Button>\n                    </View.Item>\n\n                    <Progress value={active ? 100 : 0} duration={2000} ariaLabel=\"rating value\" />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "render",
+					"id": "components-progress--render",
+					"name": "rendering",
 					"snippet": "const render = () => <Progress value={75} min={50} max={100} ariaLabel=\"progress\" />;"
 				},
 				{
-					"name": "className",
+					"id": "components-progress--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Progress className=\"test-classname\" attributes={{ id: \"test-id\" }} ariaLabel=\"progress\" />\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, Progress, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Progress/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Progress",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Progress/Progress.tsx",
-				"actualName": "Progress",
+				"methods": [],
+				"props": {
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the progress bar controlling the size of the fill",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Lower value boundary of the progress bar",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Upper value boundary of the progress bar",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"warning\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"duration": {
+						"defaultValue": null,
+						"description": "Duration of the progress bar animation in milliseconds",
+						"name": "duration",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1299,30 +7390,135 @@
 			"path": "./src/components/ProgressIndicator/tests/ProgressIndicator.stories.tsx",
 			"stories": [
 				{
+					"id": "components-progressindicator--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const [activeIndex, setActiveIndex] = React.useState(0);\n    const total = 10;\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <View gap={4}>\n                    <View direction=\"row\" gap={2} align=\"center\">\n                        <Button\n                            onClick={() => {\n                                setActiveIndex((prev) => Math.max(0, prev - 1));\n                            }}\n                        >\n                            Previous\n                        </Button>\n                        <Button\n                            onClick={() => {\n                                setActiveIndex((prev) => Math.min(total - 1, prev + 1));\n                            }}\n                        >\n                            Next\n                        </Button>\n                        <Text weight=\"medium\">Index: {activeIndex}</Text>\n                    </View>\n\n                    <View borderRadius=\"medium\" overflow=\"hidden\" width=\"300px\">\n                        <Scrim\n                            position=\"bottom\"\n                            backgroundSlot={<View aspectRatio={16 / 9} backgroundColor=\"neutral-faded\" />}\n                        >\n                            <View align=\"center\">\n                                <ProgressIndicator total={total} activeIndex={activeIndex} color=\"media\" />\n                            </View>\n                        </Scrim>\n                    </View>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-progressindicator--color",
 					"name": "color",
 					"snippet": "const color = () => {\n    return (\n        <Example>\n            <Example.Item title=\"color: primary\">\n                <ProgressIndicator total={10} activeIndex={5} color=\"primary\" />\n            </Example.Item>\n            <Example.Item title=\"color: media\">\n                <View borderRadius=\"medium\" overflow=\"hidden\" width=\"300px\">\n                    <Scrim\n                        position=\"bottom\"\n                        backgroundSlot={<View aspectRatio={16 / 9} backgroundColor=\"neutral-faded\" />}\n                    >\n                        <View align=\"center\">\n                            <ProgressIndicator total={10} activeIndex={5} color=\"media\" />\n                        </View>\n                    </Scrim>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-progressindicator--aria-label",
 					"name": "ariaLabel",
 					"snippet": "const ariaLabel = () => <ProgressIndicator total={10} className=\"test-classname\" ariaLabel=\"Progress\" />;"
 				},
 				{
-					"name": "className",
+					"id": "components-progressindicator--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ProgressIndicator total={10} className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, ProgressIndicator, Scrim, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ProgressIndicator/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ProgressIndicator",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ProgressIndicator/ProgressIndicator.tsx",
-				"actualName": "ProgressIndicator",
+				"methods": [],
+				"props": {
+					"total": {
+						"defaultValue": null,
+						"description": "Total amount of progress indicator dots",
+						"name": "total",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "number" }
+					},
+					"activeIndex": {
+						"defaultValue": null,
+						"description": "Index of the active progress indicator dot",
+						"name": "activeIndex",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\"",
+							"value": [{ "value": "\"media\"" }, { "value": "\"primary\"" }]
+						}
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1332,50 +7528,203 @@
 			"path": "./src/components/Radio/tests/Radio.stories.tsx",
 			"stories": [
 				{
+					"id": "components-radio--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"small\" defaultChecked>\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"medium\">\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"large\">\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: responsive, s: small, m: large\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size={{ s: \"small\", m: \"large\" }}>\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-radio--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Radio name=\"error\" value=\"dog\" hasError>\n                Radio\n            </Radio>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-radio--render",
+					"name": "name, value",
 					"snippet": "const render = () => (\n    <Radio name=\"test-name\" value=\"test-value\">\n        Content\n    </Radio>\n);"
 				},
 				{
-					"name": "checked",
+					"id": "components-radio--checked",
+					"name": "checked, controlled",
 					"snippet": "const checked = () => <Radio name=\"test-name\" value=\"test-value\" checked onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "checkedFalse",
+					"id": "components-radio--checked-false",
+					"name": "checked false, controlled",
 					"snippet": "const checkedFalse = () => <Radio name=\"test-name\" value=\"test-value\" checked={false} onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-radio--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Radio name=\"test-name\" value=\"test-value\" defaultChecked onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "defaultCheckedFalse",
+					"id": "components-radio--default-checked-false",
+					"name": "defaultChecked false, uncontrolled",
 					"snippet": "const defaultCheckedFalse = () => <Radio name=\"test-name\" value=\"test-value\" onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
+					"id": "components-radio--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Radio name=\"test-name\" value=\"test-value\" disabled>\n        Content\n    </Radio>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-radio--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Radio className=\"test-classname\" attributes={{ id: \"test-id\" }} value=\"value\">\n            Content\n        </Radio>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Radio, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Radio/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Radio",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Radio/Radio.tsx",
-				"actualName": "Radio",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the form field from the form submission",
+						"name": "disabled",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Indicate that the form field has an error",
+						"name": "hasError",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element",
+						"name": "value",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the input is focused",
+						"name": "onFocus",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the input is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "",
+						"name": "checked",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultChecked",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1385,26 +7734,169 @@
 			"path": "./src/components/RadioGroup/tests/RadioGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "value",
+					"id": "components-radiogroup--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <RadioGroup name=\"test-name\" value=\"1\" onChange={fn()}>\n    {/* checked should be ignored */}\n    <Radio value=\"1\" checked={false}>Content\n                    </Radio>\n    <Radio value=\"2\">Content 2</Radio>\n</RadioGroup>;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-radiogroup--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <RadioGroup name=\"test-name\" defaultValue=\"1\" onChange={fn()}>\n    {/* checked should be ignored */}\n    <Radio value=\"1\" checked={false}>Content\n                    </Radio>\n    <Radio value=\"2\">Content 2</Radio>\n</RadioGroup>;"
 				},
 				{
+					"id": "components-radiogroup--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <RadioGroup name=\"test-name\" disabled>\n        <Radio value=\"test-value\">Content</Radio>\n    </RadioGroup>\n);"
 				}
 			],
 			"import": "import { Radio, RadioGroup } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/RadioGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "RadioGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/RadioGroup/RadioGroup.tsx",
-				"actualName": "RadioGroup",
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the radio group",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the form field from the form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Indicate that the form field has an error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the input element, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1414,39 +7906,131 @@
 			"path": "./src/components/Resizable/tests/Resizable.stories.tsx",
 			"stories": [
 				{
+					"id": "components-resizable--direction",
 					"name": "direction",
 					"snippet": "const direction = () => {\n    return (\n        <Example>\n            <Example.Item title=\"row\">\n                <Resizable height=\"200px\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n            <Example.Item title=\"column\">\n                <Resizable height=\"400px\" direction=\"column\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n\n            {/* Test that page doesn't scroll on dragging */}\n            <div style={{ height: 2000 }} />\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-resizable--children",
 					"name": "children",
 					"snippet": "const children = () => {\n    return (\n        <Example>\n            <Example.Item title=\"render props, row\">\n                <Resizable height=\"200px\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n            <Example.Item title=\"render props, column\">\n                <Resizable height=\"400px\" direction=\"column\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-resizable--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"bordered, row\">\n            <Resizable height=\"200px\" variant=\"bordered\">\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n            </Resizable>\n        </Example.Item>\n        <Example.Item title=\"bordered, column\">\n            <Resizable height=\"400px\" direction=\"column\" variant=\"bordered\">\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n            </Resizable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "components-resizable--size",
+					"name": "minSize, maxSize, defaultSize",
 					"snippet": "const size = () => (\n    <Resizable className=\"test-classname\" attributes={{ id: \"test-id\" }} height=\"200px\">\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n        <Resizable.Handle />\n        <Resizable.Item minSize=\"200px\" maxSize=\"500px\" defaultSize=\"300px\">\n            <Panel />\n        </Resizable.Item>\n    </Resizable>\n);"
 				},
 				{
-					"name": "layout",
+					"id": "components-resizable--layout",
+					"name": "height, gap",
 					"snippet": "const layout = () => (\n    <Resizable height=\"100px\" gap={8}>\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n        <Resizable.Handle />\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n    </Resizable>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-resizable--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Resizable className=\"test-classname\" attributes={{ id: \"test-id\" }} height=\"200px\">\n            <Resizable.Item>\n                <Panel />\n            </Resizable.Item>\n            <Resizable.Handle />\n            <Resizable.Item>\n                <Panel />\n            </Resizable.Item>\n        </Resizable>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, Resizable, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Resizable/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Resizable",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Resizable/Resizable.tsx",
-				"actualName": "Resizable",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Resizable/Resizable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"bordered\" | \"borderless\"",
+							"value": [{ "value": "\"bordered\"" }, { "value": "\"borderless\"" }]
+						}
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Component content direction with the resize handle rendered in between the chidlren",
+						"name": "direction",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Resizable/Resizable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between children, base unit token number multiplier",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					}
+				},
+				"exportName": "Resizable"
 			}
 		},
 		"components-scrim": {
@@ -1455,26 +8039,101 @@
 			"path": "./src/components/Scrim/tests/Scrim.stories.tsx",
 			"stories": [
 				{
+					"id": "components-scrim--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: center\">\n            <Scrim backgroundSlot={<Placeholder h={200} />}>Scrim</Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <Scrim position=\"bottom\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: top\">\n            <Scrim position=\"top\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: start\">\n            <Scrim position=\"start\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <Scrim position=\"end\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-scrim--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Scrim className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Scrim>\n    </div>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "components-scrim--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"without backgroundSlot, size is based on the parent component\">\n            <div style={{ height: 300, position: \"relative\" }}>\n                <Scrim>Text</Scrim>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Placeholder, Scrim } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Scrim/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Scrim",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Scrim/Scrim.tsx",
-				"actualName": "Scrim",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"backgroundSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting background content behind the scrim",
+						"name": "backgroundSlot",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Component content position",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"bottom\" | \"start\" | \"end\" | \"full\"",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"full\"" }
+							]
+						}
+					},
+					"scrimClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the scrim element",
+						"name": "scrimClassName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1484,79 +8143,398 @@
 			"path": "./src/components/Select/tests/Select.stories.tsx",
 			"stories": [
 				{
-					"name": "nativeRender",
+					"id": "components-select--native-render",
+					"name": "native rendering, options, name, id",
 					"snippet": "const nativeRender = () => (\n    <Example>\n        <Example.Item title=\"native with options prop\">\n            <Select\n                name=\"animal\"\n                id=\"animal-1\"\n                placeholder=\"Select an animal\"\n                options={[\n                    { label: \"Dog\", value: \"dog\" },\n                    { label: \"Turtle\", value: \"turtle\" },\n                ]}\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            />\n        </Example.Item>\n        <Example.Item title=\"native with option tags\">\n            <Select\n                name=\"animal\"\n                id=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "customRender",
+					"id": "components-select--custom-render",
+					"name": "custom rendering, name, id, option groups",
 					"snippet": "const customRender = () => (\n    <Example>\n        <Example.Item title=\"custom with options\">\n            <Select.Custom\n                name=\"animal\"\n                id=\"animal-1\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"native with option tags\">\n            <Select.Custom\n                name=\"animal-2\"\n                id=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Group label=\"Birds\">\n                    <Select.Option value=\"pigeon\">Pigeon</Select.Option>\n                    <Select.Option value=\"parrot\">Parrot</Select.Option>\n                </Select.Group>\n                <Select.Group label=\"Sea Mammals\">\n                    <Select.Option value=\"whale\">Whale</Select.Option>\n                    <Select.Option value=\"dolphin\">Dolphin</Select.Option>\n                </Select.Group>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "nativeHandlers",
+					"id": "components-select--native-handlers",
+					"name": "native, controlled, uncontrolled, onFocus, onBlur, onChange",
 					"snippet": "const nativeHandlers = () => <Example>\n    <Example.Item title=\"native, uncontrolled, onChange\">\n        <Select\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n    <Example.Item title=\"native, controlled, onChange\">\n        <Select\n            name=\"animal-2\"\n            placeholder=\"Select an animal\"\n            value=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n    <Example.Item title=\"native, onFocus, onBlur, onClick\">\n        <Select\n            name=\"animal-3\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onFocus={fn()}\n            onBlur={fn()}\n            onClick={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "customHandlers",
+					"id": "components-select--custom-handlers",
+					"name": "custom, controlled, uncontrolled, onFocus, onBlur, onChange",
 					"snippet": "const customHandlers = () => <Example>\n    <Example.Item title=\"custom, uncontrolled, onChange\">\n        <Select.Custom\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n    <Example.Item title=\"custom, controlled, onChange\">\n        <Select.Custom\n            name=\"animal-2\"\n            placeholder=\"Select an animal\"\n            value=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n    <Example.Item title=\"native, onFocus, onBlur, onClick\">\n        <Select.Custom\n            name=\"animal-3\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onFocus={fn()}\n            onBlur={fn()}\n            onClick={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "triggerOnly",
+					"id": "components-select--trigger-only",
+					"name": "trigger only, onClick",
 					"snippet": "const triggerOnly = (args) => {\n    const toggle = useToggle();\n    const [value, setValue] = React.useState(\"Dog\");\n\n    const handleClick: SelectProps[\"onClick\"] = (e) => {\n        args.handleClick(e);\n        toggle.toggle();\n    };\n\n    return (\n        <Example>\n            <Example.Item title=\"trigger only, onClick\">\n                <Select\n                    name=\"animal\"\n                    placeholder=\"Select an animal\"\n                    onClick={handleClick}\n                    value=\"dog\"\n                    inputAttributes={{\n                        \"aria-label\": \"Select an animal\",\n                    }}\n                >\n                    {value}\n                </Select>\n                <Modal\n                    active={toggle.active}\n                    onClose={toggle.deactivate}\n                    position=\"bottom\"\n                    padding={2}\n                    attributes={{ \"aria-label\": \"Select an animal\" }}\n                >\n                    <div role=\"listbox\" aria-label=\"Select an animal\">\n                        <MenuItem\n                            roundedCorners\n                            onClick={() => {\n                                setValue(\"Dog\");\n                                toggle.deactivate();\n                            }}\n                            attributes={{\n                                role: \"option\",\n                            }}\n                        >\n                            Dog\n                        </MenuItem>\n                        <MenuItem\n                            roundedCorners\n                            attributes={{\n                                role: \"option\",\n                            }}\n                            onClick={() => {\n                                setValue(\"Turtle\");\n                                toggle.deactivate();\n                            }}\n                        >\n                            Turtle\n                        </MenuItem>\n                    </div>\n                </Modal>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-select--multiple",
 					"name": "multiple",
 					"snippet": "const multiple = () => <Example>\n    <Example.Item title=\"multiple\">\n        <Select.Custom\n            multiple\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue={[\"dog\"]}\n            onChange={fn()}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-select--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded, native\">\n            <Select\n                variant=\"faded\"\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n\n        <Example.Item title=\"variant: faded, custom\">\n            <Select.Custom\n                variant=\"faded\"\n                name=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless, native\">\n            <Select\n                variant=\"headless\"\n                name=\"animal-3\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless, custom\">\n            <Select.Custom\n                variant=\"headless\"\n                name=\"animal-4\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <Select.Custom size=\"small\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <Select.Custom size=\"medium\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <Select.Custom size=\"large\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: xlarge\">\n            <Select.Custom size=\"xlarge\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "startSlot",
+					"id": "components-select--start-slot",
+					"name": "icon,startSlot",
 					"snippet": "const startSlot = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Select.Custom name=\"animal\" placeholder=\"Select an animal\" icon={IconZap}>\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n\n        <Example.Item title=\"startSlot\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                startSlot={<Placeholder h={20} />}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--render-value",
 					"name": "renderValue",
 					"snippet": "const renderValue = () => {\n    const options = [\n        {\n            value: \"1\",\n            label: \"Title 1\",\n            subtitle: \"Subtitle 1\",\n        },\n        {\n            value: \"2\",\n            label: \"Title 2\",\n            subtitle: \"Subtitle 2\",\n        },\n    ];\n\n    return (\n        <Example>\n            <Example.Item title=\"default renderer, single\">\n                <Select.Custom name=\"animal\" defaultValue=\"1\" placeholder=\"Nothing selected\">\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"default renderer, multiple\">\n                <Select.Custom name=\"animal\" defaultValue={[\"1\"]} multiple placeholder=\"Nothing selected\">\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"renderValue, single\">\n                <Select.Custom\n                    name=\"animal\"\n                    defaultValue=\"1\"\n                    placeholder=\"Nothing selected\"\n                    renderValue={(args) => <Badge>Title {args.value}</Badge>}\n                >\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"renderValue, multiple\">\n                <Select.Custom\n                    name=\"animal\"\n                    defaultValue={[\"1\"]}\n                    multiple\n                    placeholder=\"Nothing selected\"\n                    renderValue={(args) => <Badge>Titles {args.value.join(\", \")}</Badge>}\n                >\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-select--error",
 					"name": "error",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Select.Custom name=\"animal\" placeholder=\"Select an animal\" hasError>\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, native\">\n            <Select\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                disabled\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n        <Example.Item title=\"disabled, custom\">\n            <Select.Custom\n                name=\"animal-2\"\n                placeholder=\"Select an animal\"\n                disabled\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-select--class-name",
+					"name": "className, attributes, inputAttributes",
 					"snippet": "const className = () => (\n    <Example>\n        <Example.Item title=\"native, className, attributes, inputAttributes\">\n            <Select\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                className=\"native-class\"\n                attributes={{ id: \"test-id\" }}\n                inputAttributes={{ \"aria-label\": \"test-label\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n        <Example.Item title=\"custom, className, attributes, inputAttributes\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                className=\"custom-class\"\n                attributes={{ id: \"test-id\" }}\n                inputAttributes={{ \"aria-label\": \"test-label\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "fallback",
+					"id": "components-select--fallback",
+					"name": "test: fallbackAdjustLayout",
 					"snippet": "const fallback = () => (\n    <Example>\n        <Example.Item title=\"fallback\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                {[...Array(100)].map((_, index) => (\n                    <Select.Option key={index} value={`item-${index}`}>\n                        Item {index + 1}\n                    </Select.Option>\n                ))}\n            </Select.Custom>\n            <div style={{ height: \"1000px\" }}></div>\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                {[...Array(100)].map((_, index) => (\n                    <Select.Option key={index} value={`item-${index}`}>\n                        Item {index + 1}\n                    </Select.Option>\n                ))}\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-select--form-control",
+					"name": "test: with FormControl",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"FormControl\">\n            <FormControl hasError>\n                <FormControl.Label>Animal</FormControl.Label>\n                <Select.Custom name=\"animal\" placeholder=\"Select an animal\">\n                    <Select.Option value=\"dog\">Dog</Select.Option>\n                    <Select.Option value=\"turtle\">Turtle</Select.Option>\n                </Select.Custom>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "components-select--test-composition",
+					"name": "test: composition",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item title=\"custom with options\">\n            <Select.Custom\n                name=\"animal\"\n                id=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Group>\n                    <Select.Option value=\"dog\">Dog</Select.Option>\n                    <Select.Option value=\"turtle\">Turtle</Select.Option>\n                </Select.Group>\n                <Select.Group>Hello</Select.Group>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Badge, Example, FormControl, MenuItem, Modal, Placeholder, Select, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Select/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Select",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Select/Select.tsx",
-				"actualName": "Select",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the select user interaction and form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value selected",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon to display in the select start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the select value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when the trigger is clicked",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"options": {
+						"defaultValue": null,
+						"description": "@deprecated Use <option /> children instead",
+						"name": "options",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NativeOption[]" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the input is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLSelectElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the input is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLSelectElement, Element>) => void)" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"select\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"renderValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "renderValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "undefined" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLSelectElement>>" }
+					}
+				},
+				"exportName": "Select"
 			}
 		},
 		"components-skeleton": {
@@ -1565,26 +8543,87 @@
 			"path": "./src/components/Skeleton/tests/Skeleton.stories.tsx",
 			"stories": [
 				{
+					"id": "components-skeleton--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"text\">\n            <Skeleton />\n        </Example.Item>\n\n        <Example.Item title=\"view, rectangle\">\n            <Skeleton width=\"100px\" height=\"100px\" />\n        </Example.Item>\n\n        <Example.Item title=\"view, circle\">\n            <Skeleton width=\"100px\" height=\"100px\" borderRadius=\"circular\" />\n        </Example.Item>\n\n        <Example.Item title=\"view, rectangle, responsive\">\n            <Skeleton width={{ s: \"100px\", m: \"200px\" }} height={{ s: \"100px\", m: \"200px\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-skeleton--radius",
 					"name": "radius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius=small\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"small\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=medium\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"medium\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=large\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"large\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=circular\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"circular\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-skeleton--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Skeleton className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Skeleton } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Skeleton/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Skeleton",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Skeleton/Skeleton.tsx",
-				"actualName": "Skeleton",
+				"methods": [],
+				"props": {
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width style, literal string value or a base unit token number multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Radius>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Skeleton/Skeleton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Skeleton/Skeleton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1594,66 +8633,421 @@
 			"path": "./src/components/Slider/tests/Slider.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "components-slider--base",
+					"name": "name, minName, maxName, range",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"single, name\">\n            <Slider name=\"slider-single\" defaultValue={30} />\n        </Example.Item>\n        <Example.Item title=\"range, name\">\n            <Slider range name=\"slider-range\" defaultMinValue={30} defaultMaxValue={85} />\n        </Example.Item>\n        <Example.Item title=\"range, minName, maxName\">\n            <Slider\n                range\n                minName=\"slider-min\"\n                maxName=\"slider-max\"\n                defaultMinValue={30}\n                defaultMaxValue={85}\n            />\n        </Example.Item>\n        <div style={{ height: 2000 }} />\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--orientation",
 					"name": "orientation",
 					"snippet": "const orientation = () => (\n    <Example>\n        <Example.Item title=\"orientation: vertical\">\n            <View height=\"200px\">\n                <Slider\n                    range\n                    name=\"slider\"\n                    defaultMinValue={30}\n                    defaultMaxValue={85}\n                    orientation=\"vertical\"\n                />\n            </View>\n        </Example.Item>\n        <View height=\"2000px\" />\n    </Example>\n);"
 				},
 				{
-					"name": "minMax",
+					"id": "components-slider--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <Example>\n        <Example.Item title=\"min, max\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={60} />\n        </Example.Item>\n        <Example.Item title=\"min, max, value < min\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={30} />\n        </Example.Item>\n        <Example.Item title=\"min, max, value > max\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={80} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--step",
 					"name": "step",
 					"snippet": "const step = () => (\n    <Example>\n        <Example.Item title=\"step: 5\">\n            <Slider name=\"slider\" defaultValue={30} step={5} />\n        </Example.Item>\n\n        <Example.Item title=\"step: 5, defaultValue: 31, rounded down to 30\">\n            <Slider name=\"slider\" defaultValue={31} step={5} />\n        </Example.Item>\n\n        <Example.Item title=\"step: 0.01, float\">\n            <Slider name=\"slider\" defaultValue={30} step={0.01} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <Slider name=\"slider\" defaultValue={30} disabled />\n        </Example.Item>\n\n        <Example.Item title=\"disabled, range\">\n            <Slider name=\"slider\" range defaultMinValue={30} defaultMaxValue={80} disabled />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--render-value",
 					"name": "renderValue",
 					"snippet": "const renderValue = () => (\n    <Example>\n        <Example.Item title=\"renderValue: $\">\n            <Slider name=\"name\" defaultValue={50} renderValue={(args) => `$${args.value}`} />\n        </Example.Item>\n        <Example.Item title=\"renderValue: false\">\n            <Slider name=\"name\" defaultValue={50} renderValue={false} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-slider--default-value",
+					"name": "defaultValue, onChange, onChangeCommit",
 					"snippet": "const defaultValue = () => <View paddingTop={10}>\n    <Slider name=\"test-name\" defaultValue={50} onChange={fn()} onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "value",
+					"id": "components-slider--value",
+					"name": "value, onChange, onChangeCommit",
 					"snippet": "const value = () => <View paddingTop={10}>\n    <Slider name=\"test-name\" value={50} onChange={fn()} onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "rangeDefaultValue",
+					"id": "components-slider--range-default-value",
+					"name": "range, defaultValue, onChange, onChangeCommit",
 					"snippet": "const rangeDefaultValue = () => <View paddingTop={10}>\n    <Slider\n        range\n        name=\"test-name\"\n        defaultMinValue={50}\n        defaultMaxValue={70}\n        onChange={fn()}\n        onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "rangeValue",
+					"id": "components-slider--range-value",
+					"name": "range, value, onChange, onChangeCommit, minName, maxName",
 					"snippet": "const rangeValue = () => <View paddingTop={10}>\n    <Slider\n        range\n        minName=\"test-name-min\"\n        maxName=\"test-name-max\"\n        minValue={50}\n        maxValue={70}\n        onChange={fn()}\n        onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "className",
+					"id": "components-slider--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Slider name=\"name\" className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				},
 				{
-					"name": "testForm",
+					"id": "components-slider--test-form",
+					"name": "test: form onChange",
 					"snippet": "const testForm = (args) => {\n    const formRef = React.useRef<HTMLFormElement>(null);\n    const [data, setData] = React.useState<[string, FormDataEntryValue][]>([]);\n\n    const handleChange = (e: React.FormEvent<HTMLFormElement>) => {\n        const formData = new FormData(e.currentTarget);\n        const nextState = [...formData.entries()];\n\n        args.handleFormChange({ formData: nextState });\n        setData(nextState);\n    };\n\n    return (\n        <View paddingTop={10} gap={4}>\n            <form onChange={handleChange} ref={formRef}>\n                <Slider\n                    range\n                    minName=\"slider-min\"\n                    maxName=\"slider-max\"\n                    defaultMinValue={30}\n                    defaultMaxValue={50}\n                />\n            </form>\n\n            {data.map((v) => v.join(\": \")).join(\", \")}\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testSwipe",
+					"id": "components-slider--test-swipe",
+					"name": "test: prevents parent swipe",
 					"snippet": "const testSwipe = () => {\n    const toggle = useToggle(true);\n\n    return (\n        <Modal active={toggle.active} onClose={toggle.deactivate} position=\"end\">\n            <View gap={4}>\n                <Modal.Title>Modal</Modal.Title>\n                <Slider name=\"slider\" defaultValue={30} />\n            </View>\n        </Modal>\n    );\n};"
 				}
 			],
 			"import": "import { Example, Modal, Slider, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Slider/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Slider",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Slider/Slider.tsx",
-				"actualName": "Slider",
+				"methods": [],
+				"props": {
+					"step": {
+						"defaultValue": null,
+						"description": "Step of the slider",
+						"name": "step",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the slider user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum value of the slider",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum value of the slider",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"orientation": {
+						"defaultValue": null,
+						"description": "Orientation of the slider",
+						"name": "orientation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"vertical\" | \"horizontal\"",
+							"value": [{ "value": "\"vertical\"" }, { "value": "\"horizontal\"" }]
+						}
+					},
+					"renderValue": {
+						"defaultValue": null,
+						"description": "Render a custom value in the thumb tooltip",
+						"name": "renderValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | ((args: { value: number; }) => string)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the slider, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the slider, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"range": {
+						"defaultValue": null,
+						"description": "Enables range slider with two thumbs",
+						"name": "range",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the slider input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"minName": {
+						"defaultValue": null,
+						"description": "Name of the slider min value input element, overrides the name",
+						"name": "minName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"maxName": {
+						"defaultValue": null,
+						"description": "Name of the slider max value input element, overrides the name",
+						"name": "maxName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the slider value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: SingleChangeArgs) => void) | ((args: RangeChangeArgs) => void) | ((args: RangeChangeArgs) => void)"
+						}
+					},
+					"onChangeCommit": {
+						"defaultValue": null,
+						"description": "Callback when the user commits the change by releasing the thumb\nCallback when the user commits the change by releasing the thumbs",
+						"name": "onChangeCommit",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: SingleChangeArgs) => void) | ((args: RangeChangeArgs) => void) | ((args: RangeChangeArgs) => void)"
+						}
+					},
+					"minValue": {
+						"defaultValue": null,
+						"description": "Minimum value of the slider",
+						"name": "minValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"maxValue": {
+						"defaultValue": null,
+						"description": "Maximum value of the slider",
+						"name": "maxValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultMinValue": {
+						"defaultValue": null,
+						"description": "Default minimum value of the slider, enables uncontrolled mode",
+						"name": "defaultMinValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultMaxValue": {
+						"defaultValue": null,
+						"description": "Default maximum value of the slider, enables uncontrolled mode",
+						"name": "defaultMaxValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1663,35 +9057,137 @@
 			"path": "./src/components/Stepper/tests/Stepper.stories.tsx",
 			"stories": [
 				{
+					"id": "components-stepper--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example>\n        <Example.Item title=\"direction: row\">\n            <Stepper activeId=\"1\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <Stepper activeId=\"1\" direction=\"column\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-stepper--label-display",
 					"name": "labelDisplay",
 					"snippet": "const labelDisplay = () => (\n    <Example>\n        <Example.Item title=\"direction: row, labels hidden\">\n            <Stepper activeId=\"1\" labelDisplay=\"hidden\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: column, labels hiden\">\n            <Stepper activeId=\"1\" direction=\"column\" labelDisplay=\"hidden\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: row, labels hidden on s\">\n            <Stepper activeId=\"1\" labelDisplay={{ s: \"hidden\", m: \"inline\" }}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-stepper--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 6, direction: row\">\n            <Stepper activeId=\"1\" gap={6}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"gap: 6, direction: column\">\n            <Stepper activeId=\"1\" direction=\"column\" gap={6}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap\", \"[s] 2\", \"[m+] 5\"]}>\n            <Stepper activeId=\"1\" gap={{ s: 2, m: 5 }}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-stepper--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Stepper className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Stepper.Item attributes={{ id: \"test-item-id\" }} className=\"test-item-classname\" />\n        </Stepper>\n    </div>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-stepper--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"multiline subtitle\",\n                \"should wrap the text correctly\",\n                \"should display the connector correctly\",\n            ]}\n        >\n            <Demo\n                activeId={0}\n                subtitle=\"It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, Placeholder, Stepper, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Stepper/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Stepper",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Stepper/Stepper.tsx",
-				"actualName": "Stepper",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"activeId": {
+						"defaultValue": null,
+						"description": "Id of the item to display as active",
+						"name": "activeId",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string | number" }
+					},
+					"labelDisplay": {
+						"defaultValue": null,
+						"description": "Display variant for the item label",
+						"name": "labelDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"hidden\" | \"inline\">" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Direction of the stepper",
+						"name": "direction",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between items (default: 3)",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
+				"exportName": "Stepper"
 			}
 		},
 		"components-switch": {
@@ -1700,38 +9196,236 @@
 			"path": "./src/components/Switch/tests/Switch.stories.tsx",
 			"stories": [
 				{
-					"name": "size",
+					"id": "components-switch--size",
+					"name": "Size",
 					"snippet": "const size = () => (\n\t<Example>\n\t\t<Example.Item title=\"size: medium\">\n\t\t\t<Switch name=\"active\" size=\"medium\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: small\">\n\t\t\t<Switch name=\"active\" size=\"small\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: large\">\n\t\t\t<Switch name=\"active\" size=\"large\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: responsive, s: small, m: large\">\n\t\t\t<Switch\n\t\t\t\tname=\"active\"\n\t\t\t\tsize={{ s: \"small\", m: \"large\" }}\n\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t/>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "label",
+					"id": "components-switch--label",
+					"name": "Label",
 					"snippet": "const label = () => (\n\t<Example>\n\t\t<Example.Item title=\"size: medium\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch reversed name=\"active\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: small\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" size=\"small\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch\n\t\t\t\t\treversed\n\t\t\t\t\tname=\"active\"\n\t\t\t\t\tsize=\"small\"\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t\t>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\n\t\t<Example.Item title=\"size: large\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" size=\"large\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch\n\t\t\t\t\treversed\n\t\t\t\t\tname=\"active\"\n\t\t\t\t\tsize=\"large\"\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t\t>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-switch--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Switch name=\"test-name\" defaultChecked onChange={fn()}>Label\n            </Switch>;"
 				},
 				{
-					"name": "checked",
+					"id": "components-switch--checked",
+					"name": "checked, uncontrolled",
 					"snippet": "const checked = () => <Switch name=\"test-name\" checked onChange={fn()}>Label\n            </Switch>;"
 				},
 				{
+					"id": "components-switch--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, unselected\">\n            <Switch name=\"active\" disabled inputAttributes={{ \"aria-label\": \"test switch\" }} />\n        </Example.Item>\n        <Example.Item title=\"disabled, selected\">\n            <Switch\n                name=\"active\"\n                disabled\n                defaultChecked\n                inputAttributes={{ \"aria-label\": \"test switch\" }}\n            />\n        </Example.Item>\n        <Example.Item title=\"disabled, with label\">\n            <Switch name=\"active\" disabled>\n                Switch\n            </Switch>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-switch--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Switch\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ \"aria-label\": \"test select\", id: \"test-input-id\" }}\n            name=\"name\"\n        >\n            Label\n        </Switch>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Switch, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Switch/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Switch",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Switch/Switch.tsx",
-				"actualName": "Switch",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the switch",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the switch input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the switch user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"reversed": {
+						"defaultValue": null,
+						"description": "Reverse the children position",
+						"name": "reversed",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the switch value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the switch is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the switch is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default value of the switch, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Value of the switch, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1741,51 +9435,112 @@
 			"path": "./src/components/Table/tests/Table.stories.tsx",
 			"stories": [
 				{
-					"name": "layout",
+					"id": "components-table--layout",
+					"name": "base",
 					"snippet": "const layout = () => (\n    <Example>\n        <Example.Item title=\"base\">\n            <Table>\n                <Table.Head>\n                    <Table.Row>\n                        <Table.Heading>Column 1</Table.Heading>\n                        <Table.Heading>Column 2</Table.Heading>\n                    </Table.Row>\n                </Table.Head>\n                <Table.Body>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell>Cell 2</Table.Cell>\n                    </Table.Row>\n                </Table.Body>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"colspan: 2 for col 2, rowspan: 2 for cell 3\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading colSpan={2}>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                    <Table.Cell rowSpan={2}>Cell 3</Table.Cell>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"align: center for heading 1, align: end for heading 2\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading align=\"center\">Column 1</Table.Heading>\n                    <Table.Heading align=\"end\">Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"valign: center for cell 2, valign: end for cell 3\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>\n                        <View height={15} backgroundColor=\"neutral-faded\" />\n                    </Table.Cell>\n                    <Table.Cell verticalAlign=\"center\">Cell 2</Table.Cell>\n                    <Table.Cell verticalAlign=\"end\">Cell 3</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"width: 40%, minWidth: 200px for col 1\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"40%\" minWidth=\"200px\">\n                        Column 1\n                    </Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-table--border",
 					"name": "border",
 					"snippet": "const border = () => (\n    <Example>\n        <Example.Item title=\"border: true\">\n            <Table border>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"columnBorder: true\">\n            <Table columnBorder>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"columnBorder: true, border: true\">\n            <Table columnBorder border>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-table--rows",
 					"name": "rows",
 					"snippet": "const rows = () => (\n    <Example>\n        <Example.Item title=\"highlighted for row 2\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row highlighted>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"clickable row 2, focus ring\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row onClick={() => {}}>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-table--render",
+					"name": "rendering",
 					"snippet": "const render = () => (\n    <Table>\n        <Table.Head>\n            <Table.Row>\n                <Table.Heading>Heading</Table.Heading>\n                <Table.Heading>Heading</Table.Heading>\n            </Table.Row>\n        </Table.Head>\n        <Table.Body>\n            <Table.Row>\n                <Table.Cell>Content</Table.Cell>\n                <Table.Cell>Content</Table.Cell>\n            </Table.Row>\n        </Table.Body>\n    </Table>\n);"
 				},
 				{
-					"name": "tbody",
+					"id": "components-table--tbody",
+					"name": "tbody rendering",
 					"snippet": "const tbody = () => (\n    <Table>\n        <Table.Row>\n            <Table.Heading>Heading</Table.Heading>\n            <Table.Heading>Heading</Table.Heading>\n        </Table.Row>\n    </Table>\n);"
 				},
 				{
-					"name": "tabIndex",
+					"id": "components-table--tab-index",
+					"name": "adds tabIndex for clickable rows",
 					"snippet": "const tabIndex = () => (\n    <Table>\n        <Table.Row>\n            <Table.Cell />\n        </Table.Row>\n        <Table.Row onClick={() => {}}>\n            <Table.Cell />\n        </Table.Row>\n        <Table.Row attributes={{ onClick: () => {} }}>\n            <Table.Cell />\n        </Table.Row>\n    </Table>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-table--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Table className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Table.Row attributes={{ id: \"test-row-id\" }}>\n                <Table.Cell attributes={{ id: \"test-cell-id\" }}></Table.Cell>\n            </Table.Row>\n        </Table>\n    </div>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-table--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"scroll fade\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"500px\">Column 1</Table.Heading>\n                    <Table.Heading width=\"500px\">Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"card with highlighted heading\">\n            <Card elevated padding={0}>\n                <Table>\n                    <Table.Row highlighted>\n                        <Table.Heading width=\"50%\" minWidth=\"200px\">\n                            Column 1\n                        </Table.Heading>\n                        <Table.Heading colSpan={2} align=\"end\">\n                            Column 2\n                        </Table.Heading>\n                    </Table.Row>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell align=\"center\">Cell 2</Table.Cell>\n                        <Table.Cell align=\"end\">Cell 3</Table.Cell>\n                    </Table.Row>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell align=\"center\">Cell 2</Table.Cell>\n                        <Table.Cell align=\"end\">Cell 3</Table.Cell>\n                    </Table.Row>\n                </Table>\n            </Card>\n        </Example.Item>\n        <Example.Item title=\"width: auto, nowrap\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"50%\">Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                    <Table.Heading>Column 3</Table.Heading>\n                    <Table.Heading width=\"auto\">Long heading title</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                    <Table.Cell>Cell 3</Table.Cell>\n                    <Table.Cell>Cell 4</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "examples",
+					"id": "components-table--examples",
+					"name": "test: selectable",
 					"snippet": "const examples = () => (\n    <Example>\n        <Example.Item title=\"selectable\">\n            <SelectionDemo />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Card, Checkbox, Example, Table, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Table/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Table",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Table/Table.tsx",
-				"actualName": "Table",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"border": {
+						"defaultValue": null,
+						"description": "Add border around the table",
+						"name": "border",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"columnBorder": {
+						"defaultValue": null,
+						"description": "Add border between the table columns",
+						"name": "columnBorder",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
+				"exportName": "Table"
 			}
 		},
 		"components-tabs": {
@@ -1794,71 +9549,196 @@
 			"path": "./src/components/Tabs/tests/Tabs.stories.tsx",
 			"stories": [
 				{
+					"id": "components-tabs--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Tabs>\n        <Tabs.List>\n            <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n            <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n        </Tabs.List>\n\n        <Tabs.Panel value=\"1\">\n            <View padding={4}>Content 1</View>\n        </Tabs.Panel>\n        <Tabs.Panel value=\"2\">\n            <View padding={4}>Content 2</View>\n        </Tabs.Panel>\n    </Tabs>\n);"
 				},
 				{
+					"id": "components-tabs--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Tabs defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills\">\n            <Tabs variant=\"pills\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills-elevated\">\n            <Tabs variant=\"pills-elevated\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: borderless\">\n            <Tabs variant=\"borderless\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"variant: default, size: large\">\n            <Tabs size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills, size: large\">\n            <Tabs variant=\"pills\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills-elevated, size: large\">\n            <Tabs variant=\"pills-elevated\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: borderless, size: large\">\n            <Tabs variant=\"borderless\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example>\n        <Example.Item title=\"direction: column, variant: underline\">\n            <Tabs direction=\"column\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: pills\">\n            <Tabs direction=\"column\" variant=\"pills\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: pills-elevated\">\n            <Tabs direction=\"column\" variant=\"pills-elevated\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: borderless\">\n            <Tabs direction=\"column\" variant=\"borderless\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Tabs>\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"1\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"icon only\">\n            <Tabs variant=\"pills-elevated\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap} attributes={{ \"aria-label\": \"Tab 1\" }} />\n                    <Tabs.Item value=\"1\" icon={IconZap} attributes={{ \"aria-label\": \"Tab 2\" }} />\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "equalWidth",
+					"id": "components-tabs--equal-width",
+					"name": "itemWidth",
 					"snippet": "const equalWidth = () => (\n    <Example>\n        <Example.Item title=\"equal width items\">\n            <Tabs onChange={console.log} itemWidth=\"equal\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"1\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                    <Tabs.Item value=\"2\" icon={IconZap}>\n                        Very long item 3\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--href",
 					"name": "href",
 					"snippet": "const href = () => (\n    <Example>\n        <Example.Item title=\"href, no onChange\">\n            <Tabs value=\"2\">\n                <Tabs.List>\n                    <Tabs.Item value=\"1\" href=\"#item-1\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"2\" href=\"#item-2\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                    <Tabs.Item value=\"3\" href=\"#item-3\" icon={IconZap}>\n                        Very long item 3\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "disabled",
+					"id": "components-tabs--disabled",
+					"name": "item, disabled",
 					"snippet": "const disabled = () => {\n    return (\n        <Example>\n            <Example.Item title=\"disabled\">\n                <Tabs defaultValue=\"1\">\n                    <Tabs.List>\n                        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"2\" disabled icon={IconZap}>\n                            Item 2\n                        </Tabs.Item>\n                        <Tabs.Item value=\"3\">Item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"1\">\n                        <View padding={4}>Content 1</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <View padding={4}>Content 2</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"3\">\n                        <View padding={4}>Content 3</View>\n                    </Tabs.Panel>\n                </Tabs>\n            </Example.Item>\n\n            <Example.Item title=\"disabled, href\">\n                <Tabs defaultValue=\"1\">\n                    <Tabs.List>\n                        <Tabs.Item href=\"#item1\" value=\"1\">\n                            Item 1\n                        </Tabs.Item>\n                        <Tabs.Item href=\"#item2\" value=\"2\" disabled icon={IconZap}>\n                            Item 2\n                        </Tabs.Item>\n                        <Tabs.Item href=\"#item3\" value=\"3\">\n                            Item 3\n                        </Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"1\">\n                        <View padding={4}>Content 1</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <View padding={4}>Content 2</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"3\">\n                        <View padding={4}>Content 3</View>\n                    </Tabs.Panel>\n                </Tabs>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-tabs--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <Tabs defaultValue=\"2\" onChange={fn()}>\n    <Tabs.List>\n        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n        <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n    </Tabs.List>\n    <Tabs.Panel value=\"1\">Content 1</Tabs.Panel>\n    <Tabs.Panel value=\"2\">Content 2</Tabs.Panel>\n</Tabs>;"
 				},
 				{
-					"name": "value",
+					"id": "components-tabs--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <Tabs value=\"2\" onChange={fn()}>\n    <Tabs.List>\n        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n        <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n    </Tabs.List>\n    <Tabs.Panel value=\"1\">Content 1</Tabs.Panel>\n    <Tabs.Panel value=\"2\">Content 2</Tabs.Panel>\n</Tabs>;"
 				},
 				{
-					"name": "className",
+					"id": "components-tabs--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Tabs>\n            <Tabs.List attributes={{ id: \"test-list-id\" }} className=\"test-list-classname\">\n                <Tabs.Item attributes={{ id: \"test-item-id\" }} value=\"1\">\n                    Item\n                </Tabs.Item>\n            </Tabs.List>\n\n            <Tabs.Panel\n                attributes={{ \"data-testid\": \"test-panel-id\" }}\n                className=\"test-panel-classname\"\n                value=\"1\"\n            />\n        </Tabs>\n    </div>\n);"
 				},
 				{
-					"name": "testFocusableContent",
+					"id": "components-tabs--test-focusable-content",
+					"name": "test: focusable content",
 					"snippet": "const testFocusableContent = () => (\n    <Example>\n        <Example.Item title=\"panels without focusable content\">\n            <Tabs>\n                <View gap={4}>\n                    <Tabs.List>\n                        <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                        <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"0\">Tab 1</Tabs.Panel>\n                    <Tabs.Panel value=\"1\">Tab 2</Tabs.Panel>\n                    <Tabs.Panel value=\"2\">Tab 3</Tabs.Panel>\n                </View>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"panels with focusable content\">\n            <Tabs>\n                <View gap={4}>\n                    <Tabs.List>\n                        <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                        <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"0\">\n                        <Button onClick={() => {}}>Tab 1 action</Button>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"1\">\n                        <Button onClick={() => {}}>Tab 2 action</Button>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <Button onClick={() => {}}>Tab 3 action</Button>\n                    </Tabs.Panel>\n                </View>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "components-tabs--test-composition",
+					"name": "test: composition",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item title=\"Viewport overflow\">\n            <Tabs>\n                <Tabs.List>\n                    {[...Array(8)].map((_, i) => (\n                        <Tabs.Item value={`${i}`} key={i} icon={IconZap}>\n                            Very long item {i}\n                        </Tabs.Item>\n                    ))}\n                </Tabs.List>\n\n                {[...Array(8)].map((_, i) => (\n                    <Tabs.Panel value={`${i}`} key={i}>\n                        Tab {i}\n                    </Tabs.Panel>\n                ))}\n            </Tabs>\n        </Example.Item>\n        <Example.Item>\n            <Tabs onChange={console.log} variant=\"pills-elevated\" name=\"hey\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">\n                        <View borderColor=\"neutral-faded\" padding={5}>\n                            Item 3\n                        </View>\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"Custom non-interactive list children\">\n            <Tabs direction=\"column\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <View height={6} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testEdgeCaseDom",
+					"id": "components-tabs--test-edge-case-dom",
+					"name": "test: scroll subscription",
 					"snippet": "const testEdgeCaseDom = () => {\n    const [activeItem, setActiveItem] = React.useState(\"1\");\n    const sectionsRef = React.useRef(null);\n\n    return (\n        <Example>\n            <Example.Item title=\"active item changes on scroll\">\n                <View justify=\"center\" align=\"center\" padding={10}>\n                    <View width={60} gap={2}>\n                        <Tabs value={activeItem} onChange={(args) => setActiveItem(args.value)}>\n                            <Tabs.List>\n                                <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                                <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n                                <Tabs.Item value=\"3\">Item 3</Tabs.Item>\n                                <Tabs.Item value=\"4\">Item 4</Tabs.Item>\n                            </Tabs.List>\n                        </Tabs>\n\n                        <ScrollArea\n                            attributes={{ ref: sectionsRef }}\n                            height={70}\n                            onScroll={(args) => {\n                                setActiveItem(Math.min(4, Math.floor(args.y * 10) + 1).toString());\n                            }}\n                        >\n                            <View gap={4}>\n                                <View gap={2}>\n                                    <Text>Section 1</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View grow height=\"100px\" backgroundColor=\"neutral-faded\" key={i} />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 2</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 3</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 4</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n                            </View>\n                        </ScrollArea>\n                    </View>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Example, ScrollArea, Tabs, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Tabs/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Tabs",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Tabs/Tabs.tsx",
-				"actualName": "Tabs",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Direction of the tab buttons",
+						"name": "direction",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"itemWidth": {
+						"defaultValue": null,
+						"description": "Equal width for the tab buttons",
+						"name": "itemWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"equal\"", "value": [{ "value": "\"equal\"" }] }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Render variant for component",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"bordered\" | \"borderless\" | \"pills\" | \"pills-elevated\"",
+							"value": [
+								{ "value": "\"bordered\"" },
+								{ "value": "\"borderless\"" },
+								{ "value": "\"pills\"" },
+								{ "value": "\"pills-elevated\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"large\" | \"medium\"",
+							"value": [{ "value": "\"large\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the tab buttons group when used as a form control",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the active tab value changes",
+						"name": "onChange",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((args: { value: string; name?: string; }) => void)" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the active tab, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the active tab, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "Tabs"
 			}
 		},
 		"components-textarea": {
@@ -1867,71 +9747,315 @@
 			"path": "./src/components/TextArea/tests/TextArea.stories.tsx",
 			"stories": [
 				{
-					"name": "variants",
+					"id": "components-textarea--variants",
+					"name": "variant",
 					"snippet": "const variants = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <TextArea variant=\"faded\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless\">\n            <TextArea variant=\"headless\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: medium\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"medium\" />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"large\" />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"xlarge\" />\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] large\", \"[m+] medium\"]}>\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size={{ s: \"xlarge\", m: \"medium\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--resize",
 					"name": "resize",
 					"snippet": "const resize = () => (\n    <Example>\n        <Example.Item title=\"resize: none\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" resize=\"none\" />\n        </Example.Item>\n        <Example.Item title=\"resize: auto\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" resize=\"auto\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-textarea--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" hasError />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner\">\n            <View gap={2}>\n                <Text variant=\"featured-2\">What problem are you trying to solve?</Text>\n                <TextArea.Aligner>\n                    <TextArea\n                        variant=\"headless\"\n                        placeholder=\"Try something like 'I have a job'\"\n                        name=\"description\"\n                    />\n                </TextArea.Aligner>\n                <View.Item>\n                    <Button>Next</Button>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-textarea--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"long value without breaks\">\n            <TextArea\n                name=\"hey\"\n                defaultValue={`<div style=\"position:relative;width:100%;padding-top:calc(150% + 72px)\">\n<iframe src=\"nskjdfdsdkjfsjkdfhbsjlhdfbsjlhfbs;jhbsdljfhsbljhfsbljhfbsjlfdhbsljhfbsdljhfbsljhfbslufbhsdlfds\" />\n</div>`}\n                resize=\"auto\"\n                placeholder=\"Placeholder\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-textarea--render",
+					"name": "base",
 					"snippet": "const render = () => <TextArea name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-textarea--placeholder",
 					"name": "placeholder",
 					"snippet": "const placeholder = () => (\n    <TextArea\n        name=\"test-name\"\n        placeholder=\"Placeholder\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-textarea--id",
 					"name": "id",
 					"snippet": "const id = () => (\n    <TextArea name=\"test-name\" id=\"test-id\" inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
+					"id": "components-textarea--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <TextArea name=\"test-name\" disabled inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-textarea--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <TextArea\n    name=\"test-name\"\n    defaultValue=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-textarea--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <TextArea\n    name=\"test-name\"\n    value=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-textarea--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <TextArea\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-textarea--form-control",
+					"name": "test: form control",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"with helper\">\n            <FormControl>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextArea name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n        <Example.Item title=\"with error\">\n            <FormControl hasError>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextArea name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, FormControl, Text, TextArea, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/TextArea/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "TextArea",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/TextArea/TextArea.tsx",
-				"actualName": "TextArea",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text area",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text area input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text area user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text area value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLTextAreaElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text area is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLTextAreaElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text area is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLTextAreaElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"textarea\">" }
+					},
+					"resize": {
+						"defaultValue": null,
+						"description": "Enable or disable the text area resizing, supports auto-sizing",
+						"name": "resize",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"none\" | \"auto\"",
+							"value": [{ "value": "\"none\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "TextArea"
 			}
 		},
 		"components-textfield": {
@@ -1940,71 +10064,445 @@
 			"path": "./src/components/TextField/tests/TextField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-textfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <TextField variant=\"faded\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless\">\n            <TextField variant=\"headless\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded\">\n            <TextField\n                rounded\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                icon={IconZap}\n                prefix=\"+31\"\n                endSlot={<Button rounded size=\"small\" icon={IconZap} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"rounded, variant: faded\">\n            <View direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <TextField\n                        rounded\n                        variant=\"faded\"\n                        name=\"Name\"\n                        placeholder=\"Enter your name\"\n                        startSlot={\n                            <Badge rounded size=\"small\">\n                                Hello\n                            </Badge>\n                        }\n                    />\n                </View.Item>\n                <Button rounded>Submit</Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-textfield--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" hasError />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "attachments",
+					"id": "components-textfield--attachments",
+					"name": "icon, endIcon, suffix, prefix, startSlot, endSlot, startSlotPadding, endSlotPadding",
 					"snippet": "const attachments = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" value=\"Reshaped\" icon={IconZap} />\n        </Example.Item>\n        <Example.Item title=\"endIcon\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" value=\"Reshaped\" endIcon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title={[\"startSlot\", \"vertical and horizontal padding aligned\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title={[\"endSlot\", \"vertical and horizontal padding aligned\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                endSlot={\n                    <Button\n                        icon={IconZap}\n                        size=\"small\"\n                        onClick={() => {}}\n                        attributes={{ \"aria-label\": \"Action\" }}\n                    />\n                }\n            />\n        </Example.Item>\n\n        <Example.Item title=\"paddingSlotStart=4, paddingSlotEnd=2\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlotPadding={4}\n                endSlotPadding={2}\n                startSlot={<Placeholder h={20} />}\n                endSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"with all affixes\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                endIcon={IconZap}\n                icon={IconZap}\n                prefix=\"Estimated value\"\n                suffix=\"m2\"\n                startSlot={<Placeholder h={20} />}\n                endSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"multiline wrap\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlot={[...Array(10).keys()].map((i) => (\n                    <Badge size=\"small\" key={i}>\n                        Item {i + 1}\n                    </Badge>\n                ))}\n                multiline\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"small\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"medium\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"large\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"xlarge\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] xlarge\", \"[m+] medium\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                size={{ s: \"xlarge\", m: \"medium\" }}\n                icon={IconZap}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner\">\n            <View gap={2}>\n                <Text variant=\"featured-2\">What problem are you trying to solve?</Text>\n                <TextField.Aligner>\n                    <TextField\n                        variant=\"headless\"\n                        placeholder=\"Try something like 'I have a job'\"\n                        name=\"description\"\n                    />\n                </TextField.Aligner>\n                <View.Item>\n                    <Button>Next</Button>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-textfield--render",
+					"name": "base",
 					"snippet": "const render = () => <TextField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-textfield--placeholder",
 					"name": "placeholder",
 					"snippet": "const placeholder = () => (\n    <TextField\n        name=\"test-name\"\n        placeholder=\"Placeholder\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-textfield--id",
 					"name": "id",
 					"snippet": "const id = () => (\n    <TextField name=\"test-name\" id=\"test-id\" inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
+					"id": "components-textfield--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <TextField name=\"test-name\" disabled inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-textfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <TextField\n    name=\"test-name\"\n    defaultValue=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-textfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <TextField\n    name=\"test-name\"\n    value=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-textfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <TextField\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-textfield--form-control",
+					"name": "test: form control",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"with helper\">\n            <FormControl>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextField name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n        <Example.Item title=\"with error\">\n            <FormControl hasError>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextField name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Badge, Button, Example, FormControl, Placeholder, Text, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/TextField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "TextField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/TextField/TextField.tsx",
-				"actualName": "TextField",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"multiline": {
+						"defaultValue": null,
+						"description": "Enable multiline text field wrapping",
+						"name": "multiline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to be fully rounded",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content after the text field value",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text field value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the text field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the text field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "TextField"
 			}
 		},
 		"components-timeline": {
@@ -2013,27 +10511,71 @@
 			"path": "./src/components/Timeline/tests/Timeline.stories.tsx",
 			"stories": [
 				{
+					"id": "components-timeline--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"children passed directly\">\n            <Timeline>\n                <Placeholder />\n                <Placeholder />\n                <Placeholder />\n            </Timeline>\n        </Example.Item>\n        <Example.Item title=\"children wrapped with Timeline.Item\">\n            <Timeline>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "marker",
+					"id": "components-timeline--marker",
+					"name": "markerSlot",
 					"snippet": "const marker = () => (\n    <Example>\n        <Example.Item title=\"slot\">\n            <Timeline>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n\n        <Example.Item title=\"null marker\">\n            <Timeline>\n                <Timeline.Item markerSlot={null}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={null}>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-timeline--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Timeline className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Timeline.Item className=\"test-item-classname\" attributes={{ id: \"test-item-id\" }}>\n                Content\n            </Timeline.Item>\n            <Timeline.Item>Content</Timeline.Item>\n        </Timeline>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Placeholder, Timeline } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Timeline/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Timeline",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Timeline/Timeline.tsx",
-				"actualName": "Timeline",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"ul\">" }
+					}
+				},
+				"exportName": "Timeline"
 			}
 		},
 		"components-toast": {
@@ -2041,32 +10583,54 @@
 			"name": "Toast",
 			"path": "./src/components/Toast/tests/Toast.stories.tsx",
 			"stories": [
-				{ "name": "size", "snippet": "const size = () => <Size />;" },
 				{
+					"id": "components-toast--size",
+					"name": "size",
+					"snippet": "const size = () => <Size />;"
+				},
+				{
+					"id": "components-toast--position",
 					"name": "position",
 					"snippet": "const position = () => <Position />;"
 				},
-				{ "name": "color", "snippet": "const color = () => <Color />;" },
-				{ "name": "timeout", "snippet": "const timeout = () => <Timeout />;" },
 				{
-					"name": "regionOptions",
+					"id": "components-toast--color",
+					"name": "color",
+					"snippet": "const color = () => <Color />;"
+				},
+				{
+					"id": "components-toast--timeout",
+					"name": "timeout",
+					"snippet": "const timeout = () => <Timeout />;"
+				},
+				{
+					"id": "components-toast--region-options",
+					"name": "expanded",
 					"snippet": "const regionOptions = () => <Expanded />;"
 				},
-				{ "name": "slots", "snippet": "const slots = () => <Slots />;" },
 				{
+					"id": "components-toast--slots",
+					"name": "slots",
+					"snippet": "const slots = () => <Slots />;"
+				},
+				{
+					"id": "components-toast--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const toast = useToast();\n\n    return (\n        <Button\n            onClick={() => {\n                const id = toast.show({\n                    title: \"Title\",\n                    text: \"Text\",\n                    children: \"Children\",\n                    startSlot: \"Slot\",\n                    actionsSlot: (\n                        <Button attributes={{ \"data-testid\": \"trigger-id\" }} onClick={() => toast.hide(id)}>\n                            Trigger\n                        </Button>\n                    ),\n                });\n            }}\n        >\n            Show toast\n        </Button>\n    );\n};"
 				},
 				{
-					"name": "nested",
+					"id": "components-toast--nested",
+					"name": "ToastProvider",
 					"snippet": "const nested = () => {\n    return (\n        <div data-testid=\"test-container-id\">\n            <ToastProvider>\n                <NestedDemo />\n            </ToastProvider>\n        </div>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-toast--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => {\n    const toast = useToast();\n\n    return (\n        <Button\n            onClick={() => {\n                const id = toast.show({\n                    text: \"Content\",\n                    attributes: { \"data-testid\": \"test-id\" },\n                    className: \"test-classname\",\n                });\n            }}\n        >\n            Show toast\n        </Button>\n    );\n};"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-toast--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"Multiline, should support dynamic height\">\n            <Multiline />\n        </Example.Item>\n        <Example.Item title=\"Nested ToastProvider\">\n            <ToastProvider>\n                <Nested />\n            </ToastProvider>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
@@ -2083,30 +10647,601 @@
 			"path": "./src/components/ToggleButton/tests/ToggleButton.stories.tsx",
 			"stories": [
 				{
+					"id": "components-togglebutton--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"outline\">\n            <ToggleButton>Button</ToggleButton>\n        </Example.Item>\n        <Example.Item title=\"ghost\">\n            <ToggleButton variant=\"ghost\">Button</ToggleButton>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-togglebutton--selected-color",
 					"name": "selectedColor",
 					"snippet": "const selectedColor = () => (\n    <Example>\n        <Example.Item title=\"selectedColor: primary\">\n            <ToggleButton selectedColor=\"primary\" defaultChecked>\n                Button\n            </ToggleButton>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onChange",
+					"id": "components-togglebutton--on-change",
+					"name": "checked, defaultChecked, onChange",
 					"snippet": "const onChange = () => <Example>\n    <Example.Item title=\"defaultChecked, onChange\">\n        <ToggleButton defaultChecked onChange={fn()} value=\"1\">Button\n                                </ToggleButton>\n    </Example.Item>\n    <Example.Item title=\"checked, onChange\">\n        <ToggleButton checked onChange={fn()} value=\"2\">Button\n                                </ToggleButton>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-togglebutton--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <ToggleButton onClick={fn()}>Button</ToggleButton>;"
 				}
 			],
 			"import": "import { Example, ToggleButton } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ToggleButton/ToggleButton.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "ToggleButton",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ToggleButton/ToggleButton.tsx",
-				"actualName": "ToggleButton",
+				"methods": [],
+				"props": {
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loading": {
+						"defaultValue": null,
+						"description": "Show loading state",
+						"name": "loading",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loadingAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the loading indicator",
+						"name": "loadingAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Make the component take the full width of the parent element",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"ghost\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"ghost\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"selectedColor": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme when selected",
+						"name": "selectedColor",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the toggle button, enables controlled mode for the ToggleButtonGroup",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the toggle button value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { checked: boolean; value: string; event: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>; }) => void)"
+						}
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default value of the toggle button, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Value of the toggle button, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2116,34 +11251,194 @@
 			"path": "./src/components/ToggleButtonGroup/tests/ToggleButtonGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "single",
+					"id": "components-togglebuttongroup--single",
+					"name": "checked, defaultChecked, onChange",
 					"snippet": "const single = () => <Example>\n    <Example.Item title=\"single, uncontrolled, onChange\">\n        <ToggleButtonGroup onChange={fn()}>\n            <ToggleButton value=\"1\" onChange={fn()}>Button\n                                    </ToggleButton>\n            <ToggleButton value=\"2\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n    <Example.Item title=\"single, controlled, onChange\">\n        <ToggleButtonGroup onChange={fn()} value={[]}>\n            <ToggleButton value=\"3\" onChange={fn()}>Button\n                                    </ToggleButton>\n            <ToggleButton value=\"4\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "multiple",
+					"id": "components-togglebuttongroup--multiple",
+					"name": "selectionMode, checked, defaultChecked, onChange",
 					"snippet": "const multiple = () => <Example>\n    <Example.Item title=\"multiple, uncontrolled, onChange\">\n        <ToggleButtonGroup onChange={fn()} selectionMode=\"multiple\">\n            <ToggleButton value=\"1\">Button</ToggleButton>\n            <ToggleButton value=\"2\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n    <Example.Item title=\"multiple, controlled, onChange\">\n        <ToggleButtonGroup onChange={fn()} value={[]} selectionMode=\"multiple\">\n            <ToggleButton value=\"3\">Button</ToggleButton>\n            <ToggleButton value=\"4\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "selectedColor",
+					"id": "components-togglebuttongroup--selected-color",
+					"name": "color,selectedColor",
 					"snippet": "const selectedColor = () => (\n    <Example>\n        <Example.Item title=\"selectedColor: primary\">\n            <ToggleButtonGroup selectedColor=\"primary\" defaultValue={[\"2\"]}>\n                <ToggleButton value=\"1\">Button</ToggleButton>\n                <ToggleButton value=\"2\">Button</ToggleButton>\n                <ToggleButton value=\"3\">Button</ToggleButton>\n            </ToggleButtonGroup>\n        </Example.Item>\n        <Example.Item title=\"color: primary, selectedColor: critical\">\n            <ToggleButtonGroup color=\"primary\" selectedColor=\"critical\" defaultValue={[\"2\"]}>\n                <ToggleButton value=\"1\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n                <ToggleButton value=\"2\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n                <ToggleButton value=\"3\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n            </ToggleButtonGroup>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-togglebuttongroup--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ToggleButtonGroup className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <ToggleButton>Button 1</ToggleButton>\n            <ToggleButton>Button 1</ToggleButton>\n        </ToggleButtonGroup>\n    </div>\n);"
 				},
 				{
-					"name": "testIcon",
+					"id": "components-togglebuttongroup--test-icon",
+					"name": "test: icon only",
 					"snippet": "const testIcon = () => (\n    <Example>\n        <Example.Item title=\"icon only\">\n            <ToggleButtonGroup selectedColor=\"primary\">\n                <ToggleButton value=\"1\" icon={IconPlus} />\n                <ToggleButton value=\"2\" icon={IconMinus} />\n                <ToggleButton value=\"3\" icon={IconCheckmark} />\n            </ToggleButtonGroup>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, ToggleButton, ToggleButtonGroup } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ToggleButtonGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ToggleButtonGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx",
-				"actualName": "ToggleButtonGroup",
+				"methods": [],
+				"props": {
+					"selectionMode": {
+						"defaultValue": { "value": "\"single\"" },
+						"description": "Selection mode for the toggle button group",
+						"name": "selectionMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"single\" | \"multiple\"",
+							"value": [{ "value": "\"single\"" }, { "value": "\"multiple\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme applied to each button",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"selectedColor": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme for the selected button",
+						"name": "selectedColor",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the toggle button group value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { value: string[]; event: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>; }) => void)"
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting child Button components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Selected values in the group, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default selected values in the group, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2153,30 +11448,269 @@
 			"path": "./src/components/Tooltip/tests/Tooltip.stories.tsx",
 			"stories": [
 				{
+					"id": "components-tooltip--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: bottom-start\">\n            <View direction=\"row\" gap={2}>\n                <Demo position=\"bottom-start\" text=\"Tooltip 1\" />\n                <Demo position=\"bottom-start\" text=\"Tooltip 2\" />\n                <Demo position=\"bottom-start\" text=\"Tooltip 3\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: bottom\">\n            <Demo position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"position: bottom-end\">\n            <Demo position=\"bottom-end\" />\n        </Example.Item>\n        <Example.Item title=\"position: top-start\">\n            <Demo position=\"top-start\" />\n        </Example.Item>\n        <Example.Item title=\"position: top\">\n            <Demo position=\"top\" />\n        </Example.Item>\n        <Example.Item title=\"position: top-end\">\n            <Demo position=\"top-end\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: start\">\n            <View align=\"end\">\n                <Demo position=\"start\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: start-top\">\n            <View align=\"end\">\n                <Demo position=\"start-top\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: start-bottom\">\n            <View align=\"end\">\n                <Demo position=\"start-bottom\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <Demo position=\"end\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: end-top\">\n            <Demo position=\"end-top\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: end-bottom\">\n            <Demo position=\"end-bottom\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tooltip--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: inverted\">\n            <Demo color=\"inverted\" position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"color: dark\">\n            <Demo color=\"dark\" position=\"bottom\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-tooltip--default-active",
+					"name": "uncontrolled",
 					"snippet": "const defaultActive = () => <Tooltip text=\"Content\" onOpen={fn()} onClose={fn()}>\n    {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n</Tooltip>;"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-tooltip--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"responsive visibility\">\n            <DemoResponsive text=\"Responsive\" />\n        </Example.Item>\n\n        <Example.Item title=\"without text\">\n            <Tooltip>{() => <Button>Button</Button>}</Tooltip>\n        </Example.Item>\n\n        <Example.Item title=\"tooltip with popover\">\n            <Tooltip text=\"Tooltip\" position=\"top\">\n                {(attributes) => (\n                    <Popover position=\"bottom\">\n                        <Popover.Trigger>\n                            {(popoverAttributes) => (\n                                <Button attributes={{ ...attributes, ...popoverAttributes }}>Action</Button>\n                            )}\n                        </Popover.Trigger>\n                        <Popover.Content>Popover</Popover.Content>\n                    </Popover>\n                )}\n            </Tooltip>\n        </Example.Item>\n\n        <Example.Item title=\"nested popovers inside a tooltip\">\n            <View direction=\"row\" gap={2}>\n                <Tooltip position=\"top\" text=\"Hello\">\n                    {(tooltipAttributes) => (\n                        <Popover position=\"bottom\" width=\"300px\">\n                            <Popover.Trigger>\n                                {(attributes) => (\n                                    <Button attributes={{ ...tooltipAttributes, ...attributes }}>\n                                        Tooltip with popover\n                                    </Button>\n                                )}\n                            </Popover.Trigger>\n                            <Popover.Content>\n                                <View gap={2} align=\"center\" direction=\"row\" justify=\"space-between\">\n                                    Popover content\n                                    <Popover position=\"bottom\" width=\"300px\">\n                                        <Popover.Trigger>\n                                            {(attributes) => <Button attributes={attributes}>Open</Button>}\n                                        </Popover.Trigger>\n                                        <Popover.Content>\n                                            <Popover.Dismissible align=\"center\" closeAriaLabel=\"Close\">\n                                                Another popover content\n                                            </Popover.Dismissible>\n                                        </Popover.Content>\n                                    </Popover>\n                                </View>\n                            </Popover.Content>\n                        </Popover>\n                    )}\n                </Tooltip>\n                <Tooltip position=\"top\" text=\"Hello\">\n                    {(tooltipAttributes) => <Button attributes={tooltipAttributes}>Just a tooltip</Button>}\n                </Tooltip>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, Popover, Tooltip, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Tooltip/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Tooltip",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Tooltip/Tooltip.tsx",
-				"actualName": "Tooltip",
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the flyout content interactivity",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"contentAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the content element",
+						"name": "contentAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"contentClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the content element",
+						"name": "contentClassName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "(attributes: TriggerAttributes) => ReactNode" }
+					},
+					"text": {
+						"defaultValue": null,
+						"description": "Text content for the tooltip",
+						"name": "text",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"inverted\"" },
+						"description": "Color of the tooltip",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"dark\" | \"inverted\"",
+							"value": [{ "value": "\"dark\"" }, { "value": "\"inverted\"" }]
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2186,51 +11720,191 @@
 			"path": "./src/components/Accordion/tests/Accordion.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-accordion--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Accordion defaultActive>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--icon-size",
 					"name": "iconSize",
 					"snippet": "const iconSize = () => (\n    <Accordion iconSize={6}>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--icon-position",
 					"name": "iconPosition",
 					"snippet": "const iconPosition = () => (\n    <Accordion iconPosition=\"start\">\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Accordion defaultActive gap={4}>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <Placeholder />\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--on-toggle",
 					"name": "onToggle",
 					"snippet": "const onToggle = () => <Accordion onToggle={fn()}>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
+					"id": "utility-components-accordion--active",
 					"name": "active",
 					"snippet": "const active = () => <Accordion onToggle={fn()} active>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
+					"id": "utility-components-accordion--default-active",
 					"name": "defaultActive",
 					"snippet": "const defaultActive = () => <Accordion onToggle={fn()} defaultActive>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
-					"name": "renderProps",
+					"id": "utility-components-accordion--render-props",
+					"name": "children: render props",
 					"snippet": "const renderProps = () => <Accordion onToggle={fn()}>\n    <Accordion.Trigger>\n        {(attributes, { active }) => (\n            <Button attributes={{ ...attributes, \"data-active\": active }}>Trigger</Button>\n        )}\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-accordion--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Accordion className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Accordion.Trigger>\n                <Placeholder>Trigger</Placeholder>\n            </Accordion.Trigger>\n            <Accordion.Content>\n                <View paddingTop={2}>\n                    <Placeholder />\n                </View>\n            </Accordion.Content>\n        </Accordion>\n    </div>\n);"
 				}
 			],
 			"import": "import { Accordion, Button, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Accordion/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Accordion",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Accordion/Accordion.tsx",
-				"actualName": "Accordion",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"iconSize": {
+						"defaultValue": null,
+						"description": "Expand / collapse icon size in units",
+						"name": "iconSize",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"iconPosition": {
+						"defaultValue": null,
+						"description": "Position of the expand / collapse icon",
+						"name": "iconPosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"start\" | \"end\"",
+							"value": [{ "value": "\"start\"" }, { "value": "\"end\"" }]
+						}
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between the trigger and the content",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the trigger and the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onToggle": {
+						"defaultValue": null,
+						"description": "Callback when the accordion is expanded or collapsed",
+						"name": "onToggle",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((active: boolean) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control whether the accordion is expanded or collapsed, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control whether the accordion is expanded or collapsed by default, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Accordion"
 			}
 		},
 		"utility-components-actionable": {
@@ -2239,54 +11913,456 @@
 			"path": "./src/components/Actionable/tests/Actionable.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "utility-components-actionable--base",
+					"name": "href, onClick",
 					"snippet": "const base = () => <Example>\n    <Example.Item title=\"span\">\n        <Actionable>Span</Actionable>\n    </Example.Item>\n    <Example.Item title=\"onClick\">\n        <Actionable onClick={fn()}>Button</Actionable>\n    </Example.Item>\n    <Example.Item title=\"href\">\n        <Actionable href=\"https://reshaped.so\" attributes={{ target: \"_blank\" }}>Link\n                            </Actionable>\n    </Example.Item>\n    <Example.Item title=\"attributes.href\">\n        <Actionable attributes={{ href: \"https://reshaped.so\" }}>Link with attributes</Actionable>\n    </Example.Item>\n    <Example.Item title=\"href, onClick\">\n        <Actionable\n            onClick={(e) => {\n                e.preventDefault();\n                args.handleSecondClick(e);\n            }}\n            href=\"https://reshaped.so\">Link with onClick\n                            </Actionable>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "utility-components-actionable--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, button\">\n            <Actionable disabled onClick={() => {}}>\n                Button\n            </Actionable>\n        </Example.Item>\n        <Example.Item title=\"disabled, link\">\n            <Actionable disabled href=\"https://reshaped.so\">\n                Link\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--full-width",
 					"name": "fullWidth",
 					"snippet": "const fullWidth = () => (\n    <Example>\n        <Example.Item title=\"fullWidth\">\n            <Actionable fullWidth href=\"https://reshaped.so\">\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--inset-focus",
 					"name": "insetFocus",
 					"snippet": "const insetFocus = () => (\n    <Example>\n        <Example.Item title=\"insetFocus\">\n            <Actionable insetFocus onClick={() => {}}>\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--disable-focus-ring",
 					"name": "disableFocusRing",
 					"snippet": "const disableFocusRing = () => (\n    <Example>\n        <Example.Item title=\"disableFocusRing\">\n            <Actionable disableFocusRing onClick={() => {}}>\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--border-radius",
 					"name": "borderRadius",
 					"snippet": "const borderRadius = () => (\n    <Example>\n        <Example.Item title=\"borderRadius: inherit\">\n            <Actionable borderRadius=\"inherit\" onClick={() => {}}>\n                <View borderRadius=\"large\">Actionable</View>\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--type",
 					"name": "type",
 					"snippet": "const type = (args) => (\n    <Example>\n        <Example.Item title=\"type: submit\">\n            <form\n                onSubmit={(e) => {\n                    e.preventDefault();\n                    args.handleSubmit();\n                }}\n            >\n                <Actionable onClick={() => {}} type=\"submit\">\n                    Submit\n                </Actionable>\n            </form>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "as",
+					"id": "utility-components-actionable--as",
+					"name": "as, render",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"as: span\">\n            <Actionable onClick={() => {}} as=\"span\">\n                Trigger\n            </Actionable>\n        </Example.Item>\n        <Example.Item title=\"render, disabled\">\n            <Actionable disabled onClick={() => {}} render={(props) => <section {...props} />}>\n                Trigger\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--stop-propagation",
 					"name": "stopPropagation",
 					"snippet": "const stopPropagation = () => <div onClick={fn()}>\n    <Actionable stopPropagation onClick={() => {}}>Trigger\n                    </Actionable>\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-actionable--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Actionable className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Actionable>\n    </div>\n);"
 				}
 			],
 			"import": "import { Actionable, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Actionable/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Actionable",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Actionable/Actionable.tsx",
-				"actualName": "Actionable",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"touchHitbox": {
+						"defaultValue": null,
+						"description": "Enable a minimum required touch hitbox",
+						"name": "touchHitbox",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Take up the full width of its parent",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"insetFocus": {
+						"defaultValue": null,
+						"description": "Enable a focus ring inside the element bounds",
+						"name": "insetFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableFocusRing": {
+						"defaultValue": null,
+						"description": "Don't show a focus ring on focus, can be used when it is within a container with a focus ring",
+						"name": "disableFocusRing",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Apply the focus ring to the child and rely on its border radius",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"inherit\"", "value": [{ "value": "\"inherit\"" }] }
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2296,30 +12372,149 @@
 			"path": "./src/components/Container/tests/Container.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-container--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: default\">\n            <Container>\n                <Placeholder />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"padding: 0\">\n            <Container padding={0}>\n                <Placeholder />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "utility-components-container--size",
+					"name": "width, height, maxHeight",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"width: 200px, height: 200px\">\n            <Container width=\"200px\" height=\"200px\">\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width: 200px, height: 200px, maxHeight: 100px\">\n            <Container width=\"200px\" height=\"200px\" maxHeight=\"100px\">\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width, height: [s] 100px, [m+] 200px\">\n            <Container width={{ s: \"100px\", m: \"200px\" }} height={{ s: \"100px\", m: \"200px\" }}>\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width, height: [s] 100px, [m+] 200px, maxHeight: [s] 50px, [m+]: 100px\">\n            <Container\n                width={{ s: \"100px\", m: \"200px\" }}\n                height={{ s: \"100px\", m: \"200px\" }}\n                maxHeight={{ s: \"50px\", m: \"100px\" }}\n            >\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "flex",
+					"id": "utility-components-container--flex",
+					"name": "align, justify",
 					"snippet": "const flex = () => (\n    <Example>\n        <Example.Item title=\"align: center, justify: center\">\n            <Container align=\"center\" justify=\"center\" height=\"200px\">\n                <Placeholder />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-container--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Container className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </Container>\n    </div>\n);"
 				}
 			],
 			"import": "import { Container, Example, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Container/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Container",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Container/Container.tsx",
-				"actualName": "Container",
+				"methods": [],
+				"props": {
+					"align": {
+						"defaultValue": null,
+						"description": "Flex align-items for the content",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Flex justify-content for the content",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier\nComponent height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" },
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height style, literal string value or a base unit token number multiplier\nComponent max height, literal css value or unit token multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" },
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Component inline padding",
+						"name": "padding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Component width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2329,34 +12524,157 @@
 			"path": "./src/components/Dismissible/tests/Dismissible.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-dismissible--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Dismissible closeAriaLabel=\"Close banner\" onClose={() => {}}>\n                <Placeholder />\n            </Dismissible>\n        </Example.Item>\n        <Example.Item title=\"variant: media\">\n            <View width=\"300px\">\n                <Dismissible variant=\"media\" closeAriaLabel=\"Close banner\" onClose={() => {}}>\n                    <View aspectRatio={16 / 9}>\n                        <Image\n                            height=\"100%\"\n                            src=\"https://images.unsplash.com/photo-1607030529528-ca6923e27f77?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1867&q=80)\"\n                        />\n                    </View>\n                </Dismissible>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-dismissible--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: center\">\n            <Dismissible align=\"center\" closeAriaLabel=\"Close\" onClose={() => {}}>\n                <Placeholder />\n            </Dismissible>\n        </Example.Item>\n\n        <Example.Item title=\"align: center, variant: media\">\n            <Dismissible align=\"center\" closeAriaLabel=\"Close\" variant=\"media\" onClose={() => {}}>\n                <View aspectRatio={16 / 9}>\n                    <Image\n                        height=\"100%\"\n                        src=\"https://images.unsplash.com/photo-1607030529528-ca6923e27f77?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1867&q=80)\"\n                    />\n                </View>\n            </Dismissible>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-dismissible--hide-close-button",
 					"name": "hideCloseButton",
 					"snippet": "const hideCloseButton = () => (\n    <Example>\n        <Example.Item title=\"hide close button\">\n            <div id=\"root\">\n                <Dismissible hideCloseButton>\n                    <Placeholder />\n                </Dismissible>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "closeAriaLabel",
+					"id": "utility-components-dismissible--close-aria-label",
+					"name": "onClose, closeAriaLabel",
 					"snippet": "const closeAriaLabel = () => <Dismissible closeAriaLabel=\"Close\" onClose={fn()}>\n    <Placeholder />\n</Dismissible>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-dismissible--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Dismissible\n            closeAriaLabel=\"Close\"\n            onClose={() => {}}\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n        >\n            <Placeholder />\n        </Dismissible>\n    </div>\n);"
 				}
 			],
 			"import": "import { Dismissible, Example, Image, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Dismissible/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Dismissible",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Dismissible/Dismissible.tsx",
-				"actualName": "Dismissible",
+				"methods": [],
+				"props": {
+					"hideCloseButton": {
+						"defaultValue": null,
+						"description": "Hide the close button\nShow the close button",
+						"name": "hideCloseButton",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"closeAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the close button",
+						"name": "closeAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"media\"", "value": [{ "value": "\"media\"" }] }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Close button alignment",
+						"name": "align",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"center\"",
+							"value": [{ "value": "\"top\"" }, { "value": "\"center\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is dismissed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2366,135 +12684,577 @@
 			"path": "./src/components/Flyout/tests/Flyout.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-flyout--position",
 					"name": "position",
 					"snippet": "const position = () => {\n    return (\n        <View gap={4} padding={50} align=\"center\" justify=\"center\" height=\"100vh\" width=\"120%\">\n            <View gap={4} direction=\"row\">\n                <Demo position=\"top-start\" defaultActive />\n                <Demo position=\"top\" />\n                <Demo position=\"top-end\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"end-top\" />\n                <Demo position=\"end\" />\n                <Demo position=\"end-bottom\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"start-top\" />\n                <Demo position=\"start\" />\n                <Demo position=\"start-bottom\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"bottom-start\" />\n                <Demo position=\"bottom\" />\n                <Demo position=\"bottom-end\" />\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "defaultActive",
+					"id": "utility-components-flyout--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <Flyout onOpen={fn()} onClose={fn()} defaultActive>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "active",
+					"id": "utility-components-flyout--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <Flyout onOpen={fn()} onClose={fn()} active>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "utility-components-flyout--active-false",
+					"name": "active: false, controlled",
 					"snippet": "const activeFalse = () => <Flyout onOpen={fn()} onClose={fn()} active={false}>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "modes",
+					"id": "utility-components-flyout--modes",
+					"name": "triggerType, trapFocusMode",
 					"snippet": "const modes = () => {\n    return (\n        <Example>\n            <Example.Item title=\"triggerType: click\">\n                <View direction=\"row\" gap={4}>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"dialog\" text=\"dialog\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"action-menu\" text=\"action-menu\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"action-bar\" text=\"action-bar\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"content-menu\" text=\"content-menu\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode={false} text=\"false\">\n                        {modeContent}\n                    </Demo>\n                </View>\n            </Example.Item>\n\n            <Example.Item title=\"triggerType: hover\">\n                <View direction=\"row\" gap={4}>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"dialog\" triggerType=\"hover\" text=\"dialog\">\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"action-menu\"\n                        triggerType=\"hover\"\n                        text=\"action-menu\"\n                    >\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"action-bar\"\n                        triggerType=\"hover\"\n                        text=\"action-bar\"\n                    >\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"content-menu\"\n                        triggerType=\"hover\"\n                        text=\"content-menu\"\n                    >\n                        {modeContent}\n                    </Demo>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "positionFallbacks",
+					"id": "utility-components-flyout--position-fallbacks",
+					"name": "fallbackPositions",
 					"snippet": "const positionFallbacks = () => {\n    return (\n        <Example>\n            <Example.Item title=\"position: top, default fallbacks\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" />\n                </View>\n            </Example.Item>\n            <Example.Item title=\"position: top, fallbackPositions: [start]\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" fallbackPositions={[\"start\"]} contentHeight={200} defaultActive />\n                </View>\n            </Example.Item>\n            <Example.Item title=\"position: top, fallbackPositions: false\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" fallbackPositions={false} contentHeight={400} />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--fallback-adjust-layout",
 					"name": "fallbackAdjustLayout",
 					"snippet": "const fallbackAdjustLayout = () => {\n    return (\n        <Demo\n            contentHeight={false}\n            position=\"bottom-start\"\n            width=\"200px\"\n            fallbackAdjustLayout\n            defaultActive\n        >\n            <div style={{ height: \"600px\" }}>Content</div>\n        </Demo>\n    );\n};"
 				},
 				{
-					"name": "fallbackAdjustLayoutShift",
+					"id": "utility-components-flyout--fallback-adjust-layout-shift",
+					"name": "fallbackAdjustLayout, shift",
 					"snippet": "const fallbackAdjustLayoutShift = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={10}>\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    attributes={{ ref: containerRef }}\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls containerRef={containerRef} />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <FallbackAdjustLayoutControls />\n            <div style={{ height: \"100vh\", width: \"250%\" }} />\n        </View>\n    );\n};"
 				},
 				{
-					"name": "fallbackAdjustLayoutSize",
+					"id": "utility-components-flyout--fallback-adjust-layout-size",
+					"name": "fallbackAdjustLayout, size",
 					"snippet": "const fallbackAdjustLayoutSize = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={10}>\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls large />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    attributes={{ ref: containerRef }}\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls containerRef={containerRef} large />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <FallbackAdjustLayoutControls large />\n            <div style={{ height: \"100vh\", width: \"250%\" }} />\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--origin-coordinates",
 					"name": "originCoordinates",
 					"snippet": "const originCoordinates = () => {\n    return (\n        <View gap={4} direction=\"row\">\n            <Demo position=\"bottom-start\" originCoordinates={{ x: 150, y: 150 }} defaultActive />\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--width",
 					"name": "width",
 					"snippet": "const width = () => (\n    <Example>\n        <Example.Item title=\"width: 300px\">\n            <Demo width=\"300px\" position=\"bottom\" />\n        </Example.Item>\n\n        <Example.Item title=\"width: trigger\">\n            <Demo width=\"trigger\" contentWidth={false} defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-flyout--content-gap",
 					"name": "contentGap",
 					"snippet": "const contentGap = () => <Demo contentGap={10} defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--content-shift",
 					"name": "contentShift",
 					"snippet": "const contentShift = () => <Demo contentShift={10} defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-content-hover",
 					"name": "disableContentHover",
 					"snippet": "const disableContentHover = () => <Demo triggerType=\"hover\" disableContentHover />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-close-on-outside-click",
 					"name": "disableCloseOnOutsideClick",
 					"snippet": "const disableCloseOnOutsideClick = () => <Demo disableCloseOnOutsideClick />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-hide-animation",
 					"name": "disableHideAnimation",
 					"snippet": "const disableHideAnimation = () => <Demo disableHideAnimation defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Flyout disabled>\n        <Flyout.Trigger>\n            {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n        </Flyout.Trigger>\n        <Flyout.Content>\n            <Content />\n        </Flyout.Content>\n    </Flyout>\n);"
 				},
 				{
+					"id": "utility-components-flyout--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const portalRef = React.useRef<HTMLDivElement>(null);\n    const portalRef2 = React.useRef<HTMLDivElement>(null);\n    const portalRef3 = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={4} direction=\"row\">\n            <View\n                grow\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef, \"data-testid\": \"container\" }}\n                justify=\"end\"\n                align=\"start\"\n                padding={4}\n            >\n                <Demo containerRef={portalRef} position=\"bottom-start\" defaultActive />\n            </View>\n            <View\n                grow\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef2 }}\n                justify=\"start\"\n                align=\"end\"\n                padding={4}\n            >\n                <Demo containerRef={portalRef2} position=\"top-end\" />\n            </View>\n            <View\n                width={50}\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef3 }}\n                padding={4}\n                overflow=\"auto\"\n            >\n                <View height={120} width=\"120%\" justify=\"center\" align=\"center\">\n                    <Demo containerRef={portalRef3} position=\"bottom-end\" />\n                </View>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--initial-focus-ref",
 					"name": "initialFocusRef",
 					"snippet": "const initialFocusRef = () => {\n    const initialFocusRef = React.useRef<HTMLInputElement>(null);\n\n    return (\n        <Demo initialFocusRef={initialFocusRef}>\n            <View gap={4}>\n                <Button onClick={() => {}}>Action 1</Button>\n                <TextField name=\"foo\" inputAttributes={{ ref: initialFocusRef }} />\n            </View>\n        </Demo>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--instance-ref",
 					"name": "instanceRef",
 					"snippet": "const instanceRef = () => {\n    const flyoutRef = React.useRef<FlyoutInstance>(null);\n\n    return (\n        <View direction=\"row\" gap={4}>\n            <Demo\n                instanceRef={flyoutRef}\n                disableCloseOnOutsideClick\n                onOpen={fn()}\n                onClose={fn()} />\n            <Button onClick={() => flyoutRef.current?.open()}>Open</Button>\n            <Button onClick={() => flyoutRef.current?.close()}>Close</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "contentAttributes",
+					"id": "utility-components-flyout--content-attributes",
+					"name": "content: className, attributes",
 					"snippet": "const contentAttributes = () => {\n    return (\n        <Flyout position=\"bottom\" defaultActive>\n            <Flyout.Trigger>\n                {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n            </Flyout.Trigger>\n            <Flyout.Content attributes={{ \"data-testid\": \"test-id\" }} className=\"test-classname\">\n                <Content />\n            </Flyout.Content>\n        </Flyout>\n    );\n};"
 				},
 				{
-					"name": "testShadowDom",
+					"id": "utility-components-flyout--test-shadow-dom",
+					"name": "test: shadow dom",
 					"snippet": "const testShadowDom = () => <custom-element-flyout />;"
 				},
 				{
-					"name": "testInsideFixed",
+					"id": "utility-components-flyout--test-inside-fixed",
+					"name": "test: inside position fixed",
 					"snippet": "const testInsideFixed = () => (\n    <React.Fragment>\n        <View\n            position=\"fixed\"\n            insetBottom={2}\n            insetStart={2}\n            insetEnd={2}\n            backgroundColor=\"elevation-overlay\"\n            borderColor=\"neutral-faded\"\n            borderRadius=\"small\"\n            padding={4}\n            zIndex={10}\n            attributes={{ \"data-testid\": \"container\" }}\n            height={20}\n        >\n            <Demo defaultActive position=\"top-start\" />\n        </View>\n        <View paddingTop={18} gap={4}>\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n        </View>\n    </React.Fragment>\n);"
 				},
 				{
-					"name": "testInsideSticky",
+					"id": "utility-components-flyout--test-inside-sticky",
+					"name": "test: inside position sticky",
 					"snippet": "const testInsideSticky = () => (\n    <React.Fragment>\n        <View\n            position=\"sticky\"\n            insetTop={4}\n            insetStart={0}\n            insetEnd={0}\n            backgroundColor=\"elevation-overlay\"\n            borderColor=\"neutral-faded\"\n            borderRadius=\"small\"\n            padding={4}\n            zIndex={10}\n            attributes={{ \"data-testid\": \"container\" }}\n        >\n            <Demo defaultActive />\n        </View>\n        <View gap={4} paddingTop={2}>\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n        </View>\n    </React.Fragment>\n);"
 				},
 				{
-					"name": "testInsideScrollable",
+					"id": "utility-components-flyout--test-inside-scrollable",
+					"name": "test: inside scrollable",
 					"snippet": "const testInsideScrollable = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View padding={20}>\n            <View height={30} overflow=\"auto\" backgroundColor=\"neutral-faded\" borderRadius=\"small\">\n                <View height={50} attributes={{ ref: containerRef }} padding={20} paddingBottom={30}>\n                    <Demo position=\"bottom\" />\n                </View>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testInsideModal",
+					"id": "utility-components-flyout--test-inside-modal",
+					"name": "test: inside modal",
 					"snippet": "const testInsideModal = () => {\n    return (\n        <Modal active position=\"end\">\n            <View gap={4} align=\"start\">\n                <Modal.Title>Title</Modal.Title>\n                <Demo position=\"bottom-start\" />\n                <View height={300} width={25} backgroundColor=\"neutral-faded\" />\n                <Demo position=\"start\" />\n                <View height={300} width={25} backgroundColor=\"neutral-faded\" />\n                <Demo position=\"bottom-start\" />\n            </View>\n        </Modal>\n    );\n};"
 				},
 				{
-					"name": "testDynamicBounds",
+					"id": "utility-components-flyout--test-dynamic-bounds",
+					"name": "test: auto position update",
 					"snippet": "const testDynamicBounds = () => {\n    const [left, setLeft] = React.useState(50);\n    const [top, setTop] = React.useState(50);\n    const [size, setSize] = React.useState<\"medium\" | \"large\">(\"medium\");\n    const flyoutRef = React.useRef<FlyoutInstance>(null);\n\n    React.useEffect(() => {\n        flyoutRef.current?.updatePosition();\n    }, [left, top]);\n\n    return (\n        <View gap={4}>\n            <View direction=\"row\" gap={2}>\n                <Button onClick={() => setLeft((prev) => prev - 10)}>Left</Button>\n                <Button onClick={() => setLeft((prev) => prev + 10)}>Right</Button>\n                <Button onClick={() => setTop((prev) => prev - 10)}>Up</Button>\n                <Button onClick={() => setTop((prev) => prev + 10)}>Down</Button>\n                <Button\n                    onClick={() => {\n                        setLeft(50);\n                        setTop(50);\n                    }}\n                >\n                    Center\n                </Button>\n                <Button onClick={() => setSize(\"large\")}>Large button</Button>\n                <Button onClick={() => setSize(\"medium\")}>Small button</Button>\n            </View>\n            <View height={100}>\n                <Flyout\n                    position=\"bottom\"\n                    instanceRef={flyoutRef}\n                    disableCloseOnOutsideClick\n                    defaultActive\n                >\n                    <Flyout.Trigger>\n                        {(attributes) => (\n                            <div style={{ position: \"absolute\", left: `${left}%`, top: `${top}%` }}>\n                                <Button color=\"primary\" attributes={attributes} size={size}>\n                                    Open\n                                </Button>\n                            </div>\n                        )}\n                    </Flyout.Trigger>\n                    <Flyout.Content>\n                        <Content />\n                    </Flyout.Content>\n                </Flyout>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testScopedTheming",
+					"id": "utility-components-flyout--test-scoped-theming",
+					"name": "test: content uses scope theme",
 					"snippet": "const testScopedTheming = () => (\n    <View gap={3} align=\"start\">\n        <Button color=\"primary\">Slate button</Button>\n        <Theme name=\"reshaped\">\n            <Flyout triggerType=\"click\" active position=\"bottom-start\">\n                <Flyout.Trigger>\n                    {(attributes) => (\n                        <Button color=\"primary\" attributes={attributes}>\n                            Reshaped button\n                        </Button>\n                    )}\n                </Flyout.Trigger>\n                <Flyout.Content>\n                    <Content>\n                        <View gap={1}>\n                            <View.Item>Portal content, rendered in body</View.Item>\n                            <Button color=\"primary\">Reshaped button</Button>\n                        </View>\n                    </Content>\n                </Flyout.Content>\n            </Flyout>\n        </Theme>\n    </View>\n);"
 				},
 				{
-					"name": "testWithoutFocusable",
+					"id": "utility-components-flyout--test-without-focusable",
+					"name": "test: without focusable content",
 					"snippet": "const testWithoutFocusable = () => <Demo position=\"bottom-start\" />;"
 				},
 				{
-					"name": "testChangeSize",
+					"id": "utility-components-flyout--test-change-size",
+					"name": "test: size updates",
 					"snippet": "const testChangeSize = () => {\n    const [position, setPosition] = React.useState<FlyoutProps[\"position\"]>(\"bottom-start\");\n    const [updatedHeight, setUpdatedHeight] = React.useState(false);\n\n    return (\n        <>\n            <View direction=\"row\" gap={4} align=\"center\">\n                <Select\n                    name=\"position\"\n                    options={[\n                        \"bottom-start\",\n                        \"bottom\",\n                        \"bottom-end\",\n                        \"top-start\",\n                        \"top\",\n                        \"top-end\",\n                        \"start-top\",\n                        \"start\",\n                        \"start-bottom\",\n                        \"end-top\",\n                        \"end\",\n                        \"end-bottom\",\n                    ].map((p) => ({ label: p, value: p }))}\n                    onChange={(args) => setPosition(args.value as FlyoutProps[\"position\"])}\n                    value={position}\n                />\n                <Switch name=\"height\" onChange={(args) => setUpdatedHeight(args.checked)}>\n                    Change height\n                </Switch>\n            </View>\n            <div\n                style={{\n                    position: \"fixed\",\n                    top: \"50%\",\n                    left: \"50%\",\n                    transform: \"translate(-50%, -50%)\",\n                }}\n            >\n                <Demo position={position} disableCloseOnOutsideClick active contentHeight={false}>\n                    <View\n                        backgroundColor=\"neutral-faded\"\n                        borderRadius=\"small\"\n                        height={updatedHeight ? 50 : 25}\n                        attributes={{ style: { transition: \"0.2s ease-in-out\" } }}\n                    />\n                </Demo>\n            </div>\n        </>\n    );\n};"
 				}
 			],
 			"import": "import {\n    Button,\n    Example,\n    Flyout,\n    Modal,\n    Reshaped,\n    Select,\n    Switch,\n    TextField,\n    Theme,\n    View,\n} from \"reshaped\";\nimport React from \"react\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Flyout/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Flyout",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Flyout/Flyout.tsx",
-				"actualName": "Flyout",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"groupTimeouts": {
+						"defaultValue": null,
+						"description": "Removes the content display delay if another flyout is already active",
+						"name": "groupTimeouts",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | TrapMode" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the flyout content interactivity",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Automatically focus the first focusable element in the content, when false the content container will be focused instead",
+						"name": "autoFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the content element",
+						"name": "contentClassName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"contentAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the content element",
+						"name": "contentAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Flyout"
 			}
 		},
 		"utility-components-formcontrol": {
@@ -2503,43 +13263,147 @@
 			"path": "./src/components/FormControl/tests/FormControl.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-formcontrol--status",
 					"name": "status",
 					"snippet": "const status = () => (\n    <Example>\n        <Example.Item title=\"status: default\">\n            <FormControl>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"status: error\">\n            <FormControl hasError>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: medium\">\n            <FormControl size=\"medium\">\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <FormControl size=\"large\">\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" size=\"large\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <FormControl disabled>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--required",
 					"name": "required",
 					"snippet": "const required = () => (\n    <Example>\n        <Example.Item title=\"required\">\n            <FormControl required>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "utility-components-formcontrol--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"horizontal\">\n            <FormControl>\n                <View direction=\"row\" gap={10} align=\"center\">\n                    <View width=\"100px\">\n                        <FormControl.Label>Label</FormControl.Label>\n                    </View>\n                    <View.Item grow>\n                        <TextField name=\"name\" placeholder=\"Enter value\" />\n                    </View.Item>\n                </View>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-formcontrol--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <FormControl id=\"test-id\" hasError>\n        <FormControl.Label>Label</FormControl.Label>\n        <TextField name=\"name\" />\n        <FormControl.Helper>Caption</FormControl.Helper>\n        <FormControl.Error>Error</FormControl.Error>\n    </FormControl>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--group",
 					"name": "group",
 					"snippet": "const group = () => (\n    <FormControl group>\n        <FormControl.Label>Label</FormControl.Label>\n        <RadioGroup name=\"name\">\n            <View gap={2}>\n                <Radio value=\"1\">One</Radio>\n                <Radio value=\"2\">Two</Radio>\n            </View>\n        </RadioGroup>\n    </FormControl>\n);"
 				}
 			],
 			"import": "import { Example, FormControl, Radio, RadioGroup, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/FormControl/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "FormControl",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/FormControl/FormControl.tsx",
-				"actualName": "FormControl",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size, to be used together with the other form component sizes",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"large\" | \"medium\"",
+							"value": [{ "value": "\"large\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"required": {
+						"defaultValue": null,
+						"description": "Change component to show a required indicator",
+						"name": "required",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Apply disabled styles",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"group": {
+						"defaultValue": null,
+						"description": "Apply semantic html markup when used for displaying multiple form fields together with a single label",
+						"name": "group",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Custom id for the form control",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "FormControl"
 			}
 		},
 		"utility-components-grid": {
@@ -2548,43 +13412,421 @@
 			"path": "./src/components/Grid/tests/Grid.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "utility-components-grid--base",
+					"name": "gap, columnGap, rowGap, align, justify, maxWidth, width, height",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"gap: 2\">\n            <Grid gap={2} columns={2}>\n                {[1, 2].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"columnGap: 2, rowGap: 4\">\n            <Grid columnGap={2} rowGap={4} columns={2}>\n                {[1, 2, 3, 4].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"align: center\">\n            <Grid gap={2} columns={2} align=\"center\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={8}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"justify: center\">\n            <Grid gap={2} columns=\"200px 200px\" justify=\"center\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"maxWidth: 400px\">\n            <Grid gap={2} columns=\"200px 200px\" maxWidth=\"400px\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"width: 400px, height: 200px\">\n            <Grid gap={2} columns={2} width=\"400px\" height=\"200px\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "layout",
+					"id": "utility-components-grid--layout",
+					"name": "rows, columns",
 					"snippet": "const layout = () => (\n    <Example>\n        <Example.Item title=\"simple: 2 rows, 3 columns\">\n            <Grid gap={4} columns={3} rows={2}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"columns template, 1fr 2fr 1fr\">\n            <Grid gap={4} columns=\"1fr 2fr 1fr\" rows={2}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"rows template, 1fr 2fr\">\n            <Grid gap={4} columns={3} rows=\"1fr 2fr\">\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"responsive\">\n            <Grid gap={4} columns={{ s: 3, m: \"1fr 2fr 1fr\" }} rows={{ s: 2, m: \"1fr 2fr\" }}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemLayout",
+					"id": "utility-components-grid--item-layout",
+					"name": "colStart, colEnd, rowStart, rowEnd",
 					"snippet": "const itemLayout = () => (\n    <Example>\n        <Example.Item title=\"column, start 1, end 3\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item colStart={1} colEnd={3}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"column, start 1, span 2\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item colStart={1} colSpan={2}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"row, start 1, end 3\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowEnd={3}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"row, start 1, span 2\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowSpan={2}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"responsive\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowSpan={{ s: 1, m: 2 }} colStart={1} colSpan={{ s: 1, m: 2 }}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-grid--areas",
 					"name": "areas",
 					"snippet": "const areas = () => (\n    <Example>\n        <Example.Item title=\"simple: 2 rows, 3 columns\">\n            <Grid gap={4} rows={2} areas={[\"a .\", \"a b\"]}>\n                {[\"a\", \"b\"].map((area) => (\n                    <Grid.Item area={area} key={area}>\n                        <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                            {area}\n                        </View>\n                    </Grid.Item>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "auto",
+					"id": "utility-components-grid--auto",
+					"name": "autoFlow, autoColumns, autoRows",
 					"snippet": "const auto = () => (\n    <Example>\n        <Example.Item title=\"auto flow: column\">\n            <Grid gap={4} autoFlow=\"column\" rows={2} columns={2}>\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"auto rows\">\n            <Grid gap={4} autoRows=\"100px\" columns={2}>\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"auto columns\">\n            <Grid gap={4} autoColumns=\"100px\" autoFlow=\"column\">\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-grid--as",
 					"name": "as",
 					"snippet": "const as = () => (\n    <Grid as=\"ul\">\n        <Grid.Item as=\"li\">Content</Grid.Item>\n    </Grid>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-grid--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Grid className=\"test-class\" attributes={{ id: \"test-id\" }}>\n            <Grid.Item className=\"test-item-class\" attributes={{ id: \"test-item-id\" }}>\n                Content\n            </Grid.Item>\n        </Grid>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Grid, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Grid/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Grid",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Grid/Grid.tsx",
-				"actualName": "Grid",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between grid items",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"columnGap": {
+						"defaultValue": null,
+						"description": "Horizontal gap between grid items",
+						"name": "columnGap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"rowGap": {
+						"defaultValue": null,
+						"description": "Vertical gap between grid items",
+						"name": "rowGap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Align grid items vertically",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Justify grid items horizontally",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"rows": {
+						"defaultValue": null,
+						"description": "Grid template rows",
+						"name": "rows",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<number | \"inherit\" | \"none\" | \"auto\" | (string & {}) | \"-moz-initial\" | \"initial\" | \"revert\" | \"revert-layer\" | \"unset\" | \"max-content\" | \"min-content\" | \"subgrid\">"
+						}
+					},
+					"columns": {
+						"defaultValue": null,
+						"description": "Grid template columns",
+						"name": "columns",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<number | \"inherit\" | \"none\" | \"auto\" | (string & {}) | \"-moz-initial\" | \"initial\" | \"revert\" | \"revert-layer\" | \"unset\" | \"max-content\" | \"min-content\" | \"subgrid\">"
+						}
+					},
+					"areas": {
+						"defaultValue": null,
+						"description": "Grid areas for template syntax",
+						"name": "areas",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string[]>" }
+					},
+					"autoFlow": {
+						"defaultValue": null,
+						"description": "Grid auto flow",
+						"name": "autoFlow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoFlow>" }
+					},
+					"autoColumns": {
+						"defaultValue": null,
+						"description": "Grid auto columns",
+						"name": "autoColumns",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoColumns<0 | (string & {})>>" }
+					},
+					"autoRows": {
+						"defaultValue": null,
+						"description": "Grid auto rows",
+						"name": "autoRows",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoRows<0 | (string & {})>>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Maximum width of the grid container, literal css value or unit token multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width of the grid container, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height of the grid container, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Custom root element html tag",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					}
+				},
+				"exportName": "Grid"
 			}
 		},
 		"utility-components-hidden": {
@@ -2593,22 +13835,261 @@
 			"path": "./src/components/Hidden/tests/Hidden.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-hidden--visibility",
 					"name": "visibility",
 					"snippet": "const visibility = () => (\n    <Example>\n        <Example.Item title=\"hide: always\">\n            <Hidden hide={true}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on s\">\n            <Hidden hide={{ s: false, m: true }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on l/xl\">\n            <Hidden hide={{ s: true, l: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on m/l/xl\">\n            <Hidden hide={{ s: true, m: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on m\">\n            <Hidden hide={{ s: true, m: false, l: true }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on s/xl\">\n            <Hidden hide={{ s: false, m: true, xl: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"hide: always, visibility\">\n            <Hidden hide visibility>\n                Content\n            </Hidden>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-hidden--as",
 					"name": "as",
 					"snippet": "const as = () => <Hidden as=\"span\">Content</Hidden>;"
 				}
 			],
 			"import": "import { Example, Hidden } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Hidden/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Hidden",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Hidden/Hidden.tsx",
-				"actualName": "Hidden",
+				"methods": [],
+				"props": {
+					"hide": {
+						"defaultValue": null,
+						"description": "Pick at which viewport sizes to hide the children",
+						"name": "hide",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"visibility": {
+						"defaultValue": null,
+						"description": "Use visibility hidden instead of display none",
+						"name": "visibility",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Custom root element html tag",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2618,22 +14099,39 @@
 			"path": "./src/components/HiddenVisually/tests/HiddenVisually.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-hiddenvisually--visibility",
 					"name": "visibility",
 					"snippet": "const visibility = () => (\n    <Example>\n        <Example.Item title=\"pronounced by screen readers\">\n            <HiddenVisually>Screen-reader only</HiddenVisually>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-hiddenvisually--children",
 					"name": "children",
 					"snippet": "const children = () => <HiddenVisually>Content</HiddenVisually>;"
 				}
 			],
 			"import": "import { Example, HiddenVisually } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/HiddenVisually/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "HiddenVisually",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/HiddenVisually/HiddenVisually.tsx",
-				"actualName": "HiddenVisually",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/HiddenVisually/HiddenVisually.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2643,34 +14141,115 @@
 			"path": "./src/components/Icon/tests/Icon.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-icon--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: 4\">\n            <Icon svg={IconZap} size={4} />\n        </Example.Item>\n        <Example.Item title=\"size: 8\">\n            <Icon svg={IconZap} size={8} />\n        </Example.Item>\n        <Example.Item title=\"size: 100%\">\n            <View width={25} height={25}>\n                <Icon svg={IconZap} size=\"100%\" />\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive size\", \"[s] 5\", \"[m]: 10\"]}>\n            <Icon svg={IconZap} size={{ s: 5, m: 10 }} />\n        </Example.Item>\n        <Example.Item title=\"size: inherit from font\">\n            <Text variant=\"title-6\">\n                <View direction=\"row\" align=\"center\" gap={2}>\n                    <Icon svg={IconZap} />\n                    <View.Item>Reshaped</View.Item>\n                </View>\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-icon--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <Icon svg={IconZap} color=\"neutral\" />\n        </Example.Item>\n        <Example.Item title=\"color: neutral-faded\">\n            <Icon svg={IconZap} color=\"neutral-faded\" />\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <Icon svg={IconZap} color=\"primary\" />\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Icon svg={IconZap} color=\"critical\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Icon svg={IconZap} color=\"positive\" />\n        </Example.Item>\n        <Example.Item title=\"color: disabled\">\n            <Icon svg={IconZap} color=\"disabled\" />\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <div style={{ color: \"tomato\" }}>\n                <Icon svg={IconZap} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "autoWidth",
+					"id": "utility-components-icon--auto-width",
+					"name": "autoWidth, blank",
 					"snippet": "const autoWidth = () => (\n    <Example>\n        <Example.Item title=\"square boundaries\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={IconMic} size={10} />\n            </div>\n        </Example.Item>\n        <Example.Item title=\"auto width boundaries\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={IconMic} size={10} autoWidth />\n            </div>\n        </Example.Item>\n        <Example.Item title=\"blank\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={null} size={10} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-icon--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Icon svg={IconZap} className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				},
 				{
-					"name": "render",
+					"id": "utility-components-icon--render",
+					"name": "test: hidden from sr",
 					"snippet": "const render = () => (\n    <div data-testid=\"root\">\n        <Icon svg={IconZap} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Icon, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Icon/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Icon",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Icon/Icon.tsx",
-				"actualName": "Icon",
+				"methods": [],
+				"props": {
+					"svg": {
+						"defaultValue": null,
+						"description": "Icon svg component or node",
+						"name": "svg",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Icon size, literal css value or unit token multiplier",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Icon color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"warning\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"autoWidth": {
+						"defaultValue": null,
+						"description": "Use the width of the svg asset instead of providing a square bounding box",
+						"name": "autoWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2680,54 +14259,230 @@
 			"path": "./src/components/Image/tests/Image.stories.tsx",
 			"stories": [
 				{
-					"name": "src",
+					"id": "utility-components-image--src",
+					"name": "src, alt",
 					"snippet": "const src = () => (\n    <Example>\n        <Example.Item title=\"src, alt\">\n            <Image src={imgUrl} alt=\"Image alt\" />\n        </Example.Item>\n\n        <Example.Item title=\"src\">\n            <Image src={imgUrl} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "utility-components-image--size",
+					"name": "width, height, maxWidth, aspectRatio",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"width: 200px\">\n            <Image src={imgUrl} width=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"height: 200px\">\n            <Image src={imgUrl} height=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"maxWidth: 200px\">\n            <Image src={imgUrl} maxWidth=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"aspectRatio: 1/1\">\n            <Image src={imgUrl} aspectRatio={1 / 1} width=\"300px\" />\n        </Example.Item>\n        <Example.Item title={[\"responsive width\", \"[s] 200px\", \"[m+] 300px\"]}>\n            <Image src={imgUrl} width={{ s: \"200px\", m: \"300px\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "radius",
+					"id": "utility-components-image--radius",
+					"name": "borderRadius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius: small\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"small\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"radius: medium\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"medium\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"radius: large\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--display-mode",
 					"name": "displayMode",
 					"snippet": "const displayMode = () => (\n    <Example>\n        <Example.Item title=\"mode: cover\">\n            <Image src={imgUrl} height=\"200px\" width=\"100%\" displayMode=\"cover\" />\n        </Example.Item>\n        <Example.Item title=\"mode: contain\">\n            <Image src={imgUrl} height=\"200px\" width=\"100%\" displayMode=\"contain\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--on-load",
 					"name": "onLoad",
 					"snippet": "const onLoad = () => <Image src={imgUrl} alt=\"photo\" onLoad={fn()} />;"
 				},
 				{
+					"id": "utility-components-image--on-error",
 					"name": "onError",
 					"snippet": "const onError = () => <Image src=\"/invalid.png\" alt=\"photo\" onError={fn()} />;"
 				},
 				{
+					"id": "utility-components-image--fallback",
 					"name": "fallback",
 					"snippet": "const fallback = () => (\n    <Example>\n        <Example.Item title=\"fallback, background, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"fallback, image, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback={imgUrl} />\n                </View>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"fallback, icon, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback={<Icon svg={IconZap} size={10} />} />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"fallback, icon, no url\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image fallback={<Icon svg={IconZap} size={10} />} />\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--render-image",
 					"name": "renderImage",
 					"snippet": "const renderImage = () => (\n    <Example>\n        <Example.Item title=\"renderImage\">\n            <Image\n                src={imgUrl}\n                alt=\"Amsterdam canal\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image\" />}\n            />\n        </Example.Item>\n        <Example.Item title=\"renderImage, fallback\">\n            <Image\n                src=\"error\"\n                fallback={imgUrl}\n                alt=\"Amsterdam canal 2\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image-fallback\" />}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "imageAttributes",
+					"id": "utility-components-image--image-attributes",
+					"name": "className, attributes,imageAttributes",
 					"snippet": "const imageAttributes = () => (\n    <div data-testid=\"root\">\n        <Image\n            src={imgUrl}\n            alt=\"photo\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            imageAttributes={{ \"data-testid\": \"test-img-id\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "ratio",
+					"id": "utility-components-image--ratio",
+					"name": "test: aspectRatio",
 					"snippet": "const ratio = () => (\n    <Example>\n        <Example.Item title=\"ratio: 16/9\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"ratio: 16/9, displayMode: contain\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} displayMode=\"contain\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Icon, Image, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Image/Image.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Image",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Image/Image.tsx",
-				"actualName": "Image",
+				"methods": [],
+				"props": {
+					"src": {
+						"defaultValue": null,
+						"description": "Image URL",
+						"name": "src",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"alt": {
+						"defaultValue": null,
+						"description": "Image alt text",
+						"name": "alt",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Image width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Image height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Image max width, literal css value or unit token multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"aspectRatio": {
+						"defaultValue": null,
+						"description": "Image aspect ratio, width / height",
+						"name": "aspectRatio",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Image border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"large\" | \"medium\"",
+							"value": [
+								{ "value": "\"small\"" },
+								{ "value": "\"large\"" },
+								{ "value": "\"medium\"" }
+							]
+						}
+					},
+					"displayMode": {
+						"defaultValue": null,
+						"description": "Image display mode for controlling how it fits into the provided boundaries",
+						"name": "displayMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"cover\" | \"contain\"",
+							"value": [{ "value": "\"cover\"" }, { "value": "\"contain\"" }]
+						}
+					},
+					"onLoad": {
+						"defaultValue": null,
+						"description": "Image on load event",
+						"name": "onLoad",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: SyntheticEvent<Element, Event>) => void)" }
+					},
+					"onError": {
+						"defaultValue": null,
+						"description": "Image on error event",
+						"name": "onError",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: SyntheticEvent<Element, Event>) => void)" }
+					},
+					"fallback": {
+						"defaultValue": null,
+						"description": "Image fallback content if the image fails to load or was not provided",
+						"name": "fallback",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"renderImage": {
+						"defaultValue": null,
+						"description": "Image render function, can be used for integrating with Image component in 3rd party frameworks",
+						"name": "renderImage",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Omit<Attributes<\"img\">, \"src\" | \"alt\"> & { src: string; alt: string; }) => ReactNode)"
+						}
+					},
+					"imageAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the image element",
+						"name": "imageAttributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"img\">" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(Attributes<\"div\"> & Attributes<\"img\">)" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2737,46 +14492,229 @@
 			"path": "./src/components/Overlay/tests/Overlay.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-overlay--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate}>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--transparent",
 					"name": "transparent",
 					"snippet": "const transparent = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate} transparent>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--blurred",
 					"name": "blurred",
 					"snippet": "const blurred = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate} blurred>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "renderProps",
+					"id": "utility-components-overlay--render-props",
+					"name": "children, render props",
 					"snippet": "const renderProps = () => (\n    <Overlay active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        {(args) => (args.active ? \"Opened\" : \"Closed\")}\n    </Overlay>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "utility-components-overlay--handlers",
+					"name": "onOpen, onClose, onAfterOpen, onAfterClose",
 					"snippet": "const handlers = () => {\n    const overlayToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => overlayToggle.toggle()}>Open overlay</Button>\n            <Overlay\n                active={overlayToggle.active}\n                onClose={(closeArgs) => {\n                    overlayToggle.deactivate();\n                    args.handleClose(closeArgs);\n                }}\n                onOpen={fn()}\n                onAfterOpen={fn()}\n                onAfterClose={fn()}>Content\n                                </Overlay>\n        </>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--disable-close-on-click",
 					"name": "disableCloseOnClick",
 					"snippet": "const disableCloseOnClick = (args) => (\n    <Overlay\n        active\n        disableCloseOnClick\n        onClose={(closeArgs) => {\n            args.handleClose(closeArgs);\n        }}\n    >\n        Content\n    </Overlay>\n);"
 				},
 				{
+					"id": "utility-components-overlay--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <>\n            <div ref={containerRef} data-testid=\"test-id\" style={{ height: 200 }} />\n            <Overlay active containerRef={containerRef}>\n                Content\n            </Overlay>\n        </>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-overlay--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <Overlay active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        Content\n    </Overlay>\n);"
 				}
 			],
 			"import": "import { Button, Example, Overlay } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Overlay/index.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Overlay",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Overlay/Overlay.tsx",
-				"actualName": "Overlay",
+				"methods": [],
+				"props": {
+					"transparent": {
+						"defaultValue": null,
+						"description": "Make the overlay transparent",
+						"name": "transparent",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number | boolean" }
+					},
+					"blurred": {
+						"defaultValue": null,
+						"description": "Make the overlay blurred",
+						"name": "blurred",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Control the overflow of the component content",
+						"name": "overflow",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"auto\"",
+							"value": [{ "value": "\"hidden\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, render function receives the state of the component as an argument",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode | ((props: { active: boolean; }) => ReactNode)" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the visibility of the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason: CloseReason; }) => void)" }
+					},
+					"onAfterClose": {
+						"defaultValue": null,
+						"description": "Callback after the component close transition is complete",
+						"name": "onAfterClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the component is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onAfterOpen": {
+						"defaultValue": null,
+						"description": "Callback after the component open transition is complete",
+						"name": "onAfterOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"disableCloseOnClick": {
+						"defaultValue": null,
+						"description": "Disable closing the component on outside click",
+						"name": "disableCloseOnClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": null,
+						"description": "Element to render the component in",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2786,42 +14724,213 @@
 			"path": "./src/components/Reshaped/tests/Reshaped.stories.tsx",
 			"stories": [
 				{
-					"name": "rtl",
+					"id": "utility-components-reshaped--rtl",
+					"name": "defaultRTL",
 					"snippet": "const rtl = () => (\n    <Reshaped defaultRTL theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				},
 				{
-					"name": "controlledMode",
+					"id": "utility-components-reshaped--controlled-mode",
+					"name": "colorMode, controlled",
 					"snippet": "const controlledMode = () => {\n    const [mode, setMode] = useState<G.ColorMode>(\"dark\");\n\n    return (\n        <Reshaped theme=\"reshaped\" colorMode={mode}>\n            <Button\n                onClick={() => {\n                    setMode(mode === \"dark\" ? \"light\" : \"dark\");\n                }}\n            >\n                Toggle color mode\n            </Button>\n        </Reshaped>\n    );\n};"
 				},
 				{
-					"name": "lightMode",
+					"id": "utility-components-reshaped--light-mode",
+					"name": "defaultColorMode=light",
 					"snippet": "const lightMode = () => <Reshaped theme=\"reshaped\">Hello</Reshaped>;"
 				},
 				{
-					"name": "darkMode",
+					"id": "utility-components-reshaped--dark-mode",
+					"name": "defaultColorMode=dark",
 					"snippet": "const darkMode = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				},
 				{
+					"id": "utility-components-reshaped--scoped",
 					"name": "scoped",
 					"snippet": "const scoped = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\" scoped>\n        Hello\n    </Reshaped>\n);"
 				},
 				{
-					"name": "testScoped",
+					"id": "utility-components-reshaped--test-scoped",
+					"name": "test: scoped switch",
 					"snippet": "const testScoped = () => (\n    <Reshaped theme=\"reshaped\">\n        <Reshaped theme=\"slate\" scoped>\n            <ScopedComponent />\n        </Reshaped>\n    </Reshaped>\n);"
 				},
 				{
-					"name": "keyboardMode",
+					"id": "utility-components-reshaped--keyboard-mode",
+					"name": "test: keyboard mode",
 					"snippet": "const keyboardMode = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				}
 			],
 			"import": "import { Button, Reshaped } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Reshaped/Reshaped.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Reshaped",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Reshaped/Reshaped.tsx",
-				"actualName": "Reshaped",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"theme": {
+						"defaultValue": null,
+						"description": "Theme of the application, enables controlled mode",
+						"name": "theme",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NonNullable<Theme>" }
+					},
+					"defaultTheme": {
+						"defaultValue": null,
+						"description": "Default theme of the application, enables uncontrolled mode",
+						"name": "defaultTheme",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NonNullable<Theme>" }
+					},
+					"defaultRTL": {
+						"defaultValue": null,
+						"description": "Default content direction of the application",
+						"name": "defaultRTL",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode of the application, enables controlled mode",
+						"name": "colorMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode",
+							"value": [{ "value": "\"light\"" }, { "value": "\"dark\"" }]
+						}
+					},
+					"defaultColorMode": {
+						"defaultValue": null,
+						"description": "Default color mode of the application, enables uncontrolled mode",
+						"name": "defaultColorMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode",
+							"value": [{ "value": "\"light\"" }, { "value": "\"dark\"" }]
+						}
+					},
+					"defaultViewport": {
+						"defaultValue": null,
+						"description": "Default viewport size of the application",
+						"name": "defaultViewport",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Viewport",
+							"value": [
+								{ "value": "\"s\"" },
+								{ "value": "\"m\"" },
+								{ "value": "\"l\"" },
+								{ "value": "\"xl\"" }
+							]
+						}
+					},
+					"toastOptions": {
+						"defaultValue": null,
+						"description": "Global options for the ToastProvider",
+						"name": "toastOptions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "Partial<Record<Position, { width?: string; expanded?: boolean; }>> | undefined"
+						}
+					},
+					"scoped": {
+						"defaultValue": null,
+						"description": "Enable scoped mode for applications not using Reshaped provider at the application root",
+						"name": "scoped",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2831,42 +14940,150 @@
 			"path": "./src/components/ScrollArea/tests/ScrollArea.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-scrollarea--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"vertical scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"horizontal scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\" height=\"100px\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"horizontal and vertical scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-scrollarea--scrollbar-display",
 					"name": "scrollbarDisplay",
 					"snippet": "const scrollbarDisplay = () => (\n    <Example>\n        <Example.Item title=\"scrollbarDisplay: hover\">\n            <ScrollArea height=\"100px\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"scrollbarDisplay: hidden\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"hidden\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"scrollbarDisplay: visible\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "height",
+					"id": "utility-components-scrollarea--height",
+					"name": "height, maxHeight",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"height: 80px\">\n            <ScrollArea height=\"80px\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"responsive height: s 80px, m: 120px\">\n            <ScrollArea height={{ s: \"80px\", m: \"120px\" }}>\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"maxHeight: 80px\">\n            <ScrollArea maxHeight=\"80px\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"responsive max height: s 80px, m: 200px\">\n            <ScrollArea maxHeight={{ s: \"80px\", m: \"200px\" }}>\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onScroll",
+					"id": "utility-components-scrollarea--on-scroll",
+					"name": "ref, onScroll",
 					"snippet": "const onScroll = () => {\n    const ref = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={4}>\n            <View.Item>\n                <Button onClick={() => ref.current?.scrollBy({ top: 50, left: 50 })}>Scroll</Button>\n            </View.Item>\n            <ScrollArea height=\"100px\" ref={ref} scrollbarDisplay=\"visible\" onScroll={fn()}>\n                <View backgroundColor=\"neutral-faded\" padding={4} width=\"1000px\" height=\"200px\">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                                            has been the industry's standard dummy text ever since the 1500s, when an unknown\n                                            printer took a galley of type and scrambled it to make a type specimen book. It has\n                                            survived not only five centuries, but also the leap into electronic typesetting,\n                                            remaining essentially unchanged. It was popularised in the 1960s with the release of\n                                            Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                                            publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                                        </View>\n            </ScrollArea>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-scrollarea--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ScrollArea className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </ScrollArea>\n    </div>\n);"
 				},
 				{
-					"name": "testNested",
+					"id": "utility-components-scrollarea--test-nested",
+					"name": "test: nested",
 					"snippet": "const testNested = () => (\n    <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n        <View padding={4} paddingInline={16}>\n            <ScrollArea height=\"200px\" scrollbarDisplay=\"visible\">\n                {Array(20)\n                    .fill(\"\")\n                    .map((_, index) => {\n                        return <div key={index}>Item {index + 1}</div>;\n                    })}\n            </ScrollArea>\n        </View>\n    </ScrollArea>\n);"
 				},
 				{
-					"name": "testDynamicHeight",
+					"id": "utility-components-scrollarea--test-dynamic-height",
+					"name": "test: dynamic height change",
 					"snippet": "const testDynamicHeight = () => {\n    const [count, setCount] = React.useState(10);\n\n    return (\n        <View gap={4}>\n            <View.Item>\n                <Button onClick={() => setCount((prev) => prev + 10)}>Add more items</Button>\n            </View.Item>\n\n            <ScrollArea height=\"200px\" scrollbarDisplay=\"visible\">\n                <View gap={2}>\n                    {new Array(count).fill(\"\").map((_, i) => (\n                        <View.Item key={i}>Item {i + 1}</View.Item>\n                    ))}\n                </View>\n            </ScrollArea>\n        </View>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Example, ScrollArea, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ScrollArea/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ScrollArea",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ScrollArea/ScrollArea.tsx",
-				"actualName": "ScrollArea",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"scrollbarDisplay": {
+						"defaultValue": null,
+						"description": "Scrollbar visibility behavior based on the user interaction",
+						"name": "scrollbarDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"hover\" | \"visible\"",
+							"value": [
+								{ "value": "\"hidden\"" },
+								{ "value": "\"hover\"" },
+								{ "value": "\"visible\"" }
+							]
+						}
+					},
+					"onScroll": {
+						"defaultValue": null,
+						"description": "Callback when the scroll area is scrolled",
+						"name": "onScroll",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: Coordinates) => void)" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height of the scroll area, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height of the scroll area, literal css value or unit token multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2876,54 +15093,387 @@
 			"path": "./src/components/Text/tests/Text.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-text--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: title-1\">\n            <Text variant=\"title-1\">Title 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-2\">\n            <Text variant=\"title-2\">Title 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-3\">\n            <Text variant=\"title-3\">Title 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-4\">\n            <Text variant=\"title-4\">Title 4</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-5\">\n            <Text variant=\"title-5\">Title 5</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-6\">\n            <Text variant=\"title-6\">Title 6</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-1\">\n            <Text variant=\"featured-1\">Featured 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-2\">\n            <Text variant=\"featured-2\">Featured 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-3\">\n            <Text variant=\"featured-3\">Featured 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-1\">\n            <Text variant=\"body-1\">Body 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-2\">\n            <Text variant=\"body-2\">Body 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-3\">\n            <Text variant=\"body-3\">Body 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: caption-1\">\n            <Text variant=\"caption-1\">Caption 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: caption-2\">\n            <Text variant=\"caption-2\">Caption 2</Text>\n        </Example.Item>\n        <Example.Item title={[\"responsive variant\", \"[s] body-3\", \"[m+] title-4\"]}>\n            <Text variant={{ s: \"body-3\", m: \"title-4\" }}>Responsive</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--weight",
 					"name": "weight",
 					"snippet": "const weight = () => (\n    <Example>\n        <Example.Item title=\"weight: regular\">\n            <Text weight=\"regular\">Regular</Text>\n        </Example.Item>\n        <Example.Item title=\"weight: medium\">\n            <Text weight=\"medium\">Medium</Text>\n        </Example.Item>\n        <Example.Item title=\"weight: bold\">\n            <Text weight=\"bold\">Bold</Text>\n        </Example.Item>\n        <Example.Item title={[\"responsive\", \"[s] weight: regular\", \"[m+] bold\"]}>\n            <Text weight={{ s: \"regular\", m: \"bold\" }}>Responsive</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: inherit\">\n            <Text>Neutral</Text>\n        </Example.Item>\n        <Example.Item title=\"color: neutral-faded\">\n            <Text color=\"neutral-faded\">Faded</Text>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Text color=\"positive\">Positive</Text>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <Text color=\"warning\">Warning</Text>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Text color=\"critical\">Critical</Text>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <Text color=\"primary\">Primary</Text>\n        </Example.Item>\n        <Example.Item title=\"color: disabled\">\n            <Text color=\"disabled\" attributes={{ \"aria-disabled\": true }}>\n                Disabled\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--decoration",
 					"name": "decoration",
 					"snippet": "const decoration = () => (\n    <Example>\n        <Example.Item title=\"decoration: line-through\">\n            <Text decoration=\"line-through\">Line through</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--wrap",
 					"name": "wrap",
 					"snippet": "const wrap = () => (\n    <Example>\n        <Example.Item title=\"wrap: balance\">\n            <Text wrap=\"balance\" variant=\"title-3\">\n                The design system you want to build\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "mono",
+					"id": "utility-components-text--mono",
+					"name": "monospace",
 					"snippet": "const mono = () => (\n    <Example>\n        <Example.Item title=\"monospace\">\n            <Text monospace>Content</Text>\n        </Example.Item>\n        <Example.Item title=\"monospace, variant, weight\">\n            <Text monospace variant=\"title-1\" weight=\"regular\">\n                Content\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--max-lines",
 					"name": "maxLines",
 					"snippet": "const maxLines = () => (\n    <Example>\n        <Example.Item title=\"maxLines: 2\">\n            <Text maxLines={2}>\n                There are many variations of passages of Lorem Ipsum available, but the majority have\n                suffered alteration in some form, by injected humour, or randomised words which don't look\n                even slightly believable. If you are going to use a passage of Lorem Ipsum, you need to be\n                sure there isn't anything embarrassing hidden in the middle of text. All the Lorem Ipsum\n                generators on the Internet tend to repeat predefined chunks as necessary, making this the\n                first true generator on the Internet. It uses a dictionary of over 200 Latin words,\n                combined with a handful of model sentence structures, to generate Lorem Ipsum which looks\n                reasonable. The generated Lorem Ipsum is therefore always free from repetition, injected\n                humour, or non-characteristic words etc.\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: start\">\n            <Text align=\"start\">Text content</Text>\n        </Example.Item>\n        <Example.Item title=\"align: center\">\n            <Text align=\"center\">Text content</Text>\n        </Example.Item>\n        <Example.Item title=\"align: end\">\n            <Text align=\"end\">Text content</Text>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive alignment\", \"[s]: center\", \"[m+] start\"]}>\n            <Text align={{ s: \"center\", m: \"start\" }}>Text content</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "asProp",
+					"id": "utility-components-text--as-prop",
+					"name": "as",
 					"snippet": "const asProp = () => (\n    <>\n        <Text as=\"h1\">Content</Text>\n        <Text variant=\"title-3\">Content</Text>\n        <Text variant={{ s: \"title-3\", m: \"title-4\" }}>Content</Text>\n    </>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-text--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Text className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Text>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Text/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Text",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Text/Text.tsx",
-				"actualName": "Text",
+				"methods": [],
+				"props": {
+					"variant": {
+						"defaultValue": null,
+						"description": "Text render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Variant>" }
+					},
+					"weight": {
+						"defaultValue": null,
+						"description": "Text font weight",
+						"name": "weight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"medium\" | \"bold\" | \"regular\">" }
+					},
+					"monospace": {
+						"defaultValue": null,
+						"description": "Render monospace font",
+						"name": "monospace",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Text color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"warning\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Text alignment",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"center\" | \"start\" | \"end\">" }
+					},
+					"wrap": {
+						"defaultValue": null,
+						"description": "CSS wrapping style",
+						"name": "wrap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"balance\"", "value": [{ "value": "\"balance\"" }] }
+					},
+					"decoration": {
+						"defaultValue": null,
+						"description": "CSS text decoration style",
+						"name": "decoration",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"line-through\"",
+							"value": [{ "value": "\"line-through\"" }]
+						}
+					},
+					"maxLines": {
+						"defaultValue": null,
+						"description": "Maximum number of lines to render, used for text truncation",
+						"name": "maxLines",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different html tag",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2933,46 +15483,114 @@
 			"path": "./src/components/Theme/tests/Theme.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-theme--scoped",
 					"name": "scoped",
 					"snippet": "const scoped = () => (\n    <Example>\n        <Example.Item title=\"scoped, single\">\n            <Theme name=\"reshaped\">\n                <Card attributes={{ \"data-testid\": \"test-id\" }}>\n                    <Button color=\"primary\">Action</Button>\n                </Card>\n            </Theme>\n        </Example.Item>\n\n        <Example.Item title=\"scoped, multiple\">\n            <Theme name={[\"reshaped\", \"figma\"]}>\n                <Card attributes={{ \"data-testid\": \"test-id-multi\" }}>\n                    <View direction=\"row\" gap={4}>\n                        <Button color=\"primary\">Action</Button>\n\n                        <Popover>\n                            <Popover.Trigger>\n                                {(attributes) => <Button attributes={attributes}>Popover</Button>}\n                            </Popover.Trigger>\n                            <Popover.Content>Content</Popover.Content>\n                        </Popover>\n                    </View>\n                </Card>\n            </Theme>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-theme--light",
 					"name": "light",
 					"snippet": "const light = () => (\n    <Theme name=\"reshaped\" colorMode=\"light\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--dark",
 					"name": "dark",
 					"snippet": "const dark = () => (\n    <Theme name=\"reshaped\" colorMode=\"dark\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--inherited",
 					"name": "inherited",
 					"snippet": "const inherited = () => (\n    <Theme name=\"reshaped\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--inverted",
 					"name": "inverted",
 					"snippet": "const inverted = () => (\n    <Theme name=\"reshaped\" colorMode=\"inverted\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--controlled",
 					"name": "controlled",
 					"snippet": "const controlled = () => {\n    const Internal = () => {\n        const { setTheme, theme } = useTheme();\n\n        return (\n            <Button color=\"primary\" onClick={() => setTheme(\"slate\")}>\n                Switch to slate\n            </Button>\n        );\n    };\n\n    return (\n        <div data-testid=\"root\">\n            <Theme name=\"reshaped\">\n                <Internal />\n            </Theme>\n        </div>\n    );\n};"
 				},
 				{
+					"id": "utility-components-theme--uncontrolled",
 					"name": "uncontrolled",
 					"snippet": "const uncontrolled = () => {\n    const Internal = () => {\n        const { setTheme } = useTheme();\n\n        return (\n            <Button color=\"primary\" onClick={() => setTheme(\"slate\")}>\n                Switch to slate\n            </Button>\n        );\n    };\n\n    return (\n        <div data-testid=\"root\">\n            <Theme defaultName=\"reshaped\">\n                <Internal />\n            </Theme>\n        </div>\n    );\n};"
 				},
 				{
-					"name": "disabledTransition",
+					"id": "utility-components-theme--disabled-transition",
+					"name": "disabled transitions",
 					"snippet": "const disabledTransition = () => {\n    const { invertColorMode } = useTheme();\n\n    return (\n        <Example>\n            <Example.Item title=\"should have no transitions while switching color mode\">\n                <View gap={3}>\n                    <Button onClick={invertColorMode}>Invert mode</Button>\n\n                    <MenuItem selected>Test transition</MenuItem>\n\n                    <Card>Default card</Card>\n\n                    <Theme colorMode=\"inverted\">\n                        <Card>Inverted card</Card>\n                    </Theme>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Card, Example, MenuItem, Popover, Theme, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Theme/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Theme",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Theme/Theme.tsx",
-				"actualName": "Theme",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the theme to use, enables controlled mode",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"defaultName": {
+						"defaultValue": null,
+						"description": "Default name of the theme to use, enables uncontrolled mode",
+						"name": "defaultName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode to use",
+						"name": "colorMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode | \"inverted\"",
+							"value": [
+								{ "value": "\"light\"" },
+								{ "value": "\"dark\"" },
+								{ "value": "\"inverted\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2982,147 +15600,880 @@
 			"path": "./src/components/View/tests/View.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-view--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example title=\"Border is used to highlight the padding value\">\n        <Example.Item title=\"padding: 4\">\n            <View padding={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <View padding={6} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: 0\">\n            <View padding={0} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: vertical 2, horizontal 4\">\n            <View paddingInline={4} paddingBlock={2} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingTop: 4\">\n            <View paddingTop={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingBottom: 4\">\n            <View paddingBottom={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingStart: 4\">\n            <View paddingStart={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingEnd: 4\">\n            <View paddingEnd={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive padding:\",\n                \"[s] vertical 2, horizontal 4\",\n                \"[m+] vertical 4, horizontal 8\",\n            ]}\n        >\n            <View paddingInline={{ s: 4, m: 8 }} paddingBlock={{ s: 2, m: 4 }} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"responsive padding:\", \"[s] top 2, bottom 4\", \"[m+] top 4, bottom 0, start: 8\"]}\n        >\n            <View\n                paddingTop={{ s: 2, m: 4 }}\n                paddingBottom={{ s: 4, m: 0 }}\n                paddingStart={{ s: 0, m: 8 }}\n                borderColor=\"neutral\"\n            >\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"nested padding, child view should have no horizontal padding\">\n            <View paddingStart={4} borderColor=\"neutral\">\n                <View borderColor=\"primary\" paddingBlock={4}>\n                    <Placeholder />\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example title=\"Item 1 is another component, Item 2 is View.Item, Item 3 is text\">\n        <Example.Item title=\"direction: column as default\">\n            <View gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <View gap={3} direction=\"column\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column-reverse\">\n            <View gap={3} direction=\"column-reverse\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row\">\n            <View gap={3} direction=\"row\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row-reverse\">\n            <View gap={3} direction=\"row-reverse\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"responsive direction\", \"[s] column-reverse\", \"[m] row-reverse\", \"[l+] row\"]}\n        >\n            <View direction={{ s: \"column-reverse\", m: \"row-reverse\", l: \"row\" }} gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 4, direction: row\">\n            <View direction=\"row\" gap={4} divided>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n                <Placeholder>Item 3</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 0, direction: row\">\n            <View direction=\"row\" gap={0}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap, direction: row\", \"[s] 4\", \"[m+] 8\"]}>\n            <View direction=\"row\" gap={{ s: 4, m: 8 }}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 4, direction: column\">\n            <View gap={4}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 0, direction: column\">\n            <View gap={0}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap, direction: column\", \"[s] 4\", \"[m+] 8\"]}>\n            <View gap={{ s: 4, m: 8 }}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--divided",
 					"name": "divided",
 					"snippet": "const divided = () => (\n    <Example>\n        <Example.Item title=\"direction: row\">\n            <View divided direction=\"row\" gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <View divided gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive divided\", \"[s] direction: row\", \"[m+] direction: column\"]}>\n            <View divided direction={{ s: \"row\", m: \"column\" }} gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row, columns\">\n            <View divided gap={3} direction=\"row\">\n                <View.Item columns={2}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={8}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={2}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"with React.Fragment\">\n            <View direction=\"row\" gap={4} divided>\n                <Placeholder>Item 1</Placeholder>\n                <>\n                    <Placeholder>Item 2</Placeholder>\n                    <Placeholder>Item 3</Placeholder>\n                </>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example title=\"Removes side borders and border radius when applied\">\n        <Example.Item title=\"bleed: 4\">\n            <View bleed={4} padding={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive bleed\", \"[s] 4\", \"[m+] 0\"]}>\n            <View bleed={{ s: 4, m: 0 }} padding={4} borderRadius=\"small\" borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--wrap",
 					"name": "wrap",
 					"snippet": "const wrap = () => (\n    <Example>\n        <Example.Item title=\"wrap: false\">\n            <View direction=\"row\" wrap={false} gap={3}>\n                <Placeholder w={600} h={100} />\n                <Placeholder w={600} h={100} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: start, direction: row\">\n            <View align=\"start\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: center, direction: row\">\n            <View align=\"center\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: end, direction: row\">\n            <View align=\"end\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"align: stretch, direction: row\",\n                \"2nd item is stretched based on the 1st item height\",\n            ]}\n        >\n            <View align=\"stretch\" direction=\"row\" gap={3}>\n                <Placeholder h={100} />\n                <Placeholder h=\"auto\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: baseline, direction: row\">\n            <View align=\"baseline\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Text variant=\"title-6\">Content</Text>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"align: start, direction: column\">\n            <View align=\"start\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: center, direction: column\">\n            <View align=\"center\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: end, direction: row\">\n            <View align=\"end\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"align: stretch, direction: column\",\n                \"1st item uses its own width, 2nd item is stretched to full width\",\n            ]}\n        >\n            <View align=\"stretch\" direction=\"column\" gap={3}>\n                <Placeholder w={100} />\n                <Placeholder w=\"auto\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--justify",
 					"name": "justify",
 					"snippet": "const justify = () => (\n    <Example>\n        <Example.Item title=\"justify: start, direction: row\">\n            <View justify=\"start\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: center, direction: row\">\n            <View justify=\"center\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: end, direction: row\">\n            <View justify=\"end\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: space-between, direction: row\">\n            <View justify=\"space-between\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"justify: start, direction: column, height: 200px\">\n            <View height=\"200px\" justify=\"start\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: center, direction: column, height: 200px\">\n            <View height=\"200px\" justify=\"center\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: end, direction: column, height: 200px\">\n            <View justify=\"end\" height=\"200px\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: space-between, direction: column, height: 200px\">\n            <View justify=\"space-between\" height=\"200px\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--text-align",
 					"name": "textAlign",
 					"snippet": "const textAlign = () => (\n    <Example>\n        <Example.Item title=\"textAlign: start\">\n            <View textAlign=\"start\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: center\">\n            <View textAlign=\"center\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: end\">\n            <View textAlign=\"end\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: [s] start, [m+] end\">\n            <View textAlign={{ s: \"start\", m: \"end\" }}>Content</View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"height: 100px, width: 100px\">\n            <View backgroundColor=\"neutral-faded\" height=\"100px\" width=\"100px\" />\n        </Example.Item>\n        <Example.Item title=\"height: 25, width: 25\">\n            <View backgroundColor=\"neutral-faded\" height={25} width={25} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive height and width\",\n                \"[s] height: 25, width: 25\",\n                \"[m+] height: 200px, width: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                height={{ s: 25, m: \"200px\" }}\n                width={{ s: 25, m: \"200px\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "ratio",
+					"id": "utility-components-view--ratio",
+					"name": "aspectRatio",
 					"snippet": "const ratio = () => (\n    <Example>\n        <Example.Item title=\"ratio: 16 / 9\">\n            <View backgroundColor=\"neutral-faded\" aspectRatio={16 / 9} width=\"200px\" />\n        </Example.Item>\n        <Example.Item title={[\"responsive ratio\", \"[s] 1/1\", \"[m+] 16/9\"]}>\n            <View backgroundColor=\"neutral-faded\" aspectRatio={{ s: 1, m: 16 / 9 }} width=\"200px\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "maxSize",
+					"id": "utility-components-view--max-size",
+					"name": "width, height, maxWidth, maxHeight",
 					"snippet": "const maxSize = () => (\n    <Example>\n        <Example.Item title=\"maxHeight: 150px, maxWidth: 150px, height: 300px\">\n            <View backgroundColor=\"neutral-faded\" maxHeight=\"150px\" maxWidth=\"150px\" height=\"300px\" />\n        </Example.Item>\n        <Example.Item title=\"maxHeight: 25, maxWidth: 25, height: 50\">\n            <View backgroundColor=\"neutral-faded\" maxHeight={25} maxWidth={25} height={50} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive maxHeight and maxWidth, height: 300\",\n                \"[s] maxHeight: 25, maxWidth: 25\",\n                \"[m+] maxHeight: 200px, maxWidth: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                maxHeight={{ s: 25, m: \"200px\" }}\n                maxWidth={{ s: 25, m: \"200px\" }}\n                height=\"300px\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "minSize",
+					"id": "utility-components-view--min-size",
+					"name": "width, height, minWidth, minHeight",
 					"snippet": "const minSize = () => (\n    <Example>\n        <Example.Item title=\"minHeight: 150px, minWidth: 150px, height: 50px, width: 50px\">\n            <View\n                backgroundColor=\"neutral-faded\"\n                minHeight=\"150px\"\n                minWidth=\"150px\"\n                height=\"50px\"\n                width=\"50px\"\n            />\n        </Example.Item>\n        <Example.Item title=\"minHeight: 25, minWidth: 25, height: 5, width: 5\">\n            <View backgroundColor=\"neutral-faded\" minHeight={25} minWidth={25} height={5} width={5} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive minHeight and minWidth, height: 50px, width: 50px\",\n                \"[s] minHeight: 25, minWidth: 25\",\n                \"[m+] minHeight: 200px, minWidth: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                minHeight={{ s: 25, m: \"200px\" }}\n                minWidth={{ s: 25, m: \"200px\" }}\n                height=\"50px\"\n                width=\"50px\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "background",
+					"id": "utility-components-view--background",
+					"name": "backgroundColor",
 					"snippet": "const background = () => (\n    <Example title=\"border is used to highlight the backround value when it's similar to the page background, text color changes based on the background\">\n        <Example.Item title=\"bg: page\">\n            <View backgroundColor=\"page\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: page-faded\">\n            <View backgroundColor=\"page-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: disabled\">\n            <View backgroundColor=\"disabled\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: disabled-faded\">\n            <View backgroundColor=\"disabled-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-base\">\n            <View backgroundColor=\"elevation-base\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-raised\">\n            <View backgroundColor=\"elevation-raised\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-overlay\">\n            <View backgroundColor=\"elevation-overlay\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: neutral\">\n            <View backgroundColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: neutral-faded\">\n            <View backgroundColor=\"neutral-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: primary\">\n            <View backgroundColor=\"primary\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: primary-faded\">\n            <View backgroundColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: critical\">\n            <View backgroundColor=\"critical\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: critical-faded\">\n            <View backgroundColor=\"critical-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: warning\">\n            <View backgroundColor=\"warning\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: warning-faded\">\n            <View backgroundColor=\"warning-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: positive\">\n            <View backgroundColor=\"positive\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: positive-faded\">\n            <View backgroundColor=\"positive-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--border-color",
 					"name": "borderColor",
 					"snippet": "const borderColor = () => (\n    <Example>\n        <Example.Item title=\"border: neutral\">\n            <View borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: neutral-faded\">\n            <View borderColor=\"neutral-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: primary\">\n            <View borderColor=\"primary\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: primary-faded\">\n            <View borderColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: critical\">\n            <View borderColor=\"critical\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: critical-faded\">\n            <View borderColor=\"critical-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: warning\">\n            <View borderColor=\"warning\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: warning-faded\">\n            <View borderColor=\"warning-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: positive\">\n            <View borderColor=\"positive\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: positive-faded\">\n            <View borderColor=\"positive-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: transparent, background: primary-faded\">\n            <View borderColor=\"transparent\" backgroundColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive\", \"[s] primary\", \"[m+] neutral\"]}>\n            <View borderColor={{ s: \"primary\", m: \"neutral\" }} padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--border",
 					"name": "border",
 					"snippet": "const border = () => (\n    <Example>\n        <Example.Item title=\"border: true\">\n            <View border borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderTop: true\">\n            <View borderTop borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderBottom: true\">\n            <View borderBottom borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderStart: true\">\n            <View borderStart borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderEnd: true\">\n            <View borderEnd borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderInline: true\">\n            <View borderInline borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderBlock: true\">\n            <View borderBlock borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderTop: true, borderStart: true, \">\n            <View borderColor=\"neutral\" borderTop borderStart padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"responsive\",\n                \"[s] borderTop: true, borderStart: true\",\n                \"[m+] borderBottom: true, borderEnd: true\",\n            ]}\n        >\n            <View\n                borderColor=\"neutral\"\n                borderTop={{ s: true, m: false }}\n                borderStart={{ s: true, m: false }}\n                borderBottom={{ s: false, m: true }}\n                borderEnd={{ s: false, m: true }}\n                padding={4}\n            >\n                Content\n            </View>\n        </Example.Item>\n\n        <div style={{ height: 100 }} />\n    </Example>\n);"
 				},
 				{
-					"name": "radius",
+					"id": "utility-components-view--radius",
+					"name": "borderRadius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius: small\">\n            <View borderRadius=\"small\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: medium\">\n            <View borderRadius=\"medium\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: large\">\n            <View borderRadius=\"large\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: circular\">\n            <View borderRadius=\"circular\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--shadow",
 					"name": "shadow",
 					"snippet": "const shadow = () => (\n    <Example>\n        <Example.Item title=\"shadow: raised, radius: medium\">\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                shadow=\"raised\"\n                borderRadius=\"medium\"\n                backgroundColor=\"elevation-raised\"\n            />\n        </Example.Item>\n        <Example.Item title=\"shadow: overlay, radius: medium\">\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                shadow=\"overlay\"\n                borderRadius=\"medium\"\n                backgroundColor=\"elevation-overlay\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--overflow",
 					"name": "overflow",
 					"snippet": "const overflow = () => (\n    <Example>\n        <Example.Item\n            title={[\"overflow: hidden, radius: medium\", \"child background should have radius\"]}\n        >\n            <View height=\"100px\" width=\"100px\" shadow=\"raised\" borderRadius=\"medium\" overflow=\"hidden\">\n                <View backgroundColor=\"primary\" height=\"100%\" width=\"100%\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positioning",
+					"id": "utility-components-view--positioning",
+					"name": "position",
 					"snippet": "const positioning = () => (\n    <Example>\n        <Example.Item title=\"position: relative + absolute\">\n            <View borderColor=\"neutral\" position=\"relative\">\n                <Placeholder />\n                <View\n                    position=\"absolute\"\n                    insetTop={0}\n                    insetEnd={0}\n                    backgroundColor=\"critical\"\n                    zIndex={5}\n                    height={10}\n                    width={10}\n                />\n                <View\n                    position=\"absolute\"\n                    insetTop={0}\n                    insetEnd={0}\n                    backgroundColor=\"primary\"\n                    height={15}\n                    width={15}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: sticky\">\n            <div style={{ overflow: \"auto\", height: 100 }} tabIndex={0}>\n                <View position=\"sticky\" borderColor=\"primary\" insetTop={0}>\n                    Content\n                </View>\n                <Placeholder h={1000} />\n            </div>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive\", \"[s] position: absolute\", \"[m+]: position: relative\"]}>\n            <div style={{ overflow: \"auto\", height: 100, position: \"relative\" }} tabIndex={0}>\n                <View position={{ s: \"absolute\", m: \"relative\" }} borderColor=\"primary\" insetTop={0}>\n                    Content\n                </View>\n                <Placeholder h={1000} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--inset",
 					"name": "inset",
 					"snippet": "const inset = () => (\n    <Example>\n        <Example.Item title=\"inset: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" inset={4} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetTop: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" insetTop={4} height={10} width={10} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetStart: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetStart={4}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetEnd: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" insetEnd={4} height={10} width={10} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetBottom: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetBottom={4}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"responsive, [s] insetBottom: 4 [m+] insetEnd: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetBottom={{ s: 4, m: \"auto\" }}\n                    insetEnd={{ s: \"auto\", m: 4 }}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--animated",
 					"name": "animated",
 					"snippet": "const animated = () => {\n    const [background, setBackground] = React.useState<ViewProps[\"backgroundColor\"]>(\"neutral\");\n\n    return (\n        <View gap={3} align=\"start\">\n            <Button\n                onClick={() => setBackground((prev) => (prev === \"neutral\" ? \"primary\" : \"neutral\"))}\n            >\n                Change background\n            </Button>\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                backgroundColor={background}\n                align=\"center\"\n                justify=\"center\"\n                animated\n            >\n                Content\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "itemGapBefore",
+					"id": "utility-components-view--item-gap-before",
+					"name": "item, gapBefore",
 					"snippet": "const itemGapBefore = () => (\n    <Example>\n        <Example.Item title={[\"gap: 4, 3rd item gapBefore: 10, direction: row\", \"increased gap\"]}>\n            <View direction=\"row\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={10}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 4, direction: row\", \"reduced gap\"]}>\n            <View direction=\"row\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={4}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 0, direction: row\", \"removed gap\"]}>\n            <View direction=\"row\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={0}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"gap: 4, direction: row, 2nd item gap: auto\">\n            <View direction=\"row\" gap={4}>\n                <Placeholder w={200} />\n                <View.Item gapBefore=\"auto\">\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"gap: 4, 3rd item gapBefore: 10, direction: column\", \"increased gap\"]}>\n            <View direction=\"column\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={10}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 4, direction: column\", \"reduced gap\"]}>\n            <View direction=\"column\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={4}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 0, direction: column\", \"removed gap\"]}>\n            <View direction=\"column\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={0}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"gap: 4, direction: column, height: 200px, 2nd item gap: auto\">\n            <View height=\"200px\" gap={4}>\n                <Placeholder />\n                <View.Item gapBefore=\"auto\">\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"responsive item gap\",\n                \"gap: 4, direction: row\",\n                \"[s] 3rd item gapBefore: 10\",\n                \"[m+] 3rd item gapBefore: 0\",\n            ]}\n        >\n            <View direction=\"row\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={{ s: 10, m: 0 }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemGrow",
+					"id": "utility-components-view--item-grow",
+					"name": "item, grow",
 					"snippet": "const itemGrow = () => (\n    <Example>\n        <Example.Item title=\"direction: row, 2nd item grow\">\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column, height: 200px, 2nd item grow\">\n            <View direction=\"column\" gap={3} height=\"200px\">\n                <Placeholder />\n                <View.Item grow>\n                    <Placeholder h=\"100%\" />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row, 2nd item grow, applied to View\">\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View grow>\n                    <Placeholder />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive item grow, direction: row\",\n                \"[s] 2nd item grow\",\n                \"[m+] 2nd item doesn't grow\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View.Item grow={{ s: true, m: false }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive item grow, direction: column, height: 200px\",\n                \"[s] 2nd item grow\",\n                \"[m+] 2nd item doesn't grow\",\n            ]}\n        >\n            <View direction=\"column\" gap={3} height=\"200px\">\n                <Placeholder />\n                <View.Item grow={{ s: true, m: false }}>\n                    <Placeholder h=\"100%\" />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemColumns",
+					"id": "utility-components-view--item-columns",
+					"name": "item, columns",
 					"snippet": "const itemColumns = () => (\n    <Example>\n        <Example.Item title=\"columns 6, 6, gap: 0\">\n            <View direction=\"row\">\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 3, 9, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={3}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, 9, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive columns\", \"[s] columns 6, 6, 12, gap: 4\", \"[m+]: 4, 4, 4\"]}>\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={{ s: 6, m: 4 }}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 6, m: 4 }}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 12, m: 4 }}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, 9, gap: 4, 2nd item gapBefore: 20\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6} gapBefore={20}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemOrder",
+					"id": "utility-components-view--item-order",
+					"name": "item, order",
 					"snippet": "const itemOrder = () => (\n    <Example>\n        <Example.Item title=\"order: 1 3 2\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={4}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={4} order={1}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={4}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive order\", \"[s] 1 2 3\", \"[m+] 1 3 2\"]}>\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={4}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={4} order={{ s: 0, m: 1 }}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={4}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive order\",\n                \"[s]: 1 3 2, 2 is full width on second row\",\n                \"[m+]: 1 2 3, 2 has grow in the center of the first row\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <View.Item columns={{ s: 6, m: \"auto\" }}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item\n                    grow={{ s: false, m: true }}\n                    order={{ s: 1, m: 0 }}\n                    columns={{ s: 12, m: \"auto\" }}\n                >\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 6, m: \"auto\" }}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "hiddenItem",
+					"id": "utility-components-view--hidden-item",
+					"name": "composition, Hidden item",
 					"snippet": "const hiddenItem = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"[s] 2nd item: visible, grow, 3rd item: !grow\",\n                \"[m+] 2nd item: hidden, 2nd item divider: hidden, 3rd item: grow\",\n            ]}\n        >\n            <View direction=\"row\" divided gap={3}>\n                <Placeholder />\n                <Hidden hide={{ s: false, m: true }}>\n                    <View.Item grow key=\"3\">\n                        <Placeholder />\n                    </View.Item>\n                </Hidden>\n                <View.Item grow={{ s: false, m: true }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"[s] 2nd item: visible, grow, 3rd item: !grow\",\n                \"[m+] 2nd item: hidden, 2nd item: grow doesn't push 3rd item, 3rd item: grow\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Placeholder />\n                <Hidden hide={{ s: false, m: true }}>\n                    <View.Item grow>\n                        <Placeholder />\n                    </View.Item>\n                </Hidden>\n                <View.Item grow={{ s: false, m: true }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "keys",
+					"id": "utility-components-view--keys",
+					"name": "item, key",
 					"snippet": "const keys = () => {\n    const toggle = useToggle();\n\n    return (\n        <View gap={2}>\n            <Button onClick={() => toggle.toggle()}>Toggle</Button>\n            <View.Item>Item 1</View.Item>\n            {toggle.active && <KeyItem>Item 2</KeyItem>}\n            <KeyItem>Item 3</KeyItem>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "nestedGaps",
+					"id": "utility-components-view--nested-gaps",
+					"name": "composition, nested gap",
 					"snippet": "const nestedGaps = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"direction: column, gap: 10\",\n                \"Child 1: direction: column, gap: 2\",\n                \"Child 2: direction column, gap: 6\",\n                \"Child 3: gapBefore: 0\",\n                \"Child 3 view: direction: row, gap: 2\",\n            ]}\n        >\n            <View gap={10}>\n                <View gap={2}>\n                    <Placeholder>Child 1</Placeholder>\n                    <Placeholder>Child 1</Placeholder>\n                </View>\n\n                <View gap={6}>\n                    <Placeholder>Child 2</Placeholder>\n                    <Placeholder>Child 2</Placeholder>\n                </View>\n\n                <View.Item gapBefore={0}>\n                    <View direction=\"row\" gap={2}>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "utility-components-view--test-composition",
+					"name": "composition, edge cases",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item>\n            <View direction=\"row\" align=\"center\" gap={4} padding={4}>\n                <View width=\"80px\" height=\"60px\" backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n\n                <View direction=\"row\" align=\"center\" gap={1} grow>\n                    <View.Item shrink>\n                        <Text>Text (like Jeff's Puzzles)</Text>\n                    </View.Item>\n\n                    <View minWidth=\"auto\" grow>\n                        <Button size=\"small\" color=\"neutral\" icon={IconPlus} />\n                    </View>\n                </View>\n\n                <Button color=\"primary\" rounded>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"View.Item, MenuItem, Aspect ratio\",\n                \"ratio should increase height on viewport change\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <View.Item>\n                    <Placeholder />\n                </View.Item>\n                <MenuItem selected roundedCorners>\n                    Menu\n                </MenuItem>\n                <View.Item grow>\n                    <View aspectRatio={16 / 9}>\n                        <Placeholder h=\"100%\" />\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"Scrollable tabs inside View.Item with grow\">\n            <View direction=\"row\" align=\"center\" gap={3}>\n                <Placeholder />\n                <View.Item grow>\n                    <View padding={0} align=\"center\">\n                        <Tabs variant=\"pills\">\n                            <Tabs.List>\n                                <Tabs.Item value=\"1\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"2\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"3\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"4\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"5\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"6\">Very long item</Tabs.Item>\n                            </Tabs.List>\n                            {[1, 2, 3, 5, 6].map((i) => (\n                                <Tabs.Panel key={i} value={i.toString()} />\n                            ))}\n                        </Tabs>\n                    </View>\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"2nd item has grow, Avatar stays circle\">\n            <View direction=\"row\" gap={3}>\n                <Avatar initials=\"DB\" />\n                <View.Item grow>\n                    Veggies sunt bona vobis, proinde vos postulo esse magis grape pea sprouts horseradish\n                    courgette maize spinach prairie turnip jícama coriander quandong gourd broccoli seakale\n                    gumbo. Parsley corn lentil zucchini radicchio maize burdock avocado sea lettuce.\n                    Garbanzo tigernut earthnut pea fennel.\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"item gapBefore from parent doesn't affect the child view\",\n                \"columns should take full width\",\n            ]}\n        >\n            <View>\n                <View.Item gapBefore={20}>\n                    <View direction=\"row\" gap={4}>\n                        <View.Item columns={6}>\n                            <Placeholder />\n                        </View.Item>\n                        <View.Item columns={6}>\n                            <Placeholder />\n                        </View.Item>\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"View becomes flexbox if there is a child with grow\">\n            <View height=\"300px\" borderColor=\"neutral-faded\">\n                <View height=\"50px\" />\n                <View grow backgroundColor=\"neutral-faded\" padding={4}>\n                    Grow\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "asProp",
+					"id": "utility-components-view--as-prop",
+					"name": "as",
 					"snippet": "const asProp = () => (\n    <View as=\"ul\">\n        <View.Item as=\"li\">Content</View.Item>\n    </View>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-view--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <View className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </View>\n    </div>\n);"
 				},
 				{
-					"name": "itemClassName",
+					"id": "utility-components-view--item-class-name",
+					"name": "item className, attributes",
 					"snippet": "const itemClassName = () => (\n    <div data-testid=\"root\">\n        <View.Item className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </View.Item>\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Button, Example, Hidden, MenuItem, Placeholder, Tabs, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/View/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "View",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/View/View.tsx",
-				"actualName": "View",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"divided": {
+						"defaultValue": null,
+						"description": "Render a divider between each child",
+						"name": "divided",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Flex direction for the content",
+						"name": "direction",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Direction>" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between children, base unit token number multiplier",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"wrap": {
+						"defaultValue": null,
+						"description": "Flex wrap for the content",
+						"name": "wrap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Flex align-items for the content",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Flex justify-content for the content",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width style, literal string value or a base unit token number multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"aspectRatio": {
+						"defaultValue": null,
+						"description": "Aspect ratio style, represented as width / height",
+						"name": "aspectRatio",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height style, literal string value or a base unit token number multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Maximum width style, literal string value or a base unit token number multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"minHeight": {
+						"defaultValue": null,
+						"description": "Minimum height style, literal string value or a base unit token number multiplier",
+						"name": "minHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"minWidth": {
+						"defaultValue": null,
+						"description": "Minimum width style, literal string value or a base unit token number multiplier",
+						"name": "minWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Padding style for all sides, base unit token number multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingTop": {
+						"defaultValue": null,
+						"description": "Padding top, base unit token number multiplier",
+						"name": "paddingTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingBottom": {
+						"defaultValue": null,
+						"description": "Padding bottom, base unit token number multiplier",
+						"name": "paddingBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingStart": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "paddingStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingEnd": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "paddingEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingInline": {
+						"defaultValue": null,
+						"description": "Padding inline, base unit token number multiplier",
+						"name": "paddingInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingBlock": {
+						"defaultValue": null,
+						"description": "Padding block, base unit token number multiplier",
+						"name": "paddingBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margin and remove side borders, base unit token number multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"textAlign": {
+						"defaultValue": null,
+						"description": "Text align for the content",
+						"name": "textAlign",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<TextAlign>" }
+					},
+					"backgroundColor": {
+						"defaultValue": null,
+						"description": "Background color, based on the color tokens",
+						"name": "backgroundColor",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"critical-faded\" | \"warning\" | \"warning-faded\" | \"positive-faded\" | \"primary-faded\" | \"elevation-base\" | \"elevation-raised\" | \"elevation-overlay\" | \"page\" | \"page-faded\" | \"disabled-faded\" | \"brand\" | \"white\" | \"black\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"critical-faded\"" },
+								{ "value": "\"warning\"" },
+								{ "value": "\"warning-faded\"" },
+								{ "value": "\"positive-faded\"" },
+								{ "value": "\"primary-faded\"" },
+								{ "value": "\"elevation-base\"" },
+								{ "value": "\"elevation-raised\"" },
+								{ "value": "\"elevation-overlay\"" },
+								{ "value": "\"page\"" },
+								{ "value": "\"page-faded\"" },
+								{ "value": "\"disabled-faded\"" },
+								{ "value": "\"brand\"" },
+								{ "value": "\"white\"" },
+								{ "value": "\"black\"" }
+							]
+						}
+					},
+					"borderColor": {
+						"defaultValue": null,
+						"description": "Border color, based on the color tokens",
+						"name": "borderColor",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<BorderColor>" }
+					},
+					"border": {
+						"defaultValue": null,
+						"description": "Add border to all sides",
+						"name": "border",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderTop": {
+						"defaultValue": null,
+						"description": "Add border to the top side",
+						"name": "borderTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderBottom": {
+						"defaultValue": null,
+						"description": "Add border to the bottom side",
+						"name": "borderBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderStart": {
+						"defaultValue": null,
+						"description": "Add border to the inline start side",
+						"name": "borderStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderEnd": {
+						"defaultValue": null,
+						"description": "Add border to the inline end side",
+						"name": "borderEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderInline": {
+						"defaultValue": null,
+						"description": "Add border to the inline direction",
+						"name": "borderInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderBlock": {
+						"defaultValue": null,
+						"description": "Add border to the block direction",
+						"name": "borderBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Radius>" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Position style",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Position>" }
+					},
+					"inset": {
+						"defaultValue": null,
+						"description": "Inset style, base unit token number multiplier when used as a number",
+						"name": "inset",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetStart": {
+						"defaultValue": null,
+						"description": "Inset start, base unit token number multiplier when used as a number",
+						"name": "insetStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetEnd": {
+						"defaultValue": null,
+						"description": "Inset end, base unit token number multiplier when used as a number",
+						"name": "insetEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetTop": {
+						"defaultValue": null,
+						"description": "Inset top, base unit token number multiplier when used as a number",
+						"name": "insetTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetBottom": {
+						"defaultValue": null,
+						"description": "Inset bottom, base unit token number multiplier when used as a number",
+						"name": "insetBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"zIndex": {
+						"defaultValue": null,
+						"description": "z-index style",
+						"name": "zIndex",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"shadow": {
+						"defaultValue": null,
+						"description": "Shadow style, based on the shadow tokens",
+						"name": "shadow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Overflow style",
+						"name": "overflow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"auto\"",
+							"value": [{ "value": "\"hidden\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"animated": {
+						"defaultValue": null,
+						"description": "Add transition for the properties",
+						"name": "animated",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					},
+					"grow": {
+						"defaultValue": null,
+						"description": "Apply flex-grow, using it on View.Item applies additional styles on the parent View",
+						"name": "grow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"shrink": {
+						"defaultValue": null,
+						"description": "Apply flex-shrink",
+						"name": "shrink",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "View"
 			}
 		},
 		"hooks-useelementid": {
@@ -3131,7 +16482,8 @@
 			"path": "./src/hooks/tests/useElementId.stories.tsx",
 			"stories": [
 				{
-					"name": "id",
+					"id": "hooks-useelementid--id",
+					"name": "passed id",
 					"snippet": "const id = () => {\n    return <Component id=\"hey\" />;\n};"
 				}
 			],
@@ -3148,6 +16500,7 @@
 			"path": "./src/hooks/tests/useHandlerRef.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usehandlerref--base",
 					"name": "base",
 					"snippet": "const base = (args) => {\n    const [count, setCount] = React.useState(0);\n\n    // Creating a new handler on each render\n    const handleEffect = () => {\n        args.handleEffect(0);\n    };\n\n    return (\n        <View gap={4}>\n            <Button onClick={() => setCount((prev) => prev + 1)}>Increase count</Button>\n            <Component onEffect={handleEffect} count={count} />\n        </View>\n    );\n};"
 				}
@@ -3165,43 +16518,53 @@
 			"path": "./src/hooks/tests/useHotkeys.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usehotkeys--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const { checkHotkeyState } = useHotkeys({\n        \"shift + b + n\": () => console.log(\"pressed\"),\n        \"c + v\": () => console.log(\"c + v\"),\n        \"Meta + k\": () => console.log(\"meta + k\"),\n        \"Meta + f\": () => console.log(\"meta + f\"),\n        \"Meta + v\": () => console.log(\"meta + v\"),\n        \"Meta + b\": () => console.log(\"meta + b\"),\n        \"control + enter\": () => console.log(\"control + enter\"),\n        \"meta + enter\": () => console.log(\"meta + enter\"),\n        \"mod + enter\": () => console.log(\"mod + enter\"),\n        \"mod + ArrowRight\": () => console.log(\"right\"),\n        \"mod + ArrowUp\": () => console.log(\"top\"),\n        \"shift + ArrowRight\": () => console.log(\"right\"),\n        \"shift + ArrowUp\": () => console.log(\"top\"),\n        \"alt+shift+n\": () => console.log(\"alt+shift+n\"),\n        \"shift+alt+n\": () => console.log(\"shift+alt+n\"),\n        \"alt+shiftLeft+n\": () => console.log(\"alt+shiftLeft+n\"),\n    });\n    const active = checkHotkeyState(\"shift + b + n\");\n    const shiftActive = checkHotkeyState(\"shift\");\n    const bActive = checkHotkeyState(\"b\");\n    const nActive = checkHotkeyState(\"n\");\n\n    return (\n        <View\n            animated\n            gap={2}\n            direction=\"row\"\n            backgroundColor={active ? \"positive-faded\" : undefined}\n            padding={2}\n            borderRadius=\"small\"\n        >\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={shiftActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={shiftActive ? undefined : \"raised\"}\n            >\n                Shift\n            </View>\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={bActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={bActive ? undefined : \"raised\"}\n            >\n                b\n            </View>\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={nActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={nActive ? undefined : \"raised\"}\n            >\n                n\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "singleKey",
+					"id": "hooks-usehotkeys--single-key",
+					"name": "single key",
 					"snippet": "const singleKey = (args) => <Component hotkeys={{ a: args.handleHotkey }} />;"
 				},
 				{
-					"name": "modKey",
+					"id": "hooks-usehotkeys--mod-key",
+					"name": "mod key",
 					"snippet": "const modKey = (args) => <Component hotkeys={{ mod: args.handleHotkey }} />;"
 				},
 				{
-					"name": "modKeyHold",
+					"id": "hooks-usehotkeys--mod-key-hold",
+					"name": "mod key on hold",
 					"snippet": "const modKeyHold = (args) => <Component hotkeys={{ \"Meta + b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyList",
+					"id": "hooks-usehotkeys--key-list",
+					"name": "key list",
 					"snippet": "const keyList = (args) => <Component hotkeys={{ \"a,b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombination",
+					"id": "hooks-usehotkeys--key-combination",
+					"name": "key combination",
 					"snippet": "const keyCombination = (args) => <Component hotkeys={{ \"a+b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationFormat",
+					"id": "hooks-usehotkeys--key-combination-format",
+					"name": "key combination without formatting",
 					"snippet": "const keyCombinationFormat = (args) => <Component hotkeys={{ \"A  + b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationOrder",
+					"id": "hooks-usehotkeys--key-combination-order",
+					"name": "key combination without order",
 					"snippet": "const keyCombinationOrder = (args) => <Component hotkeys={{ \"b+a\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationMoreThanRequired",
+					"id": "hooks-usehotkeys--key-combination-more-than-required",
+					"name": "key combination, more keys pressed",
 					"snippet": "const keyCombinationMoreThanRequired = (args) => <Component hotkeys={{ \"z + x\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "optionModified",
+					"id": "hooks-usehotkeys--option-modified",
+					"name": "modified with alt/option",
 					"snippet": "const optionModified = (args) => (\n    <Component hotkeys={{ \"alt+n\": args.handleHotkeyModified, \"alt+shift\": args.handleHotkey }} />\n);"
 				}
 			],
@@ -3218,22 +16581,27 @@
 			"path": "./src/hooks/tests/useKeyboardArrowNavigation.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usekeyboardarrownavigation--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "horizontal",
+					"id": "hooks-usekeyboardarrownavigation--horizontal",
+					"name": "orientation: horizontal",
 					"snippet": "const horizontal = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, orientation: \"horizontal\" });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "vertical",
+					"id": "hooks-usekeyboardarrownavigation--vertical",
+					"name": "orientation: vertical",
 					"snippet": "const vertical = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, orientation: \"vertical\" });\n\n    return (\n        <View gap={2} direction=\"column\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-usekeyboardarrownavigation--circular",
 					"name": "circular",
 					"snippet": "const circular = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, circular: true });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-usekeyboardarrownavigation--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, disabled: true });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				}
@@ -3249,7 +16617,13 @@
 			"id": "hooks-usekeyboardmode",
 			"name": "useKeyboardMode",
 			"path": "./src/hooks/tests/useKeyboardMode.stories.tsx",
-			"stories": [{ "name": "base", "snippet": "const base = () => <Component />;" }],
+			"stories": [
+				{
+					"id": "hooks-usekeyboardmode--base",
+					"name": "base",
+					"snippet": "const base = () => <Component />;"
+				}
+			],
 			"import": "import { Button, View } from \"reshaped\";",
 			"jsDocTags": {},
 			"error": {
@@ -3263,19 +16637,23 @@
 			"path": "./src/hooks/tests/useOnClickOutside.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-useonclickoutside--base",
 					"name": "base",
 					"snippet": "const base = (args) => {\n    const ref = React.useRef(null);\n    const [target, setTarget] = React.useState<\"inside\" | \"outside\" | null>(null);\n\n    useOnClickOutside([ref], () => {\n        args.handleOutsideClick();\n        setTarget(\"outside\");\n    });\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }} onClick={() => setTarget(\"inside\")}>\n                Trigger\n            </Button>\n            {target && `Clicked ${target}`}\n        </View>\n    );\n};"
 				},
 				{
-					"name": "refs",
+					"id": "hooks-useonclickoutside--refs",
+					"name": "multiple refs",
 					"snippet": "const refs = (args) => {\n    const ref = React.useRef(null);\n    const ref2 = React.useRef(null);\n\n    useOnClickOutside([ref, ref2], () => {\n        args.handleOutsideClick();\n    });\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }}>Trigger</Button>\n            <Button attributes={{ ref: ref2 }}>Trigger 2</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-useonclickoutside--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = (args) => {\n    const ref = React.useRef(null);\n\n    useOnClickOutside(\n        [ref],\n        () => {\n            args.handleOutsideClick();\n        },\n        {\n            disabled: true,\n        }\n    );\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }}>Trigger</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "deps",
+					"id": "hooks-useonclickoutside--deps",
+					"name": "test: handler uses latest state",
 					"snippet": "const deps = (args) => {\n    const ref = React.useRef(null);\n    const [count, setCount] = React.useState(0);\n\n    useOnClickOutside([ref], () => {\n        args.handleOutsideClick({ count });\n    });\n\n    return (\n        <Button attributes={{ ref }} onClick={() => setCount((prev) => prev + 1)}>\n            Trigger\n        </Button>\n    );\n};"
 				}
 			],
@@ -3290,7 +16668,13 @@
 			"id": "hooks-usertl",
 			"name": "useRTL",
 			"path": "./src/hooks/tests/useRTL.stories.tsx",
-			"stories": [{ "name": "setRTL", "snippet": "const setRTL = () => <Component />;" }],
+			"stories": [
+				{
+					"id": "hooks-usertl--set-rtl",
+					"name": "setRTL",
+					"snippet": "const setRTL = () => <Component />;"
+				}
+			],
 			"import": "",
 			"jsDocTags": {},
 			"error": {
@@ -3304,10 +16688,12 @@
 			"path": "./src/hooks/tests/useResponsiveClientValue.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-useresponsiveclientvalue--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const value = useResponsiveClientValue<ViewProps[\"backgroundColor\"]>({\n        s: \"neutral\",\n        m: \"critical\",\n        l: \"positive\",\n    });\n\n    return <View width={25} height={25} backgroundColor={value} />;\n};"
 				},
 				{
+					"id": "hooks-useresponsiveclientvalue--boolean",
 					"name": "boolean",
 					"snippet": "const boolean = () => {\n    const value = useResponsiveClientValue<boolean>({\n        s: true,\n        l: false,\n    });\n\n    return <div>{value?.toString()}</div>;\n};"
 				}
@@ -3325,19 +16711,23 @@
 			"path": "./src/hooks/tests/useScrollLock.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usescrolllock--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock();\n\n    return (\n        <React.Fragment>\n            <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n            <div style={{ height: \"150vh\" }} />\n        </React.Fragment>\n    );\n};"
 				},
 				{
-					"name": "origin",
+					"id": "hooks-usescrolllock--origin",
+					"name": "originRef",
 					"snippet": "const origin = () => {\n    const originRef = React.useRef<HTMLDivElement>(null);\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock({ originRef });\n\n    return (\n        <View overflow=\"auto\" height={25} attributes={{ ref: originRef, \"data-testid\": \"root\" }}>\n            <View height={50} padding={4} backgroundColor=\"neutral-faded\" borderRadius=\"medium\">\n                <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "container",
+					"id": "hooks-usescrolllock--container",
+					"name": "containerRef",
 					"snippet": "const container = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock({ containerRef });\n\n    return (\n        <View height={25} attributes={{ ref: containerRef, \"data-testid\": \"root\" }}>\n            <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testContainerAsync",
+					"id": "hooks-usescrolllock--test-container-async",
+					"name": "test: containerRef locked count",
 					"snippet": "const testContainerAsync = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const globalLock = useScrollLock();\n    const scopedLock = useScrollLock({ containerRef });\n\n    return (\n        <Example>\n            <Example.Item title=\"calling regular lock and lock with a container only requires a single unlock to remove overflow\">\n                <View attributes={{ ref: containerRef }} gap={4} direction=\"row\">\n                    <Button\n                        onClick={globalLock.scrollLocked ? globalLock.unlockScroll : globalLock.lockScroll}\n                    >\n                        Toggle\n                    </Button>\n                    <Button\n                        onClick={scopedLock.scrollLocked ? scopedLock.unlockScroll : scopedLock.lockScroll}\n                    >\n                        Toggle\n                    </Button>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
@@ -3354,14 +16744,17 @@
 			"path": "./src/hooks/tests/useToggle.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usetoggle--toggle",
 					"name": "toggle",
 					"snippet": "const toggle = () => {\n    const { toggle, active } = useToggle();\n\n    return (\n        <Button onClick={() => toggle()} attributes={{ \"data-active\": active }}>\n            {active ? \"Deactivate\" : \"Activate\"}\n        </Button>\n    );\n};"
 				},
 				{
+					"id": "hooks-usetoggle--activate",
 					"name": "activate",
 					"snippet": "const activate = () => {\n    const { activate, active } = useToggle();\n\n    return (\n        <React.Fragment>\n            <Button onClick={activate} attributes={{ \"data-active\": active }}>\n                Activate\n            </Button>\n        </React.Fragment>\n    );\n};"
 				},
 				{
+					"id": "hooks-usetoggle--deactivate",
 					"name": "deactivate",
 					"snippet": "const deactivate = () => {\n    const { deactivate, active } = useToggle(true);\n\n    return (\n        <Button onClick={deactivate} attributes={{ \"data-active\": active }}>\n            Deactivate\n        </Button>\n    );\n};"
 				}
@@ -3379,39 +16772,48 @@
 			"path": "./src/utilities/a11y/tests/TrapFocus.stories.tsx",
 			"stories": [
 				{
-					"name": "modeDialog",
+					"id": "utilities-trapfocus--mode-dialog",
+					"name": "mode: dialog",
 					"snippet": "const modeDialog = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, { mode: \"dialog\" });\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\"mode: dialog\", \"tab navigation, always stays inside until released\"]}\n            >\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View.Item>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeActionMenu",
+					"id": "utilities-trapfocus--mode-action-menu",
+					"name": "mode: action-menu",
 					"snippet": "const modeActionMenu = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"action-menu\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: action-menu\",\n                    \"up/down arrow navigation, tab and shift+tab release the focus and follows natural tab order\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeActionBar",
+					"id": "utilities-trapfocus--mode-action-bar",
+					"name": "mode: action-bar",
 					"snippet": "const modeActionBar = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"action-bar\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: action-bar\",\n                    \"left/right arrow navigation, tab and shift+tab release the focus and follows natural tab order\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeContentMenu",
+					"id": "utilities-trapfocus--mode-content-menu",
+					"name": "mode: content-menu",
 					"snippet": "const modeContentMenu = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"content-menu\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: content-menu\",\n                    \"tab navigation, tabbing outside the content will trigger the release\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utilities-trapfocus--include-trigger",
 					"name": "includeTrigger",
 					"snippet": "const includeTrigger = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n            includeTrigger: true,\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utilities-trapfocus--initial-focus-el",
 					"name": "initialFocusEl",
 					"snippet": "const initialFocusEl = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const initialFocusRef = React.useRef<HTMLButtonElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n            initialFocusEl: initialFocusRef.current,\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View\n                            gap={4}\n                            direction=\"row\"\n                            padding={4}\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            attributes={{ ref: rootRef }}\n                        >\n                            <Button onClick={() => {}}>Action 1</Button>\n                            <Button onClick={() => {}} attributes={{ ref: initialFocusRef }}>\n                                Action 2\n                            </Button>\n                            <Button onClick={() => {}}>Action 3</Button>\n                            <Button onClick={trapToggle.deactivate}>Release</Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "focusableElements",
+					"id": "utilities-trapfocus--focusable-elements",
+					"name": "test: focusable elements",
 					"snippet": "const focusableElements = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current);\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title=\"test with all types of focusable elements\">\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={trapToggle.activate}>Activate</Button>\n                    </View.Item>\n\n                    {trapToggle.active && (\n                        <View\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            padding={4}\n                            gap={4}\n                            attributes={{ ref: rootRef }}\n                            align=\"start\"\n                        >\n                            <Link href=\"#\" attributes={{ \"data-testid\": \"test-link\" }}>\n                                Link\n                            </Link>\n\n                            <TextField\n                                name=\"input\"\n                                placeholder=\"Input\"\n                                inputAttributes={{ \"data-testid\": \"test-text-field\" }}\n                            />\n\n                            <TextArea name=\"textarea\" inputAttributes={{ \"data-testid\": \"test-text-area\" }} />\n\n                            <Select\n                                name=\"select\"\n                                options={[\n                                    { label: \"Option 1\", value: \"1\" },\n                                    { label: \"Option 2\", value: \"2\" },\n                                ]}\n                                inputAttributes={{ \"data-testid\": \"test-select\" }}\n                            />\n\n                            <RadioGroup name=\"radio\">\n                                <Radio value=\"1\" inputAttributes={{ \"data-testid\": \"test-radio-1\" }}>\n                                    Option 1\n                                </Radio>\n                                <Radio value=\"2\" inputAttributes={{ \"data-testid\": \"test-radio-2\" }}>\n                                    Option 2\n                                </Radio>\n                            </RadioGroup>\n\n                            <Editor />\n\n                            <div tabIndex={0} role=\"button\" data-testid=\"test-tabindex\">\n                                div with tabIndex\n                            </div>\n\n                            <div style={{ display: \"none\" }}>\n                                <Button onClick={() => {}} attributes={{ \"data-testid\": \"test-hidden-button\" }}>\n                                    Hidden\n                                </Button>\n                            </div>\n\n                            <Button\n                                onClick={() => {}}\n                                attributes={{ tabIndex: -1, \"data-testid\": \"test-button-negative-tabindex\" }}\n                            >\n                                Excluded\n                            </Button>\n\n                            <input type=\"hidden\" data-testid=\"test-input-hidden\" />\n\n                            <Button\n                                onClick={trapToggle.deactivate}\n                                attributes={{ \"data-testid\": \"test-button\" }}\n                            >\n                                Release button\n                            </Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "nested",
+					"id": "utilities-trapfocus--nested",
+					"name": "test: nested",
 					"snippet": "const nested = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const innerRootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n    const innerTrapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    React.useEffect(() => {\n        if (!innerTrapToggle.active) return;\n        if (!innerRootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(innerRootRef.current, {\n            mode: \"dialog\",\n        });\n\n        return () => trapFocus.release();\n    }, [innerTrapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"nested, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View gap={4}>\n                            <View\n                                gap={4}\n                                direction=\"row\"\n                                padding={4}\n                                backgroundColor=\"neutral-faded\"\n                                borderRadius=\"medium\"\n                                attributes={{ ref: rootRef }}\n                            >\n                                <Button onClick={() => {}}>Action</Button>\n                                <Button onClick={innerTrapToggle.activate}>Inner trap focus</Button>\n                                <Button onClick={trapToggle.deactivate}>Release</Button>\n                            </View>\n\n                            {innerTrapToggle.active && (\n                                <View\n                                    gap={4}\n                                    direction=\"row\"\n                                    padding={4}\n                                    backgroundColor=\"neutral-faded\"\n                                    borderRadius=\"medium\"\n                                    attributes={{ ref: innerRootRef }}\n                                >\n                                    <Button onClick={() => {}}>Action</Button>\n                                    <Button onClick={innerTrapToggle.deactivate}>Release</Button>\n                                </View>\n                            )}\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "mutationObserver",
+					"id": "utilities-trapfocus--mutation-observer",
+					"name": "test: mutation observer",
 					"snippet": "const mutationObserver = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n    const [mutated, setMutated] = React.useState(false);\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n        });\n\n        setTimeout(() => {\n            setMutated(true);\n        }, 50);\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View\n                            gap={4}\n                            direction=\"row\"\n                            padding={4}\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            attributes={{ ref: rootRef }}\n                        >\n                            {!mutated && (\n                                <>\n                                    <Button onClick={() => {}}>Action 1</Button>\n                                    <Button onClick={() => {}}>Action 2</Button>\n                                </>\n                            )}\n                            <Button onClick={() => {}}>Action 3</Button>\n                            <Button onClick={trapToggle.deactivate}>Release</Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
@@ -3428,15 +16830,35 @@
 			"path": "./src/components/_private/Portal/tests/Portal.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "internal-portal--base",
+					"name": "Base",
 					"snippet": "const base = () => {\n\tconst ref = React.useRef<HTMLDivElement>(null);\n\tconst [mounted, setMounted] = React.useState(false);\n\n\tReact.useEffect(() => {\n\t\tsetMounted(true);\n\t}, []);\n\n\treturn (\n\t\t<>\n\t\t\t<div style={{ border: \"2px solid #333\", padding: 16 }}>\n\t\t\t\tApp\n\t\t\t\t{mounted && <Portal targetRef={ref}>Ported to green</Portal>}\n\t\t\t</div>\n\t\t\t<div ref={ref} style={{ border: \"2px solid green\", padding: 16 }} />\n\t\t</>\n\t);\n};"
 				}
 			],
 			"import": "import { Portal } from \"reshaped\";",
 			"jsDocTags": {},
-			"error": {
-				"name": "No component definition found",
-				"message": "File: /Users/shilman/projects/design-systems/reshaped/src/components/_private/Portal/index.ts\nError:\nNo suitable component definition found.\nYou can debug your component file in this playground: https://react-docgen.dev/playground\nCode:\nimport Portal, { PortalScope } from \"./Portal\";\n\nconst PortalRoot = Portal as typeof Portal & {\n\tScope: typeof PortalScope;\n};\n\nPortalRoot.Scope = PortalScope;\n\nexport default PortalRoot;\nexport type { Props as PortalProps } from \"./Portal.types\";\n\n\nFile: /Users/shilman/projects/design-systems/reshaped/src/components/_private/Portal/Portal.types.ts\nError:\nNo suitable component definition found.\nYou can debug your component file in this playground: https://react-docgen.dev/playground\nCode:\nimport React from \"react\";\n\nexport type Props = {\n\tchildren?: React.ReactNode;\n\ttargetRef?: React.RefObject<HTMLElement | ShadowRoot | null>;\n};\n\nexport type ScopeProps<T extends HTMLElement> = {\n\tchildren: (ref: React.RefObject<T | null>) => React.ReactNode;\n};\n\nexport type Context = {\n\tscopeRef: React.RefObject<HTMLElement | null>;\n};\n"
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/_private/Portal/index.ts",
+				"description": "",
+				"displayName": "Portal",
+				"methods": [],
+				"props": {
+					"targetRef": {
+						"defaultValue": null,
+						"description": "",
+						"name": "targetRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/_private/Portal/Portal.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | ShadowRoot | null>" }
+					}
+				},
+				"exportName": "Portal"
 			}
 		},
 		"internal-usedrag": {
@@ -3444,24 +16866,33 @@
 			"name": "useDrag",
 			"path": "./src/hooks/tests/useDrag.stories.tsx",
 			"stories": [
-				{ "name": "base", "snippet": "const base = () => <Example />;" },
 				{
-					"name": "mouseEvents",
+					"id": "internal-usedrag--base",
+					"name": "base",
+					"snippet": "const base = () => <Example />;"
+				},
+				{
+					"id": "internal-usedrag--mouse-events",
+					"name": "onDrag, mouse events",
 					"snippet": "const mouseEvents = () => {\n    return <Demo onDrag={fn()} />;\n};"
 				},
 				{
-					"name": "touchEvents",
+					"id": "internal-usedrag--touch-events",
+					"name": "onDrag, touch events",
 					"snippet": "const touchEvents = () => {\n    return <Demo onDrag={fn()} />;\n};"
 				},
 				{
-					"name": "orientationHorizontal",
+					"id": "internal-usedrag--orientation-horizontal",
+					"name": "orientation horizontal",
 					"snippet": "const orientationHorizontal = () => {\n    return <Demo onDrag={fn()} orientation=\"horizontal\" />;\n};"
 				},
 				{
-					"name": "orientationVertical",
+					"id": "internal-usedrag--orientation-vertical",
+					"name": "orientation vertical",
 					"snippet": "const orientationVertical = () => {\n    return <Demo onDrag={fn()} orientation=\"vertical\" />;\n};"
 				},
 				{
+					"id": "internal-usedrag--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => {\n    return <Demo onDrag={fn()} disabled />;\n};"
 				}
@@ -3479,7 +16910,8 @@
 			"path": "./src/tests/ShadowDOM.stories.tsx",
 			"stories": [
 				{
-					"name": "behavior",
+					"id": "internal-shadowdom--behavior",
+					"name": "Behavior",
 					"snippet": "const behavior = () => (\n\t<Example>\n\t\t<Example.Item title=\"base\">\n\t\t\t<Component />\n\t\t</Example.Item>\n\t</Example>\n);"
 				}
 			],
@@ -3496,30 +16928,94 @@
 			"path": "./src/tests/themes.stories.tsx",
 			"stories": [
 				{
-					"name": "test",
+					"id": "internal-themes--test",
+					"name": "Test",
 					"snippet": "const test = () => {\n\tconst { colorMode } = useTheme();\n\tconst [activeColor, setColor] = useState(colors[0]);\n\tconst [theme, setTheme] = useState(\"\");\n\tconst [algo, setAlgo] = useState<\"wcag\" | \"apca\">(\"wcag\");\n\n\tuseLayoutEffect(() => {\n\t\tsetTheme(\n\t\t\tgetThemeCSS(\n\t\t\t\t\"test\",\n\t\t\t\t{\n\t\t\t\t\tcolor: generateThemeColors({\n\t\t\t\t\t\tprimary: activeColor === colors[0] ? undefined : activeColor,\n\t\t\t\t\t}),\n\t\t\t\t},\n\t\t\t\t{\n\t\t\t\t\tcolorContrastAlgorithm: algo,\n\t\t\t\t}\n\t\t\t)\n\t\t);\n\t}, [activeColor, algo]);\n\n\treturn (\n\t\t<>\n\t\t\t<style>{theme}</style>\n\t\t\t<Theme name=\"test\">\n\t\t\t\t<View gap={4}>\n\t\t\t\t\t<View direction=\"row\" align=\"center\" gap={4}>\n\t\t\t\t\t\t{colors.map((color) => {\n\t\t\t\t\t\t\tconst hex = colorMode === \"dark\" && color === \"#000000\" ? \"#ffffff\" : color;\n\n\t\t\t\t\t\t\treturn (\n\t\t\t\t\t\t\t\t<Actionable key={color} onClick={() => setColor(color)} borderRadius=\"inherit\">\n\t\t\t\t\t\t\t\t\t<View\n\t\t\t\t\t\t\t\t\t\twidth={5}\n\t\t\t\t\t\t\t\t\t\theight={5}\n\t\t\t\t\t\t\t\t\t\tborderRadius=\"circular\"\n\t\t\t\t\t\t\t\t\t\tattributes={{\n\t\t\t\t\t\t\t\t\t\t\tstyle: {\n\t\t\t\t\t\t\t\t\t\t\t\ttransition: `box-shadow var(--rs-duration-fast) var(--rs-easing-standard)`,\n\t\t\t\t\t\t\t\t\t\t\t\tbackground: hex,\n\t\t\t\t\t\t\t\t\t\t\t\tboxShadow:\n\t\t\t\t\t\t\t\t\t\t\t\t\tcolor === activeColor\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t? `0 0 0 3px var(--rs-color-background-elevation-base), 0 0 0 5px ${hex}`\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t: undefined,\n\t\t\t\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t\t\t\t}}\n\t\t\t\t\t\t\t\t\t/>\n\t\t\t\t\t\t\t\t</Actionable>\n\t\t\t\t\t\t\t);\n\t\t\t\t\t\t})}\n\t\t\t\t\t\t<View.Item gapBefore=\"auto\">\n\t\t\t\t\t\t\t<Switch name=\"algo\" onChange={(args) => setAlgo(args.checked ? \"apca\" : \"wcag\")}>\n\t\t\t\t\t\t\t\tUse APCA\n\t\t\t\t\t\t\t</Switch>\n\t\t\t\t\t\t</View.Item>\n\t\t\t\t\t</View>\n\n\t\t\t\t\t<ThemePlayground />\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</>\n\t);\n};"
 				},
 				{
-					"name": "base",
+					"id": "internal-themes--base",
+					"name": "Base",
 					"snippet": "const base = () => (\n\t<Example>\n\t\t<Example.Item title=\"custom runtime theme\">\n\t\t\t<style>{css}</style>\n\t\t\t<Theme name=\"green\">\n\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"on colors generation\">\n\t\t\t<style>{css2}</style>\n\t\t\t<Theme name=\"peach\">\n\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "generation",
+					"id": "internal-themes--generation",
+					"name": "Generation",
 					"snippet": "const generation = () => (\n\t<div>\n\t\t<style>{cssGenerated}</style>\n\t\t<Theme name=\"generated\">{componentExamples}</Theme>\n\t</div>\n);"
 				},
 				{
-					"name": "onColors",
+					"id": "internal-themes--on-colors",
+					"name": "On Colors",
 					"snippet": "const onColors = () => (\n\t<Example>\n\t\t<Example.Item title=\"custom on color values\">\n\t\t\t<style>{onColorsCss}</style>\n\t\t\t<Theme name=\"on-color\">\n\t\t\t\t<View gap={2} direction=\"row\">\n\t\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t\t\t<Button color=\"critical\">Critical button</Button>\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"custom on color values, apca\">\n\t\t\t<style>{onColorsCssApca}</style>\n\t\t\t<Theme name=\"on-color-apca\">\n\t\t\t\t<View gap={2} direction=\"row\">\n\t\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t\t\t<Button color=\"critical\">Critical button</Button>\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t</Example>\n);"
 				}
 			],
 			"import": "import {\n    Actionable,\n    Alert,\n    Avatar,\n    Badge,\n    Button,\n    Card,\n    DropdownMenu,\n    Example,\n    Link,\n    Switch,\n    Text,\n    TextField,\n    Theme,\n    ThemePlayground,\n    View,\n} from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Theme/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Theme",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Theme/Theme.tsx",
-				"actualName": "Theme",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the theme to use, enables controlled mode",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"defaultName": {
+						"defaultValue": null,
+						"description": "Default name of the theme to use, enables uncontrolled mode",
+						"name": "defaultName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode to use",
+						"name": "colorMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode | \"inverted\"",
+							"value": [
+								{ "value": "\"light\"" },
+								{ "value": "\"dark\"" },
+								{ "value": "\"inverted\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -3529,7 +17025,8 @@
 			"path": "./src/Sandbox.stories.tsx",
 			"stories": [
 				{
-					"name": "preview",
+					"id": "sandbox--preview",
+					"name": "Preview",
 					"snippet": "const preview = () => {\n\treturn (\n\t\t<Preview>\n\t\t\t<Component />\n\t\t</Preview>\n\t);\n};"
 				}
 			],
@@ -3540,5 +17037,6 @@
 				"message": "We could not detect the component from your story file. Specify meta.component.\n   7 | import MenuItem from \"components/MenuItem\";\n   8 |\n>  9 | export default {\n     | ^\n  10 | \ttitle: \"Sandbox\",\n  11 | \tchromatic: { disableSnapshot: true },\n  12 | };\n\n./src/Sandbox.stories.tsx:\nimport View from \"components/View\";\nimport Image from \"components/Image\";\nimport React from \"react\";\nimport Select from \"components/Select\";\nimport useToggle from \"hooks/useToggle\";\nimport Modal from \"components/Modal\";\nimport MenuItem from \"components/MenuItem\";\n\nexport default {\n\ttitle: \"Sandbox\",\n\tchromatic: { disableSnapshot: true },\n};\n\nconst Preview: React.FC<{ children: React.ReactNode }> = (props) => {\n\treturn (\n\t\t<View padding={20} gap={6}>\n\t\t\t<View position=\"absolute\" insetTop={0} insetStart={0}>\n\t\t\t\t<Image src=\"./logo.svg\" />\n\t\t\t</View>\n\n\t\t\t{props.children}\n\t\t</View>\n\t);\n};\n\nexport const preview = () => {\n\treturn (\n\t\t<Preview>\n\t\t\t<Component />\n\t\t</Preview>\n\t);\n};\n\nconst Component = () => {\n\tconst toggle = useToggle();\n\tconst [value, setValue] = React.useState(\"Dog\");\n\n\tconst handleClick = () => {\n\t\ttoggle.toggle();\n\t};\n\n\treturn (\n\t\t<>\n\t\t\t<Select name=\"animal\" placeholder=\"Select an animal\" onClick={handleClick}>\n\t\t\t\t{value}\n\t\t\t</Select>\n\t\t\t<Modal active={toggle.active} onClose={toggle.deactivate} position=\"bottom\" padding={2}>\n\t\t\t\t<MenuItem\n\t\t\t\t\troundedCorners\n\t\t\t\t\tonClick={() => {\n\t\t\t\t\t\tsetValue(\"Dog\");\n\t\t\t\t\t\ttoggle.deactivate();\n\t\t\t\t\t}}\n\t\t\t\t\tattributes={{\n\t\t\t\t\t\trole: \"option\",\n\t\t\t\t\t}}\n\t\t\t\t>\n\t\t\t\t\tDog\n\t\t\t\t</MenuItem>\n\t\t\t\t<MenuItem\n\t\t\t\t\troundedCorners\n\t\t\t\t\tattributes={{\n\t\t\t\t\t\trole: \"option\",\n\t\t\t\t\t}}\n\t\t\t\t\tonClick={() => {\n\t\t\t\t\t\tsetValue(\"Turtle\");\n\t\t\t\t\t\ttoggle.deactivate();\n\t\t\t\t\t}}\n\t\t\t\t>\n\t\t\t\t\tTurtle\n\t\t\t\t</MenuItem>\n\t\t\t</Modal>\n\t\t</>\n\t);\n};\n"
 			}
 		}
-	}
+	},
+	"meta": { "docgen": "react-docgen-typescript", "durationMs": 2919 }
 }

--- a/eval/tasks/903-create-component-async-fetch-reshaped/manifests/components.json
+++ b/eval/tasks/903-create-component-async-fetch-reshaped/manifests/components.json
@@ -7,46 +7,201 @@
 			"path": "./src/components/ActionBar/tests/ActionBar.stories.tsx",
 			"stories": [
 				{
-					"name": "positionRelative",
+					"id": "components-actionbar--position-relative",
+					"name": "position, positionType: relative",
 					"snippet": "const positionRelative = () => (\n    <Example>\n        <Example.Item title=\"position: top\">\n            <ActionBar position=\"top\">\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <ActionBar position=\"bottom\">\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positionAbsolute",
+					"id": "components-actionbar--position-absolute",
+					"name": "position, positionType: absolute",
 					"snippet": "const positionAbsolute = () => (\n    <Example>\n        <Example.Item title=\"position: top-start\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top-start\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: top\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: top-end\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top-end\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom-start\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom-start\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom-end\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positionFixed",
+					"id": "components-actionbar--position-fixed",
+					"name": "position, positionType: fixed",
 					"snippet": "const positionFixed = () => (\n    <>\n        <ActionBar padding={2} position=\"top-start\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"top\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"top-end\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom-start\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom-end\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <div style={{ height: 2000 }} />\n    </>\n);"
 				},
 				{
+					"id": "components-actionbar--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated, position: top\">\n            <ActionBar position=\"top\" elevated>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"elevated, position: bottom\">\n            <ActionBar elevated>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"auto elevated, position: bottom\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-actionbar--offset",
 					"name": "offset",
 					"snippet": "const offset = () => (\n    <Example>\n        <Example.Item title=\"offset 2, position: top\">\n            <Fixtures.Container>\n                <ActionBar position=\"top\" positionType=\"absolute\" offset={2}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"offset 2, position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\" offset={2}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"offset s: 2, m: 4, position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\" offset={{ s: 2, m: 4 }}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-actionbar--active",
 					"name": "active",
 					"snippet": "const active = () => {\n    const barToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => barToggle.toggle()}>Toggle</Button>\n            <ActionBar active={barToggle.active} positionType=\"fixed\" position=\"top-end\">\n                <Fixtures.Actions />\n            </ActionBar>\n        </>\n    );\n};"
 				},
 				{
-					"name": "padding",
+					"id": "components-actionbar--padding",
+					"name": "padding, paddingBlock, paddingInline",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 6\">\n            <ActionBar padding={6}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"paddingBlock: 2, paddingInline: 4\">\n            <ActionBar paddingBlock={2} paddingInline={4}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"padding: [s] 4, [m+] 6\">\n            <ActionBar padding={{ s: 4, m: 6 }}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-actionbar--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ActionBar className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </ActionBar>\n    </div>\n);"
 				}
 			],
 			"import": "import { ActionBar, Button, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ActionBar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ActionBar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ActionBar/ActionBar.tsx",
-				"actualName": "ActionBar",
+				"methods": [],
+				"props": {
+					"paddingBlock": {
+						"defaultValue": null,
+						"description": "Padding block, base unit token number multiplier",
+						"name": "paddingBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingInline": {
+						"defaultValue": null,
+						"description": "Padding inline, base unit token number multiplier",
+						"name": "paddingInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Padding style for all sides, base unit token number multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Show or hide the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"offset": {
+						"defaultValue": null,
+						"description": "Offset from the container bounds",
+						"name": "offset",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"position": {
+						"defaultValue": { "value": "\"bottom\"" },
+						"description": "Position based on the container bounds",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"top-end\" | \"top-start\" | \"bottom\" | \"bottom-start\" | \"bottom-end\"",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" }
+							]
+						}
+					},
+					"positionType": {
+						"defaultValue": null,
+						"description": "CSS position style",
+						"name": "positionType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"relative\" | \"absolute\" | \"fixed\">" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Display above the content with elevated shadow and background",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -56,30 +211,138 @@
 			"path": "./src/components/Alert/tests/Alert.stories.tsx",
 			"stories": [
 				{
+					"id": "components-alert--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        {([\"neutral\", \"primary\", \"critical\", \"positive\", \"warning\"] as const).map((color) => (\n            <Example.Item title={`color: ${color}`} key={color}>\n                <Alert\n                    color={color}\n                    title=\"Alert title goes here\"\n                    icon={IconZap}\n                    actionsSlot={\n                        <>\n                            <Link\n                                variant=\"plain\"\n                                color={color === \"neutral\" ? \"primary\" : color}\n                                onClick={() => {}}\n                            >\n                                View now\n                            </Link>\n                            <Link\n                                variant=\"plain\"\n                                color={color === \"neutral\" ? \"primary\" : color}\n                                onClick={() => {}}\n                            >\n                                Dismiss\n                            </Link>\n                        </>\n                    }\n                >\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard\n                </Alert>\n            </Example.Item>\n        ))}\n    </Example>\n);"
 				},
 				{
+					"id": "components-alert--inline",
 					"name": "inline",
 					"snippet": "const inline = () => (\n    <Example>\n        <Example.Item title=\"inline: true\">\n            <Alert\n                inline\n                title=\"Alert title goes here\"\n                icon={IconZap}\n                actionsSlot={\n                    <>\n                        <Link variant=\"plain\" onClick={() => {}}>\n                            View now\n                        </Link>\n                        <Link variant=\"plain\" onClick={() => {}}>\n                            Dismiss\n                        </Link>\n                    </>\n                }\n            >\n                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has\n                been the industry's standard\n            </Alert>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-alert--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4\">\n            <Alert bleed={4} icon={IconZap}>\n                Content\n            </Alert>\n        </Example.Item>\n        <Example.Item title=\"bleed: [s] 4, [m+] 0\">\n            <Alert bleed={{ s: 4, m: 0 }} icon={IconZap}>\n                Content\n            </Alert>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-alert--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Alert className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </Alert>\n    </div>\n);"
 				}
 			],
 			"import": "import { Alert, Example, Link, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Alert/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Alert",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Alert/Alert.tsx",
-				"actualName": "Alert",
+				"methods": [],
+				"props": {
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"title": {
+						"defaultValue": null,
+						"description": "Title slot",
+						"name": "title",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Slot for rendering the main content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"actionsSlot": {
+						"defaultValue": null,
+						"description": "Actions slot, usually used for Buttons and Links, automatically adds a gap between the actions",
+						"name": "actionsSlot",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Color scheme of the alert elements",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"inline": {
+						"defaultValue": null,
+						"description": "Display action to the right of the content",
+						"name": "inline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margin and remove side borders, base unit token number multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -89,35 +352,573 @@
 			"path": "./src/components/Autocomplete/tests/Autocomplete.stories.tsx",
 			"stories": [
 				{
-					"name": "active",
+					"id": "components-autocomplete--active",
+					"name": "active, onOpen, onClose",
 					"snippet": "const active = (args) => {\n    const toggle = useToggle(true);\n\n    return (\n        <Example>\n            <Example.Item title=\"active, onOpen, onClose\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete\n                        name=\"fruit\"\n                        placeholder=\"Pick your food\"\n                        active={toggle.active}\n                        onOpen={() => {\n                            args.handleOpen();\n                            toggle.activate();\n                        }}\n                        onClose={() => {\n                            args.handleClose();\n                            toggle.deactivate();\n                        }}\n                        onChange={(args) => console.log(args)}\n                    >\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "base",
+					"id": "components-autocomplete--base",
+					"name": "onInput, onItemSelect, onBackspace",
 					"snippet": "const base = () => {\n    const [value, setValue] = React.useState(\"\");\n\n    return (\n        <Example>\n            <Example.Item title=\"Base\">\n                <FormControl>\n                    <FormControl.Label>Food</FormControl.Label>\n                    <Autocomplete\n                        name=\"fruit\"\n                        placeholder=\"Pick your food\"\n                        value={value}\n                        onChange={(args) => setValue(args.value)}\n                        onBackspace={fn()}\n                        onItemSelect={fn()}>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "itemData",
+					"id": "components-autocomplete--item-data",
+					"name": "item data",
 					"snippet": "const itemData = () => {\n    return (\n        <Example>\n            <Example.Item title=\"item data\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete name=\"fruit\" placeholder=\"Pick your food\" onItemSelect={fn()} active>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v} data={i === 1 ? { foo: true } : undefined}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "itemDisabled",
+					"id": "components-autocomplete--item-disabled",
+					"name": "item disabled",
 					"snippet": "const itemDisabled = () => {\n    return (\n        <Example>\n            <Example.Item title=\"item disabled\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete name=\"fruit\" placeholder=\"Pick your food\" active>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v} disabled={i === 1}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "multiselect",
+					"id": "components-autocomplete--multiselect",
+					"name": "test: multiselect",
 					"snippet": "const multiselect = () => {\n    const options = [\n        \"Pizza\",\n        \"Pie\",\n        \"Ice-cream\",\n        \"Fries\",\n        \"Salad\",\n        \"Option 4\",\n        \"Option 5\",\n        \"Option 6\",\n    ];\n\n    const inputRef = React.useRef<HTMLInputElement>(null);\n    const [values, setValues] = React.useState<string[]>([\n        \"Option 4\",\n        \"Option 5\",\n        \"Option 6\",\n        \"Pizza\",\n        \"Ice-cream\",\n    ]);\n    const [query, setQuery] = React.useState(\"\");\n\n    const handleDismiss = (dismissedValue: string) => {\n        const nextValues = values.filter((value) => value !== dismissedValue);\n        setValues(nextValues);\n        inputRef.current?.focus();\n    };\n\n    const valuesNode = values.map((value) => (\n        <Badge dismissAriaLabel=\"Dismiss value\" onDismiss={() => handleDismiss(value)} key={value}>\n            {value}\n        </Badge>\n    ));\n\n    return (\n        <FormControl>\n            <FormControl.Label>Food</FormControl.Label>\n            <Autocomplete\n                name=\"fruit\"\n                value={query}\n                placeholder=\"Pick your food\"\n                startSlot={valuesNode}\n                multiline\n                inputAttributes={{ ref: inputRef }}\n                onChange={(args) => setQuery(args.value)}\n                onBackspace={() => {\n                    if (query.length === 0) {\n                        setValues((prev) => prev.slice(0, -1));\n                    }\n                }}\n                onItemSelect={(args) => {\n                    setQuery(\"\");\n                    setValues((prev) => [...prev, args.value]);\n                }}\n            >\n                {options.map((v) => {\n                    if (!v.toLowerCase().includes(query.toLowerCase())) return;\n                    if (values.includes(v)) return;\n\n                    return (\n                        <Autocomplete.Item key={v} value={v}>\n                            {v}\n                        </Autocomplete.Item>\n                    );\n                })}\n            </Autocomplete>\n        </FormControl>\n    );\n};"
 				}
 			],
 			"import": "import { Autocomplete, Badge, Example, FormControl } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Autocomplete/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Autocomplete",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Autocomplete/Autocomplete.tsx",
-				"actualName": "Autocomplete",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"multiline": {
+						"defaultValue": null,
+						"description": "Enable multiline text field wrapping",
+						"name": "multiline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to be fully rounded",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content after the text field value",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text field value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the text field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the text field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"onInput": {
+						"defaultValue": null,
+						"description": "Callback for when value changes from user input",
+						"name": "onInput",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onItemSelect": {
+						"defaultValue": null,
+						"description": "Callback for when an item is selected in the dropdown",
+						"name": "onItemSelect",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: SelectArgs) => void)" }
+					},
+					"onBackspace": {
+						"defaultValue": null,
+						"description": "Callback for when the backspace key is pressed while the input is focused",
+						"name": "onBackspace",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onEnter": {
+						"defaultValue": null,
+						"description": "Callback for when the enter key is pressed while the input is focused",
+						"name": "onEnter",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Slot for rendering the Autocomplete.Item components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					}
+				},
+				"exportName": "Autocomplete"
 			}
 		},
 		"components-avatar": {
@@ -126,46 +927,230 @@
 			"path": "./src/components/Avatar/tests/Avatar.stories.tsx",
 			"stories": [
 				{
-					"name": "src",
+					"id": "components-avatar--src",
+					"name": "src, alt",
 					"snippet": "const src = () => (\n    <Example>\n        <Example.Item title=\"src, alt\">\n            <Avatar\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n                alt=\"Amsterdam canal\"\n                size={12}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"src\">\n            <Avatar src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "initials",
+					"id": "components-avatar--initials",
+					"name": "initials, icon",
 					"snippet": "const initials = () => (\n    <Example>\n        <Example.Item title=\"initials\">\n            <Avatar initials=\"RS\" />\n        </Example.Item>\n\n        <Example.Item title=\"icon\">\n            <Avatar icon={IconZap} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-avatar--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: 6\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={6} icon={IconZap} />\n                <Avatar size={6} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: 15\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={15} icon={IconZap} />\n                <Avatar size={15} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: 40\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={40} icon={IconZap} />\n                <Avatar size={40} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] 10\", \"[m+] 20\"]}>\n            <View direction=\"row\" gap={3}>\n                <Avatar size={{ s: 10, m: 20 }} icon={IconZap} />\n                <Avatar size={{ s: 10, m: 20 }} icon={IconZap} squared />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-avatar--squared",
 					"name": "squared",
 					"snippet": "const squared = () => (\n    <Example>\n        <Example.Item title=\"squared, with image\">\n            <Avatar\n                squared\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n            />\n        </Example.Item>\n        <Example.Item title=\"squared, with initials\">\n            <Avatar squared initials=\"RS\" />\n        </Example.Item>\n        <Example.Item title=\"squared, with initials\">\n            <Avatar squared icon={IconZap} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "colors",
+					"id": "components-avatar--colors",
+					"name": "color, variant",
 					"snippet": "const colors = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"neutral\" icon={IconZap} />\n                <Avatar color=\"neutral\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"primary\" icon={IconZap} />\n                <Avatar color=\"primary\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"positive\" icon={IconZap} />\n                <Avatar color=\"positive\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"warning\" icon={IconZap} />\n                <Avatar color=\"warning\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"critical\" icon={IconZap} />\n                <Avatar color=\"critical\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "fallback",
+					"id": "components-avatar--fallback",
+					"name": "test: fallback",
 					"snippet": "const fallback = (args) => {\n    const [error, setError] = useState(false);\n\n    return (\n        <Avatar\n            src={error ? undefined : \"/foo\"}\n            icon={IconZap}\n            imageAttributes={{\n                onError: () => {\n                    setError(true);\n                    args.handleError();\n                },\n            }}\n        />\n    );\n};"
 				},
 				{
+					"id": "components-avatar--render-image",
 					"name": "renderImage",
 					"snippet": "const renderImage = () => (\n    <Example>\n        <Example.Item title=\"renderImage\">\n            <Avatar\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n                alt=\"Amsterdam canal\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image\" />}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-avatar--class-name",
+					"name": "className, attributes, imageAttributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Avatar\n            src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            imageAttributes={{ id: \"test-image-id\", alt: \"test image\" }}\n        />\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Avatar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Avatar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Avatar/Avatar.tsx",
-				"actualName": "Avatar",
+				"methods": [],
+				"props": {
+					"src": {
+						"defaultValue": null,
+						"description": "Image URL",
+						"name": "src",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"alt": {
+						"defaultValue": null,
+						"description": "Image alt text",
+						"name": "alt",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"imageAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the image element",
+						"name": "imageAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"img\">" }
+					},
+					"renderImage": {
+						"defaultValue": null,
+						"description": "Render prop for the image element, useful for integrating with the Image component from third party frameworks",
+						"name": "renderImage",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Omit<Attributes<\"img\">, \"src\" | \"alt\"> & { src: string; alt: string; }) => ReactNode)"
+						}
+					},
+					"initials": {
+						"defaultValue": null,
+						"description": "Initials to display if no image is provided",
+						"name": "initials",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon, used when no image is provided",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"squared": {
+						"defaultValue": null,
+						"description": "Change the shape to rounded square",
+						"name": "squared",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"faded\"",
+							"value": [{ "value": "\"solid\"" }, { "value": "\"faded\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "12" },
+						"description": "Size of the component, base unit token number multiplier",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -175,63 +1160,273 @@
 			"path": "./src/components/Badge/tests/Badge.stories.tsx",
 			"stories": [
 				{
+					"id": "components-badge--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Badge>Badge</Badge>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <Badge variant=\"faded\">Badge</Badge>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <Badge variant=\"outline\">Badge</Badge>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"primary\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"primary\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"primary\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: positive, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"positive\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"positive\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"positive\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: critical, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"critical\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"critical\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"critical\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: warning, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"warning\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"warning\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"warning\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"small\">Badge</Badge>\n                <Badge rounded size=\"small\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge>Badge</Badge>\n                <Badge rounded>Badge</Badge>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"large\">Badge</Badge>\n                <Badge rounded size=\"large\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={3} direction=\"row\">\n                <Badge icon={IconCheckmark} endIcon={IconChevronRight} size=\"small\">\n                    Badge\n                </Badge>\n                <Badge icon={IconCheckmark} size=\"small\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={3} direction=\"row\">\n                <Badge icon={IconCheckmark} endIcon={IconChevronRight}>\n                    Badge\n                </Badge>\n                <Badge icon={IconCheckmark} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"large\" icon={IconCheckmark} endIcon={IconChevronRight}>\n                    Badge\n                </Badge>\n\n                <Badge icon={IconCheckmark} size=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onDismiss",
+					"id": "components-badge--on-dismiss",
+					"name": "onDismiss, dismissAriaLabel",
 					"snippet": "const onDismiss = () => <Example>\n    <Example.Item title=\"onDismiss\">\n        <Badge onDismiss={fn()} dismissAriaLabel=\"Dismiss\">Badge\n                            </Badge>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-badge--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded>Badge</Badge>\n                <Badge rounded variant=\"faded\">\n                    Badge\n                </Badge>\n                <Badge rounded variant=\"outline\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"rounded, all sizes, color: critical\", \"one character, renders as circle\"]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Badge rounded color=\"critical\" size=\"small\">\n                    2\n                </Badge>\n                <Badge rounded color=\"critical\">\n                    2\n                </Badge>\n                <Badge rounded color=\"critical\" size=\"large\">\n                    2\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--empty",
 					"name": "empty",
 					"snippet": "const empty = () => (\n    <Example>\n        <Example.Item title=\"empty, not rounded, all sizes, color: critical\">\n            <View direction=\"row\" gap={3}>\n                <Badge size=\"small\" color=\"critical\" />\n                <Badge color=\"critical\" />\n                <Badge size=\"large\" color=\"critical\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"empty, rounded, all sizes, color: critical\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded size=\"small\" color=\"critical\" />\n                <Badge rounded color=\"critical\" />\n                <Badge rounded size=\"large\" color=\"critical\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"empty, rounded, all sizes, color: neutral\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded size=\"small\" color=\"neutral\" />\n                <Badge rounded />\n                <Badge rounded size=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--highlighted",
 					"name": "highlighted",
 					"snippet": "const highlighted = () => (\n    <Example>\n        <Example.Item title=\"highlighted, color: neutral\">\n            <View gap={3} direction=\"row\">\n                <Badge highlighted>Badge</Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--container",
 					"name": "container",
 					"snippet": "const container = () => {\n    const [hidden, setHidden] = React.useState(false);\n\n    return (\n        <Example title={<Button onClick={() => setHidden(!hidden)}>Toggle badges</Button>}>\n            <Example.Item title=\"position: top-end\">\n                <Badge.Container>\n                    <Badge color=\"primary\" hidden={hidden}>\n                        5\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: bottom-end\">\n                <Badge.Container position=\"bottom-end\">\n                    <Badge color=\"primary\" hidden={hidden}>\n                        5\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: top-end, rounded, multiple digits\">\n                <Badge.Container>\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        123\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: top-end, rounded, empty\">\n                <Badge.Container>\n                    <Badge color=\"primary\" rounded hidden={hidden} />\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: top-end, overlap\", \"should cover the circular avatar\"]}>\n                <Badge.Container overlap>\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        2\n                    </Badge>\n                    <Avatar initials=\"A\" />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: bottom-end, overlap\", \"should cover the circular avatar\"]}>\n                <Badge.Container overlap position=\"bottom-end\">\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        2\n                    </Badge>\n                    <Avatar initials=\"A\" />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: top-end, overlap\", \"should cover the icon\"]}>\n                <Badge.Container overlap position=\"top-end\">\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden} />\n                    <Icon svg={IconCheckmark} size={5} />\n                </Badge.Container>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-badge--href",
 					"name": "href",
 					"snippet": "const href = () => (\n    <Badge href=\"https://reshaped.so\" dismissAriaLabel=\"Dismiss\">\n        Badge\n    </Badge>\n);"
 				},
 				{
+					"id": "components-badge--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Badge onClick={fn()}>Badge</Badge>;"
 				},
 				{
-					"name": "className",
+					"id": "components-badge--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Badge color=\"primary\" className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Badge, Button, Example, Icon, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Badge/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Badge",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Badge/Badge.tsx",
-				"actualName": "Badge",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"large\" | \"medium\"",
+							"value": [
+								{ "value": "\"small\"" },
+								{ "value": "\"large\"" },
+								{ "value": "\"medium\"" }
+							]
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "highlighted",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hidden": {
+						"defaultValue": null,
+						"description": "Transition the component to hidden state",
+						"name": "hidden",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting text or other content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"onDismiss": {
+						"defaultValue": null,
+						"description": "Callback triggered when the dismiss button is pressed",
+						"name": "onDismiss",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"dismissAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the dismiss button",
+						"name": "dismissAriaLabel",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "Badge"
 			}
 		},
 		"components-breadcrumbs": {
@@ -240,51 +1435,185 @@
 			"path": "./src/components/Breadcrumbs/tests/Breadcrumbs.stories.tsx",
 			"stories": [
 				{
+					"id": "components-breadcrumbs--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <Breadcrumbs ariaLabel=\"breadcrumb neutral\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"color: primary\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb primary\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "item",
+					"id": "components-breadcrumbs--item",
+					"name": "item, disabled",
 					"snippet": "const item = () => (\n    <Example>\n        <Example.Item title=\"disabled item\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb disabled\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}} disabled>\n                    Disabled item 2\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "icon",
+					"id": "components-breadcrumbs--icon",
+					"name": "item, icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"item with icon\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb with icon\">\n                <Breadcrumbs.Item icon={IconZap} onClick={() => {}}>\n                    Item 1\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "slots",
+					"id": "components-breadcrumbs--slots",
+					"name": "separator, children",
 					"snippet": "const slots = () => (\n    <Example>\n        <Example.Item title=\"slot: separator\">\n            <Breadcrumbs color=\"primary\" separator=\"/\" ariaLabel=\"breadcrumb with separator\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"custom child content\">\n            <Breadcrumbs ariaLabel=\"breadcrumb with custom children\">\n                <Breadcrumbs.Item onClick={() => {}}>\n                    <Badge>Item 1</Badge>\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>\n                    <Badge>Item 2</Badge>\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-breadcrumbs--collapsed",
 					"name": "collapsed",
 					"snippet": "const collapsed = () => (\n    <Example>\n        <Example.Item title=\"collapsed, 3 items shown by default\">\n            <Breadcrumbs\n                defaultVisibleItems={3}\n                ariaLabel=\"breadcrumbs one\"\n                expandAriaLabel=\"Expand items\"\n            >\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"collapsed, 4 items shown by default\">\n            <Breadcrumbs\n                defaultVisibleItems={4}\n                ariaLabel=\"breadcrumb two\"\n                expandAriaLabel=\"Expand items\"\n            >\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"collapsed, 3 items shown by default, not expandable\">\n            <Breadcrumbs defaultVisibleItems={3} ariaLabel=\"breadcrumb three\" disableExpand>\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "multiline",
+					"id": "components-breadcrumbs--multiline",
+					"name": "composition, multiline",
 					"snippet": "const multiline = () => (\n    <Example>\n        <Example.Item title=\"wraps content when multiline\">\n            <Breadcrumbs ariaLabel=\"breadcrumb multiline\">\n                {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((i) => (\n                    <Breadcrumbs.Item onClick={() => {}} key={i}>\n                        Item {i}\n                    </Breadcrumbs.Item>\n                ))}\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onClick",
+					"id": "components-breadcrumbs--on-click",
+					"name": "item, onClick, disabled",
 					"snippet": "const onClick = () => <Breadcrumbs>\n    <Breadcrumbs.Item onClick={fn()}>Trigger</Breadcrumbs.Item>\n    <Breadcrumbs.Item onClick={fn()} disabled>Trigger\n                    </Breadcrumbs.Item>\n</Breadcrumbs>;"
 				},
 				{
-					"name": "href",
+					"id": "components-breadcrumbs--href",
+					"name": "item, href",
 					"snippet": "const href = () => (\n    <Breadcrumbs>\n        <Breadcrumbs.Item href=\"https://reshaped.so\">Trigger</Breadcrumbs.Item>\n    </Breadcrumbs>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-breadcrumbs--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Breadcrumbs className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Breadcrumbs.Item>Trigger</Breadcrumbs.Item>\n        </Breadcrumbs>\n    </div>\n);"
 				}
 			],
 			"import": "import { Badge, Breadcrumbs, Example } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Breadcrumbs/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Breadcrumbs",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Breadcrumbs/Breadcrumbs.tsx",
-				"actualName": "Breadcrumbs",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children to position items",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ReactElement<unknown, string | JSXElementConstructor<any>>[]"
+						}
+					},
+					"separator": {
+						"defaultValue": null,
+						"description": "Node for defining custom separator between items",
+						"name": "separator",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"neutral\"",
+							"value": [{ "value": "\"primary\"" }, { "value": "\"neutral\"" }]
+						}
+					},
+					"defaultVisibleItems": {
+						"defaultValue": null,
+						"description": "Number of items to show by default, others will be hidden and can be expanded",
+						"name": "defaultVisibleItems",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"expandAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the expand button",
+						"name": "expandAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disableExpand": {
+						"defaultValue": null,
+						"description": "Turn expand button into static text and disable the expand functionality",
+						"name": "disableExpand",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the component",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"nav\">" }
+					}
+				},
+				"exportName": "Breadcrumbs"
 			}
 		},
 		"components-button": {
@@ -293,87 +1622,599 @@
 			"path": "./src/components/Button/tests/Button.stories.tsx",
 			"stories": [
 				{
-					"name": "variantAndColor",
+					"id": "components-button--variant-and-color",
+					"name": "variant, color",
 					"snippet": "const variantAndColor = () => (\n    <Example>\n        <Example.Item title=\"variant: solid\">\n            <View gap={4} direction=\"row\">\n                <Button onClick={() => {}}>Button</Button>\n                <Button onClick={() => {}} color=\"primary\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"faded\">\n                    Button\n                </Button>\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"outline\">\n                    Button\n                </Button>\n\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: ghost\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"ghost\">\n                    Button\n                </Button>\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: media\">\n            <View backgroundColor=\"primary\" borderRadius=\"medium\" padding={4} direction=\"row\" gap={4}>\n                <Button onClick={() => {}} color=\"media\">\n                    Button\n                </Button>\n\n                <Button onClick={() => {}} color=\"media\" variant=\"faded\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Button onClick={() => {}} icon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"endIcon\">\n            <Button onClick={() => {}} endIcon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"icon, endIcon\">\n            <Button onClick={() => {}} icon={IconZap} endIcon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"icon only\">\n            <Button onClick={() => {}} icon={IconZap} attributes={{ \"aria-label\": \"Action\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"small\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"small\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Button icon={IconZap}>Button</Button>\n                <Button variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"large\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"large\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"xlarge\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"xlarge\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"xlarge\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large, [m+] medium\">\n            <Button size={{ s: \"large\", m: \"medium\" }} icon={IconZap}>\n                Responsive\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated, color: neutral\">\n            <View direction=\"row\" gap={4}>\n                <Button elevated onClick={() => {}}>\n                    Button\n                </Button>\n                <Button elevated variant=\"outline\" onClick={() => {}}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"elevated, color\">\n            <View direction=\"row\" gap={4}>\n                <Button elevated color=\"primary\">\n                    Button\n                </Button>\n                <Button elevated variant=\"outline\" color=\"primary\">\n                    Button\n                </Button>\n                <View backgroundColor=\"primary\" padding={4} borderRadius=\"medium\">\n                    <Button color=\"media\" elevated>\n                        Button\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded, size: small, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, size: medium, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, size: large, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, icon only, all sizes\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"small\" icon={IconZap} />\n                <Button rounded icon={IconZap} />\n                <Button rounded size=\"large\" icon={IconZap} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--full-width",
 					"name": "fullWidth",
 					"snippet": "const fullWidth = () => (\n    <Example>\n        <Example.Item title=\"fullWidth, all variants\">\n            <View gap={3}>\n                <Button fullWidth>Neutral</Button>\n                <Button fullWidth variant=\"faded\">\n                    Faded\n                </Button>\n                <Button fullWidth variant=\"outline\">\n                    Outline\n                </Button>\n                <Button fullWidth variant=\"ghost\">\n                    Ghost\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive fullWidth\", \"[s] true\", \"[m+] false\"]}>\n            <Button fullWidth={{ s: true, m: false }}>Button</Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--loading",
 					"name": "loading",
 					"snippet": "const loading = () => (\n    <Example>\n        <Example.Item title=\"loading, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"loading, color critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"loading, color positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"loading, color: media\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n\n                <div style={{ position: \"absolute\", top: 16, left: 16 }}>\n                    <View gap={3} direction=\"row\">\n                        <Button color=\"media\" loading loadingAriaLabel=\"Loading\">\n                            Button\n                        </Button>\n                        <Button color=\"media\" variant=\"faded\" loading loadingAriaLabel=\"Loading\">\n                            Button\n                        </Button>\n                    </View>\n                </div>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"loading, long button text\", \"button size should stay the same\"]}>\n            <Button loading loadingAriaLabel=\"Loading\" color=\"primary\">\n                Long button text\n            </Button>\n        </Example.Item>\n\n        <Example.Item title={[\"loading, icon only\", \"button keep square 1/1 ratio\"]}>\n            <Button icon={IconZap} rounded loading loadingAriaLabel=\"Loading\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--highlighted",
 					"name": "highlighted",
 					"snippet": "const highlighted = () => (\n    <Example>\n        <Example.Item title=\"highlighted, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"highlighted, color: critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted color=\"critical\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"highlighted, color: positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted color=\"positive\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled icon={IconZap} onClick={() => {}}>\n                    Button\n                </Button>\n                <Button disabled variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"disabled, color: critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled color=\"critical\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"disabled, color: positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled color=\"positive\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"disabled, color: media\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n\n                <div style={{ position: \"absolute\", top: 16, left: 16 }}>\n                    <View gap={3} direction=\"row\">\n                        <Button color=\"media\" disabled>\n                            Button\n                        </Button>\n                        <Button color=\"media\" variant=\"faded\" disabled>\n                            Button\n                        </Button>\n                    </View>\n                </div>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner: all\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>Content</View.Item>\n                <Button.Aligner>\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: top\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"top\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: top and end\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side={[\"top\", \"end\"]}>\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: bottom\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2} align=\"end\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"bottom\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: start\">\n            <View padding={4} borderColor=\"neutral-faded\" gap={2} align=\"start\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"start\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: end\">\n            <View padding={4} borderColor=\"neutral-faded\" gap={2} align=\"end\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"end\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "components-button--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"slot gap\">\n            <Button variant=\"outline\">\n                <Avatar size={6} initials=\"RS\" />\n                Label\n                <Hotkey>B</Hotkey>\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--href",
 					"name": "href",
 					"snippet": "const href = () => <Button href=\"https://reshaped.so\">Trigger</Button>;"
 				},
 				{
+					"id": "components-button--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Button onClick={fn()}>Trigger</Button>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-button--href-on-click",
+					"name": "href, onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <Button\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </Button>\n);"
 				},
 				{
+					"id": "components-button--as",
 					"name": "as",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"as: span\">\n            <Button onClick={() => {}} as=\"span\">\n                Trigger\n            </Button>\n        </Example.Item>\n        <Example.Item title=\"render, disabled\">\n            <Button\n                disabled\n                onClick={() => {}}\n                render={(props) => <section {...props} />}\n                attributes={{ \"data-testid\": \"render-el\" }}\n            >\n                Trigger\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-button--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Button className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Button>\n    </div>\n);"
 				},
 				{
+					"id": "components-button--group",
 					"name": "group",
 					"snippet": "const group = () => (\n    <Example>\n        <Example.Item title=\"with icon\">\n            <Button.Group>\n                <Button rounded>Submit</Button>\n                <Button rounded icon={IconZap} />\n            </Button.Group>\n        </Example.Item>\n        <Example.Item title=\"variant: solid\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\", \"media\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color}>One</Button>\n                        <Button color={color}>Two</Button>\n                        <Button color={color}>Three</Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"outline\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"outline\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"outline\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\", \"media\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"faded\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"faded\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"faded\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"variant: ghost\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"ghost\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"ghost\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"ghost\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "groupClassName",
+					"id": "components-button--group-class-name",
+					"name": "group className, attributes",
 					"snippet": "const groupClassName = () => (\n    <div data-testid=\"root\">\n        <Button.Group className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Button>Trigger</Button>\n        </Button.Group>\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Button, Example, Hotkey, Image, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Button/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Button",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Button/Button.tsx",
-				"actualName": "Button",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"ghost\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"ghost\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loading": {
+						"defaultValue": null,
+						"description": "Show loading state",
+						"name": "loading",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loadingAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the loading indicator",
+						"name": "loadingAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Make the component take the full width of the parent element",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "highlighted",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Button"
 			}
 		},
 		"components-calendar": {
@@ -382,54 +2223,363 @@
 			"path": "./src/components/Calendar/tests/Calendar.stories.tsx",
 			"stories": [
 				{
+					"id": "components-calendar--default-month",
 					"name": "defaultMonth",
 					"snippet": "const defaultMonth = () => (\n    <Example>\n        <Example.Item title=\"defaultMonth: 2020 January\">\n            <Calendar defaultMonth={new Date(2020, 0)} range />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "uncontrolled",
+					"id": "components-calendar--uncontrolled",
+					"name": "defaultValue, range",
 					"snippet": "const uncontrolled = () => <Example>\n    <Example.Item title=\"defaultValue\">\n        <Calendar\n            defaultMonth={new Date(2020, 0)}\n            defaultValue={new Date(2020, 0, 10)}\n            onChange={fn()} />\n    </Example.Item>\n    <Example.Item title=\"defaultValue, range\">\n        <Calendar\n            range\n            defaultMonth={new Date(2020, 0)}\n            defaultValue={{ start: new Date(2020, 0, 10), end: new Date(2020, 0, 15) }}\n            onChange={fn()} />\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "controlled",
+					"id": "components-calendar--controlled",
+					"name": "value, range",
 					"snippet": "const controlled = () => <Example>\n    <Example.Item title=\"value\">\n        <Calendar\n            defaultMonth={new Date(2020, 0)}\n            value={new Date(2020, 0, 10)}\n            onChange={fn()} />\n    </Example.Item>\n    <Example.Item title=\"defaultValue, range\">\n        <Calendar\n            range\n            defaultMonth={new Date(2020, 0)}\n            value={{ start: new Date(2020, 0, 10), end: new Date(2020, 0, 15) }}\n            onChange={fn()} />\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-calendar--selected-dates",
 					"name": "selectedDates",
 					"snippet": "const selectedDates = () => (\n    <Example>\n        <Example.Item title=\"selectedDates: [4,8]\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                value={null}\n                selectedDates={[new Date(2020, 0, 4), new Date(2020, 0, 8)]}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "minMax",
+					"id": "components-calendar--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <Example>\n        <Example.Item title=\"min: 4, max: 20\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                min={new Date(2020, 0, 4)}\n                max={new Date(2020, 0, 20)}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-calendar--first-week-day",
 					"name": "firstWeekDay",
 					"snippet": "const firstWeekDay = () => (\n    <Example>\n        <Example.Item title=\"firstWeekDay: 3 (Wed)\">\n            <Calendar defaultMonth={new Date(2020, 0)} firstWeekDay={3} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "translation",
+					"id": "components-calendar--translation",
+					"name": "render functions",
 					"snippet": "const translation = () => (\n    <Example>\n        <Example.Item title=\"translated to NL\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                renderMonthLabel={({ date }) => date.toLocaleDateString(\"nl\", { month: \"short\" })}\n                renderSelectedMonthLabel={({ date }) =>\n                    date.toLocaleDateString(\"nl\", { month: \"long\", year: \"numeric\" })\n                }\n                renderWeekDay={({ date }) => date.toLocaleDateString(\"nl\", { weekday: \"short\" })}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "ariaLabels",
+					"id": "components-calendar--aria-labels",
+					"name": "aria labels",
 					"snippet": "const ariaLabels = () => (\n    <Example>\n        <Example.Item title=\"aria labels\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                nextYearAriaLabel=\"Test next year\"\n                nextMonthAriaLabel=\"Test next month\"\n                renderDateAriaLabel={() => \"Test date\"}\n                renderMonthAriaLabel={() => \"Test month\"}\n                previousYearAriaLabel=\"Test previous year\"\n                previousMonthAriaLabel=\"Test previous month\"\n                monthSelectionAriaLabel=\"Test month selection\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "monthSelection",
+					"id": "components-calendar--month-selection",
+					"name": "test: month selection",
 					"snippet": "const monthSelection = () => (\n    <Example>\n        <Example.Item title=\"month selection\">\n            <Calendar defaultMonth={new Date(2020, 1)} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "keyboardNavigation",
+					"id": "components-calendar--keyboard-navigation",
+					"name": "test: keyboard navigation",
 					"snippet": "const keyboardNavigation = () => (\n    <Example>\n        <Example.Item title=\"keyboard navigation\">\n            <Calendar defaultMonth={new Date(2020, 0)} />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Calendar, Example } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Calendar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Calendar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Calendar/Calendar.tsx",
-				"actualName": "Calendar",
+				"methods": [],
+				"props": {
+					"range": {
+						"defaultValue": null,
+						"description": "Disable range selection\nEnable range selection",
+						"name": "range",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Current selected date value, enables controlled mode\nCurrent selected range value, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date | RangeValue | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default selected date value, enables uncontrolled mode\nDefault selected range value, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date | RangeValue" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when date selection changes\nCallback when range selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { value: Date; }) => void) | ((args: { value: Date; }) => void) | ((args: { value: RangeValue; }) => void) | ((args: { value: RangeValue; }) => void)"
+						}
+					},
+					"defaultMonth": {
+						"defaultValue": { "value": "Date.now()" },
+						"description": "Default month to display",
+						"name": "defaultMonth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum date that can be selected",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum date that can be selected",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"firstWeekDay": {
+						"defaultValue": { "value": "1, Monday" },
+						"description": "First day of the week",
+						"name": "firstWeekDay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"selectedDates": {
+						"defaultValue": null,
+						"description": "Dates that are selected",
+						"name": "selectedDates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date[]" }
+					},
+					"renderWeekDay": {
+						"defaultValue": null,
+						"description": "Render a custom weekday label, can be used for localization",
+						"name": "renderWeekDay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { weekDay: number; date: Date; }) => string)" }
+					},
+					"renderSelectedMonthLabel": {
+						"defaultValue": null,
+						"description": "Render a custom month label, can be used for localization",
+						"name": "renderSelectedMonthLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { date: Date; }) => string)" }
+					},
+					"renderMonthLabel": {
+						"defaultValue": null,
+						"description": "Render a custom month label, can be used for localization",
+						"name": "renderMonthLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { month: number; date: Date; }) => string)" }
+					},
+					"previousMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the previous month button",
+						"name": "previousMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"nextMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "",
+						"name": "nextMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"previousYearAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the previous year button",
+						"name": "previousYearAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"nextYearAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the next year button",
+						"name": "nextYearAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"monthSelectionAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the month selection button",
+						"name": "monthSelectionAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"renderDateAriaLabel": {
+						"defaultValue": null,
+						"description": "Dynamic aria label applied to each date cell based on the arguments",
+						"name": "renderDateAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { date: Date; }) => string)" }
+					},
+					"renderMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "Dynamic aria label applied to each month element based on the arguments",
+						"name": "renderMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { month: number; }) => string)" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -439,50 +2589,356 @@
 			"path": "./src/components/Card/tests/Card.stories.tsx",
 			"stories": [
 				{
+					"id": "components-card--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: default\">\n            <Card>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title=\"padding: 2\">\n            <Card padding={2}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title=\"padding: 0\">\n            <Card padding={0}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive padding\", \"[s] 4\", \"[m+] 8\"]}>\n            <Card padding={{ s: 4, m: 8 }}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--selected",
 					"name": "selected",
 					"snippet": "const selected = () => (\n    <Example>\n        <Example.Item title=\"selected\">\n            <Card selected>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated\">\n            <Card elevated>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4\">\n            <Card bleed={4}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n        <Example.Item title={[\"responsive bleed\", \"[s] 4\", \"[m+] 0\"]}>\n            <Card bleed={{ s: 4, m: 0 }}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--height",
 					"name": "height",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"height: 200px\">\n            <Card height=\"200px\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Card onClick={fn()}>Trigger</Card>;"
 				},
 				{
+					"id": "components-card--href",
 					"name": "href",
 					"snippet": "const href = () => <Card href=\"https://reshaped.so\">Trigger</Card>;"
 				},
 				{
+					"id": "components-card--as",
 					"name": "as",
 					"snippet": "const as = () => <Card as=\"span\" attributes={{ \"data-testid\": \"root\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-card--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Card className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Card, Example, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Card/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Card",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Card/Card.tsx",
-				"actualName": "Card",
+				"methods": [],
+				"props": {
+					"padding": {
+						"defaultValue": null,
+						"description": "Component padding, base unit multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Remove side borders and apply negative margins, base unit multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"selected": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "selected",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when the component is clicked, turns component into a button",
+						"name": "onClick",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL to navigate to when the component is clicked, turns component into a link",
+						"name": "href",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"as": {
+						"defaultValue": { "value": "\"div\"" },
+						"description": "Custom component tag name",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(Attributes<keyof IntrinsicElements> & (Attributes))" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -492,56 +2948,181 @@
 			"path": "./src/components/Carousel/tests/Carousel.stories.tsx",
 			"stories": [
 				{
+					"id": "components-carousel--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Carousel attributes={{ \"data-testid\": \"test-id\" }} visibleItems={3}>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n    </Carousel>\n);"
 				},
 				{
+					"id": "components-carousel--visible-items",
 					"name": "visibleItems",
 					"snippet": "const visibleItems = () => (\n    <Example>\n        <Example.Item title=\"visibleItems: 3\">\n            <Carousel visibleItems={3}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive visibleItems\", \"s: 2, m+ 3\"]}>\n            <Carousel visibleItems={{ s: 2, m: 3 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title=\"visibleItems: auto\">\n            <Carousel>\n                <Placeholder h={100} />\n                <Placeholder h={100} w={200} />\n                <Placeholder h={100} w={300} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 2, visibleItems 3\">\n            <Carousel visibleItems={3} gap={2}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"gap: responsive, visibleItems: 3\", \"s: 2, l: 8\"]}>\n            <Carousel visibleItems={3} gap={{ s: 2, l: 8 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4, visibleItems: 3\">\n            <Carousel visibleItems={3} bleed={4}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive bleed, visibleItems: 3\", \"[s] 4, [l+] 0\"]}>\n            <Carousel visibleItems={3} bleed={{ s: 4, l: 0 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--navigation-display",
 					"name": "navigationDisplay",
 					"snippet": "const navigationDisplay = () => (\n    <Example>\n        <Example.Item title=\"navigationDisplay: hidden\">\n            <Carousel\n                visibleItems={3}\n                navigationDisplay=\"hidden\"\n                attributes={{ \"data-testid\": \"test-id\" }}\n            >\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "instanceRef",
+					"id": "components-carousel--instance-ref",
+					"name": "instanceRef, onChange",
 					"snippet": "const instanceRef = (args) => {\n    const carouselRef = React.useRef<CarouselInstanceRef>(null);\n    const [index, setIndex] = React.useState(0);\n\n    return (\n        <Example>\n            <Example.Item title=\"instanceRef, onChange\">\n                <View gap={3}>\n                    <View gap={3} direction=\"row\" align=\"center\">\n                        <Button onClick={() => carouselRef.current?.navigateBack()}>Back</Button>\n                        <Button onClick={() => carouselRef.current?.navigateForward()}>Forward</Button>\n                        <Button onClick={() => carouselRef.current?.navigateTo(3)}>To 3</Button>\n                        <View.Item>Index: {index}</View.Item>\n                    </View>\n                    <Carousel\n                        visibleItems={2}\n                        instanceRef={carouselRef}\n                        navigationDisplay=\"hidden\"\n                        onChange={(changeArgs) => {\n                            args.handleChange(changeArgs);\n                            setIndex(changeArgs.index);\n                        }}\n                    >\n                        <Placeholder h={100}>Item 0</Placeholder>\n                        <Placeholder h={100}>Item 1</Placeholder>\n                        <Placeholder h={100}>Item 2</Placeholder>\n                        <Placeholder h={100}>Item 3</Placeholder>\n                        <Placeholder h={100}>Item 4</Placeholder>\n                        <Placeholder h={100}>Item 5</Placeholder>\n                    </Carousel>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-carousel--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Carousel visibleItems={2} className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder h={100}>Item 0</Placeholder>\n            <Placeholder h={100}>Item 1</Placeholder>\n            <Placeholder h={100}>Item 2</Placeholder>\n            <Placeholder h={100}>Item 3</Placeholder>\n            <Placeholder h={100}>Item 4</Placeholder>\n            <Placeholder h={100}>Item 5</Placeholder>\n        </Carousel>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Carousel, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Carousel/index.ts",
 				"description": "",
-				"methods": [
-					{
-						"name": "navigateTo",
-						"docblock": null,
-						"modifiers": [],
-						"params": [
+				"displayName": "Carousel",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, each child is rendered as a carousel item",
+						"name": "children",
+						"declarations": [
 							{
-								"name": "index",
-								"optional": false,
-								"type": { "name": "number" }
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
 							}
 						],
-						"returns": null
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"visibleItems": {
+						"defaultValue": null,
+						"description": "Number of items visible at once in the container",
+						"name": "visibleItems",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between items in the container, base unit multiplier",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margins, base unit multiplier, can be used to make sure the items don't get clipped when scrolling",
+						"name": "bleed",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"navigationDisplay": {
+						"defaultValue": null,
+						"description": "Hide navigation controls",
+						"name": "navigationDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"hidden\"", "value": [{ "value": "\"hidden\"" }] }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the carousel methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the first visible carousel index changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { index: number; }) => void)" }
+					},
+					"onScroll": {
+						"defaultValue": null,
+						"description": "Callback when the carousel scrolls",
+						"name": "onScroll",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: UIEvent<HTMLUListElement, UIEvent>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
 					}
-				],
-				"displayName": "Carousel",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Carousel/Carousel.tsx",
-				"actualName": "Carousel",
+				},
 				"exportName": "default"
 			}
 		},
@@ -551,46 +3132,259 @@
 			"path": "./src/components/Checkbox/tests/Checkbox.stories.tsx",
 			"stories": [
 				{
-					"name": "render",
+					"id": "components-checkbox--render",
+					"name": "name, value",
 					"snippet": "const render = () => (\n    <Checkbox name=\"test-name\" value=\"test-value\">\n        Content\n    </Checkbox>\n);"
 				},
 				{
+					"id": "components-checkbox--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"small\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"small\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"medium\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"medium\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"large\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"large\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: responsive, s: small, m: large\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size={{ s: \"small\", m: \"large\" }} defaultChecked>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-checkbox--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Checkbox name=\"animal\" value=\"dog\" hasError>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-checkbox--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n        <Example.Item title=\"disabled, checked\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled checked>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n        <Example.Item title=\"disabled, indeterminate\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled indeterminate>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "checked",
+					"id": "components-checkbox--checked",
+					"name": "checked, controlled",
 					"snippet": "const checked = () => <Checkbox name=\"test-name\" value=\"test-value\" checked onChange={fn()}>Content\n            </Checkbox>;"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-checkbox--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Checkbox name=\"test-name\" value=\"test-value\" defaultChecked onChange={fn()}>Content\n            </Checkbox>;"
 				},
 				{
+					"id": "components-checkbox--indeterminate",
 					"name": "indeterminate",
 					"snippet": "const indeterminate = () => (\n    <Checkbox name=\"test-name\" value=\"test-value\" indeterminate>\n        Content\n    </Checkbox>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-checkbox--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Checkbox className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Checkbox>\n    </div>\n);"
 				}
 			],
 			"import": "import { Checkbox, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Checkbox/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Checkbox",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Checkbox/Checkbox.tsx",
-				"actualName": "Checkbox",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the label",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Component name attribute",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the component",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Component value used for form submission",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"indeterminate": {
+						"defaultValue": null,
+						"description": "Show a indeterminate state, used for \"select all\" checkboxes with some of the individual checkboxes selected",
+						"name": "indeterminate",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the component is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the component is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Component checked state, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default checked state, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -600,26 +3394,143 @@
 			"path": "./src/components/CheckboxGroup/tests/CheckboxGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "value",
+					"id": "components-checkboxgroup--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <View gap={2}>\n    <CheckboxGroup name=\"test-name\" value={[\"1\"]} onChange={fn()}>\n        {/* checked should be ignored */}\n        <Checkbox value=\"1\" checked={false}>Content\n                            </Checkbox>\n        <Checkbox value=\"2\">Content 2</Checkbox>\n    </CheckboxGroup>\n</View>;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-checkboxgroup--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <View gap={2}>\n    <CheckboxGroup name=\"test-name\" defaultValue={[\"1\"]} onChange={fn()}>\n        {/* checked should be ignored */}\n        <Checkbox value=\"1\" checked={false}>Content\n                            </Checkbox>\n        <Checkbox value=\"2\">Content 2</Checkbox>\n    </CheckboxGroup>\n</View>;"
 				},
 				{
+					"id": "components-checkboxgroup--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <CheckboxGroup name=\"test-name\" disabled>\n        <Checkbox value=\"test-value\">Item 1</Checkbox>\n        <Checkbox value=\"test-value-2\">Item 2</Checkbox>\n    </CheckboxGroup>\n);"
 				}
 			],
 			"import": "import { Checkbox, CheckboxGroup, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/CheckboxGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "CheckboxGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/CheckboxGroup/CheckboxGroup.tsx",
-				"actualName": "CheckboxGroup",
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Component id attribute",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting checkboxes or custom layout components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the component from form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Component name attribute",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string[], ChangeEvent<HTMLInputElement>>" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Component value, enables controlled mode\nComponent value, enables uncontrolled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -629,23 +3540,346 @@
 			"path": "./src/components/ContextMenu/tests/ContextMenu.stories.tsx",
 			"stories": [
 				{
+					"id": "components-contextmenu--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"base\">\n            <div style={{ height: 200, overflow: \"auto\" }}>\n                <ContextMenu>\n                    <View height=\"400px\" backgroundColor=\"neutral-faded\" borderRadius=\"medium\" />\n\n                    <ContextMenu.Content>\n                        <ContextMenu.Item>Item 1</ContextMenu.Item>\n                        <ContextMenu.Item>Item 2</ContextMenu.Item>\n                    </ContextMenu.Content>\n                </ContextMenu>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "components-contextmenu--handlers",
+					"name": "handleOpen, handleClose",
 					"snippet": "const handlers = () => <div style={{ height: 200, overflow: \"auto\" }} data-testid=\"scroll\">\n    <ContextMenu onOpen={fn()} onClose={fn()}>\n        <View\n            height=\"400px\"\n            backgroundColor=\"neutral-faded\"\n            borderRadius=\"medium\"\n            attributes={{ \"data-testid\": \"root\" }} />\n        <ContextMenu.Content>\n            <ContextMenu.Item>Item</ContextMenu.Item>\n        </ContextMenu.Content>\n    </ContextMenu>\n</div>;"
 				}
 			],
 			"import": "import { ContextMenu, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ContextMenu/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ContextMenu",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ContextMenu/ContextMenu.tsx",
-				"actualName": "ContextMenu",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/DropdownMenu/DropdownMenu.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | \"action-menu\" | \"selection-menu\"" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					}
+				},
+				"exportName": "ContextMenu"
 			}
 		},
 		"components-divider": {
@@ -654,30 +3888,118 @@
 			"path": "./src/components/Divider/tests/Divider.stories.tsx",
 			"stories": [
 				{
-					"name": "rendering",
+					"id": "components-divider--rendering",
+					"name": "base",
 					"snippet": "const rendering = () => (\n    <Example>\n        <Example.Item title=\"default rendering\">\n            <Divider />\n        </Example.Item>\n\n        <Example.Item title={[\"blank rendering\", \"box should overlap with divider\"]}>\n            <View width=\"40px\" height=\"10px\" backgroundColor=\"primary\" />\n            <Divider blank />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-divider--vertical",
 					"name": "vertical",
 					"snippet": "const vertical = () => (\n    <Example>\n        <Example.Item title=\"vertical\">\n            <View gap={3} direction=\"row\" align=\"stretch\">\n                <Placeholder />\n                <View.Item>\n                    <Divider vertical />\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive vertical\", \"[s] true\", \"[m+]: false\"]}>\n            <View gap={3} direction={{ s: \"row\", m: \"column\" }} align=\"stretch\">\n                <Placeholder />\n                <View.Item>\n                    <Divider vertical={{ s: true, m: false }} />\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "label",
+					"id": "components-divider--label",
+					"name": "children, contentPosition",
 					"snippet": "const label = () => {\n    return (\n        <Example>\n            <Example.Item title=\"alignment\">\n                <View gap={4}>\n                    <Divider>Centered label</Divider>\n                    <Divider contentPosition=\"start\">Start label</Divider>\n                    <Divider contentPosition=\"end\">End label</Divider>\n                </View>\n            </Example.Item>\n\n            <Example.Item title=\"responsive\">\n                <View gap={3} direction={{ s: \"column\", m: \"row\" }} align=\"stretch\">\n                    <Placeholder />\n                    <View.Item>\n                        <Divider vertical={{ s: false, m: true }}>or pick second option</Divider>\n                    </View.Item>\n                    <Placeholder />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-divider--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Divider className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Divider, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Divider/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Divider",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Divider/Divider.tsx",
-				"actualName": "Divider",
+				"methods": [],
+				"props": {
+					"blank": {
+						"defaultValue": null,
+						"description": "Change component to take no space, useful for using it as a border in components like Tabs",
+						"name": "blank",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"vertical": {
+						"defaultValue": null,
+						"description": "Change component to render vertically",
+						"name": "vertical",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"contentPosition": {
+						"defaultValue": null,
+						"description": "Position for rendering children",
+						"name": "contentPosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"center\" | \"start\" | \"end\"",
+							"value": [{ "value": "\"center\"" }, { "value": "\"start\"" }, { "value": "\"end\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting text labels or custom components as a part of divider",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"hr\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -687,51 +4009,415 @@
 			"path": "./src/components/DropdownMenu/tests/DropdownMenu.stories.tsx",
 			"stories": [
 				{
+					"id": "components-dropdownmenu--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: default\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <DropdownMenu position=\"end\">\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n\n        <Example.Item title={[\"position: top-start\", \"should change to top-start to fit viewport\"]}>\n            <DropdownMenu position=\"top-end\">\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n        <div style={{ height: 2000 }} />\n    </Example>\n);"
 				},
 				{
+					"id": "components-dropdownmenu--sections",
 					"name": "sections",
 					"snippet": "const sections = () => (\n    <Example>\n        <Example.Item title=\"2 sections\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Section>\n                        <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                    </DropdownMenu.Section>\n\n                    <DropdownMenu.Section>\n                        <DropdownMenu.Item>Item 3</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 4</DropdownMenu.Item>\n                    </DropdownMenu.Section>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-dropdownmenu--submenu",
 					"name": "submenu",
 					"snippet": "const submenu = () => (\n    <Example>\n        <Example.Item title=\"submenu\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item onClick={() => {}}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger>Item 2</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger>Item 3</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2-1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2-2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger disabled>Item 4, disabled</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 3-1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 3-2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-dropdownmenu--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <DropdownMenu onOpen={fn()} onClose={fn()} defaultActive>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "active",
+					"id": "components-dropdownmenu--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <DropdownMenu onOpen={fn()} onClose={fn()} active>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "components-dropdownmenu--active-false",
+					"name": "active false, controlled",
 					"snippet": "const activeFalse = () => <DropdownMenu onOpen={fn()} onClose={fn()} active={false}>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "className",
+					"id": "components-dropdownmenu--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <DropdownMenu active>\n            <DropdownMenu.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </DropdownMenu.Trigger>\n            <DropdownMenu.Content className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n                <DropdownMenu.Item>Item</DropdownMenu.Item>\n            </DropdownMenu.Content>\n        </DropdownMenu>\n    </div>\n);"
 				},
 				{
-					"name": "testScroll",
+					"id": "components-dropdownmenu--test-scroll",
+					"name": "test: scroll",
 					"snippet": "const testScroll = () => (\n    <Example>\n        <Example.Item title=\"Scrolls on page mount to the dropdown\">\n            <div style={{ height: 1000 }} />\n            <DropdownMenu position=\"end\" key=\"scroll\" defaultActive>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testTheme",
+					"id": "components-dropdownmenu--test-theme",
+					"name": "test: theme",
 					"snippet": "const testTheme = () => (\n    <Example>\n        <Example.Item title=\"switch color mode while dropdown is active and check that it still works\">\n            <ThemeSwitching />\n        </Example.Item>\n        <Example.Item title=\"dropdown inherits multiple themes\">\n            <ThemeMultiple />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, DropdownMenu, Example, Theme, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/DropdownMenu/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "DropdownMenu",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/DropdownMenu/DropdownMenu.tsx",
-				"actualName": "DropdownMenu",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/DropdownMenu/DropdownMenu.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | \"action-menu\" | \"selection-menu\"" }
+					}
+				},
+				"exportName": "DropdownMenu"
 			}
 		},
 		"components-fileupload": {
@@ -740,35 +4426,165 @@
 			"path": "./src/components/FileUpload/tests/FileUpload.stories.tsx",
 			"stories": [
 				{
+					"id": "components-fileupload--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"Base upload with previews\">\n            <Demo />\n        </Example.Item>\n        <Example.Item title=\"With trigger\">\n            <FileUpload name=\"file\">\n                <div>\n                    Drop files to attach, or{\" \"}\n                    <FileUpload.Trigger>\n                        <Link variant=\"plain\">browse</Link>\n                    </FileUpload.Trigger>\n                </div>\n            </FileUpload>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "inline",
+					"id": "components-fileupload--inline",
+					"name": "inline, variant, render props",
 					"snippet": "const inline = () => {\n    return (\n        <Example>\n            <Example.Item title=\"inline\">\n                <FileUpload name=\"file\" inline onChange={console.log}>\n                    <View padding={2} paddingInline={3}>\n                        Upload\n                    </View>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"variant headless\">\n                <FileUpload name=\"file2\" variant=\"headless\" onChange={console.log}>\n                    <Button variant=\"outline\" fullWidth>\n                        Upload\n                    </Button>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"variant headless, inline\">\n                <FileUpload name=\"file2\" variant=\"headless\" inline onChange={console.log}>\n                    <Button>Upload</Button>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"inline, render props\">\n                <FileUpload name=\"file3\" variant=\"headless\" inline onChange={console.log}>\n                    {(props) => <Button highlighted={props.highlighted}>Upload</Button>}\n                </FileUpload>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-fileupload--height",
 					"name": "height",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"Custom height\">\n            <FileUpload name=\"file\" height=\"300px\">\n                <View gap={3}>\n                    <Icon svg={IconMic} size={8} />\n                    Drop files to attach\n                </View>\n            </FileUpload>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onChange",
+					"id": "components-fileupload--on-change",
+					"name": "name, onChange",
 					"snippet": "const onChange = () => <div data-testid=\"root\">\n    <FileUpload name=\"test-name\" onChange={fn()}>Content\n                    </FileUpload>\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "components-fileupload--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <FileUpload\n            name=\"name\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ id: \"test-input-id\" }}\n        >\n            Content\n        </FileUpload>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, FileUpload, Icon, Image, Link, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/FileUpload/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "FileUpload",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/FileUpload/FileUpload.tsx",
-				"actualName": "FileUpload",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, can be a render function that receives component state",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode | ((props: { highlighted?: boolean; }) => ReactNode)" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component value is changed",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ChangeHandler<File[], ChangeEvent<HTMLInputElement> | DragEvent<HTMLDivElement>>"
+						}
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Component height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component variant, headless variant is useful for rendering custom triggers like a Button",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"headless\"",
+							"value": [{ "value": "\"outline\"" }, { "value": "\"headless\"" }]
+						}
+					},
+					"inline": {
+						"defaultValue": null,
+						"description": "Change component to render inline making it more compact",
+						"name": "inline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					}
+				},
+				"exportName": "FileUpload"
 			}
 		},
 		"components-hotkey": {
@@ -777,22 +4593,78 @@
 			"path": "./src/components/Hotkey/tests/Hotkey.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "components-hotkey--base",
+					"name": "Base",
 					"snippet": "const base = () => (\n\t<Example>\n\t\t<Example.Item title=\"Base\">\n\t\t\t<Demo />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"Active\">\n\t\t\t<Hotkey active>⌘K</Hotkey>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"Inside input slot\">\n\t\t\t<View width=\"300px\">\n\t\t\t\t<TextField\n\t\t\t\t\tname=\"hey\"\n\t\t\t\t\tendSlot={<Demo />}\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"hotkey test\" }}\n\t\t\t\t/>\n\t\t\t</View>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-hotkey--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Hotkey className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            ⌘K\n        </Hotkey>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Hotkey, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Hotkey/Hotkey.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Hotkey",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Hotkey/Hotkey.tsx",
-				"actualName": "Hotkey",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Highlight the component, can be used to show when hotkey is pressed",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -802,54 +4674,241 @@
 			"path": "./src/components/Link/tests/Link.stories.tsx",
 			"stories": [
 				{
+					"id": "components-link--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: underline\">\n            <Link href=\"http://reshaped.so\" attributes={{ target: \"_blank\" }}>\n                Reshaped\n            </Link>\n        </Example.Item>\n        <Example.Item title=\"variant: plain\">\n            <Link onClick={() => {}} variant=\"plain\">\n                Link\n            </Link>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary\">\n            <Link color=\"primary\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Link color=\"critical\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Link color=\"positive\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <Link color=\"warning\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <Link color=\"inherit\">Link</Link>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon, variant: underline\">\n            <Link icon={IconZap}>Link</Link>\n        </Example.Item>\n        <Example.Item title=\"icon, variant: plain\">\n            <Link icon={IconZap} variant=\"plain\">\n                Link\n            </Link>\n        </Example.Item>\n        <Example.Item\n            title={[\"icon, variant: underline\", \"should inherit display-1 size from the parent\"]}\n        >\n            <Text variant=\"title-3\">\n                <Link icon={IconZap} variant=\"underline\">\n                    Instant delivery\n                </Link>\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--href",
 					"name": "href",
 					"snippet": "const href = () => <Link href=\"https://reshaped.so\">Trigger</Link>;"
 				},
 				{
+					"id": "components-link--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Link onClick={fn()}>Trigger</Link>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-link--href-on-click",
+					"name": "href + onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <Link\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </Link>\n);"
 				},
 				{
+					"id": "components-link--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Link disabled onClick={() => {}}>\n        Trigger\n    </Link>\n);"
 				},
 				{
+					"id": "components-link--render",
 					"name": "render",
 					"snippet": "const render = () => <Link render={(props) => <section {...props} />}>Trigger</Link>;"
 				},
 				{
-					"name": "className",
+					"id": "components-link--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Link className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Link>\n    </div>\n);"
 				},
 				{
-					"name": "testMultilineInText",
+					"id": "components-link--test-multiline-in-text",
+					"name": "test: multiline",
 					"snippet": "const testMultilineInText = () => (\n    <Example>\n        <Example.Item title=\"should wrap inside the text\">\n            <div>\n                Someone asked me to write this text that is boring to ready for everyone and to add&nbsp;\n                <Link href=\"/\">this very very long link</Link> to it.\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Link, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Link/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Link",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Link/Link.tsx",
-				"actualName": "Link",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon at the start position",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"primary\"" },
+						"description": "Link color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"inherit\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"inherit\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"underline\"" },
+						"description": "Link render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"plain\" | \"underline\"",
+							"value": [{ "value": "\"plain\"" }, { "value": "\"underline\"" }]
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -859,30 +4918,110 @@
 			"path": "./src/components/Loader/tests/Loader.stories.tsx",
 			"stories": [
 				{
+					"id": "components-loader--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: medium\">\n                <Loader size=\"medium\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title=\"size: small\">\n                <Loader size=\"small\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title=\"size: large\">\n                <Loader size=\"large\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title={[\"responsive size\", \"[s] small\", \"[m+] medium\"]}>\n                <Loader size={{ s: \"small\", m: \"medium\" }} ariaLabel=\"Loading\" />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-loader--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary\">\n            <Loader ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Loader color=\"critical\" ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Loader color=\"positive\" ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <Loader color=\"inherit\" ariaLabel=\"Loading\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-loader--aria-label",
 					"name": "ariaLabel",
 					"snippet": "const ariaLabel = () => <Loader ariaLabel=\"Loading\" attributes={{ \"data-testid\": \"root\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-loader--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Loader className=\"test-classname\" attributes={{ id: \"test-id\" }} ariaLabel=\"Loading\" />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Loader } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Loader/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Loader",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Loader/Loader.tsx",
-				"actualName": "Loader",
+				"methods": [],
+				"props": {
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"inherit\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -892,67 +5031,504 @@
 			"path": "./src/components/MenuItem/tests/MenuItem.stories.tsx",
 			"stories": [
 				{
+					"id": "components-menuitem--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <MenuItem size=\"small\" icon={IconZap} onClick={() => {}} endSlot={<Hotkey>⌘K</Hotkey>}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <MenuItem icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <MenuItem size=\"large\" icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title={[\"responsive size\", \"[s] small\", \"[m] medium\", \"[l+] large\"]}>\n            <MenuItem size={{ s: \"small\", m: \"medium\", l: \"large\" }} icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <MenuItem color=\"neutral\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <MenuItem color=\"primary\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <MenuItem color=\"critical\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--selected",
 					"name": "selected",
 					"snippet": "const selected = () => (\n    <Example>\n        <Example.Item title=\"selected, color: neutral\">\n            <MenuItem color=\"neutral\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"selected, color: primary\">\n            <MenuItem color=\"primary\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"selected, color: critical\">\n            <MenuItem color=\"critical\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--rounded-corners",
 					"name": "roundedCorners",
 					"snippet": "const roundedCorners = () => (\n    <Example>\n        <Example.Item title=\"roundedCorners\">\n            <MenuItem roundedCorners selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive roundedCorners\", \"[s]: false\", \"[m+]: true\"]}>\n            <MenuItem roundedCorners={{ s: false, m: true }} selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "slots",
+					"id": "components-menuitem--slots",
+					"name": "startSlot, endSlot",
 					"snippet": "const slots = () => (\n    <Example>\n        <Example.Item title=\"startSlot, endSlot, selected\">\n            <MenuItem startSlot={<Placeholder h={20} />} endSlot={<Placeholder h={20} />} selected>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem size=\"small\" selected onClick={() => {}}>\n                        Menu item\n                    </MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem selected>Menu item</MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem size=\"large\" selected>\n                        Menu item\n                    </MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--href",
 					"name": "href",
 					"snippet": "const href = () => <MenuItem href=\"https://reshaped.so\">Trigger</MenuItem>;"
 				},
 				{
+					"id": "components-menuitem--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <MenuItem onClick={fn()}>Trigger</MenuItem>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-menuitem--href-on-click",
+					"name": "href + onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <MenuItem\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </MenuItem>\n);"
 				},
 				{
+					"id": "components-menuitem--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <MenuItem disabled onClick={() => {}}>\n        Trigger\n    </MenuItem>\n);"
 				},
 				{
-					"name": "as",
+					"id": "components-menuitem--as",
+					"name": "as, render",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"render, disabled\">\n            <MenuItem\n                disabled\n                onClick={() => {}}\n                render={(props) => <section {...props} />}\n                attributes={{ \"data-testid\": \"render-el\" }}\n            >\n                Trigger\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-menuitem--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <MenuItem className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </MenuItem>\n    </div>\n);"
 				},
 				{
-					"name": "alignerClassName",
+					"id": "components-menuitem--aligner-class-name",
+					"name": "aligner, className, attributes",
 					"snippet": "const alignerClassName = () => (\n    <div data-testid=\"root\">\n        <MenuItem.Aligner className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <MenuItem>Trigger</MenuItem>\n        </MenuItem.Aligner>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Hotkey, MenuItem, Placeholder, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/MenuItem/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "MenuItem",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/MenuItem/MenuItem.tsx",
-				"actualName": "MenuItem",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content\nNode for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"neutral\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"neutral\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content at the start side of the component",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content at the end side of the component",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component as hovered or focused. For example, when displaying currently focused item in Autocomplete",
+						"name": "highlighted",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"selected": {
+						"defaultValue": null,
+						"description": "Highlight the component as selected",
+						"name": "selected",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"roundedCorners": {
+						"defaultValue": null,
+						"description": "Round the corners of the component",
+						"name": "roundedCorners",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					}
+				},
+				"exportName": "MenuItem"
 			}
 		},
 		"components-modal": {
@@ -961,67 +5537,301 @@
 			"path": "./src/components/Modal/tests/Modal.stories.tsx",
 			"stories": [
 				{
+					"id": "components-modal--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title={[\"responsive position\", \"[s] full-screen\", \"[m] center\", \"[l] end\"]}>\n            <Demo position={{ s: \"full-screen\", m: \"center\", l: \"end\" }} />\n        </Example.Item>\n        <Example.Item title=\"position: center\">\n            <Demo position=\"center\" />\n        </Example.Item>\n        <Example.Item title=\"position: bottom\">\n            <Demo position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"position: start\">\n            <Demo position=\"start\" />\n        </Example.Item>\n        <Example.Item title=\"position: end\">\n            <Demo position=\"end\" />\n        </Example.Item>\n        <Example.Item title=\"position: full-screen\">\n            <Demo position=\"full-screen\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: default\">\n                <Demo />\n            </Example.Item>\n            <Example.Item title=\"size: 300px\">\n                <Demo size=\"300px\" />\n            </Example.Item>\n            <Example.Item\n                title={[\"size: 800px\", \"should have max width of 100% minus gaps on the sides\"]}\n            >\n                <Demo size=\"800px\" />\n            </Example.Item>\n            <Example.Item\n                title={[\n                    \"responsive size, responsive position\",\n                    \"[s] auto\",\n                    \"[m+] 600px\",\n                    \"bottom position changes height instead of width\",\n                ]}\n            >\n                <Demo\n                    position={{ s: \"bottom\", m: \"center\", l: \"end\" }}\n                    size={{ s: \"auto\", m: \"600px\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-modal--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 0\">\n            <Demo padding={0} />\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <Demo padding={6} />\n        </Example.Item>\n        <Example.Item title={[\"responsive padding\", \"[s] 2\", \"[m+]: 6\"]}>\n            <Demo padding={{ s: 2, m: 6 }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--overflow",
 					"name": "overflow",
 					"snippet": "const overflow = () => (\n    <Example>\n        <Example.Item title=\"default overflow\">\n            <Demo>\n                <div\n                    style={{\n                        position: \"absolute\",\n                        top: -32,\n                        left: -32,\n                        height: 100,\n                        width: 100,\n                        background: \"tomato\",\n                    }}\n                />\n            </Demo>\n        </Example.Item>\n\n        <Example.Item title=\"overflow: visible\">\n            <Demo overflow=\"visible\">\n                <div\n                    style={{\n                        position: \"absolute\",\n                        top: -32,\n                        left: -32,\n                        height: 100,\n                        width: 100,\n                        background: \"tomato\",\n                    }}\n                />\n            </Demo>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--composition",
 					"name": "composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"title, subtitle, dismissible\">\n            <Demo title=\"Modal title\" subtitle=\"Modal subtitle\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--overlay",
 					"name": "overlay",
 					"snippet": "const overlay = () => (\n    <Example>\n        <Example.Item title=\"transparentOverlay, doesn't lock scroll\">\n            <Demo transparentOverlay />\n        </Example.Item>\n        <Example.Item title=\"blurredOverlay\">\n            <Demo blurredOverlay />\n        </Example.Item>\n        <View height=\"1000px\" />\n    </Example>\n);"
 				},
 				{
-					"name": "flags",
+					"id": "components-modal--flags",
+					"name": "disableCloseOnOutsideClick",
 					"snippet": "const flags = () => {\n    return (\n        <Example>\n            <Example.Item title=\"disableCloseOnOutsideClick\">\n                <Demo disableCloseOnOutsideClick onClose={fn()} active />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-modal--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const containerRef2 = React.useRef<HTMLDivElement>(null);\n    const toggle = useToggle();\n    const toggle2 = useToggle();\n\n    return (\n        <Example>\n            <Example.Item title={[\"in scrollable container\", \"scroll and then open\"]}>\n                <View\n                    attributes={{ ref: containerRef2 }}\n                    borderRadius=\"medium\"\n                    height=\"400px\"\n                    overflow=\"auto\"\n                    backgroundColor=\"neutral-faded\"\n                    padding={4}\n                >\n                    <View gap={4} align=\"start\">\n                        <Button onClick={toggle2.activate}>Open modal</Button>\n                        <View height=\"500px\" backgroundColor=\"primary\" width=\"500px\" borderRadius=\"medium\" />\n                    </View>\n                    <Modal\n                        containerRef={containerRef2}\n                        active={toggle2.active}\n                        onClose={toggle2.deactivate}\n                        position=\"end\"\n                    >\n                        <Placeholder />\n                    </Modal>\n                </View>\n            </Example.Item>\n            <Example.Item title=\"in static container\">\n                <View\n                    attributes={{ ref: containerRef }}\n                    borderRadius=\"medium\"\n                    height=\"400px\"\n                    overflow=\"hidden\"\n                    backgroundColor=\"neutral-faded\"\n                    padding={4}\n                >\n                    <Button onClick={toggle.activate}>Open modal</Button>\n                    <Modal\n                        containerRef={containerRef}\n                        active={toggle.active}\n                        onClose={toggle.deactivate}\n                        position=\"end\"\n                    >\n                        <Placeholder />\n                    </Modal>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "renderProps",
+					"id": "components-modal--render-props",
+					"name": "children, render props",
 					"snippet": "const renderProps = () => (\n    <Modal active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        <Modal.Title>Title</Modal.Title>\n        Content\n    </Modal>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "components-modal--handlers",
+					"name": "onOpen, onClose, onAfterOpen, onAfterClose",
 					"snippet": "const handlers = () => {\n    const overlayToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => overlayToggle.toggle()}>Open overlay</Button>\n            <Modal\n                active={overlayToggle.active}\n                onClose={(closeArgs) => {\n                    overlayToggle.deactivate();\n                    args.handleClose(closeArgs);\n                }}\n                onOpen={fn()}\n                onAfterOpen={fn()}\n                onAfterClose={fn()}>\n                <Modal.Title>Title</Modal.Title>Content\n                                </Modal>\n        </>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-modal--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <Modal active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        <Modal.Title>Title</Modal.Title>\n        Content\n    </Modal>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-modal--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => {\n    const menuModalToggle = useToggle();\n    const menuModalToggleInner = useToggle();\n    const scrollModalToggle = useToggle();\n    const inputRef = React.useRef<HTMLInputElement>(null);\n\n    return (\n        <Example>\n            <Example.Item title=\"Scrolls with long content on touch devices\">\n                <Demo position=\"center\">\n                    <Button onClick={() => {}}>Action</Button>\n                    <View height=\"2000px\" backgroundColor=\"primary-faded\" />\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"keyboard focus stays on the modal first\">\n                <Demo title=\"Modal title\" autoFocus={false} />\n            </Example.Item>\n            <Example.Item title=\"trap focus works with custom children components\">\n                <Demo title=\"Modal title\">\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <Switch name=\"switch\" />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"focus moves to the input\">\n                <Demo\n                    title=\"Modal title\"\n                    onOpen={() => {\n                        inputRef.current?.focus();\n                    }}\n                >\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <TextField name=\"name\" inputAttributes={{ ref: inputRef }} />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"Focus moves to the input with autoFocus\">\n                <Demo title=\"Modal title\">\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <TextField\n                            name=\"name\"\n                            placeholder=\"autofocus\"\n                            inputAttributes={{ autoFocus: true }}\n                        />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"scrollable area in modal ignores swipe-to-close\">\n                <View gap={3} direction=\"row\">\n                    <Button onClick={scrollModalToggle.activate}>Open</Button>\n                    <Modal\n                        active={scrollModalToggle.active}\n                        onClose={scrollModalToggle.deactivate}\n                        size=\"300px\"\n                        position=\"bottom\"\n                    >\n                        <View\n                            height=\"1000px\"\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            padding={4}\n                        >\n                            Content\n                        </View>\n                    </Modal>\n                </View>\n            </Example.Item>\n            <Example.Item\n                title={[\n                    \"trap focus works correctly when it was already trapped\",\n                    \"focus return back to the dropdown trigger on modal close\",\n                    \"closing dropdown inside the modal doesn't close the modal\",\n                ]}\n            >\n                <DropdownMenu>\n                    <DropdownMenu.Trigger>\n                        {(attributes) => <Button attributes={attributes}>Open menu</Button>}\n                    </DropdownMenu.Trigger>\n                    <DropdownMenu.Content>\n                        <DropdownMenu.Item onClick={menuModalToggle.activate}>Open dialog</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                    </DropdownMenu.Content>\n                </DropdownMenu>\n                <Modal active={menuModalToggle.active} onClose={menuModalToggle.deactivate}>\n                    <View gap={3}>\n                        <DropdownMenu>\n                            <DropdownMenu.Trigger>\n                                {(attributes) => <Button attributes={attributes}>Open menu</Button>}\n                            </DropdownMenu.Trigger>\n                            <DropdownMenu.Content>\n                                <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                                <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                            </DropdownMenu.Content>\n                        </DropdownMenu>\n                        <Button onClick={menuModalToggleInner.activate}>Open dialog</Button>\n                        <Button onClick={menuModalToggle.deactivate}>Close</Button>\n                        <Modal active={menuModalToggleInner.active} onClose={menuModalToggleInner.deactivate}>\n                            <Button onClick={menuModalToggleInner.deactivate}>Close</Button>\n                        </Modal>\n                    </View>\n                </Modal>\n            </Example.Item>\n\n            <Example.Item title=\"disableSwipeGesture\">\n                <Demo disableSwipeGesture position=\"start\" />\n            </Example.Item>\n\n            <Example.Item title=\"scroll locks on open\">\n                <Demo />\n                <View height=\"1000px\" />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "trapFocusEdgeCases",
+					"id": "components-modal--trap-focus-edge-cases",
+					"name": "test: trap focus edge cases",
 					"snippet": "const trapFocusEdgeCases = () => {\n    const toggle = useToggle();\n\n    return (\n        <Example>\n            <Example.Item title=\"Radio should be navigatable with arrow keys\">\n                <Button onClick={toggle.activate}>Open modal</Button>\n                <Modal active={toggle.active} onClose={toggle.deactivate}>\n                    <View gap={2}>\n                        <Button onClick={() => {}}>Action 1</Button>\n                        <Radio name=\"radio\" value=\"1\">\n                            Option 1\n                        </Radio>\n                        <Radio name=\"radio\" value=\"2\">\n                            Option 2\n                        </Radio>\n                        <Button onClick={() => {}}>Action 2</Button>\n                    </View>\n                </Modal>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import {\n    Button,\n    Dismissible,\n    DropdownMenu,\n    Example,\n    Modal,\n    Placeholder,\n    Radio,\n    Switch,\n    TextField,\n    View,\n} from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Modal/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Modal",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Modal/Modal.tsx",
-				"actualName": "Modal",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Component position on the screen",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<\"bottom\" | \"center\" | \"start\" | \"end\" | \"full-screen\">"
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size, literal css value",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Component padding, unit token multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Remove overflow from the component content",
+						"name": "overflow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"visible\"", "value": [{ "value": "\"visible\"" }] }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is closed",
+						"name": "onClose",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((args: { reason: CloseReason | \"drag\"; }) => void)" }
+					},
+					"transparentOverlay": {
+						"defaultValue": null,
+						"description": "Make the overlay transparent",
+						"name": "transparentOverlay",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"blurredOverlay": {
+						"defaultValue": null,
+						"description": "Make the overlay blurred",
+						"name": "blurredOverlay",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableSwipeGesture": {
+						"defaultValue": null,
+						"description": "Disable swipe gesture to close the component on touch devices",
+						"name": "disableSwipeGesture",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable closing the component on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Focus the first focusable element in the component when it is opened, when false, focus will be set on the component content container",
+						"name": "autoFocus",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element, useful when there is no visible title",
+						"name": "ariaLabel",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"overlayClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the overlay element",
+						"name": "overlayClassName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "(Attributes<\"div\"> & { ref?: RefObject<HTMLDivElement | null>; })"
+						}
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the visibility of the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the component is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"containerRef": {
+						"defaultValue": null,
+						"description": "Element to render the component in",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"onAfterOpen": {
+						"defaultValue": null,
+						"description": "Callback after the component open transition is complete",
+						"name": "onAfterOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onAfterClose": {
+						"defaultValue": null,
+						"description": "Callback after the component close transition is complete",
+						"name": "onAfterClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					}
+				},
+				"exportName": "Modal"
 			}
 		},
 		"components-numberfield": {
@@ -1030,54 +5840,450 @@
 			"path": "./src/components/NumberField/tests/NumberField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-numberfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => {\n    return (\n        <Example>\n            <Example.Item title=\"variant: outline\">\n                <NumberField\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"variant: faded\">\n                <NumberField\n                    variant=\"faded\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"variant: headless\">\n                <NumberField\n                    variant=\"headless\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-numberfield--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: small\">\n                <NumberField\n                    size=\"small\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    suffix=\"m2\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: medium\">\n                <NumberField\n                    size=\"medium\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: large\">\n                <NumberField\n                    size=\"large\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: xlarge\">\n                <NumberField\n                    size=\"xlarge\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-numberfield--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <NumberField\n    name=\"test-name\"\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    disabled\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-numberfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <NumberField\n    name=\"test-name\"\n    defaultValue={2}\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-numberfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <NumberField\n    name=\"test-name\"\n    value={2}\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "minMax",
+					"id": "components-numberfield--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <NumberField\n        name=\"test-name\"\n        defaultValue={6}\n        min={5}\n        max={10}\n        increaseAriaLabel=\"Increase\"\n        decreaseAriaLabel=\"Decrease\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-numberfield--step",
 					"name": "step",
 					"snippet": "const step = () => (\n    <NumberField\n        name=\"test-name\"\n        defaultValue={6}\n        step={0.5}\n        increaseAriaLabel=\"Increase\"\n        decreaseAriaLabel=\"Decrease\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-numberfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <NumberField\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n            increaseAriaLabel=\"Increase\"\n            decreaseAriaLabel=\"Decrease\"\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-numberfield--form-control",
+					"name": "test: FormControl",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"FormControl\">\n            <FormControl>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"FormControl, disabled\">\n            <FormControl disabled>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"FormControl, error\">\n            <FormControl hasError>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "valueChanges",
+					"id": "components-numberfield--value-changes",
+					"name": "test: keyboard",
 					"snippet": "const valueChanges = () => (\n    <Example>\n        <Example.Item title=\"keyboard\">\n            <NumberField\n                name=\"name\"\n                increaseAriaLabel=\"Increase\"\n                decreaseAriaLabel=\"Decrease\"\n                inputAttributes={{ \"aria-label\": \"Label\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, FormControl, NumberField } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/NumberField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "NumberField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/NumberField/NumberField.tsx",
-				"actualName": "NumberField",
+				"methods": [],
+				"props": {
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component value is changed",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<number, ChangeEvent<HTMLInputElement>>" }
+					},
+					"increaseAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the increase button",
+						"name": "increaseAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"decreaseAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the decrease button",
+						"name": "decreaseAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum value supported in the form field",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum value supported in the form field",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"step": {
+						"defaultValue": null,
+						"description": "Step at which the value will increase or decrease when clicking the button controls",
+						"name": "step",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the form field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the form field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1087,34 +6293,166 @@
 			"path": "./src/components/Pagination/tests/Pagination.stories.tsx",
 			"stories": [
 				{
+					"id": "components-pagination--truncate",
 					"name": "truncate",
 					"snippet": "const truncate = () => {\n    return (\n        <Example>\n            <Example.Item title=\"start\">\n                <Pagination\n                    total={10}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"middle\">\n                <Pagination\n                    total={10}\n                    defaultPage={5}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"end\">\n                <Pagination\n                    total={10}\n                    defaultPage={10}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"no truncation\">\n                <Pagination\n                    total={4}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "render",
+					"id": "components-pagination--render",
+					"name": "rendering",
 					"snippet": "const render = () => (\n    <div data-testid=\"root\">\n        <Pagination\n            total={10}\n            previousAriaLabel=\"Previous\"\n            nextAriaLabel=\"Next\"\n            pageAriaLabel={(args) => `Page ${args.page}`}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "defaultPage",
+					"id": "components-pagination--default-page",
+					"name": "defaultPage, uncontrolled",
 					"snippet": "const defaultPage = () => <div data-testid=\"root\">\n    <Pagination\n        total={10}\n        defaultPage={2}\n        onChange={fn()}\n        previousAriaLabel=\"Previous\"\n        nextAriaLabel=\"Next\" />\n</div>;"
 				},
 				{
-					"name": "page",
+					"id": "components-pagination--page",
+					"name": "page, controlled",
 					"snippet": "const page = () => <div data-testid=\"root\">\n    <Pagination\n        total={10}\n        page={2}\n        onChange={fn()}\n        previousAriaLabel=\"Previous\"\n        nextAriaLabel=\"Next\" />\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "components-pagination--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Pagination\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            total={10}\n            previousAriaLabel=\"Previous\"\n            nextAriaLabel=\"Next\"\n        />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Pagination } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Pagination/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Pagination",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Pagination/Pagination.tsx",
-				"actualName": "Pagination",
+				"methods": [],
+				"props": {
+					"total": {
+						"defaultValue": null,
+						"description": "Total number of pages available",
+						"name": "total",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "number" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the current page changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { page: number; }) => void)" }
+					},
+					"pageAriaLabel": {
+						"defaultValue": null,
+						"description": "Function to dynamically get an aria-label for each page",
+						"name": "pageAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { page: number; }) => string)" }
+					},
+					"previousAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the previous page button",
+						"name": "previousAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"nextAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the next page button",
+						"name": "nextAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"page": {
+						"defaultValue": null,
+						"description": "Currently selected page number, starts with 1, enables controlled mode",
+						"name": "page",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultPage": {
+						"defaultValue": null,
+						"description": "Default selected page number, starts with 1, enables uncontrolled mode",
+						"name": "defaultPage",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1124,54 +6462,229 @@
 			"path": "./src/components/PinField/tests/PinField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-pinfield--base",
 					"name": "base",
 					"snippet": "const base = () => <PinField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-pinfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <PinField name=\"pin\" variant=\"faded\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-pinfield--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <PinField name=\"pin\" size=\"small\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <PinField name=\"pin\" size=\"medium\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <PinField name=\"pin\" size=\"large\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <PinField name=\"pin\" size=\"xlarge\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: responsive, s: medium, m+: xlarge\">\n            <PinField\n                name=\"pin\"\n                size={{ s: \"medium\", m: \"xlarge\" }}\n                inputAttributes={{ \"aria-label\": \"Pin\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-pinfield--value-length",
 					"name": "valueLength",
 					"snippet": "const valueLength = () => (\n    <PinField name=\"test-name\" valueLength={6} inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-pinfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <PinField\n    name=\"test-name\"\n    onChange={fn()}\n    defaultValue=\"12\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-pinfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <PinField\n    name=\"test-name\"\n    onChange={fn()}\n    value=\"12\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-pinfield--pattern",
 					"name": "pattern",
 					"snippet": "const pattern = () => <PinField\n    name=\"test-name\"\n    pattern=\"alphabetic\"\n    defaultValue=\"ab\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-pinfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <PinField\n            name=\"test-name\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ \"aria-label\": \"Label\", id: \"test-input-id\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-pinfield--form-control",
+					"name": "test: with FormControl",
 					"snippet": "const formControl = () => (\n    <FormControl>\n        <FormControl.Label>Label</FormControl.Label>\n        <PinField name=\"test-name\" />\n    </FormControl>\n);"
 				},
 				{
-					"name": "keyboard",
+					"id": "components-pinfield--keyboard",
+					"name": "test: keyboard navigation",
 					"snippet": "const keyboard = () => <PinField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				}
 			],
 			"import": "import { Example, FormControl, PinField } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/PinField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "PinField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/PinField/PinField.tsx",
-				"actualName": "PinField",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"valueLength": {
+						"defaultValue": null,
+						"description": "Amount of characters in the pin",
+						"name": "valueLength",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"pattern": {
+						"defaultValue": null,
+						"description": "Character pattern used in the input value",
+						"name": "pattern",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"numeric\" | \"alphabetic\" | \"alphanumeric\"",
+							"value": [
+								{ "value": "\"numeric\"" },
+								{ "value": "\"alphabetic\"" },
+								{ "value": "\"alphanumeric\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Input fields render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\"",
+							"value": [{ "value": "\"outline\"" }, { "value": "\"faded\"" }]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the input element, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1181,75 +6694,514 @@
 			"path": "./src/components/Popover/tests/Popover.stories.tsx",
 			"stories": [
 				{
+					"id": "components-popover--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: bottom\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"bottom-start\" />\n                <Demo position=\"bottom\" />\n                <Demo position=\"bottom-end\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: top\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"top-start\" />\n                <Demo position=\"top\" />\n                <Demo position=\"top-end\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: start\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"start-top\" />\n                <Demo position=\"start\" />\n                <Demo position=\"start-bottom\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: end\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"end-top\" />\n                <Demo position=\"end\" />\n                <Demo position=\"end-bottom\" defaultActive />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "widthNumber",
+					"id": "components-popover--width-number",
+					"name": "width: px",
 					"snippet": "const widthNumber = () => <Demo width=\"400px\" defaultActive />;"
 				},
 				{
-					"name": "widthFull",
+					"id": "components-popover--width-full",
+					"name": "width: 100%",
 					"snippet": "const widthFull = () => <Demo width=\"100%\" defaultActive />;"
 				},
 				{
+					"id": "components-popover--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 0\">\n            <Demo padding={0} />\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <Demo padding={6} defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-popover--elevation",
 					"name": "elevation",
 					"snippet": "const elevation = () => (\n    <Example>\n        <Example.Item title=\"elevation: raised\">\n            <Demo elevation=\"raised\" defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-popover--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <Popover onOpen={fn()} onClose={fn()} defaultActive>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "active",
+					"id": "components-popover--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <Popover onOpen={fn()} onClose={fn()} active>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "components-popover--active-false",
+					"name": "active false, controlled",
 					"snippet": "const activeFalse = () => <Popover onOpen={fn()} onClose={fn()} active={false}>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "dismissible",
+					"id": "components-popover--dismissible",
+					"name": "dismissible, onClose, className, attributes, closeAriaLabel",
 					"snippet": "const dismissible = () => <Popover onClose={fn()} defaultActive>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>\n        <Popover.Dismissible\n            closeAriaLabel=\"Close\"\n            attributes={{ \"data-testid\": \"test-id\" }}\n            className=\"test-classname\">Content\n                            </Popover.Dismissible>\n    </Popover.Content>\n</Popover>;"
 				},
 				{
+					"id": "components-popover--auto-focus",
 					"name": "autoFocus",
 					"snippet": "const autoFocus = () => (\n    <Example>\n        <Example.Item title=\"autoFocus=false\">\n            <Demo autoFocus={false} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-popover--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Popover active>\n            <Popover.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </Popover.Trigger>\n            <Popover.Content className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n                Content\n            </Popover.Content>\n        </Popover>\n    </div>\n);"
 				},
 				{
-					"name": "testNested",
+					"id": "components-popover--test-nested",
+					"name": "test: nested",
 					"snippet": "const testNested = () => (\n    <Popover position=\"bottom\">\n        <Popover.Trigger>\n            {(attributes) => <Button attributes={attributes}>Open</Button>}\n        </Popover.Trigger>\n        <Popover.Content>\n            <View gap={2} align=\"start\">\n                Popover content\n                <Popover>\n                    <Popover.Trigger>\n                        {(attributes) => <Button attributes={attributes}>Open</Button>}\n                    </Popover.Trigger>\n                    <Popover.Content>Hello</Popover.Content>\n                </Popover>\n            </View>\n        </Popover.Content>\n    </Popover>\n);"
 				},
 				{
-					"name": "testWithTooltip",
+					"id": "components-popover--test-with-tooltip",
+					"name": "test: with tooltip",
 					"snippet": "const testWithTooltip = () => (\n    <View paddingTop={10}>\n        <Tooltip position=\"top\" text=\"Hello\">\n            {(tooltipAttributes) => (\n                <Popover position=\"bottom\">\n                    <Popover.Trigger>\n                        {(attributes) => (\n                            <Button\n                                attributes={{\n                                    ...attributes,\n                                    ...tooltipAttributes,\n                                }}\n                            >\n                                Open\n                            </Button>\n                        )}\n                    </Popover.Trigger>\n                    <Popover.Content>\n                        <View gap={2} align=\"start\">\n                            Popover content\n                            <Button onClick={() => {}}>Button</Button>\n                        </View>\n                    </Popover.Content>\n                </Popover>\n            )}\n        </Tooltip>\n    </View>\n);"
 				},
 				{
-					"name": "testContentEditable",
+					"id": "components-popover--test-content-editable",
+					"name": "test: contenteditable",
 					"snippet": "const testContentEditable = () => {\n    const [active, setActive] = useState(false);\n\n    return (\n        <Popover>\n            <Popover.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </Popover.Trigger>\n            <Popover.Content>\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={() => {}}>Hello</Button>\n                    </View.Item>\n\n                    <ScrollArea height=\"100px\">\n                        <div\n                            style={{ height: \"200px\" }}\n                            contentEditable\n                            tabIndex={0}\n                            onInput={(e) => {\n                                setActive(e.currentTarget.innerText.startsWith(\"@\"));\n                            }}\n                            onKeyDown={(e) => {\n                                console.log(e.key);\n                                if (e.key === \"Enter\" && active) {\n                                    e.preventDefault();\n                                    e.currentTarget.innerText = \"@hello\";\n                                    setActive(false);\n                                }\n                            }}\n                        />\n                    </ScrollArea>\n\n                    <Popover\n                        active={active}\n                        onClose={() => setActive(false)}\n                        originCoordinates={{ x: 300, y: 300 }}\n                        trapFocusMode=\"selection-menu\"\n                    >\n                        <Popover.Content>\n                            <View gap={4}>\n                                <MenuItem onClick={() => {}}>Action</MenuItem>\n                                <MenuItem onClick={() => {}}>Close</MenuItem>\n                            </View>\n                        </Popover.Content>\n                    </Popover>\n                </View>\n            </Popover.Content>\n        </Popover>\n    );\n};"
 				},
 				{
-					"name": "variant",
+					"id": "components-popover--variant",
+					"name": "variant [deprecated]",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: headless\">\n            <Popover variant=\"headless\" defaultActive position=\"bottom-start\">\n                <Popover.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </Popover.Trigger>\n                <Popover.Content>\n                    <View\n                        height=\"100px\"\n                        width=\"100px\"\n                        borderColor=\"primary\"\n                        borderRadius=\"medium\"\n                        backgroundColor=\"primary-faded\"\n                    />\n                </Popover.Content>\n            </Popover>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, MenuItem, Popover, ScrollArea, Tooltip, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Popover/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Popover",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Popover/Popover.tsx",
-				"actualName": "Popover",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Automatically focus the first focusable element in the content, when false the content container will be focused instead",
+						"name": "autoFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | TrapMode" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Content element padding, unit token multiplier",
+						"name": "padding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "@deprecated use Flyout utility instead, will be removed in v4",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"elevated\" | \"headless\"",
+							"value": [{ "value": "\"elevated\"" }, { "value": "\"headless\"" }]
+						}
+					}
+				},
+				"exportName": "Popover"
 			}
 		},
 		"components-progress": {
@@ -1258,38 +7210,177 @@
 			"path": "./src/components/Progress/tests/Progress.stories.tsx",
 			"stories": [
 				{
+					"id": "components-progress--value",
 					"name": "value",
 					"snippet": "const value = () => (\n    <Example>\n        <Example.Item title=\"value: 50\">\n            <Progress value={50} ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"value: 20, min: 0, max: 40\">\n            <Progress value={20} min={0} max={40} ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"value: 50, min: 0, max: 40\">\n            <Progress value={50} min={0} max={40} ariaLabel=\"rating value\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small, value: 50\">\n            <Progress value={50} size=\"small\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"size: medium, value: 50\">\n            <Progress value={50} size=\"medium\" ariaLabel=\"rating value\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: critical, value: 50\">\n            <Progress value={50} color=\"critical\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: warning, value: 50\">\n            <Progress value={50} color=\"warning\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive, value: 50\">\n            <Progress value={50} color=\"positive\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: media, value: 50\">\n            <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                <Progress value={50} color=\"media\" ariaLabel=\"rating value\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--duration",
 					"name": "duration",
 					"snippet": "const duration = () => {\n    const [active, setActive] = React.useState(false);\n\n    const handleChange = () => {\n        setActive((state) => !state);\n    };\n\n    return (\n        <Example>\n            <Example.Item title=\"duration: 2000\">\n                <View gap={3}>\n                    <View.Item>\n                        <Button onClick={handleChange}>Change</Button>\n                    </View.Item>\n\n                    <Progress value={active ? 100 : 0} duration={2000} ariaLabel=\"rating value\" />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "render",
+					"id": "components-progress--render",
+					"name": "rendering",
 					"snippet": "const render = () => <Progress value={75} min={50} max={100} ariaLabel=\"progress\" />;"
 				},
 				{
-					"name": "className",
+					"id": "components-progress--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Progress className=\"test-classname\" attributes={{ id: \"test-id\" }} ariaLabel=\"progress\" />\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, Progress, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Progress/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Progress",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Progress/Progress.tsx",
-				"actualName": "Progress",
+				"methods": [],
+				"props": {
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the progress bar controlling the size of the fill",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Lower value boundary of the progress bar",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Upper value boundary of the progress bar",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"warning\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"duration": {
+						"defaultValue": null,
+						"description": "Duration of the progress bar animation in milliseconds",
+						"name": "duration",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1299,30 +7390,135 @@
 			"path": "./src/components/ProgressIndicator/tests/ProgressIndicator.stories.tsx",
 			"stories": [
 				{
+					"id": "components-progressindicator--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const [activeIndex, setActiveIndex] = React.useState(0);\n    const total = 10;\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <View gap={4}>\n                    <View direction=\"row\" gap={2} align=\"center\">\n                        <Button\n                            onClick={() => {\n                                setActiveIndex((prev) => Math.max(0, prev - 1));\n                            }}\n                        >\n                            Previous\n                        </Button>\n                        <Button\n                            onClick={() => {\n                                setActiveIndex((prev) => Math.min(total - 1, prev + 1));\n                            }}\n                        >\n                            Next\n                        </Button>\n                        <Text weight=\"medium\">Index: {activeIndex}</Text>\n                    </View>\n\n                    <View borderRadius=\"medium\" overflow=\"hidden\" width=\"300px\">\n                        <Scrim\n                            position=\"bottom\"\n                            backgroundSlot={<View aspectRatio={16 / 9} backgroundColor=\"neutral-faded\" />}\n                        >\n                            <View align=\"center\">\n                                <ProgressIndicator total={total} activeIndex={activeIndex} color=\"media\" />\n                            </View>\n                        </Scrim>\n                    </View>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-progressindicator--color",
 					"name": "color",
 					"snippet": "const color = () => {\n    return (\n        <Example>\n            <Example.Item title=\"color: primary\">\n                <ProgressIndicator total={10} activeIndex={5} color=\"primary\" />\n            </Example.Item>\n            <Example.Item title=\"color: media\">\n                <View borderRadius=\"medium\" overflow=\"hidden\" width=\"300px\">\n                    <Scrim\n                        position=\"bottom\"\n                        backgroundSlot={<View aspectRatio={16 / 9} backgroundColor=\"neutral-faded\" />}\n                    >\n                        <View align=\"center\">\n                            <ProgressIndicator total={10} activeIndex={5} color=\"media\" />\n                        </View>\n                    </Scrim>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-progressindicator--aria-label",
 					"name": "ariaLabel",
 					"snippet": "const ariaLabel = () => <ProgressIndicator total={10} className=\"test-classname\" ariaLabel=\"Progress\" />;"
 				},
 				{
-					"name": "className",
+					"id": "components-progressindicator--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ProgressIndicator total={10} className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, ProgressIndicator, Scrim, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ProgressIndicator/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ProgressIndicator",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ProgressIndicator/ProgressIndicator.tsx",
-				"actualName": "ProgressIndicator",
+				"methods": [],
+				"props": {
+					"total": {
+						"defaultValue": null,
+						"description": "Total amount of progress indicator dots",
+						"name": "total",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "number" }
+					},
+					"activeIndex": {
+						"defaultValue": null,
+						"description": "Index of the active progress indicator dot",
+						"name": "activeIndex",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\"",
+							"value": [{ "value": "\"media\"" }, { "value": "\"primary\"" }]
+						}
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1332,50 +7528,203 @@
 			"path": "./src/components/Radio/tests/Radio.stories.tsx",
 			"stories": [
 				{
+					"id": "components-radio--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"small\" defaultChecked>\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"medium\">\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"large\">\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: responsive, s: small, m: large\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size={{ s: \"small\", m: \"large\" }}>\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-radio--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Radio name=\"error\" value=\"dog\" hasError>\n                Radio\n            </Radio>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-radio--render",
+					"name": "name, value",
 					"snippet": "const render = () => (\n    <Radio name=\"test-name\" value=\"test-value\">\n        Content\n    </Radio>\n);"
 				},
 				{
-					"name": "checked",
+					"id": "components-radio--checked",
+					"name": "checked, controlled",
 					"snippet": "const checked = () => <Radio name=\"test-name\" value=\"test-value\" checked onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "checkedFalse",
+					"id": "components-radio--checked-false",
+					"name": "checked false, controlled",
 					"snippet": "const checkedFalse = () => <Radio name=\"test-name\" value=\"test-value\" checked={false} onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-radio--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Radio name=\"test-name\" value=\"test-value\" defaultChecked onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "defaultCheckedFalse",
+					"id": "components-radio--default-checked-false",
+					"name": "defaultChecked false, uncontrolled",
 					"snippet": "const defaultCheckedFalse = () => <Radio name=\"test-name\" value=\"test-value\" onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
+					"id": "components-radio--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Radio name=\"test-name\" value=\"test-value\" disabled>\n        Content\n    </Radio>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-radio--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Radio className=\"test-classname\" attributes={{ id: \"test-id\" }} value=\"value\">\n            Content\n        </Radio>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Radio, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Radio/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Radio",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Radio/Radio.tsx",
-				"actualName": "Radio",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the form field from the form submission",
+						"name": "disabled",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Indicate that the form field has an error",
+						"name": "hasError",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element",
+						"name": "value",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the input is focused",
+						"name": "onFocus",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the input is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "",
+						"name": "checked",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultChecked",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1385,26 +7734,169 @@
 			"path": "./src/components/RadioGroup/tests/RadioGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "value",
+					"id": "components-radiogroup--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <RadioGroup name=\"test-name\" value=\"1\" onChange={fn()}>\n    {/* checked should be ignored */}\n    <Radio value=\"1\" checked={false}>Content\n                    </Radio>\n    <Radio value=\"2\">Content 2</Radio>\n</RadioGroup>;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-radiogroup--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <RadioGroup name=\"test-name\" defaultValue=\"1\" onChange={fn()}>\n    {/* checked should be ignored */}\n    <Radio value=\"1\" checked={false}>Content\n                    </Radio>\n    <Radio value=\"2\">Content 2</Radio>\n</RadioGroup>;"
 				},
 				{
+					"id": "components-radiogroup--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <RadioGroup name=\"test-name\" disabled>\n        <Radio value=\"test-value\">Content</Radio>\n    </RadioGroup>\n);"
 				}
 			],
 			"import": "import { Radio, RadioGroup } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/RadioGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "RadioGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/RadioGroup/RadioGroup.tsx",
-				"actualName": "RadioGroup",
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the radio group",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the form field from the form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Indicate that the form field has an error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the input element, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1414,39 +7906,131 @@
 			"path": "./src/components/Resizable/tests/Resizable.stories.tsx",
 			"stories": [
 				{
+					"id": "components-resizable--direction",
 					"name": "direction",
 					"snippet": "const direction = () => {\n    return (\n        <Example>\n            <Example.Item title=\"row\">\n                <Resizable height=\"200px\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n            <Example.Item title=\"column\">\n                <Resizable height=\"400px\" direction=\"column\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n\n            {/* Test that page doesn't scroll on dragging */}\n            <div style={{ height: 2000 }} />\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-resizable--children",
 					"name": "children",
 					"snippet": "const children = () => {\n    return (\n        <Example>\n            <Example.Item title=\"render props, row\">\n                <Resizable height=\"200px\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n            <Example.Item title=\"render props, column\">\n                <Resizable height=\"400px\" direction=\"column\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-resizable--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"bordered, row\">\n            <Resizable height=\"200px\" variant=\"bordered\">\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n            </Resizable>\n        </Example.Item>\n        <Example.Item title=\"bordered, column\">\n            <Resizable height=\"400px\" direction=\"column\" variant=\"bordered\">\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n            </Resizable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "components-resizable--size",
+					"name": "minSize, maxSize, defaultSize",
 					"snippet": "const size = () => (\n    <Resizable className=\"test-classname\" attributes={{ id: \"test-id\" }} height=\"200px\">\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n        <Resizable.Handle />\n        <Resizable.Item minSize=\"200px\" maxSize=\"500px\" defaultSize=\"300px\">\n            <Panel />\n        </Resizable.Item>\n    </Resizable>\n);"
 				},
 				{
-					"name": "layout",
+					"id": "components-resizable--layout",
+					"name": "height, gap",
 					"snippet": "const layout = () => (\n    <Resizable height=\"100px\" gap={8}>\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n        <Resizable.Handle />\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n    </Resizable>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-resizable--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Resizable className=\"test-classname\" attributes={{ id: \"test-id\" }} height=\"200px\">\n            <Resizable.Item>\n                <Panel />\n            </Resizable.Item>\n            <Resizable.Handle />\n            <Resizable.Item>\n                <Panel />\n            </Resizable.Item>\n        </Resizable>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, Resizable, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Resizable/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Resizable",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Resizable/Resizable.tsx",
-				"actualName": "Resizable",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Resizable/Resizable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"bordered\" | \"borderless\"",
+							"value": [{ "value": "\"bordered\"" }, { "value": "\"borderless\"" }]
+						}
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Component content direction with the resize handle rendered in between the chidlren",
+						"name": "direction",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Resizable/Resizable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between children, base unit token number multiplier",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					}
+				},
+				"exportName": "Resizable"
 			}
 		},
 		"components-scrim": {
@@ -1455,26 +8039,101 @@
 			"path": "./src/components/Scrim/tests/Scrim.stories.tsx",
 			"stories": [
 				{
+					"id": "components-scrim--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: center\">\n            <Scrim backgroundSlot={<Placeholder h={200} />}>Scrim</Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <Scrim position=\"bottom\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: top\">\n            <Scrim position=\"top\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: start\">\n            <Scrim position=\"start\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <Scrim position=\"end\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-scrim--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Scrim className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Scrim>\n    </div>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "components-scrim--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"without backgroundSlot, size is based on the parent component\">\n            <div style={{ height: 300, position: \"relative\" }}>\n                <Scrim>Text</Scrim>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Placeholder, Scrim } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Scrim/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Scrim",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Scrim/Scrim.tsx",
-				"actualName": "Scrim",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"backgroundSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting background content behind the scrim",
+						"name": "backgroundSlot",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Component content position",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"bottom\" | \"start\" | \"end\" | \"full\"",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"full\"" }
+							]
+						}
+					},
+					"scrimClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the scrim element",
+						"name": "scrimClassName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1484,79 +8143,398 @@
 			"path": "./src/components/Select/tests/Select.stories.tsx",
 			"stories": [
 				{
-					"name": "nativeRender",
+					"id": "components-select--native-render",
+					"name": "native rendering, options, name, id",
 					"snippet": "const nativeRender = () => (\n    <Example>\n        <Example.Item title=\"native with options prop\">\n            <Select\n                name=\"animal\"\n                id=\"animal-1\"\n                placeholder=\"Select an animal\"\n                options={[\n                    { label: \"Dog\", value: \"dog\" },\n                    { label: \"Turtle\", value: \"turtle\" },\n                ]}\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            />\n        </Example.Item>\n        <Example.Item title=\"native with option tags\">\n            <Select\n                name=\"animal\"\n                id=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "customRender",
+					"id": "components-select--custom-render",
+					"name": "custom rendering, name, id, option groups",
 					"snippet": "const customRender = () => (\n    <Example>\n        <Example.Item title=\"custom with options\">\n            <Select.Custom\n                name=\"animal\"\n                id=\"animal-1\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"native with option tags\">\n            <Select.Custom\n                name=\"animal-2\"\n                id=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Group label=\"Birds\">\n                    <Select.Option value=\"pigeon\">Pigeon</Select.Option>\n                    <Select.Option value=\"parrot\">Parrot</Select.Option>\n                </Select.Group>\n                <Select.Group label=\"Sea Mammals\">\n                    <Select.Option value=\"whale\">Whale</Select.Option>\n                    <Select.Option value=\"dolphin\">Dolphin</Select.Option>\n                </Select.Group>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "nativeHandlers",
+					"id": "components-select--native-handlers",
+					"name": "native, controlled, uncontrolled, onFocus, onBlur, onChange",
 					"snippet": "const nativeHandlers = () => <Example>\n    <Example.Item title=\"native, uncontrolled, onChange\">\n        <Select\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n    <Example.Item title=\"native, controlled, onChange\">\n        <Select\n            name=\"animal-2\"\n            placeholder=\"Select an animal\"\n            value=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n    <Example.Item title=\"native, onFocus, onBlur, onClick\">\n        <Select\n            name=\"animal-3\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onFocus={fn()}\n            onBlur={fn()}\n            onClick={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "customHandlers",
+					"id": "components-select--custom-handlers",
+					"name": "custom, controlled, uncontrolled, onFocus, onBlur, onChange",
 					"snippet": "const customHandlers = () => <Example>\n    <Example.Item title=\"custom, uncontrolled, onChange\">\n        <Select.Custom\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n    <Example.Item title=\"custom, controlled, onChange\">\n        <Select.Custom\n            name=\"animal-2\"\n            placeholder=\"Select an animal\"\n            value=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n    <Example.Item title=\"native, onFocus, onBlur, onClick\">\n        <Select.Custom\n            name=\"animal-3\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onFocus={fn()}\n            onBlur={fn()}\n            onClick={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "triggerOnly",
+					"id": "components-select--trigger-only",
+					"name": "trigger only, onClick",
 					"snippet": "const triggerOnly = (args) => {\n    const toggle = useToggle();\n    const [value, setValue] = React.useState(\"Dog\");\n\n    const handleClick: SelectProps[\"onClick\"] = (e) => {\n        args.handleClick(e);\n        toggle.toggle();\n    };\n\n    return (\n        <Example>\n            <Example.Item title=\"trigger only, onClick\">\n                <Select\n                    name=\"animal\"\n                    placeholder=\"Select an animal\"\n                    onClick={handleClick}\n                    value=\"dog\"\n                    inputAttributes={{\n                        \"aria-label\": \"Select an animal\",\n                    }}\n                >\n                    {value}\n                </Select>\n                <Modal\n                    active={toggle.active}\n                    onClose={toggle.deactivate}\n                    position=\"bottom\"\n                    padding={2}\n                    attributes={{ \"aria-label\": \"Select an animal\" }}\n                >\n                    <div role=\"listbox\" aria-label=\"Select an animal\">\n                        <MenuItem\n                            roundedCorners\n                            onClick={() => {\n                                setValue(\"Dog\");\n                                toggle.deactivate();\n                            }}\n                            attributes={{\n                                role: \"option\",\n                            }}\n                        >\n                            Dog\n                        </MenuItem>\n                        <MenuItem\n                            roundedCorners\n                            attributes={{\n                                role: \"option\",\n                            }}\n                            onClick={() => {\n                                setValue(\"Turtle\");\n                                toggle.deactivate();\n                            }}\n                        >\n                            Turtle\n                        </MenuItem>\n                    </div>\n                </Modal>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-select--multiple",
 					"name": "multiple",
 					"snippet": "const multiple = () => <Example>\n    <Example.Item title=\"multiple\">\n        <Select.Custom\n            multiple\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue={[\"dog\"]}\n            onChange={fn()}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-select--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded, native\">\n            <Select\n                variant=\"faded\"\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n\n        <Example.Item title=\"variant: faded, custom\">\n            <Select.Custom\n                variant=\"faded\"\n                name=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless, native\">\n            <Select\n                variant=\"headless\"\n                name=\"animal-3\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless, custom\">\n            <Select.Custom\n                variant=\"headless\"\n                name=\"animal-4\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <Select.Custom size=\"small\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <Select.Custom size=\"medium\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <Select.Custom size=\"large\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: xlarge\">\n            <Select.Custom size=\"xlarge\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "startSlot",
+					"id": "components-select--start-slot",
+					"name": "icon,startSlot",
 					"snippet": "const startSlot = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Select.Custom name=\"animal\" placeholder=\"Select an animal\" icon={IconZap}>\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n\n        <Example.Item title=\"startSlot\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                startSlot={<Placeholder h={20} />}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--render-value",
 					"name": "renderValue",
 					"snippet": "const renderValue = () => {\n    const options = [\n        {\n            value: \"1\",\n            label: \"Title 1\",\n            subtitle: \"Subtitle 1\",\n        },\n        {\n            value: \"2\",\n            label: \"Title 2\",\n            subtitle: \"Subtitle 2\",\n        },\n    ];\n\n    return (\n        <Example>\n            <Example.Item title=\"default renderer, single\">\n                <Select.Custom name=\"animal\" defaultValue=\"1\" placeholder=\"Nothing selected\">\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"default renderer, multiple\">\n                <Select.Custom name=\"animal\" defaultValue={[\"1\"]} multiple placeholder=\"Nothing selected\">\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"renderValue, single\">\n                <Select.Custom\n                    name=\"animal\"\n                    defaultValue=\"1\"\n                    placeholder=\"Nothing selected\"\n                    renderValue={(args) => <Badge>Title {args.value}</Badge>}\n                >\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"renderValue, multiple\">\n                <Select.Custom\n                    name=\"animal\"\n                    defaultValue={[\"1\"]}\n                    multiple\n                    placeholder=\"Nothing selected\"\n                    renderValue={(args) => <Badge>Titles {args.value.join(\", \")}</Badge>}\n                >\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-select--error",
 					"name": "error",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Select.Custom name=\"animal\" placeholder=\"Select an animal\" hasError>\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, native\">\n            <Select\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                disabled\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n        <Example.Item title=\"disabled, custom\">\n            <Select.Custom\n                name=\"animal-2\"\n                placeholder=\"Select an animal\"\n                disabled\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-select--class-name",
+					"name": "className, attributes, inputAttributes",
 					"snippet": "const className = () => (\n    <Example>\n        <Example.Item title=\"native, className, attributes, inputAttributes\">\n            <Select\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                className=\"native-class\"\n                attributes={{ id: \"test-id\" }}\n                inputAttributes={{ \"aria-label\": \"test-label\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n        <Example.Item title=\"custom, className, attributes, inputAttributes\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                className=\"custom-class\"\n                attributes={{ id: \"test-id\" }}\n                inputAttributes={{ \"aria-label\": \"test-label\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "fallback",
+					"id": "components-select--fallback",
+					"name": "test: fallbackAdjustLayout",
 					"snippet": "const fallback = () => (\n    <Example>\n        <Example.Item title=\"fallback\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                {[...Array(100)].map((_, index) => (\n                    <Select.Option key={index} value={`item-${index}`}>\n                        Item {index + 1}\n                    </Select.Option>\n                ))}\n            </Select.Custom>\n            <div style={{ height: \"1000px\" }}></div>\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                {[...Array(100)].map((_, index) => (\n                    <Select.Option key={index} value={`item-${index}`}>\n                        Item {index + 1}\n                    </Select.Option>\n                ))}\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-select--form-control",
+					"name": "test: with FormControl",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"FormControl\">\n            <FormControl hasError>\n                <FormControl.Label>Animal</FormControl.Label>\n                <Select.Custom name=\"animal\" placeholder=\"Select an animal\">\n                    <Select.Option value=\"dog\">Dog</Select.Option>\n                    <Select.Option value=\"turtle\">Turtle</Select.Option>\n                </Select.Custom>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "components-select--test-composition",
+					"name": "test: composition",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item title=\"custom with options\">\n            <Select.Custom\n                name=\"animal\"\n                id=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Group>\n                    <Select.Option value=\"dog\">Dog</Select.Option>\n                    <Select.Option value=\"turtle\">Turtle</Select.Option>\n                </Select.Group>\n                <Select.Group>Hello</Select.Group>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Badge, Example, FormControl, MenuItem, Modal, Placeholder, Select, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Select/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Select",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Select/Select.tsx",
-				"actualName": "Select",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the select user interaction and form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value selected",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon to display in the select start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the select value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when the trigger is clicked",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"options": {
+						"defaultValue": null,
+						"description": "@deprecated Use <option /> children instead",
+						"name": "options",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NativeOption[]" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the input is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLSelectElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the input is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLSelectElement, Element>) => void)" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"select\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"renderValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "renderValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "undefined" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLSelectElement>>" }
+					}
+				},
+				"exportName": "Select"
 			}
 		},
 		"components-skeleton": {
@@ -1565,26 +8543,87 @@
 			"path": "./src/components/Skeleton/tests/Skeleton.stories.tsx",
 			"stories": [
 				{
+					"id": "components-skeleton--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"text\">\n            <Skeleton />\n        </Example.Item>\n\n        <Example.Item title=\"view, rectangle\">\n            <Skeleton width=\"100px\" height=\"100px\" />\n        </Example.Item>\n\n        <Example.Item title=\"view, circle\">\n            <Skeleton width=\"100px\" height=\"100px\" borderRadius=\"circular\" />\n        </Example.Item>\n\n        <Example.Item title=\"view, rectangle, responsive\">\n            <Skeleton width={{ s: \"100px\", m: \"200px\" }} height={{ s: \"100px\", m: \"200px\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-skeleton--radius",
 					"name": "radius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius=small\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"small\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=medium\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"medium\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=large\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"large\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=circular\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"circular\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-skeleton--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Skeleton className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Skeleton } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Skeleton/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Skeleton",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Skeleton/Skeleton.tsx",
-				"actualName": "Skeleton",
+				"methods": [],
+				"props": {
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width style, literal string value or a base unit token number multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Radius>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Skeleton/Skeleton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Skeleton/Skeleton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1594,66 +8633,421 @@
 			"path": "./src/components/Slider/tests/Slider.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "components-slider--base",
+					"name": "name, minName, maxName, range",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"single, name\">\n            <Slider name=\"slider-single\" defaultValue={30} />\n        </Example.Item>\n        <Example.Item title=\"range, name\">\n            <Slider range name=\"slider-range\" defaultMinValue={30} defaultMaxValue={85} />\n        </Example.Item>\n        <Example.Item title=\"range, minName, maxName\">\n            <Slider\n                range\n                minName=\"slider-min\"\n                maxName=\"slider-max\"\n                defaultMinValue={30}\n                defaultMaxValue={85}\n            />\n        </Example.Item>\n        <div style={{ height: 2000 }} />\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--orientation",
 					"name": "orientation",
 					"snippet": "const orientation = () => (\n    <Example>\n        <Example.Item title=\"orientation: vertical\">\n            <View height=\"200px\">\n                <Slider\n                    range\n                    name=\"slider\"\n                    defaultMinValue={30}\n                    defaultMaxValue={85}\n                    orientation=\"vertical\"\n                />\n            </View>\n        </Example.Item>\n        <View height=\"2000px\" />\n    </Example>\n);"
 				},
 				{
-					"name": "minMax",
+					"id": "components-slider--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <Example>\n        <Example.Item title=\"min, max\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={60} />\n        </Example.Item>\n        <Example.Item title=\"min, max, value < min\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={30} />\n        </Example.Item>\n        <Example.Item title=\"min, max, value > max\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={80} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--step",
 					"name": "step",
 					"snippet": "const step = () => (\n    <Example>\n        <Example.Item title=\"step: 5\">\n            <Slider name=\"slider\" defaultValue={30} step={5} />\n        </Example.Item>\n\n        <Example.Item title=\"step: 5, defaultValue: 31, rounded down to 30\">\n            <Slider name=\"slider\" defaultValue={31} step={5} />\n        </Example.Item>\n\n        <Example.Item title=\"step: 0.01, float\">\n            <Slider name=\"slider\" defaultValue={30} step={0.01} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <Slider name=\"slider\" defaultValue={30} disabled />\n        </Example.Item>\n\n        <Example.Item title=\"disabled, range\">\n            <Slider name=\"slider\" range defaultMinValue={30} defaultMaxValue={80} disabled />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--render-value",
 					"name": "renderValue",
 					"snippet": "const renderValue = () => (\n    <Example>\n        <Example.Item title=\"renderValue: $\">\n            <Slider name=\"name\" defaultValue={50} renderValue={(args) => `$${args.value}`} />\n        </Example.Item>\n        <Example.Item title=\"renderValue: false\">\n            <Slider name=\"name\" defaultValue={50} renderValue={false} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-slider--default-value",
+					"name": "defaultValue, onChange, onChangeCommit",
 					"snippet": "const defaultValue = () => <View paddingTop={10}>\n    <Slider name=\"test-name\" defaultValue={50} onChange={fn()} onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "value",
+					"id": "components-slider--value",
+					"name": "value, onChange, onChangeCommit",
 					"snippet": "const value = () => <View paddingTop={10}>\n    <Slider name=\"test-name\" value={50} onChange={fn()} onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "rangeDefaultValue",
+					"id": "components-slider--range-default-value",
+					"name": "range, defaultValue, onChange, onChangeCommit",
 					"snippet": "const rangeDefaultValue = () => <View paddingTop={10}>\n    <Slider\n        range\n        name=\"test-name\"\n        defaultMinValue={50}\n        defaultMaxValue={70}\n        onChange={fn()}\n        onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "rangeValue",
+					"id": "components-slider--range-value",
+					"name": "range, value, onChange, onChangeCommit, minName, maxName",
 					"snippet": "const rangeValue = () => <View paddingTop={10}>\n    <Slider\n        range\n        minName=\"test-name-min\"\n        maxName=\"test-name-max\"\n        minValue={50}\n        maxValue={70}\n        onChange={fn()}\n        onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "className",
+					"id": "components-slider--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Slider name=\"name\" className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				},
 				{
-					"name": "testForm",
+					"id": "components-slider--test-form",
+					"name": "test: form onChange",
 					"snippet": "const testForm = (args) => {\n    const formRef = React.useRef<HTMLFormElement>(null);\n    const [data, setData] = React.useState<[string, FormDataEntryValue][]>([]);\n\n    const handleChange = (e: React.FormEvent<HTMLFormElement>) => {\n        const formData = new FormData(e.currentTarget);\n        const nextState = [...formData.entries()];\n\n        args.handleFormChange({ formData: nextState });\n        setData(nextState);\n    };\n\n    return (\n        <View paddingTop={10} gap={4}>\n            <form onChange={handleChange} ref={formRef}>\n                <Slider\n                    range\n                    minName=\"slider-min\"\n                    maxName=\"slider-max\"\n                    defaultMinValue={30}\n                    defaultMaxValue={50}\n                />\n            </form>\n\n            {data.map((v) => v.join(\": \")).join(\", \")}\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testSwipe",
+					"id": "components-slider--test-swipe",
+					"name": "test: prevents parent swipe",
 					"snippet": "const testSwipe = () => {\n    const toggle = useToggle(true);\n\n    return (\n        <Modal active={toggle.active} onClose={toggle.deactivate} position=\"end\">\n            <View gap={4}>\n                <Modal.Title>Modal</Modal.Title>\n                <Slider name=\"slider\" defaultValue={30} />\n            </View>\n        </Modal>\n    );\n};"
 				}
 			],
 			"import": "import { Example, Modal, Slider, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Slider/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Slider",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Slider/Slider.tsx",
-				"actualName": "Slider",
+				"methods": [],
+				"props": {
+					"step": {
+						"defaultValue": null,
+						"description": "Step of the slider",
+						"name": "step",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the slider user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum value of the slider",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum value of the slider",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"orientation": {
+						"defaultValue": null,
+						"description": "Orientation of the slider",
+						"name": "orientation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"vertical\" | \"horizontal\"",
+							"value": [{ "value": "\"vertical\"" }, { "value": "\"horizontal\"" }]
+						}
+					},
+					"renderValue": {
+						"defaultValue": null,
+						"description": "Render a custom value in the thumb tooltip",
+						"name": "renderValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | ((args: { value: number; }) => string)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the slider, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the slider, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"range": {
+						"defaultValue": null,
+						"description": "Enables range slider with two thumbs",
+						"name": "range",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the slider input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"minName": {
+						"defaultValue": null,
+						"description": "Name of the slider min value input element, overrides the name",
+						"name": "minName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"maxName": {
+						"defaultValue": null,
+						"description": "Name of the slider max value input element, overrides the name",
+						"name": "maxName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the slider value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: SingleChangeArgs) => void) | ((args: RangeChangeArgs) => void) | ((args: RangeChangeArgs) => void)"
+						}
+					},
+					"onChangeCommit": {
+						"defaultValue": null,
+						"description": "Callback when the user commits the change by releasing the thumb\nCallback when the user commits the change by releasing the thumbs",
+						"name": "onChangeCommit",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: SingleChangeArgs) => void) | ((args: RangeChangeArgs) => void) | ((args: RangeChangeArgs) => void)"
+						}
+					},
+					"minValue": {
+						"defaultValue": null,
+						"description": "Minimum value of the slider",
+						"name": "minValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"maxValue": {
+						"defaultValue": null,
+						"description": "Maximum value of the slider",
+						"name": "maxValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultMinValue": {
+						"defaultValue": null,
+						"description": "Default minimum value of the slider, enables uncontrolled mode",
+						"name": "defaultMinValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultMaxValue": {
+						"defaultValue": null,
+						"description": "Default maximum value of the slider, enables uncontrolled mode",
+						"name": "defaultMaxValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1663,35 +9057,137 @@
 			"path": "./src/components/Stepper/tests/Stepper.stories.tsx",
 			"stories": [
 				{
+					"id": "components-stepper--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example>\n        <Example.Item title=\"direction: row\">\n            <Stepper activeId=\"1\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <Stepper activeId=\"1\" direction=\"column\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-stepper--label-display",
 					"name": "labelDisplay",
 					"snippet": "const labelDisplay = () => (\n    <Example>\n        <Example.Item title=\"direction: row, labels hidden\">\n            <Stepper activeId=\"1\" labelDisplay=\"hidden\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: column, labels hiden\">\n            <Stepper activeId=\"1\" direction=\"column\" labelDisplay=\"hidden\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: row, labels hidden on s\">\n            <Stepper activeId=\"1\" labelDisplay={{ s: \"hidden\", m: \"inline\" }}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-stepper--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 6, direction: row\">\n            <Stepper activeId=\"1\" gap={6}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"gap: 6, direction: column\">\n            <Stepper activeId=\"1\" direction=\"column\" gap={6}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap\", \"[s] 2\", \"[m+] 5\"]}>\n            <Stepper activeId=\"1\" gap={{ s: 2, m: 5 }}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-stepper--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Stepper className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Stepper.Item attributes={{ id: \"test-item-id\" }} className=\"test-item-classname\" />\n        </Stepper>\n    </div>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-stepper--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"multiline subtitle\",\n                \"should wrap the text correctly\",\n                \"should display the connector correctly\",\n            ]}\n        >\n            <Demo\n                activeId={0}\n                subtitle=\"It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, Placeholder, Stepper, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Stepper/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Stepper",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Stepper/Stepper.tsx",
-				"actualName": "Stepper",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"activeId": {
+						"defaultValue": null,
+						"description": "Id of the item to display as active",
+						"name": "activeId",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string | number" }
+					},
+					"labelDisplay": {
+						"defaultValue": null,
+						"description": "Display variant for the item label",
+						"name": "labelDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"hidden\" | \"inline\">" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Direction of the stepper",
+						"name": "direction",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between items (default: 3)",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
+				"exportName": "Stepper"
 			}
 		},
 		"components-switch": {
@@ -1700,38 +9196,236 @@
 			"path": "./src/components/Switch/tests/Switch.stories.tsx",
 			"stories": [
 				{
-					"name": "size",
+					"id": "components-switch--size",
+					"name": "Size",
 					"snippet": "const size = () => (\n\t<Example>\n\t\t<Example.Item title=\"size: medium\">\n\t\t\t<Switch name=\"active\" size=\"medium\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: small\">\n\t\t\t<Switch name=\"active\" size=\"small\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: large\">\n\t\t\t<Switch name=\"active\" size=\"large\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: responsive, s: small, m: large\">\n\t\t\t<Switch\n\t\t\t\tname=\"active\"\n\t\t\t\tsize={{ s: \"small\", m: \"large\" }}\n\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t/>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "label",
+					"id": "components-switch--label",
+					"name": "Label",
 					"snippet": "const label = () => (\n\t<Example>\n\t\t<Example.Item title=\"size: medium\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch reversed name=\"active\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: small\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" size=\"small\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch\n\t\t\t\t\treversed\n\t\t\t\t\tname=\"active\"\n\t\t\t\t\tsize=\"small\"\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t\t>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\n\t\t<Example.Item title=\"size: large\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" size=\"large\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch\n\t\t\t\t\treversed\n\t\t\t\t\tname=\"active\"\n\t\t\t\t\tsize=\"large\"\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t\t>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-switch--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Switch name=\"test-name\" defaultChecked onChange={fn()}>Label\n            </Switch>;"
 				},
 				{
-					"name": "checked",
+					"id": "components-switch--checked",
+					"name": "checked, uncontrolled",
 					"snippet": "const checked = () => <Switch name=\"test-name\" checked onChange={fn()}>Label\n            </Switch>;"
 				},
 				{
+					"id": "components-switch--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, unselected\">\n            <Switch name=\"active\" disabled inputAttributes={{ \"aria-label\": \"test switch\" }} />\n        </Example.Item>\n        <Example.Item title=\"disabled, selected\">\n            <Switch\n                name=\"active\"\n                disabled\n                defaultChecked\n                inputAttributes={{ \"aria-label\": \"test switch\" }}\n            />\n        </Example.Item>\n        <Example.Item title=\"disabled, with label\">\n            <Switch name=\"active\" disabled>\n                Switch\n            </Switch>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-switch--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Switch\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ \"aria-label\": \"test select\", id: \"test-input-id\" }}\n            name=\"name\"\n        >\n            Label\n        </Switch>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Switch, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Switch/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Switch",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Switch/Switch.tsx",
-				"actualName": "Switch",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the switch",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the switch input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the switch user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"reversed": {
+						"defaultValue": null,
+						"description": "Reverse the children position",
+						"name": "reversed",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the switch value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the switch is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the switch is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default value of the switch, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Value of the switch, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1741,51 +9435,112 @@
 			"path": "./src/components/Table/tests/Table.stories.tsx",
 			"stories": [
 				{
-					"name": "layout",
+					"id": "components-table--layout",
+					"name": "base",
 					"snippet": "const layout = () => (\n    <Example>\n        <Example.Item title=\"base\">\n            <Table>\n                <Table.Head>\n                    <Table.Row>\n                        <Table.Heading>Column 1</Table.Heading>\n                        <Table.Heading>Column 2</Table.Heading>\n                    </Table.Row>\n                </Table.Head>\n                <Table.Body>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell>Cell 2</Table.Cell>\n                    </Table.Row>\n                </Table.Body>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"colspan: 2 for col 2, rowspan: 2 for cell 3\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading colSpan={2}>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                    <Table.Cell rowSpan={2}>Cell 3</Table.Cell>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"align: center for heading 1, align: end for heading 2\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading align=\"center\">Column 1</Table.Heading>\n                    <Table.Heading align=\"end\">Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"valign: center for cell 2, valign: end for cell 3\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>\n                        <View height={15} backgroundColor=\"neutral-faded\" />\n                    </Table.Cell>\n                    <Table.Cell verticalAlign=\"center\">Cell 2</Table.Cell>\n                    <Table.Cell verticalAlign=\"end\">Cell 3</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"width: 40%, minWidth: 200px for col 1\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"40%\" minWidth=\"200px\">\n                        Column 1\n                    </Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-table--border",
 					"name": "border",
 					"snippet": "const border = () => (\n    <Example>\n        <Example.Item title=\"border: true\">\n            <Table border>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"columnBorder: true\">\n            <Table columnBorder>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"columnBorder: true, border: true\">\n            <Table columnBorder border>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-table--rows",
 					"name": "rows",
 					"snippet": "const rows = () => (\n    <Example>\n        <Example.Item title=\"highlighted for row 2\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row highlighted>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"clickable row 2, focus ring\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row onClick={() => {}}>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-table--render",
+					"name": "rendering",
 					"snippet": "const render = () => (\n    <Table>\n        <Table.Head>\n            <Table.Row>\n                <Table.Heading>Heading</Table.Heading>\n                <Table.Heading>Heading</Table.Heading>\n            </Table.Row>\n        </Table.Head>\n        <Table.Body>\n            <Table.Row>\n                <Table.Cell>Content</Table.Cell>\n                <Table.Cell>Content</Table.Cell>\n            </Table.Row>\n        </Table.Body>\n    </Table>\n);"
 				},
 				{
-					"name": "tbody",
+					"id": "components-table--tbody",
+					"name": "tbody rendering",
 					"snippet": "const tbody = () => (\n    <Table>\n        <Table.Row>\n            <Table.Heading>Heading</Table.Heading>\n            <Table.Heading>Heading</Table.Heading>\n        </Table.Row>\n    </Table>\n);"
 				},
 				{
-					"name": "tabIndex",
+					"id": "components-table--tab-index",
+					"name": "adds tabIndex for clickable rows",
 					"snippet": "const tabIndex = () => (\n    <Table>\n        <Table.Row>\n            <Table.Cell />\n        </Table.Row>\n        <Table.Row onClick={() => {}}>\n            <Table.Cell />\n        </Table.Row>\n        <Table.Row attributes={{ onClick: () => {} }}>\n            <Table.Cell />\n        </Table.Row>\n    </Table>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-table--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Table className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Table.Row attributes={{ id: \"test-row-id\" }}>\n                <Table.Cell attributes={{ id: \"test-cell-id\" }}></Table.Cell>\n            </Table.Row>\n        </Table>\n    </div>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-table--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"scroll fade\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"500px\">Column 1</Table.Heading>\n                    <Table.Heading width=\"500px\">Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"card with highlighted heading\">\n            <Card elevated padding={0}>\n                <Table>\n                    <Table.Row highlighted>\n                        <Table.Heading width=\"50%\" minWidth=\"200px\">\n                            Column 1\n                        </Table.Heading>\n                        <Table.Heading colSpan={2} align=\"end\">\n                            Column 2\n                        </Table.Heading>\n                    </Table.Row>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell align=\"center\">Cell 2</Table.Cell>\n                        <Table.Cell align=\"end\">Cell 3</Table.Cell>\n                    </Table.Row>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell align=\"center\">Cell 2</Table.Cell>\n                        <Table.Cell align=\"end\">Cell 3</Table.Cell>\n                    </Table.Row>\n                </Table>\n            </Card>\n        </Example.Item>\n        <Example.Item title=\"width: auto, nowrap\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"50%\">Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                    <Table.Heading>Column 3</Table.Heading>\n                    <Table.Heading width=\"auto\">Long heading title</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                    <Table.Cell>Cell 3</Table.Cell>\n                    <Table.Cell>Cell 4</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "examples",
+					"id": "components-table--examples",
+					"name": "test: selectable",
 					"snippet": "const examples = () => (\n    <Example>\n        <Example.Item title=\"selectable\">\n            <SelectionDemo />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Card, Checkbox, Example, Table, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Table/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Table",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Table/Table.tsx",
-				"actualName": "Table",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"border": {
+						"defaultValue": null,
+						"description": "Add border around the table",
+						"name": "border",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"columnBorder": {
+						"defaultValue": null,
+						"description": "Add border between the table columns",
+						"name": "columnBorder",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
+				"exportName": "Table"
 			}
 		},
 		"components-tabs": {
@@ -1794,71 +9549,196 @@
 			"path": "./src/components/Tabs/tests/Tabs.stories.tsx",
 			"stories": [
 				{
+					"id": "components-tabs--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Tabs>\n        <Tabs.List>\n            <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n            <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n        </Tabs.List>\n\n        <Tabs.Panel value=\"1\">\n            <View padding={4}>Content 1</View>\n        </Tabs.Panel>\n        <Tabs.Panel value=\"2\">\n            <View padding={4}>Content 2</View>\n        </Tabs.Panel>\n    </Tabs>\n);"
 				},
 				{
+					"id": "components-tabs--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Tabs defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills\">\n            <Tabs variant=\"pills\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills-elevated\">\n            <Tabs variant=\"pills-elevated\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: borderless\">\n            <Tabs variant=\"borderless\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"variant: default, size: large\">\n            <Tabs size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills, size: large\">\n            <Tabs variant=\"pills\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills-elevated, size: large\">\n            <Tabs variant=\"pills-elevated\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: borderless, size: large\">\n            <Tabs variant=\"borderless\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example>\n        <Example.Item title=\"direction: column, variant: underline\">\n            <Tabs direction=\"column\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: pills\">\n            <Tabs direction=\"column\" variant=\"pills\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: pills-elevated\">\n            <Tabs direction=\"column\" variant=\"pills-elevated\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: borderless\">\n            <Tabs direction=\"column\" variant=\"borderless\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Tabs>\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"1\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"icon only\">\n            <Tabs variant=\"pills-elevated\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap} attributes={{ \"aria-label\": \"Tab 1\" }} />\n                    <Tabs.Item value=\"1\" icon={IconZap} attributes={{ \"aria-label\": \"Tab 2\" }} />\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "equalWidth",
+					"id": "components-tabs--equal-width",
+					"name": "itemWidth",
 					"snippet": "const equalWidth = () => (\n    <Example>\n        <Example.Item title=\"equal width items\">\n            <Tabs onChange={console.log} itemWidth=\"equal\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"1\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                    <Tabs.Item value=\"2\" icon={IconZap}>\n                        Very long item 3\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--href",
 					"name": "href",
 					"snippet": "const href = () => (\n    <Example>\n        <Example.Item title=\"href, no onChange\">\n            <Tabs value=\"2\">\n                <Tabs.List>\n                    <Tabs.Item value=\"1\" href=\"#item-1\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"2\" href=\"#item-2\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                    <Tabs.Item value=\"3\" href=\"#item-3\" icon={IconZap}>\n                        Very long item 3\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "disabled",
+					"id": "components-tabs--disabled",
+					"name": "item, disabled",
 					"snippet": "const disabled = () => {\n    return (\n        <Example>\n            <Example.Item title=\"disabled\">\n                <Tabs defaultValue=\"1\">\n                    <Tabs.List>\n                        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"2\" disabled icon={IconZap}>\n                            Item 2\n                        </Tabs.Item>\n                        <Tabs.Item value=\"3\">Item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"1\">\n                        <View padding={4}>Content 1</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <View padding={4}>Content 2</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"3\">\n                        <View padding={4}>Content 3</View>\n                    </Tabs.Panel>\n                </Tabs>\n            </Example.Item>\n\n            <Example.Item title=\"disabled, href\">\n                <Tabs defaultValue=\"1\">\n                    <Tabs.List>\n                        <Tabs.Item href=\"#item1\" value=\"1\">\n                            Item 1\n                        </Tabs.Item>\n                        <Tabs.Item href=\"#item2\" value=\"2\" disabled icon={IconZap}>\n                            Item 2\n                        </Tabs.Item>\n                        <Tabs.Item href=\"#item3\" value=\"3\">\n                            Item 3\n                        </Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"1\">\n                        <View padding={4}>Content 1</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <View padding={4}>Content 2</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"3\">\n                        <View padding={4}>Content 3</View>\n                    </Tabs.Panel>\n                </Tabs>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-tabs--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <Tabs defaultValue=\"2\" onChange={fn()}>\n    <Tabs.List>\n        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n        <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n    </Tabs.List>\n    <Tabs.Panel value=\"1\">Content 1</Tabs.Panel>\n    <Tabs.Panel value=\"2\">Content 2</Tabs.Panel>\n</Tabs>;"
 				},
 				{
-					"name": "value",
+					"id": "components-tabs--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <Tabs value=\"2\" onChange={fn()}>\n    <Tabs.List>\n        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n        <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n    </Tabs.List>\n    <Tabs.Panel value=\"1\">Content 1</Tabs.Panel>\n    <Tabs.Panel value=\"2\">Content 2</Tabs.Panel>\n</Tabs>;"
 				},
 				{
-					"name": "className",
+					"id": "components-tabs--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Tabs>\n            <Tabs.List attributes={{ id: \"test-list-id\" }} className=\"test-list-classname\">\n                <Tabs.Item attributes={{ id: \"test-item-id\" }} value=\"1\">\n                    Item\n                </Tabs.Item>\n            </Tabs.List>\n\n            <Tabs.Panel\n                attributes={{ \"data-testid\": \"test-panel-id\" }}\n                className=\"test-panel-classname\"\n                value=\"1\"\n            />\n        </Tabs>\n    </div>\n);"
 				},
 				{
-					"name": "testFocusableContent",
+					"id": "components-tabs--test-focusable-content",
+					"name": "test: focusable content",
 					"snippet": "const testFocusableContent = () => (\n    <Example>\n        <Example.Item title=\"panels without focusable content\">\n            <Tabs>\n                <View gap={4}>\n                    <Tabs.List>\n                        <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                        <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"0\">Tab 1</Tabs.Panel>\n                    <Tabs.Panel value=\"1\">Tab 2</Tabs.Panel>\n                    <Tabs.Panel value=\"2\">Tab 3</Tabs.Panel>\n                </View>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"panels with focusable content\">\n            <Tabs>\n                <View gap={4}>\n                    <Tabs.List>\n                        <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                        <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"0\">\n                        <Button onClick={() => {}}>Tab 1 action</Button>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"1\">\n                        <Button onClick={() => {}}>Tab 2 action</Button>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <Button onClick={() => {}}>Tab 3 action</Button>\n                    </Tabs.Panel>\n                </View>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "components-tabs--test-composition",
+					"name": "test: composition",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item title=\"Viewport overflow\">\n            <Tabs>\n                <Tabs.List>\n                    {[...Array(8)].map((_, i) => (\n                        <Tabs.Item value={`${i}`} key={i} icon={IconZap}>\n                            Very long item {i}\n                        </Tabs.Item>\n                    ))}\n                </Tabs.List>\n\n                {[...Array(8)].map((_, i) => (\n                    <Tabs.Panel value={`${i}`} key={i}>\n                        Tab {i}\n                    </Tabs.Panel>\n                ))}\n            </Tabs>\n        </Example.Item>\n        <Example.Item>\n            <Tabs onChange={console.log} variant=\"pills-elevated\" name=\"hey\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">\n                        <View borderColor=\"neutral-faded\" padding={5}>\n                            Item 3\n                        </View>\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"Custom non-interactive list children\">\n            <Tabs direction=\"column\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <View height={6} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testEdgeCaseDom",
+					"id": "components-tabs--test-edge-case-dom",
+					"name": "test: scroll subscription",
 					"snippet": "const testEdgeCaseDom = () => {\n    const [activeItem, setActiveItem] = React.useState(\"1\");\n    const sectionsRef = React.useRef(null);\n\n    return (\n        <Example>\n            <Example.Item title=\"active item changes on scroll\">\n                <View justify=\"center\" align=\"center\" padding={10}>\n                    <View width={60} gap={2}>\n                        <Tabs value={activeItem} onChange={(args) => setActiveItem(args.value)}>\n                            <Tabs.List>\n                                <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                                <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n                                <Tabs.Item value=\"3\">Item 3</Tabs.Item>\n                                <Tabs.Item value=\"4\">Item 4</Tabs.Item>\n                            </Tabs.List>\n                        </Tabs>\n\n                        <ScrollArea\n                            attributes={{ ref: sectionsRef }}\n                            height={70}\n                            onScroll={(args) => {\n                                setActiveItem(Math.min(4, Math.floor(args.y * 10) + 1).toString());\n                            }}\n                        >\n                            <View gap={4}>\n                                <View gap={2}>\n                                    <Text>Section 1</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View grow height=\"100px\" backgroundColor=\"neutral-faded\" key={i} />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 2</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 3</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 4</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n                            </View>\n                        </ScrollArea>\n                    </View>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Example, ScrollArea, Tabs, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Tabs/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Tabs",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Tabs/Tabs.tsx",
-				"actualName": "Tabs",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Direction of the tab buttons",
+						"name": "direction",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"itemWidth": {
+						"defaultValue": null,
+						"description": "Equal width for the tab buttons",
+						"name": "itemWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"equal\"", "value": [{ "value": "\"equal\"" }] }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Render variant for component",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"bordered\" | \"borderless\" | \"pills\" | \"pills-elevated\"",
+							"value": [
+								{ "value": "\"bordered\"" },
+								{ "value": "\"borderless\"" },
+								{ "value": "\"pills\"" },
+								{ "value": "\"pills-elevated\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"large\" | \"medium\"",
+							"value": [{ "value": "\"large\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the tab buttons group when used as a form control",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the active tab value changes",
+						"name": "onChange",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((args: { value: string; name?: string; }) => void)" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the active tab, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the active tab, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "Tabs"
 			}
 		},
 		"components-textarea": {
@@ -1867,71 +9747,315 @@
 			"path": "./src/components/TextArea/tests/TextArea.stories.tsx",
 			"stories": [
 				{
-					"name": "variants",
+					"id": "components-textarea--variants",
+					"name": "variant",
 					"snippet": "const variants = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <TextArea variant=\"faded\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless\">\n            <TextArea variant=\"headless\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: medium\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"medium\" />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"large\" />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"xlarge\" />\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] large\", \"[m+] medium\"]}>\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size={{ s: \"xlarge\", m: \"medium\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--resize",
 					"name": "resize",
 					"snippet": "const resize = () => (\n    <Example>\n        <Example.Item title=\"resize: none\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" resize=\"none\" />\n        </Example.Item>\n        <Example.Item title=\"resize: auto\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" resize=\"auto\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-textarea--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" hasError />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner\">\n            <View gap={2}>\n                <Text variant=\"featured-2\">What problem are you trying to solve?</Text>\n                <TextArea.Aligner>\n                    <TextArea\n                        variant=\"headless\"\n                        placeholder=\"Try something like 'I have a job'\"\n                        name=\"description\"\n                    />\n                </TextArea.Aligner>\n                <View.Item>\n                    <Button>Next</Button>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-textarea--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"long value without breaks\">\n            <TextArea\n                name=\"hey\"\n                defaultValue={`<div style=\"position:relative;width:100%;padding-top:calc(150% + 72px)\">\n<iframe src=\"nskjdfdsdkjfsjkdfhbsjlhdfbsjlhfbs;jhbsdljfhsbljhfsbljhfbsjlfdhbsljhfbsdljhfbsljhfbslufbhsdlfds\" />\n</div>`}\n                resize=\"auto\"\n                placeholder=\"Placeholder\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-textarea--render",
+					"name": "base",
 					"snippet": "const render = () => <TextArea name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-textarea--placeholder",
 					"name": "placeholder",
 					"snippet": "const placeholder = () => (\n    <TextArea\n        name=\"test-name\"\n        placeholder=\"Placeholder\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-textarea--id",
 					"name": "id",
 					"snippet": "const id = () => (\n    <TextArea name=\"test-name\" id=\"test-id\" inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
+					"id": "components-textarea--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <TextArea name=\"test-name\" disabled inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-textarea--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <TextArea\n    name=\"test-name\"\n    defaultValue=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-textarea--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <TextArea\n    name=\"test-name\"\n    value=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-textarea--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <TextArea\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-textarea--form-control",
+					"name": "test: form control",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"with helper\">\n            <FormControl>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextArea name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n        <Example.Item title=\"with error\">\n            <FormControl hasError>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextArea name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, FormControl, Text, TextArea, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/TextArea/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "TextArea",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/TextArea/TextArea.tsx",
-				"actualName": "TextArea",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text area",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text area input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text area user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text area value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLTextAreaElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text area is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLTextAreaElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text area is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLTextAreaElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"textarea\">" }
+					},
+					"resize": {
+						"defaultValue": null,
+						"description": "Enable or disable the text area resizing, supports auto-sizing",
+						"name": "resize",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"none\" | \"auto\"",
+							"value": [{ "value": "\"none\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "TextArea"
 			}
 		},
 		"components-textfield": {
@@ -1940,71 +10064,445 @@
 			"path": "./src/components/TextField/tests/TextField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-textfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <TextField variant=\"faded\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless\">\n            <TextField variant=\"headless\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded\">\n            <TextField\n                rounded\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                icon={IconZap}\n                prefix=\"+31\"\n                endSlot={<Button rounded size=\"small\" icon={IconZap} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"rounded, variant: faded\">\n            <View direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <TextField\n                        rounded\n                        variant=\"faded\"\n                        name=\"Name\"\n                        placeholder=\"Enter your name\"\n                        startSlot={\n                            <Badge rounded size=\"small\">\n                                Hello\n                            </Badge>\n                        }\n                    />\n                </View.Item>\n                <Button rounded>Submit</Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-textfield--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" hasError />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "attachments",
+					"id": "components-textfield--attachments",
+					"name": "icon, endIcon, suffix, prefix, startSlot, endSlot, startSlotPadding, endSlotPadding",
 					"snippet": "const attachments = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" value=\"Reshaped\" icon={IconZap} />\n        </Example.Item>\n        <Example.Item title=\"endIcon\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" value=\"Reshaped\" endIcon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title={[\"startSlot\", \"vertical and horizontal padding aligned\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title={[\"endSlot\", \"vertical and horizontal padding aligned\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                endSlot={\n                    <Button\n                        icon={IconZap}\n                        size=\"small\"\n                        onClick={() => {}}\n                        attributes={{ \"aria-label\": \"Action\" }}\n                    />\n                }\n            />\n        </Example.Item>\n\n        <Example.Item title=\"paddingSlotStart=4, paddingSlotEnd=2\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlotPadding={4}\n                endSlotPadding={2}\n                startSlot={<Placeholder h={20} />}\n                endSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"with all affixes\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                endIcon={IconZap}\n                icon={IconZap}\n                prefix=\"Estimated value\"\n                suffix=\"m2\"\n                startSlot={<Placeholder h={20} />}\n                endSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"multiline wrap\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlot={[...Array(10).keys()].map((i) => (\n                    <Badge size=\"small\" key={i}>\n                        Item {i + 1}\n                    </Badge>\n                ))}\n                multiline\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"small\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"medium\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"large\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"xlarge\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] xlarge\", \"[m+] medium\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                size={{ s: \"xlarge\", m: \"medium\" }}\n                icon={IconZap}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner\">\n            <View gap={2}>\n                <Text variant=\"featured-2\">What problem are you trying to solve?</Text>\n                <TextField.Aligner>\n                    <TextField\n                        variant=\"headless\"\n                        placeholder=\"Try something like 'I have a job'\"\n                        name=\"description\"\n                    />\n                </TextField.Aligner>\n                <View.Item>\n                    <Button>Next</Button>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-textfield--render",
+					"name": "base",
 					"snippet": "const render = () => <TextField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-textfield--placeholder",
 					"name": "placeholder",
 					"snippet": "const placeholder = () => (\n    <TextField\n        name=\"test-name\"\n        placeholder=\"Placeholder\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-textfield--id",
 					"name": "id",
 					"snippet": "const id = () => (\n    <TextField name=\"test-name\" id=\"test-id\" inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
+					"id": "components-textfield--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <TextField name=\"test-name\" disabled inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-textfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <TextField\n    name=\"test-name\"\n    defaultValue=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-textfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <TextField\n    name=\"test-name\"\n    value=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-textfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <TextField\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-textfield--form-control",
+					"name": "test: form control",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"with helper\">\n            <FormControl>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextField name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n        <Example.Item title=\"with error\">\n            <FormControl hasError>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextField name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Badge, Button, Example, FormControl, Placeholder, Text, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/TextField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "TextField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/TextField/TextField.tsx",
-				"actualName": "TextField",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"multiline": {
+						"defaultValue": null,
+						"description": "Enable multiline text field wrapping",
+						"name": "multiline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to be fully rounded",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content after the text field value",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text field value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the text field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the text field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "TextField"
 			}
 		},
 		"components-timeline": {
@@ -2013,27 +10511,71 @@
 			"path": "./src/components/Timeline/tests/Timeline.stories.tsx",
 			"stories": [
 				{
+					"id": "components-timeline--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"children passed directly\">\n            <Timeline>\n                <Placeholder />\n                <Placeholder />\n                <Placeholder />\n            </Timeline>\n        </Example.Item>\n        <Example.Item title=\"children wrapped with Timeline.Item\">\n            <Timeline>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "marker",
+					"id": "components-timeline--marker",
+					"name": "markerSlot",
 					"snippet": "const marker = () => (\n    <Example>\n        <Example.Item title=\"slot\">\n            <Timeline>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n\n        <Example.Item title=\"null marker\">\n            <Timeline>\n                <Timeline.Item markerSlot={null}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={null}>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-timeline--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Timeline className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Timeline.Item className=\"test-item-classname\" attributes={{ id: \"test-item-id\" }}>\n                Content\n            </Timeline.Item>\n            <Timeline.Item>Content</Timeline.Item>\n        </Timeline>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Placeholder, Timeline } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Timeline/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Timeline",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Timeline/Timeline.tsx",
-				"actualName": "Timeline",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"ul\">" }
+					}
+				},
+				"exportName": "Timeline"
 			}
 		},
 		"components-toast": {
@@ -2041,32 +10583,54 @@
 			"name": "Toast",
 			"path": "./src/components/Toast/tests/Toast.stories.tsx",
 			"stories": [
-				{ "name": "size", "snippet": "const size = () => <Size />;" },
 				{
+					"id": "components-toast--size",
+					"name": "size",
+					"snippet": "const size = () => <Size />;"
+				},
+				{
+					"id": "components-toast--position",
 					"name": "position",
 					"snippet": "const position = () => <Position />;"
 				},
-				{ "name": "color", "snippet": "const color = () => <Color />;" },
-				{ "name": "timeout", "snippet": "const timeout = () => <Timeout />;" },
 				{
-					"name": "regionOptions",
+					"id": "components-toast--color",
+					"name": "color",
+					"snippet": "const color = () => <Color />;"
+				},
+				{
+					"id": "components-toast--timeout",
+					"name": "timeout",
+					"snippet": "const timeout = () => <Timeout />;"
+				},
+				{
+					"id": "components-toast--region-options",
+					"name": "expanded",
 					"snippet": "const regionOptions = () => <Expanded />;"
 				},
-				{ "name": "slots", "snippet": "const slots = () => <Slots />;" },
 				{
+					"id": "components-toast--slots",
+					"name": "slots",
+					"snippet": "const slots = () => <Slots />;"
+				},
+				{
+					"id": "components-toast--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const toast = useToast();\n\n    return (\n        <Button\n            onClick={() => {\n                const id = toast.show({\n                    title: \"Title\",\n                    text: \"Text\",\n                    children: \"Children\",\n                    startSlot: \"Slot\",\n                    actionsSlot: (\n                        <Button attributes={{ \"data-testid\": \"trigger-id\" }} onClick={() => toast.hide(id)}>\n                            Trigger\n                        </Button>\n                    ),\n                });\n            }}\n        >\n            Show toast\n        </Button>\n    );\n};"
 				},
 				{
-					"name": "nested",
+					"id": "components-toast--nested",
+					"name": "ToastProvider",
 					"snippet": "const nested = () => {\n    return (\n        <div data-testid=\"test-container-id\">\n            <ToastProvider>\n                <NestedDemo />\n            </ToastProvider>\n        </div>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-toast--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => {\n    const toast = useToast();\n\n    return (\n        <Button\n            onClick={() => {\n                const id = toast.show({\n                    text: \"Content\",\n                    attributes: { \"data-testid\": \"test-id\" },\n                    className: \"test-classname\",\n                });\n            }}\n        >\n            Show toast\n        </Button>\n    );\n};"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-toast--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"Multiline, should support dynamic height\">\n            <Multiline />\n        </Example.Item>\n        <Example.Item title=\"Nested ToastProvider\">\n            <ToastProvider>\n                <Nested />\n            </ToastProvider>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
@@ -2083,30 +10647,601 @@
 			"path": "./src/components/ToggleButton/tests/ToggleButton.stories.tsx",
 			"stories": [
 				{
+					"id": "components-togglebutton--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"outline\">\n            <ToggleButton>Button</ToggleButton>\n        </Example.Item>\n        <Example.Item title=\"ghost\">\n            <ToggleButton variant=\"ghost\">Button</ToggleButton>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-togglebutton--selected-color",
 					"name": "selectedColor",
 					"snippet": "const selectedColor = () => (\n    <Example>\n        <Example.Item title=\"selectedColor: primary\">\n            <ToggleButton selectedColor=\"primary\" defaultChecked>\n                Button\n            </ToggleButton>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onChange",
+					"id": "components-togglebutton--on-change",
+					"name": "checked, defaultChecked, onChange",
 					"snippet": "const onChange = () => <Example>\n    <Example.Item title=\"defaultChecked, onChange\">\n        <ToggleButton defaultChecked onChange={fn()} value=\"1\">Button\n                                </ToggleButton>\n    </Example.Item>\n    <Example.Item title=\"checked, onChange\">\n        <ToggleButton checked onChange={fn()} value=\"2\">Button\n                                </ToggleButton>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-togglebutton--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <ToggleButton onClick={fn()}>Button</ToggleButton>;"
 				}
 			],
 			"import": "import { Example, ToggleButton } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ToggleButton/ToggleButton.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "ToggleButton",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ToggleButton/ToggleButton.tsx",
-				"actualName": "ToggleButton",
+				"methods": [],
+				"props": {
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loading": {
+						"defaultValue": null,
+						"description": "Show loading state",
+						"name": "loading",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loadingAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the loading indicator",
+						"name": "loadingAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Make the component take the full width of the parent element",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"ghost\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"ghost\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"selectedColor": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme when selected",
+						"name": "selectedColor",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the toggle button, enables controlled mode for the ToggleButtonGroup",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the toggle button value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { checked: boolean; value: string; event: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>; }) => void)"
+						}
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default value of the toggle button, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Value of the toggle button, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2116,34 +11251,194 @@
 			"path": "./src/components/ToggleButtonGroup/tests/ToggleButtonGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "single",
+					"id": "components-togglebuttongroup--single",
+					"name": "checked, defaultChecked, onChange",
 					"snippet": "const single = () => <Example>\n    <Example.Item title=\"single, uncontrolled, onChange\">\n        <ToggleButtonGroup onChange={fn()}>\n            <ToggleButton value=\"1\" onChange={fn()}>Button\n                                    </ToggleButton>\n            <ToggleButton value=\"2\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n    <Example.Item title=\"single, controlled, onChange\">\n        <ToggleButtonGroup onChange={fn()} value={[]}>\n            <ToggleButton value=\"3\" onChange={fn()}>Button\n                                    </ToggleButton>\n            <ToggleButton value=\"4\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "multiple",
+					"id": "components-togglebuttongroup--multiple",
+					"name": "selectionMode, checked, defaultChecked, onChange",
 					"snippet": "const multiple = () => <Example>\n    <Example.Item title=\"multiple, uncontrolled, onChange\">\n        <ToggleButtonGroup onChange={fn()} selectionMode=\"multiple\">\n            <ToggleButton value=\"1\">Button</ToggleButton>\n            <ToggleButton value=\"2\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n    <Example.Item title=\"multiple, controlled, onChange\">\n        <ToggleButtonGroup onChange={fn()} value={[]} selectionMode=\"multiple\">\n            <ToggleButton value=\"3\">Button</ToggleButton>\n            <ToggleButton value=\"4\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "selectedColor",
+					"id": "components-togglebuttongroup--selected-color",
+					"name": "color,selectedColor",
 					"snippet": "const selectedColor = () => (\n    <Example>\n        <Example.Item title=\"selectedColor: primary\">\n            <ToggleButtonGroup selectedColor=\"primary\" defaultValue={[\"2\"]}>\n                <ToggleButton value=\"1\">Button</ToggleButton>\n                <ToggleButton value=\"2\">Button</ToggleButton>\n                <ToggleButton value=\"3\">Button</ToggleButton>\n            </ToggleButtonGroup>\n        </Example.Item>\n        <Example.Item title=\"color: primary, selectedColor: critical\">\n            <ToggleButtonGroup color=\"primary\" selectedColor=\"critical\" defaultValue={[\"2\"]}>\n                <ToggleButton value=\"1\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n                <ToggleButton value=\"2\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n                <ToggleButton value=\"3\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n            </ToggleButtonGroup>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-togglebuttongroup--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ToggleButtonGroup className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <ToggleButton>Button 1</ToggleButton>\n            <ToggleButton>Button 1</ToggleButton>\n        </ToggleButtonGroup>\n    </div>\n);"
 				},
 				{
-					"name": "testIcon",
+					"id": "components-togglebuttongroup--test-icon",
+					"name": "test: icon only",
 					"snippet": "const testIcon = () => (\n    <Example>\n        <Example.Item title=\"icon only\">\n            <ToggleButtonGroup selectedColor=\"primary\">\n                <ToggleButton value=\"1\" icon={IconPlus} />\n                <ToggleButton value=\"2\" icon={IconMinus} />\n                <ToggleButton value=\"3\" icon={IconCheckmark} />\n            </ToggleButtonGroup>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, ToggleButton, ToggleButtonGroup } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ToggleButtonGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ToggleButtonGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx",
-				"actualName": "ToggleButtonGroup",
+				"methods": [],
+				"props": {
+					"selectionMode": {
+						"defaultValue": { "value": "\"single\"" },
+						"description": "Selection mode for the toggle button group",
+						"name": "selectionMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"single\" | \"multiple\"",
+							"value": [{ "value": "\"single\"" }, { "value": "\"multiple\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme applied to each button",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"selectedColor": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme for the selected button",
+						"name": "selectedColor",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the toggle button group value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { value: string[]; event: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>; }) => void)"
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting child Button components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Selected values in the group, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default selected values in the group, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2153,30 +11448,269 @@
 			"path": "./src/components/Tooltip/tests/Tooltip.stories.tsx",
 			"stories": [
 				{
+					"id": "components-tooltip--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: bottom-start\">\n            <View direction=\"row\" gap={2}>\n                <Demo position=\"bottom-start\" text=\"Tooltip 1\" />\n                <Demo position=\"bottom-start\" text=\"Tooltip 2\" />\n                <Demo position=\"bottom-start\" text=\"Tooltip 3\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: bottom\">\n            <Demo position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"position: bottom-end\">\n            <Demo position=\"bottom-end\" />\n        </Example.Item>\n        <Example.Item title=\"position: top-start\">\n            <Demo position=\"top-start\" />\n        </Example.Item>\n        <Example.Item title=\"position: top\">\n            <Demo position=\"top\" />\n        </Example.Item>\n        <Example.Item title=\"position: top-end\">\n            <Demo position=\"top-end\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: start\">\n            <View align=\"end\">\n                <Demo position=\"start\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: start-top\">\n            <View align=\"end\">\n                <Demo position=\"start-top\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: start-bottom\">\n            <View align=\"end\">\n                <Demo position=\"start-bottom\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <Demo position=\"end\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: end-top\">\n            <Demo position=\"end-top\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: end-bottom\">\n            <Demo position=\"end-bottom\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tooltip--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: inverted\">\n            <Demo color=\"inverted\" position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"color: dark\">\n            <Demo color=\"dark\" position=\"bottom\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-tooltip--default-active",
+					"name": "uncontrolled",
 					"snippet": "const defaultActive = () => <Tooltip text=\"Content\" onOpen={fn()} onClose={fn()}>\n    {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n</Tooltip>;"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-tooltip--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"responsive visibility\">\n            <DemoResponsive text=\"Responsive\" />\n        </Example.Item>\n\n        <Example.Item title=\"without text\">\n            <Tooltip>{() => <Button>Button</Button>}</Tooltip>\n        </Example.Item>\n\n        <Example.Item title=\"tooltip with popover\">\n            <Tooltip text=\"Tooltip\" position=\"top\">\n                {(attributes) => (\n                    <Popover position=\"bottom\">\n                        <Popover.Trigger>\n                            {(popoverAttributes) => (\n                                <Button attributes={{ ...attributes, ...popoverAttributes }}>Action</Button>\n                            )}\n                        </Popover.Trigger>\n                        <Popover.Content>Popover</Popover.Content>\n                    </Popover>\n                )}\n            </Tooltip>\n        </Example.Item>\n\n        <Example.Item title=\"nested popovers inside a tooltip\">\n            <View direction=\"row\" gap={2}>\n                <Tooltip position=\"top\" text=\"Hello\">\n                    {(tooltipAttributes) => (\n                        <Popover position=\"bottom\" width=\"300px\">\n                            <Popover.Trigger>\n                                {(attributes) => (\n                                    <Button attributes={{ ...tooltipAttributes, ...attributes }}>\n                                        Tooltip with popover\n                                    </Button>\n                                )}\n                            </Popover.Trigger>\n                            <Popover.Content>\n                                <View gap={2} align=\"center\" direction=\"row\" justify=\"space-between\">\n                                    Popover content\n                                    <Popover position=\"bottom\" width=\"300px\">\n                                        <Popover.Trigger>\n                                            {(attributes) => <Button attributes={attributes}>Open</Button>}\n                                        </Popover.Trigger>\n                                        <Popover.Content>\n                                            <Popover.Dismissible align=\"center\" closeAriaLabel=\"Close\">\n                                                Another popover content\n                                            </Popover.Dismissible>\n                                        </Popover.Content>\n                                    </Popover>\n                                </View>\n                            </Popover.Content>\n                        </Popover>\n                    )}\n                </Tooltip>\n                <Tooltip position=\"top\" text=\"Hello\">\n                    {(tooltipAttributes) => <Button attributes={tooltipAttributes}>Just a tooltip</Button>}\n                </Tooltip>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, Popover, Tooltip, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Tooltip/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Tooltip",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Tooltip/Tooltip.tsx",
-				"actualName": "Tooltip",
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the flyout content interactivity",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"contentAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the content element",
+						"name": "contentAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"contentClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the content element",
+						"name": "contentClassName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "(attributes: TriggerAttributes) => ReactNode" }
+					},
+					"text": {
+						"defaultValue": null,
+						"description": "Text content for the tooltip",
+						"name": "text",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"inverted\"" },
+						"description": "Color of the tooltip",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"dark\" | \"inverted\"",
+							"value": [{ "value": "\"dark\"" }, { "value": "\"inverted\"" }]
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2186,51 +11720,191 @@
 			"path": "./src/components/Accordion/tests/Accordion.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-accordion--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Accordion defaultActive>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--icon-size",
 					"name": "iconSize",
 					"snippet": "const iconSize = () => (\n    <Accordion iconSize={6}>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--icon-position",
 					"name": "iconPosition",
 					"snippet": "const iconPosition = () => (\n    <Accordion iconPosition=\"start\">\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Accordion defaultActive gap={4}>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <Placeholder />\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--on-toggle",
 					"name": "onToggle",
 					"snippet": "const onToggle = () => <Accordion onToggle={fn()}>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
+					"id": "utility-components-accordion--active",
 					"name": "active",
 					"snippet": "const active = () => <Accordion onToggle={fn()} active>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
+					"id": "utility-components-accordion--default-active",
 					"name": "defaultActive",
 					"snippet": "const defaultActive = () => <Accordion onToggle={fn()} defaultActive>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
-					"name": "renderProps",
+					"id": "utility-components-accordion--render-props",
+					"name": "children: render props",
 					"snippet": "const renderProps = () => <Accordion onToggle={fn()}>\n    <Accordion.Trigger>\n        {(attributes, { active }) => (\n            <Button attributes={{ ...attributes, \"data-active\": active }}>Trigger</Button>\n        )}\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-accordion--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Accordion className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Accordion.Trigger>\n                <Placeholder>Trigger</Placeholder>\n            </Accordion.Trigger>\n            <Accordion.Content>\n                <View paddingTop={2}>\n                    <Placeholder />\n                </View>\n            </Accordion.Content>\n        </Accordion>\n    </div>\n);"
 				}
 			],
 			"import": "import { Accordion, Button, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Accordion/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Accordion",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Accordion/Accordion.tsx",
-				"actualName": "Accordion",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"iconSize": {
+						"defaultValue": null,
+						"description": "Expand / collapse icon size in units",
+						"name": "iconSize",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"iconPosition": {
+						"defaultValue": null,
+						"description": "Position of the expand / collapse icon",
+						"name": "iconPosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"start\" | \"end\"",
+							"value": [{ "value": "\"start\"" }, { "value": "\"end\"" }]
+						}
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between the trigger and the content",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the trigger and the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onToggle": {
+						"defaultValue": null,
+						"description": "Callback when the accordion is expanded or collapsed",
+						"name": "onToggle",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((active: boolean) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control whether the accordion is expanded or collapsed, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control whether the accordion is expanded or collapsed by default, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Accordion"
 			}
 		},
 		"utility-components-actionable": {
@@ -2239,54 +11913,456 @@
 			"path": "./src/components/Actionable/tests/Actionable.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "utility-components-actionable--base",
+					"name": "href, onClick",
 					"snippet": "const base = () => <Example>\n    <Example.Item title=\"span\">\n        <Actionable>Span</Actionable>\n    </Example.Item>\n    <Example.Item title=\"onClick\">\n        <Actionable onClick={fn()}>Button</Actionable>\n    </Example.Item>\n    <Example.Item title=\"href\">\n        <Actionable href=\"https://reshaped.so\" attributes={{ target: \"_blank\" }}>Link\n                            </Actionable>\n    </Example.Item>\n    <Example.Item title=\"attributes.href\">\n        <Actionable attributes={{ href: \"https://reshaped.so\" }}>Link with attributes</Actionable>\n    </Example.Item>\n    <Example.Item title=\"href, onClick\">\n        <Actionable\n            onClick={(e) => {\n                e.preventDefault();\n                args.handleSecondClick(e);\n            }}\n            href=\"https://reshaped.so\">Link with onClick\n                            </Actionable>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "utility-components-actionable--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, button\">\n            <Actionable disabled onClick={() => {}}>\n                Button\n            </Actionable>\n        </Example.Item>\n        <Example.Item title=\"disabled, link\">\n            <Actionable disabled href=\"https://reshaped.so\">\n                Link\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--full-width",
 					"name": "fullWidth",
 					"snippet": "const fullWidth = () => (\n    <Example>\n        <Example.Item title=\"fullWidth\">\n            <Actionable fullWidth href=\"https://reshaped.so\">\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--inset-focus",
 					"name": "insetFocus",
 					"snippet": "const insetFocus = () => (\n    <Example>\n        <Example.Item title=\"insetFocus\">\n            <Actionable insetFocus onClick={() => {}}>\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--disable-focus-ring",
 					"name": "disableFocusRing",
 					"snippet": "const disableFocusRing = () => (\n    <Example>\n        <Example.Item title=\"disableFocusRing\">\n            <Actionable disableFocusRing onClick={() => {}}>\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--border-radius",
 					"name": "borderRadius",
 					"snippet": "const borderRadius = () => (\n    <Example>\n        <Example.Item title=\"borderRadius: inherit\">\n            <Actionable borderRadius=\"inherit\" onClick={() => {}}>\n                <View borderRadius=\"large\">Actionable</View>\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--type",
 					"name": "type",
 					"snippet": "const type = (args) => (\n    <Example>\n        <Example.Item title=\"type: submit\">\n            <form\n                onSubmit={(e) => {\n                    e.preventDefault();\n                    args.handleSubmit();\n                }}\n            >\n                <Actionable onClick={() => {}} type=\"submit\">\n                    Submit\n                </Actionable>\n            </form>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "as",
+					"id": "utility-components-actionable--as",
+					"name": "as, render",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"as: span\">\n            <Actionable onClick={() => {}} as=\"span\">\n                Trigger\n            </Actionable>\n        </Example.Item>\n        <Example.Item title=\"render, disabled\">\n            <Actionable disabled onClick={() => {}} render={(props) => <section {...props} />}>\n                Trigger\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--stop-propagation",
 					"name": "stopPropagation",
 					"snippet": "const stopPropagation = () => <div onClick={fn()}>\n    <Actionable stopPropagation onClick={() => {}}>Trigger\n                    </Actionable>\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-actionable--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Actionable className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Actionable>\n    </div>\n);"
 				}
 			],
 			"import": "import { Actionable, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Actionable/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Actionable",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Actionable/Actionable.tsx",
-				"actualName": "Actionable",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"touchHitbox": {
+						"defaultValue": null,
+						"description": "Enable a minimum required touch hitbox",
+						"name": "touchHitbox",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Take up the full width of its parent",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"insetFocus": {
+						"defaultValue": null,
+						"description": "Enable a focus ring inside the element bounds",
+						"name": "insetFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableFocusRing": {
+						"defaultValue": null,
+						"description": "Don't show a focus ring on focus, can be used when it is within a container with a focus ring",
+						"name": "disableFocusRing",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Apply the focus ring to the child and rely on its border radius",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"inherit\"", "value": [{ "value": "\"inherit\"" }] }
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2296,30 +12372,149 @@
 			"path": "./src/components/Container/tests/Container.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-container--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: default\">\n            <Container>\n                <Placeholder />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"padding: 0\">\n            <Container padding={0}>\n                <Placeholder />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "utility-components-container--size",
+					"name": "width, height, maxHeight",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"width: 200px, height: 200px\">\n            <Container width=\"200px\" height=\"200px\">\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width: 200px, height: 200px, maxHeight: 100px\">\n            <Container width=\"200px\" height=\"200px\" maxHeight=\"100px\">\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width, height: [s] 100px, [m+] 200px\">\n            <Container width={{ s: \"100px\", m: \"200px\" }} height={{ s: \"100px\", m: \"200px\" }}>\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width, height: [s] 100px, [m+] 200px, maxHeight: [s] 50px, [m+]: 100px\">\n            <Container\n                width={{ s: \"100px\", m: \"200px\" }}\n                height={{ s: \"100px\", m: \"200px\" }}\n                maxHeight={{ s: \"50px\", m: \"100px\" }}\n            >\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "flex",
+					"id": "utility-components-container--flex",
+					"name": "align, justify",
 					"snippet": "const flex = () => (\n    <Example>\n        <Example.Item title=\"align: center, justify: center\">\n            <Container align=\"center\" justify=\"center\" height=\"200px\">\n                <Placeholder />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-container--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Container className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </Container>\n    </div>\n);"
 				}
 			],
 			"import": "import { Container, Example, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Container/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Container",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Container/Container.tsx",
-				"actualName": "Container",
+				"methods": [],
+				"props": {
+					"align": {
+						"defaultValue": null,
+						"description": "Flex align-items for the content",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Flex justify-content for the content",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier\nComponent height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" },
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height style, literal string value or a base unit token number multiplier\nComponent max height, literal css value or unit token multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" },
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Component inline padding",
+						"name": "padding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Component width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2329,34 +12524,157 @@
 			"path": "./src/components/Dismissible/tests/Dismissible.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-dismissible--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Dismissible closeAriaLabel=\"Close banner\" onClose={() => {}}>\n                <Placeholder />\n            </Dismissible>\n        </Example.Item>\n        <Example.Item title=\"variant: media\">\n            <View width=\"300px\">\n                <Dismissible variant=\"media\" closeAriaLabel=\"Close banner\" onClose={() => {}}>\n                    <View aspectRatio={16 / 9}>\n                        <Image\n                            height=\"100%\"\n                            src=\"https://images.unsplash.com/photo-1607030529528-ca6923e27f77?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1867&q=80)\"\n                        />\n                    </View>\n                </Dismissible>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-dismissible--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: center\">\n            <Dismissible align=\"center\" closeAriaLabel=\"Close\" onClose={() => {}}>\n                <Placeholder />\n            </Dismissible>\n        </Example.Item>\n\n        <Example.Item title=\"align: center, variant: media\">\n            <Dismissible align=\"center\" closeAriaLabel=\"Close\" variant=\"media\" onClose={() => {}}>\n                <View aspectRatio={16 / 9}>\n                    <Image\n                        height=\"100%\"\n                        src=\"https://images.unsplash.com/photo-1607030529528-ca6923e27f77?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1867&q=80)\"\n                    />\n                </View>\n            </Dismissible>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-dismissible--hide-close-button",
 					"name": "hideCloseButton",
 					"snippet": "const hideCloseButton = () => (\n    <Example>\n        <Example.Item title=\"hide close button\">\n            <div id=\"root\">\n                <Dismissible hideCloseButton>\n                    <Placeholder />\n                </Dismissible>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "closeAriaLabel",
+					"id": "utility-components-dismissible--close-aria-label",
+					"name": "onClose, closeAriaLabel",
 					"snippet": "const closeAriaLabel = () => <Dismissible closeAriaLabel=\"Close\" onClose={fn()}>\n    <Placeholder />\n</Dismissible>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-dismissible--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Dismissible\n            closeAriaLabel=\"Close\"\n            onClose={() => {}}\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n        >\n            <Placeholder />\n        </Dismissible>\n    </div>\n);"
 				}
 			],
 			"import": "import { Dismissible, Example, Image, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Dismissible/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Dismissible",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Dismissible/Dismissible.tsx",
-				"actualName": "Dismissible",
+				"methods": [],
+				"props": {
+					"hideCloseButton": {
+						"defaultValue": null,
+						"description": "Hide the close button\nShow the close button",
+						"name": "hideCloseButton",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"closeAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the close button",
+						"name": "closeAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"media\"", "value": [{ "value": "\"media\"" }] }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Close button alignment",
+						"name": "align",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"center\"",
+							"value": [{ "value": "\"top\"" }, { "value": "\"center\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is dismissed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2366,135 +12684,577 @@
 			"path": "./src/components/Flyout/tests/Flyout.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-flyout--position",
 					"name": "position",
 					"snippet": "const position = () => {\n    return (\n        <View gap={4} padding={50} align=\"center\" justify=\"center\" height=\"100vh\" width=\"120%\">\n            <View gap={4} direction=\"row\">\n                <Demo position=\"top-start\" defaultActive />\n                <Demo position=\"top\" />\n                <Demo position=\"top-end\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"end-top\" />\n                <Demo position=\"end\" />\n                <Demo position=\"end-bottom\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"start-top\" />\n                <Demo position=\"start\" />\n                <Demo position=\"start-bottom\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"bottom-start\" />\n                <Demo position=\"bottom\" />\n                <Demo position=\"bottom-end\" />\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "defaultActive",
+					"id": "utility-components-flyout--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <Flyout onOpen={fn()} onClose={fn()} defaultActive>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "active",
+					"id": "utility-components-flyout--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <Flyout onOpen={fn()} onClose={fn()} active>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "utility-components-flyout--active-false",
+					"name": "active: false, controlled",
 					"snippet": "const activeFalse = () => <Flyout onOpen={fn()} onClose={fn()} active={false}>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "modes",
+					"id": "utility-components-flyout--modes",
+					"name": "triggerType, trapFocusMode",
 					"snippet": "const modes = () => {\n    return (\n        <Example>\n            <Example.Item title=\"triggerType: click\">\n                <View direction=\"row\" gap={4}>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"dialog\" text=\"dialog\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"action-menu\" text=\"action-menu\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"action-bar\" text=\"action-bar\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"content-menu\" text=\"content-menu\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode={false} text=\"false\">\n                        {modeContent}\n                    </Demo>\n                </View>\n            </Example.Item>\n\n            <Example.Item title=\"triggerType: hover\">\n                <View direction=\"row\" gap={4}>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"dialog\" triggerType=\"hover\" text=\"dialog\">\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"action-menu\"\n                        triggerType=\"hover\"\n                        text=\"action-menu\"\n                    >\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"action-bar\"\n                        triggerType=\"hover\"\n                        text=\"action-bar\"\n                    >\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"content-menu\"\n                        triggerType=\"hover\"\n                        text=\"content-menu\"\n                    >\n                        {modeContent}\n                    </Demo>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "positionFallbacks",
+					"id": "utility-components-flyout--position-fallbacks",
+					"name": "fallbackPositions",
 					"snippet": "const positionFallbacks = () => {\n    return (\n        <Example>\n            <Example.Item title=\"position: top, default fallbacks\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" />\n                </View>\n            </Example.Item>\n            <Example.Item title=\"position: top, fallbackPositions: [start]\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" fallbackPositions={[\"start\"]} contentHeight={200} defaultActive />\n                </View>\n            </Example.Item>\n            <Example.Item title=\"position: top, fallbackPositions: false\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" fallbackPositions={false} contentHeight={400} />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--fallback-adjust-layout",
 					"name": "fallbackAdjustLayout",
 					"snippet": "const fallbackAdjustLayout = () => {\n    return (\n        <Demo\n            contentHeight={false}\n            position=\"bottom-start\"\n            width=\"200px\"\n            fallbackAdjustLayout\n            defaultActive\n        >\n            <div style={{ height: \"600px\" }}>Content</div>\n        </Demo>\n    );\n};"
 				},
 				{
-					"name": "fallbackAdjustLayoutShift",
+					"id": "utility-components-flyout--fallback-adjust-layout-shift",
+					"name": "fallbackAdjustLayout, shift",
 					"snippet": "const fallbackAdjustLayoutShift = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={10}>\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    attributes={{ ref: containerRef }}\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls containerRef={containerRef} />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <FallbackAdjustLayoutControls />\n            <div style={{ height: \"100vh\", width: \"250%\" }} />\n        </View>\n    );\n};"
 				},
 				{
-					"name": "fallbackAdjustLayoutSize",
+					"id": "utility-components-flyout--fallback-adjust-layout-size",
+					"name": "fallbackAdjustLayout, size",
 					"snippet": "const fallbackAdjustLayoutSize = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={10}>\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls large />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    attributes={{ ref: containerRef }}\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls containerRef={containerRef} large />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <FallbackAdjustLayoutControls large />\n            <div style={{ height: \"100vh\", width: \"250%\" }} />\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--origin-coordinates",
 					"name": "originCoordinates",
 					"snippet": "const originCoordinates = () => {\n    return (\n        <View gap={4} direction=\"row\">\n            <Demo position=\"bottom-start\" originCoordinates={{ x: 150, y: 150 }} defaultActive />\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--width",
 					"name": "width",
 					"snippet": "const width = () => (\n    <Example>\n        <Example.Item title=\"width: 300px\">\n            <Demo width=\"300px\" position=\"bottom\" />\n        </Example.Item>\n\n        <Example.Item title=\"width: trigger\">\n            <Demo width=\"trigger\" contentWidth={false} defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-flyout--content-gap",
 					"name": "contentGap",
 					"snippet": "const contentGap = () => <Demo contentGap={10} defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--content-shift",
 					"name": "contentShift",
 					"snippet": "const contentShift = () => <Demo contentShift={10} defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-content-hover",
 					"name": "disableContentHover",
 					"snippet": "const disableContentHover = () => <Demo triggerType=\"hover\" disableContentHover />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-close-on-outside-click",
 					"name": "disableCloseOnOutsideClick",
 					"snippet": "const disableCloseOnOutsideClick = () => <Demo disableCloseOnOutsideClick />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-hide-animation",
 					"name": "disableHideAnimation",
 					"snippet": "const disableHideAnimation = () => <Demo disableHideAnimation defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Flyout disabled>\n        <Flyout.Trigger>\n            {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n        </Flyout.Trigger>\n        <Flyout.Content>\n            <Content />\n        </Flyout.Content>\n    </Flyout>\n);"
 				},
 				{
+					"id": "utility-components-flyout--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const portalRef = React.useRef<HTMLDivElement>(null);\n    const portalRef2 = React.useRef<HTMLDivElement>(null);\n    const portalRef3 = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={4} direction=\"row\">\n            <View\n                grow\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef, \"data-testid\": \"container\" }}\n                justify=\"end\"\n                align=\"start\"\n                padding={4}\n            >\n                <Demo containerRef={portalRef} position=\"bottom-start\" defaultActive />\n            </View>\n            <View\n                grow\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef2 }}\n                justify=\"start\"\n                align=\"end\"\n                padding={4}\n            >\n                <Demo containerRef={portalRef2} position=\"top-end\" />\n            </View>\n            <View\n                width={50}\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef3 }}\n                padding={4}\n                overflow=\"auto\"\n            >\n                <View height={120} width=\"120%\" justify=\"center\" align=\"center\">\n                    <Demo containerRef={portalRef3} position=\"bottom-end\" />\n                </View>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--initial-focus-ref",
 					"name": "initialFocusRef",
 					"snippet": "const initialFocusRef = () => {\n    const initialFocusRef = React.useRef<HTMLInputElement>(null);\n\n    return (\n        <Demo initialFocusRef={initialFocusRef}>\n            <View gap={4}>\n                <Button onClick={() => {}}>Action 1</Button>\n                <TextField name=\"foo\" inputAttributes={{ ref: initialFocusRef }} />\n            </View>\n        </Demo>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--instance-ref",
 					"name": "instanceRef",
 					"snippet": "const instanceRef = () => {\n    const flyoutRef = React.useRef<FlyoutInstance>(null);\n\n    return (\n        <View direction=\"row\" gap={4}>\n            <Demo\n                instanceRef={flyoutRef}\n                disableCloseOnOutsideClick\n                onOpen={fn()}\n                onClose={fn()} />\n            <Button onClick={() => flyoutRef.current?.open()}>Open</Button>\n            <Button onClick={() => flyoutRef.current?.close()}>Close</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "contentAttributes",
+					"id": "utility-components-flyout--content-attributes",
+					"name": "content: className, attributes",
 					"snippet": "const contentAttributes = () => {\n    return (\n        <Flyout position=\"bottom\" defaultActive>\n            <Flyout.Trigger>\n                {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n            </Flyout.Trigger>\n            <Flyout.Content attributes={{ \"data-testid\": \"test-id\" }} className=\"test-classname\">\n                <Content />\n            </Flyout.Content>\n        </Flyout>\n    );\n};"
 				},
 				{
-					"name": "testShadowDom",
+					"id": "utility-components-flyout--test-shadow-dom",
+					"name": "test: shadow dom",
 					"snippet": "const testShadowDom = () => <custom-element-flyout />;"
 				},
 				{
-					"name": "testInsideFixed",
+					"id": "utility-components-flyout--test-inside-fixed",
+					"name": "test: inside position fixed",
 					"snippet": "const testInsideFixed = () => (\n    <React.Fragment>\n        <View\n            position=\"fixed\"\n            insetBottom={2}\n            insetStart={2}\n            insetEnd={2}\n            backgroundColor=\"elevation-overlay\"\n            borderColor=\"neutral-faded\"\n            borderRadius=\"small\"\n            padding={4}\n            zIndex={10}\n            attributes={{ \"data-testid\": \"container\" }}\n            height={20}\n        >\n            <Demo defaultActive position=\"top-start\" />\n        </View>\n        <View paddingTop={18} gap={4}>\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n        </View>\n    </React.Fragment>\n);"
 				},
 				{
-					"name": "testInsideSticky",
+					"id": "utility-components-flyout--test-inside-sticky",
+					"name": "test: inside position sticky",
 					"snippet": "const testInsideSticky = () => (\n    <React.Fragment>\n        <View\n            position=\"sticky\"\n            insetTop={4}\n            insetStart={0}\n            insetEnd={0}\n            backgroundColor=\"elevation-overlay\"\n            borderColor=\"neutral-faded\"\n            borderRadius=\"small\"\n            padding={4}\n            zIndex={10}\n            attributes={{ \"data-testid\": \"container\" }}\n        >\n            <Demo defaultActive />\n        </View>\n        <View gap={4} paddingTop={2}>\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n        </View>\n    </React.Fragment>\n);"
 				},
 				{
-					"name": "testInsideScrollable",
+					"id": "utility-components-flyout--test-inside-scrollable",
+					"name": "test: inside scrollable",
 					"snippet": "const testInsideScrollable = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View padding={20}>\n            <View height={30} overflow=\"auto\" backgroundColor=\"neutral-faded\" borderRadius=\"small\">\n                <View height={50} attributes={{ ref: containerRef }} padding={20} paddingBottom={30}>\n                    <Demo position=\"bottom\" />\n                </View>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testInsideModal",
+					"id": "utility-components-flyout--test-inside-modal",
+					"name": "test: inside modal",
 					"snippet": "const testInsideModal = () => {\n    return (\n        <Modal active position=\"end\">\n            <View gap={4} align=\"start\">\n                <Modal.Title>Title</Modal.Title>\n                <Demo position=\"bottom-start\" />\n                <View height={300} width={25} backgroundColor=\"neutral-faded\" />\n                <Demo position=\"start\" />\n                <View height={300} width={25} backgroundColor=\"neutral-faded\" />\n                <Demo position=\"bottom-start\" />\n            </View>\n        </Modal>\n    );\n};"
 				},
 				{
-					"name": "testDynamicBounds",
+					"id": "utility-components-flyout--test-dynamic-bounds",
+					"name": "test: auto position update",
 					"snippet": "const testDynamicBounds = () => {\n    const [left, setLeft] = React.useState(50);\n    const [top, setTop] = React.useState(50);\n    const [size, setSize] = React.useState<\"medium\" | \"large\">(\"medium\");\n    const flyoutRef = React.useRef<FlyoutInstance>(null);\n\n    React.useEffect(() => {\n        flyoutRef.current?.updatePosition();\n    }, [left, top]);\n\n    return (\n        <View gap={4}>\n            <View direction=\"row\" gap={2}>\n                <Button onClick={() => setLeft((prev) => prev - 10)}>Left</Button>\n                <Button onClick={() => setLeft((prev) => prev + 10)}>Right</Button>\n                <Button onClick={() => setTop((prev) => prev - 10)}>Up</Button>\n                <Button onClick={() => setTop((prev) => prev + 10)}>Down</Button>\n                <Button\n                    onClick={() => {\n                        setLeft(50);\n                        setTop(50);\n                    }}\n                >\n                    Center\n                </Button>\n                <Button onClick={() => setSize(\"large\")}>Large button</Button>\n                <Button onClick={() => setSize(\"medium\")}>Small button</Button>\n            </View>\n            <View height={100}>\n                <Flyout\n                    position=\"bottom\"\n                    instanceRef={flyoutRef}\n                    disableCloseOnOutsideClick\n                    defaultActive\n                >\n                    <Flyout.Trigger>\n                        {(attributes) => (\n                            <div style={{ position: \"absolute\", left: `${left}%`, top: `${top}%` }}>\n                                <Button color=\"primary\" attributes={attributes} size={size}>\n                                    Open\n                                </Button>\n                            </div>\n                        )}\n                    </Flyout.Trigger>\n                    <Flyout.Content>\n                        <Content />\n                    </Flyout.Content>\n                </Flyout>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testScopedTheming",
+					"id": "utility-components-flyout--test-scoped-theming",
+					"name": "test: content uses scope theme",
 					"snippet": "const testScopedTheming = () => (\n    <View gap={3} align=\"start\">\n        <Button color=\"primary\">Slate button</Button>\n        <Theme name=\"reshaped\">\n            <Flyout triggerType=\"click\" active position=\"bottom-start\">\n                <Flyout.Trigger>\n                    {(attributes) => (\n                        <Button color=\"primary\" attributes={attributes}>\n                            Reshaped button\n                        </Button>\n                    )}\n                </Flyout.Trigger>\n                <Flyout.Content>\n                    <Content>\n                        <View gap={1}>\n                            <View.Item>Portal content, rendered in body</View.Item>\n                            <Button color=\"primary\">Reshaped button</Button>\n                        </View>\n                    </Content>\n                </Flyout.Content>\n            </Flyout>\n        </Theme>\n    </View>\n);"
 				},
 				{
-					"name": "testWithoutFocusable",
+					"id": "utility-components-flyout--test-without-focusable",
+					"name": "test: without focusable content",
 					"snippet": "const testWithoutFocusable = () => <Demo position=\"bottom-start\" />;"
 				},
 				{
-					"name": "testChangeSize",
+					"id": "utility-components-flyout--test-change-size",
+					"name": "test: size updates",
 					"snippet": "const testChangeSize = () => {\n    const [position, setPosition] = React.useState<FlyoutProps[\"position\"]>(\"bottom-start\");\n    const [updatedHeight, setUpdatedHeight] = React.useState(false);\n\n    return (\n        <>\n            <View direction=\"row\" gap={4} align=\"center\">\n                <Select\n                    name=\"position\"\n                    options={[\n                        \"bottom-start\",\n                        \"bottom\",\n                        \"bottom-end\",\n                        \"top-start\",\n                        \"top\",\n                        \"top-end\",\n                        \"start-top\",\n                        \"start\",\n                        \"start-bottom\",\n                        \"end-top\",\n                        \"end\",\n                        \"end-bottom\",\n                    ].map((p) => ({ label: p, value: p }))}\n                    onChange={(args) => setPosition(args.value as FlyoutProps[\"position\"])}\n                    value={position}\n                />\n                <Switch name=\"height\" onChange={(args) => setUpdatedHeight(args.checked)}>\n                    Change height\n                </Switch>\n            </View>\n            <div\n                style={{\n                    position: \"fixed\",\n                    top: \"50%\",\n                    left: \"50%\",\n                    transform: \"translate(-50%, -50%)\",\n                }}\n            >\n                <Demo position={position} disableCloseOnOutsideClick active contentHeight={false}>\n                    <View\n                        backgroundColor=\"neutral-faded\"\n                        borderRadius=\"small\"\n                        height={updatedHeight ? 50 : 25}\n                        attributes={{ style: { transition: \"0.2s ease-in-out\" } }}\n                    />\n                </Demo>\n            </div>\n        </>\n    );\n};"
 				}
 			],
 			"import": "import {\n    Button,\n    Example,\n    Flyout,\n    Modal,\n    Reshaped,\n    Select,\n    Switch,\n    TextField,\n    Theme,\n    View,\n} from \"reshaped\";\nimport React from \"react\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Flyout/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Flyout",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Flyout/Flyout.tsx",
-				"actualName": "Flyout",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"groupTimeouts": {
+						"defaultValue": null,
+						"description": "Removes the content display delay if another flyout is already active",
+						"name": "groupTimeouts",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | TrapMode" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the flyout content interactivity",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Automatically focus the first focusable element in the content, when false the content container will be focused instead",
+						"name": "autoFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the content element",
+						"name": "contentClassName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"contentAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the content element",
+						"name": "contentAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Flyout"
 			}
 		},
 		"utility-components-formcontrol": {
@@ -2503,43 +13263,147 @@
 			"path": "./src/components/FormControl/tests/FormControl.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-formcontrol--status",
 					"name": "status",
 					"snippet": "const status = () => (\n    <Example>\n        <Example.Item title=\"status: default\">\n            <FormControl>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"status: error\">\n            <FormControl hasError>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: medium\">\n            <FormControl size=\"medium\">\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <FormControl size=\"large\">\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" size=\"large\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <FormControl disabled>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--required",
 					"name": "required",
 					"snippet": "const required = () => (\n    <Example>\n        <Example.Item title=\"required\">\n            <FormControl required>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "utility-components-formcontrol--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"horizontal\">\n            <FormControl>\n                <View direction=\"row\" gap={10} align=\"center\">\n                    <View width=\"100px\">\n                        <FormControl.Label>Label</FormControl.Label>\n                    </View>\n                    <View.Item grow>\n                        <TextField name=\"name\" placeholder=\"Enter value\" />\n                    </View.Item>\n                </View>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-formcontrol--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <FormControl id=\"test-id\" hasError>\n        <FormControl.Label>Label</FormControl.Label>\n        <TextField name=\"name\" />\n        <FormControl.Helper>Caption</FormControl.Helper>\n        <FormControl.Error>Error</FormControl.Error>\n    </FormControl>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--group",
 					"name": "group",
 					"snippet": "const group = () => (\n    <FormControl group>\n        <FormControl.Label>Label</FormControl.Label>\n        <RadioGroup name=\"name\">\n            <View gap={2}>\n                <Radio value=\"1\">One</Radio>\n                <Radio value=\"2\">Two</Radio>\n            </View>\n        </RadioGroup>\n    </FormControl>\n);"
 				}
 			],
 			"import": "import { Example, FormControl, Radio, RadioGroup, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/FormControl/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "FormControl",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/FormControl/FormControl.tsx",
-				"actualName": "FormControl",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size, to be used together with the other form component sizes",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"large\" | \"medium\"",
+							"value": [{ "value": "\"large\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"required": {
+						"defaultValue": null,
+						"description": "Change component to show a required indicator",
+						"name": "required",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Apply disabled styles",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"group": {
+						"defaultValue": null,
+						"description": "Apply semantic html markup when used for displaying multiple form fields together with a single label",
+						"name": "group",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Custom id for the form control",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "FormControl"
 			}
 		},
 		"utility-components-grid": {
@@ -2548,43 +13412,421 @@
 			"path": "./src/components/Grid/tests/Grid.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "utility-components-grid--base",
+					"name": "gap, columnGap, rowGap, align, justify, maxWidth, width, height",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"gap: 2\">\n            <Grid gap={2} columns={2}>\n                {[1, 2].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"columnGap: 2, rowGap: 4\">\n            <Grid columnGap={2} rowGap={4} columns={2}>\n                {[1, 2, 3, 4].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"align: center\">\n            <Grid gap={2} columns={2} align=\"center\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={8}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"justify: center\">\n            <Grid gap={2} columns=\"200px 200px\" justify=\"center\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"maxWidth: 400px\">\n            <Grid gap={2} columns=\"200px 200px\" maxWidth=\"400px\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"width: 400px, height: 200px\">\n            <Grid gap={2} columns={2} width=\"400px\" height=\"200px\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "layout",
+					"id": "utility-components-grid--layout",
+					"name": "rows, columns",
 					"snippet": "const layout = () => (\n    <Example>\n        <Example.Item title=\"simple: 2 rows, 3 columns\">\n            <Grid gap={4} columns={3} rows={2}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"columns template, 1fr 2fr 1fr\">\n            <Grid gap={4} columns=\"1fr 2fr 1fr\" rows={2}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"rows template, 1fr 2fr\">\n            <Grid gap={4} columns={3} rows=\"1fr 2fr\">\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"responsive\">\n            <Grid gap={4} columns={{ s: 3, m: \"1fr 2fr 1fr\" }} rows={{ s: 2, m: \"1fr 2fr\" }}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemLayout",
+					"id": "utility-components-grid--item-layout",
+					"name": "colStart, colEnd, rowStart, rowEnd",
 					"snippet": "const itemLayout = () => (\n    <Example>\n        <Example.Item title=\"column, start 1, end 3\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item colStart={1} colEnd={3}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"column, start 1, span 2\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item colStart={1} colSpan={2}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"row, start 1, end 3\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowEnd={3}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"row, start 1, span 2\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowSpan={2}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"responsive\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowSpan={{ s: 1, m: 2 }} colStart={1} colSpan={{ s: 1, m: 2 }}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-grid--areas",
 					"name": "areas",
 					"snippet": "const areas = () => (\n    <Example>\n        <Example.Item title=\"simple: 2 rows, 3 columns\">\n            <Grid gap={4} rows={2} areas={[\"a .\", \"a b\"]}>\n                {[\"a\", \"b\"].map((area) => (\n                    <Grid.Item area={area} key={area}>\n                        <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                            {area}\n                        </View>\n                    </Grid.Item>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "auto",
+					"id": "utility-components-grid--auto",
+					"name": "autoFlow, autoColumns, autoRows",
 					"snippet": "const auto = () => (\n    <Example>\n        <Example.Item title=\"auto flow: column\">\n            <Grid gap={4} autoFlow=\"column\" rows={2} columns={2}>\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"auto rows\">\n            <Grid gap={4} autoRows=\"100px\" columns={2}>\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"auto columns\">\n            <Grid gap={4} autoColumns=\"100px\" autoFlow=\"column\">\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-grid--as",
 					"name": "as",
 					"snippet": "const as = () => (\n    <Grid as=\"ul\">\n        <Grid.Item as=\"li\">Content</Grid.Item>\n    </Grid>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-grid--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Grid className=\"test-class\" attributes={{ id: \"test-id\" }}>\n            <Grid.Item className=\"test-item-class\" attributes={{ id: \"test-item-id\" }}>\n                Content\n            </Grid.Item>\n        </Grid>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Grid, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Grid/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Grid",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Grid/Grid.tsx",
-				"actualName": "Grid",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between grid items",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"columnGap": {
+						"defaultValue": null,
+						"description": "Horizontal gap between grid items",
+						"name": "columnGap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"rowGap": {
+						"defaultValue": null,
+						"description": "Vertical gap between grid items",
+						"name": "rowGap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Align grid items vertically",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Justify grid items horizontally",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"rows": {
+						"defaultValue": null,
+						"description": "Grid template rows",
+						"name": "rows",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<number | \"inherit\" | \"none\" | \"auto\" | (string & {}) | \"-moz-initial\" | \"initial\" | \"revert\" | \"revert-layer\" | \"unset\" | \"max-content\" | \"min-content\" | \"subgrid\">"
+						}
+					},
+					"columns": {
+						"defaultValue": null,
+						"description": "Grid template columns",
+						"name": "columns",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<number | \"inherit\" | \"none\" | \"auto\" | (string & {}) | \"-moz-initial\" | \"initial\" | \"revert\" | \"revert-layer\" | \"unset\" | \"max-content\" | \"min-content\" | \"subgrid\">"
+						}
+					},
+					"areas": {
+						"defaultValue": null,
+						"description": "Grid areas for template syntax",
+						"name": "areas",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string[]>" }
+					},
+					"autoFlow": {
+						"defaultValue": null,
+						"description": "Grid auto flow",
+						"name": "autoFlow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoFlow>" }
+					},
+					"autoColumns": {
+						"defaultValue": null,
+						"description": "Grid auto columns",
+						"name": "autoColumns",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoColumns<0 | (string & {})>>" }
+					},
+					"autoRows": {
+						"defaultValue": null,
+						"description": "Grid auto rows",
+						"name": "autoRows",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoRows<0 | (string & {})>>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Maximum width of the grid container, literal css value or unit token multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width of the grid container, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height of the grid container, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Custom root element html tag",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					}
+				},
+				"exportName": "Grid"
 			}
 		},
 		"utility-components-hidden": {
@@ -2593,22 +13835,261 @@
 			"path": "./src/components/Hidden/tests/Hidden.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-hidden--visibility",
 					"name": "visibility",
 					"snippet": "const visibility = () => (\n    <Example>\n        <Example.Item title=\"hide: always\">\n            <Hidden hide={true}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on s\">\n            <Hidden hide={{ s: false, m: true }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on l/xl\">\n            <Hidden hide={{ s: true, l: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on m/l/xl\">\n            <Hidden hide={{ s: true, m: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on m\">\n            <Hidden hide={{ s: true, m: false, l: true }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on s/xl\">\n            <Hidden hide={{ s: false, m: true, xl: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"hide: always, visibility\">\n            <Hidden hide visibility>\n                Content\n            </Hidden>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-hidden--as",
 					"name": "as",
 					"snippet": "const as = () => <Hidden as=\"span\">Content</Hidden>;"
 				}
 			],
 			"import": "import { Example, Hidden } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Hidden/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Hidden",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Hidden/Hidden.tsx",
-				"actualName": "Hidden",
+				"methods": [],
+				"props": {
+					"hide": {
+						"defaultValue": null,
+						"description": "Pick at which viewport sizes to hide the children",
+						"name": "hide",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"visibility": {
+						"defaultValue": null,
+						"description": "Use visibility hidden instead of display none",
+						"name": "visibility",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Custom root element html tag",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2618,22 +14099,39 @@
 			"path": "./src/components/HiddenVisually/tests/HiddenVisually.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-hiddenvisually--visibility",
 					"name": "visibility",
 					"snippet": "const visibility = () => (\n    <Example>\n        <Example.Item title=\"pronounced by screen readers\">\n            <HiddenVisually>Screen-reader only</HiddenVisually>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-hiddenvisually--children",
 					"name": "children",
 					"snippet": "const children = () => <HiddenVisually>Content</HiddenVisually>;"
 				}
 			],
 			"import": "import { Example, HiddenVisually } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/HiddenVisually/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "HiddenVisually",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/HiddenVisually/HiddenVisually.tsx",
-				"actualName": "HiddenVisually",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/HiddenVisually/HiddenVisually.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2643,34 +14141,115 @@
 			"path": "./src/components/Icon/tests/Icon.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-icon--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: 4\">\n            <Icon svg={IconZap} size={4} />\n        </Example.Item>\n        <Example.Item title=\"size: 8\">\n            <Icon svg={IconZap} size={8} />\n        </Example.Item>\n        <Example.Item title=\"size: 100%\">\n            <View width={25} height={25}>\n                <Icon svg={IconZap} size=\"100%\" />\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive size\", \"[s] 5\", \"[m]: 10\"]}>\n            <Icon svg={IconZap} size={{ s: 5, m: 10 }} />\n        </Example.Item>\n        <Example.Item title=\"size: inherit from font\">\n            <Text variant=\"title-6\">\n                <View direction=\"row\" align=\"center\" gap={2}>\n                    <Icon svg={IconZap} />\n                    <View.Item>Reshaped</View.Item>\n                </View>\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-icon--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <Icon svg={IconZap} color=\"neutral\" />\n        </Example.Item>\n        <Example.Item title=\"color: neutral-faded\">\n            <Icon svg={IconZap} color=\"neutral-faded\" />\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <Icon svg={IconZap} color=\"primary\" />\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Icon svg={IconZap} color=\"critical\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Icon svg={IconZap} color=\"positive\" />\n        </Example.Item>\n        <Example.Item title=\"color: disabled\">\n            <Icon svg={IconZap} color=\"disabled\" />\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <div style={{ color: \"tomato\" }}>\n                <Icon svg={IconZap} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "autoWidth",
+					"id": "utility-components-icon--auto-width",
+					"name": "autoWidth, blank",
 					"snippet": "const autoWidth = () => (\n    <Example>\n        <Example.Item title=\"square boundaries\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={IconMic} size={10} />\n            </div>\n        </Example.Item>\n        <Example.Item title=\"auto width boundaries\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={IconMic} size={10} autoWidth />\n            </div>\n        </Example.Item>\n        <Example.Item title=\"blank\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={null} size={10} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-icon--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Icon svg={IconZap} className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				},
 				{
-					"name": "render",
+					"id": "utility-components-icon--render",
+					"name": "test: hidden from sr",
 					"snippet": "const render = () => (\n    <div data-testid=\"root\">\n        <Icon svg={IconZap} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Icon, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Icon/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Icon",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Icon/Icon.tsx",
-				"actualName": "Icon",
+				"methods": [],
+				"props": {
+					"svg": {
+						"defaultValue": null,
+						"description": "Icon svg component or node",
+						"name": "svg",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Icon size, literal css value or unit token multiplier",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Icon color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"warning\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"autoWidth": {
+						"defaultValue": null,
+						"description": "Use the width of the svg asset instead of providing a square bounding box",
+						"name": "autoWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2680,54 +14259,230 @@
 			"path": "./src/components/Image/tests/Image.stories.tsx",
 			"stories": [
 				{
-					"name": "src",
+					"id": "utility-components-image--src",
+					"name": "src, alt",
 					"snippet": "const src = () => (\n    <Example>\n        <Example.Item title=\"src, alt\">\n            <Image src={imgUrl} alt=\"Image alt\" />\n        </Example.Item>\n\n        <Example.Item title=\"src\">\n            <Image src={imgUrl} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "utility-components-image--size",
+					"name": "width, height, maxWidth, aspectRatio",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"width: 200px\">\n            <Image src={imgUrl} width=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"height: 200px\">\n            <Image src={imgUrl} height=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"maxWidth: 200px\">\n            <Image src={imgUrl} maxWidth=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"aspectRatio: 1/1\">\n            <Image src={imgUrl} aspectRatio={1 / 1} width=\"300px\" />\n        </Example.Item>\n        <Example.Item title={[\"responsive width\", \"[s] 200px\", \"[m+] 300px\"]}>\n            <Image src={imgUrl} width={{ s: \"200px\", m: \"300px\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "radius",
+					"id": "utility-components-image--radius",
+					"name": "borderRadius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius: small\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"small\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"radius: medium\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"medium\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"radius: large\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--display-mode",
 					"name": "displayMode",
 					"snippet": "const displayMode = () => (\n    <Example>\n        <Example.Item title=\"mode: cover\">\n            <Image src={imgUrl} height=\"200px\" width=\"100%\" displayMode=\"cover\" />\n        </Example.Item>\n        <Example.Item title=\"mode: contain\">\n            <Image src={imgUrl} height=\"200px\" width=\"100%\" displayMode=\"contain\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--on-load",
 					"name": "onLoad",
 					"snippet": "const onLoad = () => <Image src={imgUrl} alt=\"photo\" onLoad={fn()} />;"
 				},
 				{
+					"id": "utility-components-image--on-error",
 					"name": "onError",
 					"snippet": "const onError = () => <Image src=\"/invalid.png\" alt=\"photo\" onError={fn()} />;"
 				},
 				{
+					"id": "utility-components-image--fallback",
 					"name": "fallback",
 					"snippet": "const fallback = () => (\n    <Example>\n        <Example.Item title=\"fallback, background, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"fallback, image, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback={imgUrl} />\n                </View>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"fallback, icon, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback={<Icon svg={IconZap} size={10} />} />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"fallback, icon, no url\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image fallback={<Icon svg={IconZap} size={10} />} />\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--render-image",
 					"name": "renderImage",
 					"snippet": "const renderImage = () => (\n    <Example>\n        <Example.Item title=\"renderImage\">\n            <Image\n                src={imgUrl}\n                alt=\"Amsterdam canal\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image\" />}\n            />\n        </Example.Item>\n        <Example.Item title=\"renderImage, fallback\">\n            <Image\n                src=\"error\"\n                fallback={imgUrl}\n                alt=\"Amsterdam canal 2\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image-fallback\" />}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "imageAttributes",
+					"id": "utility-components-image--image-attributes",
+					"name": "className, attributes,imageAttributes",
 					"snippet": "const imageAttributes = () => (\n    <div data-testid=\"root\">\n        <Image\n            src={imgUrl}\n            alt=\"photo\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            imageAttributes={{ \"data-testid\": \"test-img-id\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "ratio",
+					"id": "utility-components-image--ratio",
+					"name": "test: aspectRatio",
 					"snippet": "const ratio = () => (\n    <Example>\n        <Example.Item title=\"ratio: 16/9\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"ratio: 16/9, displayMode: contain\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} displayMode=\"contain\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Icon, Image, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Image/Image.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Image",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Image/Image.tsx",
-				"actualName": "Image",
+				"methods": [],
+				"props": {
+					"src": {
+						"defaultValue": null,
+						"description": "Image URL",
+						"name": "src",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"alt": {
+						"defaultValue": null,
+						"description": "Image alt text",
+						"name": "alt",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Image width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Image height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Image max width, literal css value or unit token multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"aspectRatio": {
+						"defaultValue": null,
+						"description": "Image aspect ratio, width / height",
+						"name": "aspectRatio",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Image border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"large\" | \"medium\"",
+							"value": [
+								{ "value": "\"small\"" },
+								{ "value": "\"large\"" },
+								{ "value": "\"medium\"" }
+							]
+						}
+					},
+					"displayMode": {
+						"defaultValue": null,
+						"description": "Image display mode for controlling how it fits into the provided boundaries",
+						"name": "displayMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"cover\" | \"contain\"",
+							"value": [{ "value": "\"cover\"" }, { "value": "\"contain\"" }]
+						}
+					},
+					"onLoad": {
+						"defaultValue": null,
+						"description": "Image on load event",
+						"name": "onLoad",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: SyntheticEvent<Element, Event>) => void)" }
+					},
+					"onError": {
+						"defaultValue": null,
+						"description": "Image on error event",
+						"name": "onError",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: SyntheticEvent<Element, Event>) => void)" }
+					},
+					"fallback": {
+						"defaultValue": null,
+						"description": "Image fallback content if the image fails to load or was not provided",
+						"name": "fallback",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"renderImage": {
+						"defaultValue": null,
+						"description": "Image render function, can be used for integrating with Image component in 3rd party frameworks",
+						"name": "renderImage",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Omit<Attributes<\"img\">, \"src\" | \"alt\"> & { src: string; alt: string; }) => ReactNode)"
+						}
+					},
+					"imageAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the image element",
+						"name": "imageAttributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"img\">" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(Attributes<\"div\"> & Attributes<\"img\">)" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2737,46 +14492,229 @@
 			"path": "./src/components/Overlay/tests/Overlay.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-overlay--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate}>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--transparent",
 					"name": "transparent",
 					"snippet": "const transparent = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate} transparent>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--blurred",
 					"name": "blurred",
 					"snippet": "const blurred = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate} blurred>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "renderProps",
+					"id": "utility-components-overlay--render-props",
+					"name": "children, render props",
 					"snippet": "const renderProps = () => (\n    <Overlay active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        {(args) => (args.active ? \"Opened\" : \"Closed\")}\n    </Overlay>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "utility-components-overlay--handlers",
+					"name": "onOpen, onClose, onAfterOpen, onAfterClose",
 					"snippet": "const handlers = () => {\n    const overlayToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => overlayToggle.toggle()}>Open overlay</Button>\n            <Overlay\n                active={overlayToggle.active}\n                onClose={(closeArgs) => {\n                    overlayToggle.deactivate();\n                    args.handleClose(closeArgs);\n                }}\n                onOpen={fn()}\n                onAfterOpen={fn()}\n                onAfterClose={fn()}>Content\n                                </Overlay>\n        </>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--disable-close-on-click",
 					"name": "disableCloseOnClick",
 					"snippet": "const disableCloseOnClick = (args) => (\n    <Overlay\n        active\n        disableCloseOnClick\n        onClose={(closeArgs) => {\n            args.handleClose(closeArgs);\n        }}\n    >\n        Content\n    </Overlay>\n);"
 				},
 				{
+					"id": "utility-components-overlay--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <>\n            <div ref={containerRef} data-testid=\"test-id\" style={{ height: 200 }} />\n            <Overlay active containerRef={containerRef}>\n                Content\n            </Overlay>\n        </>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-overlay--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <Overlay active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        Content\n    </Overlay>\n);"
 				}
 			],
 			"import": "import { Button, Example, Overlay } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Overlay/index.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Overlay",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Overlay/Overlay.tsx",
-				"actualName": "Overlay",
+				"methods": [],
+				"props": {
+					"transparent": {
+						"defaultValue": null,
+						"description": "Make the overlay transparent",
+						"name": "transparent",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number | boolean" }
+					},
+					"blurred": {
+						"defaultValue": null,
+						"description": "Make the overlay blurred",
+						"name": "blurred",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Control the overflow of the component content",
+						"name": "overflow",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"auto\"",
+							"value": [{ "value": "\"hidden\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, render function receives the state of the component as an argument",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode | ((props: { active: boolean; }) => ReactNode)" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the visibility of the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason: CloseReason; }) => void)" }
+					},
+					"onAfterClose": {
+						"defaultValue": null,
+						"description": "Callback after the component close transition is complete",
+						"name": "onAfterClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the component is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onAfterOpen": {
+						"defaultValue": null,
+						"description": "Callback after the component open transition is complete",
+						"name": "onAfterOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"disableCloseOnClick": {
+						"defaultValue": null,
+						"description": "Disable closing the component on outside click",
+						"name": "disableCloseOnClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": null,
+						"description": "Element to render the component in",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2786,42 +14724,213 @@
 			"path": "./src/components/Reshaped/tests/Reshaped.stories.tsx",
 			"stories": [
 				{
-					"name": "rtl",
+					"id": "utility-components-reshaped--rtl",
+					"name": "defaultRTL",
 					"snippet": "const rtl = () => (\n    <Reshaped defaultRTL theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				},
 				{
-					"name": "controlledMode",
+					"id": "utility-components-reshaped--controlled-mode",
+					"name": "colorMode, controlled",
 					"snippet": "const controlledMode = () => {\n    const [mode, setMode] = useState<G.ColorMode>(\"dark\");\n\n    return (\n        <Reshaped theme=\"reshaped\" colorMode={mode}>\n            <Button\n                onClick={() => {\n                    setMode(mode === \"dark\" ? \"light\" : \"dark\");\n                }}\n            >\n                Toggle color mode\n            </Button>\n        </Reshaped>\n    );\n};"
 				},
 				{
-					"name": "lightMode",
+					"id": "utility-components-reshaped--light-mode",
+					"name": "defaultColorMode=light",
 					"snippet": "const lightMode = () => <Reshaped theme=\"reshaped\">Hello</Reshaped>;"
 				},
 				{
-					"name": "darkMode",
+					"id": "utility-components-reshaped--dark-mode",
+					"name": "defaultColorMode=dark",
 					"snippet": "const darkMode = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				},
 				{
+					"id": "utility-components-reshaped--scoped",
 					"name": "scoped",
 					"snippet": "const scoped = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\" scoped>\n        Hello\n    </Reshaped>\n);"
 				},
 				{
-					"name": "testScoped",
+					"id": "utility-components-reshaped--test-scoped",
+					"name": "test: scoped switch",
 					"snippet": "const testScoped = () => (\n    <Reshaped theme=\"reshaped\">\n        <Reshaped theme=\"slate\" scoped>\n            <ScopedComponent />\n        </Reshaped>\n    </Reshaped>\n);"
 				},
 				{
-					"name": "keyboardMode",
+					"id": "utility-components-reshaped--keyboard-mode",
+					"name": "test: keyboard mode",
 					"snippet": "const keyboardMode = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				}
 			],
 			"import": "import { Button, Reshaped } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Reshaped/Reshaped.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Reshaped",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Reshaped/Reshaped.tsx",
-				"actualName": "Reshaped",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"theme": {
+						"defaultValue": null,
+						"description": "Theme of the application, enables controlled mode",
+						"name": "theme",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NonNullable<Theme>" }
+					},
+					"defaultTheme": {
+						"defaultValue": null,
+						"description": "Default theme of the application, enables uncontrolled mode",
+						"name": "defaultTheme",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NonNullable<Theme>" }
+					},
+					"defaultRTL": {
+						"defaultValue": null,
+						"description": "Default content direction of the application",
+						"name": "defaultRTL",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode of the application, enables controlled mode",
+						"name": "colorMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode",
+							"value": [{ "value": "\"light\"" }, { "value": "\"dark\"" }]
+						}
+					},
+					"defaultColorMode": {
+						"defaultValue": null,
+						"description": "Default color mode of the application, enables uncontrolled mode",
+						"name": "defaultColorMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode",
+							"value": [{ "value": "\"light\"" }, { "value": "\"dark\"" }]
+						}
+					},
+					"defaultViewport": {
+						"defaultValue": null,
+						"description": "Default viewport size of the application",
+						"name": "defaultViewport",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Viewport",
+							"value": [
+								{ "value": "\"s\"" },
+								{ "value": "\"m\"" },
+								{ "value": "\"l\"" },
+								{ "value": "\"xl\"" }
+							]
+						}
+					},
+					"toastOptions": {
+						"defaultValue": null,
+						"description": "Global options for the ToastProvider",
+						"name": "toastOptions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "Partial<Record<Position, { width?: string; expanded?: boolean; }>> | undefined"
+						}
+					},
+					"scoped": {
+						"defaultValue": null,
+						"description": "Enable scoped mode for applications not using Reshaped provider at the application root",
+						"name": "scoped",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2831,42 +14940,150 @@
 			"path": "./src/components/ScrollArea/tests/ScrollArea.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-scrollarea--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"vertical scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"horizontal scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\" height=\"100px\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"horizontal and vertical scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-scrollarea--scrollbar-display",
 					"name": "scrollbarDisplay",
 					"snippet": "const scrollbarDisplay = () => (\n    <Example>\n        <Example.Item title=\"scrollbarDisplay: hover\">\n            <ScrollArea height=\"100px\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"scrollbarDisplay: hidden\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"hidden\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"scrollbarDisplay: visible\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "height",
+					"id": "utility-components-scrollarea--height",
+					"name": "height, maxHeight",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"height: 80px\">\n            <ScrollArea height=\"80px\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"responsive height: s 80px, m: 120px\">\n            <ScrollArea height={{ s: \"80px\", m: \"120px\" }}>\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"maxHeight: 80px\">\n            <ScrollArea maxHeight=\"80px\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"responsive max height: s 80px, m: 200px\">\n            <ScrollArea maxHeight={{ s: \"80px\", m: \"200px\" }}>\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onScroll",
+					"id": "utility-components-scrollarea--on-scroll",
+					"name": "ref, onScroll",
 					"snippet": "const onScroll = () => {\n    const ref = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={4}>\n            <View.Item>\n                <Button onClick={() => ref.current?.scrollBy({ top: 50, left: 50 })}>Scroll</Button>\n            </View.Item>\n            <ScrollArea height=\"100px\" ref={ref} scrollbarDisplay=\"visible\" onScroll={fn()}>\n                <View backgroundColor=\"neutral-faded\" padding={4} width=\"1000px\" height=\"200px\">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                                            has been the industry's standard dummy text ever since the 1500s, when an unknown\n                                            printer took a galley of type and scrambled it to make a type specimen book. It has\n                                            survived not only five centuries, but also the leap into electronic typesetting,\n                                            remaining essentially unchanged. It was popularised in the 1960s with the release of\n                                            Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                                            publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                                        </View>\n            </ScrollArea>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-scrollarea--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ScrollArea className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </ScrollArea>\n    </div>\n);"
 				},
 				{
-					"name": "testNested",
+					"id": "utility-components-scrollarea--test-nested",
+					"name": "test: nested",
 					"snippet": "const testNested = () => (\n    <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n        <View padding={4} paddingInline={16}>\n            <ScrollArea height=\"200px\" scrollbarDisplay=\"visible\">\n                {Array(20)\n                    .fill(\"\")\n                    .map((_, index) => {\n                        return <div key={index}>Item {index + 1}</div>;\n                    })}\n            </ScrollArea>\n        </View>\n    </ScrollArea>\n);"
 				},
 				{
-					"name": "testDynamicHeight",
+					"id": "utility-components-scrollarea--test-dynamic-height",
+					"name": "test: dynamic height change",
 					"snippet": "const testDynamicHeight = () => {\n    const [count, setCount] = React.useState(10);\n\n    return (\n        <View gap={4}>\n            <View.Item>\n                <Button onClick={() => setCount((prev) => prev + 10)}>Add more items</Button>\n            </View.Item>\n\n            <ScrollArea height=\"200px\" scrollbarDisplay=\"visible\">\n                <View gap={2}>\n                    {new Array(count).fill(\"\").map((_, i) => (\n                        <View.Item key={i}>Item {i + 1}</View.Item>\n                    ))}\n                </View>\n            </ScrollArea>\n        </View>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Example, ScrollArea, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ScrollArea/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ScrollArea",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ScrollArea/ScrollArea.tsx",
-				"actualName": "ScrollArea",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"scrollbarDisplay": {
+						"defaultValue": null,
+						"description": "Scrollbar visibility behavior based on the user interaction",
+						"name": "scrollbarDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"hover\" | \"visible\"",
+							"value": [
+								{ "value": "\"hidden\"" },
+								{ "value": "\"hover\"" },
+								{ "value": "\"visible\"" }
+							]
+						}
+					},
+					"onScroll": {
+						"defaultValue": null,
+						"description": "Callback when the scroll area is scrolled",
+						"name": "onScroll",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: Coordinates) => void)" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height of the scroll area, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height of the scroll area, literal css value or unit token multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2876,54 +15093,387 @@
 			"path": "./src/components/Text/tests/Text.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-text--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: title-1\">\n            <Text variant=\"title-1\">Title 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-2\">\n            <Text variant=\"title-2\">Title 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-3\">\n            <Text variant=\"title-3\">Title 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-4\">\n            <Text variant=\"title-4\">Title 4</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-5\">\n            <Text variant=\"title-5\">Title 5</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-6\">\n            <Text variant=\"title-6\">Title 6</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-1\">\n            <Text variant=\"featured-1\">Featured 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-2\">\n            <Text variant=\"featured-2\">Featured 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-3\">\n            <Text variant=\"featured-3\">Featured 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-1\">\n            <Text variant=\"body-1\">Body 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-2\">\n            <Text variant=\"body-2\">Body 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-3\">\n            <Text variant=\"body-3\">Body 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: caption-1\">\n            <Text variant=\"caption-1\">Caption 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: caption-2\">\n            <Text variant=\"caption-2\">Caption 2</Text>\n        </Example.Item>\n        <Example.Item title={[\"responsive variant\", \"[s] body-3\", \"[m+] title-4\"]}>\n            <Text variant={{ s: \"body-3\", m: \"title-4\" }}>Responsive</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--weight",
 					"name": "weight",
 					"snippet": "const weight = () => (\n    <Example>\n        <Example.Item title=\"weight: regular\">\n            <Text weight=\"regular\">Regular</Text>\n        </Example.Item>\n        <Example.Item title=\"weight: medium\">\n            <Text weight=\"medium\">Medium</Text>\n        </Example.Item>\n        <Example.Item title=\"weight: bold\">\n            <Text weight=\"bold\">Bold</Text>\n        </Example.Item>\n        <Example.Item title={[\"responsive\", \"[s] weight: regular\", \"[m+] bold\"]}>\n            <Text weight={{ s: \"regular\", m: \"bold\" }}>Responsive</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: inherit\">\n            <Text>Neutral</Text>\n        </Example.Item>\n        <Example.Item title=\"color: neutral-faded\">\n            <Text color=\"neutral-faded\">Faded</Text>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Text color=\"positive\">Positive</Text>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <Text color=\"warning\">Warning</Text>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Text color=\"critical\">Critical</Text>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <Text color=\"primary\">Primary</Text>\n        </Example.Item>\n        <Example.Item title=\"color: disabled\">\n            <Text color=\"disabled\" attributes={{ \"aria-disabled\": true }}>\n                Disabled\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--decoration",
 					"name": "decoration",
 					"snippet": "const decoration = () => (\n    <Example>\n        <Example.Item title=\"decoration: line-through\">\n            <Text decoration=\"line-through\">Line through</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--wrap",
 					"name": "wrap",
 					"snippet": "const wrap = () => (\n    <Example>\n        <Example.Item title=\"wrap: balance\">\n            <Text wrap=\"balance\" variant=\"title-3\">\n                The design system you want to build\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "mono",
+					"id": "utility-components-text--mono",
+					"name": "monospace",
 					"snippet": "const mono = () => (\n    <Example>\n        <Example.Item title=\"monospace\">\n            <Text monospace>Content</Text>\n        </Example.Item>\n        <Example.Item title=\"monospace, variant, weight\">\n            <Text monospace variant=\"title-1\" weight=\"regular\">\n                Content\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--max-lines",
 					"name": "maxLines",
 					"snippet": "const maxLines = () => (\n    <Example>\n        <Example.Item title=\"maxLines: 2\">\n            <Text maxLines={2}>\n                There are many variations of passages of Lorem Ipsum available, but the majority have\n                suffered alteration in some form, by injected humour, or randomised words which don't look\n                even slightly believable. If you are going to use a passage of Lorem Ipsum, you need to be\n                sure there isn't anything embarrassing hidden in the middle of text. All the Lorem Ipsum\n                generators on the Internet tend to repeat predefined chunks as necessary, making this the\n                first true generator on the Internet. It uses a dictionary of over 200 Latin words,\n                combined with a handful of model sentence structures, to generate Lorem Ipsum which looks\n                reasonable. The generated Lorem Ipsum is therefore always free from repetition, injected\n                humour, or non-characteristic words etc.\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: start\">\n            <Text align=\"start\">Text content</Text>\n        </Example.Item>\n        <Example.Item title=\"align: center\">\n            <Text align=\"center\">Text content</Text>\n        </Example.Item>\n        <Example.Item title=\"align: end\">\n            <Text align=\"end\">Text content</Text>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive alignment\", \"[s]: center\", \"[m+] start\"]}>\n            <Text align={{ s: \"center\", m: \"start\" }}>Text content</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "asProp",
+					"id": "utility-components-text--as-prop",
+					"name": "as",
 					"snippet": "const asProp = () => (\n    <>\n        <Text as=\"h1\">Content</Text>\n        <Text variant=\"title-3\">Content</Text>\n        <Text variant={{ s: \"title-3\", m: \"title-4\" }}>Content</Text>\n    </>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-text--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Text className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Text>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Text/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Text",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Text/Text.tsx",
-				"actualName": "Text",
+				"methods": [],
+				"props": {
+					"variant": {
+						"defaultValue": null,
+						"description": "Text render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Variant>" }
+					},
+					"weight": {
+						"defaultValue": null,
+						"description": "Text font weight",
+						"name": "weight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"medium\" | \"bold\" | \"regular\">" }
+					},
+					"monospace": {
+						"defaultValue": null,
+						"description": "Render monospace font",
+						"name": "monospace",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Text color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"warning\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Text alignment",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"center\" | \"start\" | \"end\">" }
+					},
+					"wrap": {
+						"defaultValue": null,
+						"description": "CSS wrapping style",
+						"name": "wrap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"balance\"", "value": [{ "value": "\"balance\"" }] }
+					},
+					"decoration": {
+						"defaultValue": null,
+						"description": "CSS text decoration style",
+						"name": "decoration",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"line-through\"",
+							"value": [{ "value": "\"line-through\"" }]
+						}
+					},
+					"maxLines": {
+						"defaultValue": null,
+						"description": "Maximum number of lines to render, used for text truncation",
+						"name": "maxLines",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different html tag",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2933,46 +15483,114 @@
 			"path": "./src/components/Theme/tests/Theme.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-theme--scoped",
 					"name": "scoped",
 					"snippet": "const scoped = () => (\n    <Example>\n        <Example.Item title=\"scoped, single\">\n            <Theme name=\"reshaped\">\n                <Card attributes={{ \"data-testid\": \"test-id\" }}>\n                    <Button color=\"primary\">Action</Button>\n                </Card>\n            </Theme>\n        </Example.Item>\n\n        <Example.Item title=\"scoped, multiple\">\n            <Theme name={[\"reshaped\", \"figma\"]}>\n                <Card attributes={{ \"data-testid\": \"test-id-multi\" }}>\n                    <View direction=\"row\" gap={4}>\n                        <Button color=\"primary\">Action</Button>\n\n                        <Popover>\n                            <Popover.Trigger>\n                                {(attributes) => <Button attributes={attributes}>Popover</Button>}\n                            </Popover.Trigger>\n                            <Popover.Content>Content</Popover.Content>\n                        </Popover>\n                    </View>\n                </Card>\n            </Theme>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-theme--light",
 					"name": "light",
 					"snippet": "const light = () => (\n    <Theme name=\"reshaped\" colorMode=\"light\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--dark",
 					"name": "dark",
 					"snippet": "const dark = () => (\n    <Theme name=\"reshaped\" colorMode=\"dark\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--inherited",
 					"name": "inherited",
 					"snippet": "const inherited = () => (\n    <Theme name=\"reshaped\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--inverted",
 					"name": "inverted",
 					"snippet": "const inverted = () => (\n    <Theme name=\"reshaped\" colorMode=\"inverted\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--controlled",
 					"name": "controlled",
 					"snippet": "const controlled = () => {\n    const Internal = () => {\n        const { setTheme, theme } = useTheme();\n\n        return (\n            <Button color=\"primary\" onClick={() => setTheme(\"slate\")}>\n                Switch to slate\n            </Button>\n        );\n    };\n\n    return (\n        <div data-testid=\"root\">\n            <Theme name=\"reshaped\">\n                <Internal />\n            </Theme>\n        </div>\n    );\n};"
 				},
 				{
+					"id": "utility-components-theme--uncontrolled",
 					"name": "uncontrolled",
 					"snippet": "const uncontrolled = () => {\n    const Internal = () => {\n        const { setTheme } = useTheme();\n\n        return (\n            <Button color=\"primary\" onClick={() => setTheme(\"slate\")}>\n                Switch to slate\n            </Button>\n        );\n    };\n\n    return (\n        <div data-testid=\"root\">\n            <Theme defaultName=\"reshaped\">\n                <Internal />\n            </Theme>\n        </div>\n    );\n};"
 				},
 				{
-					"name": "disabledTransition",
+					"id": "utility-components-theme--disabled-transition",
+					"name": "disabled transitions",
 					"snippet": "const disabledTransition = () => {\n    const { invertColorMode } = useTheme();\n\n    return (\n        <Example>\n            <Example.Item title=\"should have no transitions while switching color mode\">\n                <View gap={3}>\n                    <Button onClick={invertColorMode}>Invert mode</Button>\n\n                    <MenuItem selected>Test transition</MenuItem>\n\n                    <Card>Default card</Card>\n\n                    <Theme colorMode=\"inverted\">\n                        <Card>Inverted card</Card>\n                    </Theme>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Card, Example, MenuItem, Popover, Theme, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Theme/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Theme",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Theme/Theme.tsx",
-				"actualName": "Theme",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the theme to use, enables controlled mode",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"defaultName": {
+						"defaultValue": null,
+						"description": "Default name of the theme to use, enables uncontrolled mode",
+						"name": "defaultName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode to use",
+						"name": "colorMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode | \"inverted\"",
+							"value": [
+								{ "value": "\"light\"" },
+								{ "value": "\"dark\"" },
+								{ "value": "\"inverted\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2982,147 +15600,880 @@
 			"path": "./src/components/View/tests/View.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-view--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example title=\"Border is used to highlight the padding value\">\n        <Example.Item title=\"padding: 4\">\n            <View padding={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <View padding={6} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: 0\">\n            <View padding={0} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: vertical 2, horizontal 4\">\n            <View paddingInline={4} paddingBlock={2} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingTop: 4\">\n            <View paddingTop={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingBottom: 4\">\n            <View paddingBottom={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingStart: 4\">\n            <View paddingStart={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingEnd: 4\">\n            <View paddingEnd={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive padding:\",\n                \"[s] vertical 2, horizontal 4\",\n                \"[m+] vertical 4, horizontal 8\",\n            ]}\n        >\n            <View paddingInline={{ s: 4, m: 8 }} paddingBlock={{ s: 2, m: 4 }} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"responsive padding:\", \"[s] top 2, bottom 4\", \"[m+] top 4, bottom 0, start: 8\"]}\n        >\n            <View\n                paddingTop={{ s: 2, m: 4 }}\n                paddingBottom={{ s: 4, m: 0 }}\n                paddingStart={{ s: 0, m: 8 }}\n                borderColor=\"neutral\"\n            >\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"nested padding, child view should have no horizontal padding\">\n            <View paddingStart={4} borderColor=\"neutral\">\n                <View borderColor=\"primary\" paddingBlock={4}>\n                    <Placeholder />\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example title=\"Item 1 is another component, Item 2 is View.Item, Item 3 is text\">\n        <Example.Item title=\"direction: column as default\">\n            <View gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <View gap={3} direction=\"column\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column-reverse\">\n            <View gap={3} direction=\"column-reverse\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row\">\n            <View gap={3} direction=\"row\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row-reverse\">\n            <View gap={3} direction=\"row-reverse\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"responsive direction\", \"[s] column-reverse\", \"[m] row-reverse\", \"[l+] row\"]}\n        >\n            <View direction={{ s: \"column-reverse\", m: \"row-reverse\", l: \"row\" }} gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 4, direction: row\">\n            <View direction=\"row\" gap={4} divided>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n                <Placeholder>Item 3</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 0, direction: row\">\n            <View direction=\"row\" gap={0}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap, direction: row\", \"[s] 4\", \"[m+] 8\"]}>\n            <View direction=\"row\" gap={{ s: 4, m: 8 }}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 4, direction: column\">\n            <View gap={4}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 0, direction: column\">\n            <View gap={0}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap, direction: column\", \"[s] 4\", \"[m+] 8\"]}>\n            <View gap={{ s: 4, m: 8 }}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--divided",
 					"name": "divided",
 					"snippet": "const divided = () => (\n    <Example>\n        <Example.Item title=\"direction: row\">\n            <View divided direction=\"row\" gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <View divided gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive divided\", \"[s] direction: row\", \"[m+] direction: column\"]}>\n            <View divided direction={{ s: \"row\", m: \"column\" }} gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row, columns\">\n            <View divided gap={3} direction=\"row\">\n                <View.Item columns={2}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={8}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={2}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"with React.Fragment\">\n            <View direction=\"row\" gap={4} divided>\n                <Placeholder>Item 1</Placeholder>\n                <>\n                    <Placeholder>Item 2</Placeholder>\n                    <Placeholder>Item 3</Placeholder>\n                </>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example title=\"Removes side borders and border radius when applied\">\n        <Example.Item title=\"bleed: 4\">\n            <View bleed={4} padding={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive bleed\", \"[s] 4\", \"[m+] 0\"]}>\n            <View bleed={{ s: 4, m: 0 }} padding={4} borderRadius=\"small\" borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--wrap",
 					"name": "wrap",
 					"snippet": "const wrap = () => (\n    <Example>\n        <Example.Item title=\"wrap: false\">\n            <View direction=\"row\" wrap={false} gap={3}>\n                <Placeholder w={600} h={100} />\n                <Placeholder w={600} h={100} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: start, direction: row\">\n            <View align=\"start\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: center, direction: row\">\n            <View align=\"center\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: end, direction: row\">\n            <View align=\"end\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"align: stretch, direction: row\",\n                \"2nd item is stretched based on the 1st item height\",\n            ]}\n        >\n            <View align=\"stretch\" direction=\"row\" gap={3}>\n                <Placeholder h={100} />\n                <Placeholder h=\"auto\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: baseline, direction: row\">\n            <View align=\"baseline\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Text variant=\"title-6\">Content</Text>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"align: start, direction: column\">\n            <View align=\"start\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: center, direction: column\">\n            <View align=\"center\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: end, direction: row\">\n            <View align=\"end\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"align: stretch, direction: column\",\n                \"1st item uses its own width, 2nd item is stretched to full width\",\n            ]}\n        >\n            <View align=\"stretch\" direction=\"column\" gap={3}>\n                <Placeholder w={100} />\n                <Placeholder w=\"auto\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--justify",
 					"name": "justify",
 					"snippet": "const justify = () => (\n    <Example>\n        <Example.Item title=\"justify: start, direction: row\">\n            <View justify=\"start\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: center, direction: row\">\n            <View justify=\"center\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: end, direction: row\">\n            <View justify=\"end\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: space-between, direction: row\">\n            <View justify=\"space-between\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"justify: start, direction: column, height: 200px\">\n            <View height=\"200px\" justify=\"start\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: center, direction: column, height: 200px\">\n            <View height=\"200px\" justify=\"center\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: end, direction: column, height: 200px\">\n            <View justify=\"end\" height=\"200px\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: space-between, direction: column, height: 200px\">\n            <View justify=\"space-between\" height=\"200px\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--text-align",
 					"name": "textAlign",
 					"snippet": "const textAlign = () => (\n    <Example>\n        <Example.Item title=\"textAlign: start\">\n            <View textAlign=\"start\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: center\">\n            <View textAlign=\"center\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: end\">\n            <View textAlign=\"end\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: [s] start, [m+] end\">\n            <View textAlign={{ s: \"start\", m: \"end\" }}>Content</View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"height: 100px, width: 100px\">\n            <View backgroundColor=\"neutral-faded\" height=\"100px\" width=\"100px\" />\n        </Example.Item>\n        <Example.Item title=\"height: 25, width: 25\">\n            <View backgroundColor=\"neutral-faded\" height={25} width={25} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive height and width\",\n                \"[s] height: 25, width: 25\",\n                \"[m+] height: 200px, width: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                height={{ s: 25, m: \"200px\" }}\n                width={{ s: 25, m: \"200px\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "ratio",
+					"id": "utility-components-view--ratio",
+					"name": "aspectRatio",
 					"snippet": "const ratio = () => (\n    <Example>\n        <Example.Item title=\"ratio: 16 / 9\">\n            <View backgroundColor=\"neutral-faded\" aspectRatio={16 / 9} width=\"200px\" />\n        </Example.Item>\n        <Example.Item title={[\"responsive ratio\", \"[s] 1/1\", \"[m+] 16/9\"]}>\n            <View backgroundColor=\"neutral-faded\" aspectRatio={{ s: 1, m: 16 / 9 }} width=\"200px\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "maxSize",
+					"id": "utility-components-view--max-size",
+					"name": "width, height, maxWidth, maxHeight",
 					"snippet": "const maxSize = () => (\n    <Example>\n        <Example.Item title=\"maxHeight: 150px, maxWidth: 150px, height: 300px\">\n            <View backgroundColor=\"neutral-faded\" maxHeight=\"150px\" maxWidth=\"150px\" height=\"300px\" />\n        </Example.Item>\n        <Example.Item title=\"maxHeight: 25, maxWidth: 25, height: 50\">\n            <View backgroundColor=\"neutral-faded\" maxHeight={25} maxWidth={25} height={50} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive maxHeight and maxWidth, height: 300\",\n                \"[s] maxHeight: 25, maxWidth: 25\",\n                \"[m+] maxHeight: 200px, maxWidth: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                maxHeight={{ s: 25, m: \"200px\" }}\n                maxWidth={{ s: 25, m: \"200px\" }}\n                height=\"300px\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "minSize",
+					"id": "utility-components-view--min-size",
+					"name": "width, height, minWidth, minHeight",
 					"snippet": "const minSize = () => (\n    <Example>\n        <Example.Item title=\"minHeight: 150px, minWidth: 150px, height: 50px, width: 50px\">\n            <View\n                backgroundColor=\"neutral-faded\"\n                minHeight=\"150px\"\n                minWidth=\"150px\"\n                height=\"50px\"\n                width=\"50px\"\n            />\n        </Example.Item>\n        <Example.Item title=\"minHeight: 25, minWidth: 25, height: 5, width: 5\">\n            <View backgroundColor=\"neutral-faded\" minHeight={25} minWidth={25} height={5} width={5} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive minHeight and minWidth, height: 50px, width: 50px\",\n                \"[s] minHeight: 25, minWidth: 25\",\n                \"[m+] minHeight: 200px, minWidth: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                minHeight={{ s: 25, m: \"200px\" }}\n                minWidth={{ s: 25, m: \"200px\" }}\n                height=\"50px\"\n                width=\"50px\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "background",
+					"id": "utility-components-view--background",
+					"name": "backgroundColor",
 					"snippet": "const background = () => (\n    <Example title=\"border is used to highlight the backround value when it's similar to the page background, text color changes based on the background\">\n        <Example.Item title=\"bg: page\">\n            <View backgroundColor=\"page\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: page-faded\">\n            <View backgroundColor=\"page-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: disabled\">\n            <View backgroundColor=\"disabled\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: disabled-faded\">\n            <View backgroundColor=\"disabled-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-base\">\n            <View backgroundColor=\"elevation-base\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-raised\">\n            <View backgroundColor=\"elevation-raised\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-overlay\">\n            <View backgroundColor=\"elevation-overlay\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: neutral\">\n            <View backgroundColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: neutral-faded\">\n            <View backgroundColor=\"neutral-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: primary\">\n            <View backgroundColor=\"primary\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: primary-faded\">\n            <View backgroundColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: critical\">\n            <View backgroundColor=\"critical\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: critical-faded\">\n            <View backgroundColor=\"critical-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: warning\">\n            <View backgroundColor=\"warning\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: warning-faded\">\n            <View backgroundColor=\"warning-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: positive\">\n            <View backgroundColor=\"positive\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: positive-faded\">\n            <View backgroundColor=\"positive-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--border-color",
 					"name": "borderColor",
 					"snippet": "const borderColor = () => (\n    <Example>\n        <Example.Item title=\"border: neutral\">\n            <View borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: neutral-faded\">\n            <View borderColor=\"neutral-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: primary\">\n            <View borderColor=\"primary\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: primary-faded\">\n            <View borderColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: critical\">\n            <View borderColor=\"critical\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: critical-faded\">\n            <View borderColor=\"critical-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: warning\">\n            <View borderColor=\"warning\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: warning-faded\">\n            <View borderColor=\"warning-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: positive\">\n            <View borderColor=\"positive\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: positive-faded\">\n            <View borderColor=\"positive-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: transparent, background: primary-faded\">\n            <View borderColor=\"transparent\" backgroundColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive\", \"[s] primary\", \"[m+] neutral\"]}>\n            <View borderColor={{ s: \"primary\", m: \"neutral\" }} padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--border",
 					"name": "border",
 					"snippet": "const border = () => (\n    <Example>\n        <Example.Item title=\"border: true\">\n            <View border borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderTop: true\">\n            <View borderTop borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderBottom: true\">\n            <View borderBottom borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderStart: true\">\n            <View borderStart borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderEnd: true\">\n            <View borderEnd borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderInline: true\">\n            <View borderInline borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderBlock: true\">\n            <View borderBlock borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderTop: true, borderStart: true, \">\n            <View borderColor=\"neutral\" borderTop borderStart padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"responsive\",\n                \"[s] borderTop: true, borderStart: true\",\n                \"[m+] borderBottom: true, borderEnd: true\",\n            ]}\n        >\n            <View\n                borderColor=\"neutral\"\n                borderTop={{ s: true, m: false }}\n                borderStart={{ s: true, m: false }}\n                borderBottom={{ s: false, m: true }}\n                borderEnd={{ s: false, m: true }}\n                padding={4}\n            >\n                Content\n            </View>\n        </Example.Item>\n\n        <div style={{ height: 100 }} />\n    </Example>\n);"
 				},
 				{
-					"name": "radius",
+					"id": "utility-components-view--radius",
+					"name": "borderRadius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius: small\">\n            <View borderRadius=\"small\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: medium\">\n            <View borderRadius=\"medium\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: large\">\n            <View borderRadius=\"large\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: circular\">\n            <View borderRadius=\"circular\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--shadow",
 					"name": "shadow",
 					"snippet": "const shadow = () => (\n    <Example>\n        <Example.Item title=\"shadow: raised, radius: medium\">\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                shadow=\"raised\"\n                borderRadius=\"medium\"\n                backgroundColor=\"elevation-raised\"\n            />\n        </Example.Item>\n        <Example.Item title=\"shadow: overlay, radius: medium\">\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                shadow=\"overlay\"\n                borderRadius=\"medium\"\n                backgroundColor=\"elevation-overlay\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--overflow",
 					"name": "overflow",
 					"snippet": "const overflow = () => (\n    <Example>\n        <Example.Item\n            title={[\"overflow: hidden, radius: medium\", \"child background should have radius\"]}\n        >\n            <View height=\"100px\" width=\"100px\" shadow=\"raised\" borderRadius=\"medium\" overflow=\"hidden\">\n                <View backgroundColor=\"primary\" height=\"100%\" width=\"100%\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positioning",
+					"id": "utility-components-view--positioning",
+					"name": "position",
 					"snippet": "const positioning = () => (\n    <Example>\n        <Example.Item title=\"position: relative + absolute\">\n            <View borderColor=\"neutral\" position=\"relative\">\n                <Placeholder />\n                <View\n                    position=\"absolute\"\n                    insetTop={0}\n                    insetEnd={0}\n                    backgroundColor=\"critical\"\n                    zIndex={5}\n                    height={10}\n                    width={10}\n                />\n                <View\n                    position=\"absolute\"\n                    insetTop={0}\n                    insetEnd={0}\n                    backgroundColor=\"primary\"\n                    height={15}\n                    width={15}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: sticky\">\n            <div style={{ overflow: \"auto\", height: 100 }} tabIndex={0}>\n                <View position=\"sticky\" borderColor=\"primary\" insetTop={0}>\n                    Content\n                </View>\n                <Placeholder h={1000} />\n            </div>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive\", \"[s] position: absolute\", \"[m+]: position: relative\"]}>\n            <div style={{ overflow: \"auto\", height: 100, position: \"relative\" }} tabIndex={0}>\n                <View position={{ s: \"absolute\", m: \"relative\" }} borderColor=\"primary\" insetTop={0}>\n                    Content\n                </View>\n                <Placeholder h={1000} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--inset",
 					"name": "inset",
 					"snippet": "const inset = () => (\n    <Example>\n        <Example.Item title=\"inset: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" inset={4} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetTop: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" insetTop={4} height={10} width={10} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetStart: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetStart={4}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetEnd: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" insetEnd={4} height={10} width={10} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetBottom: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetBottom={4}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"responsive, [s] insetBottom: 4 [m+] insetEnd: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetBottom={{ s: 4, m: \"auto\" }}\n                    insetEnd={{ s: \"auto\", m: 4 }}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--animated",
 					"name": "animated",
 					"snippet": "const animated = () => {\n    const [background, setBackground] = React.useState<ViewProps[\"backgroundColor\"]>(\"neutral\");\n\n    return (\n        <View gap={3} align=\"start\">\n            <Button\n                onClick={() => setBackground((prev) => (prev === \"neutral\" ? \"primary\" : \"neutral\"))}\n            >\n                Change background\n            </Button>\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                backgroundColor={background}\n                align=\"center\"\n                justify=\"center\"\n                animated\n            >\n                Content\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "itemGapBefore",
+					"id": "utility-components-view--item-gap-before",
+					"name": "item, gapBefore",
 					"snippet": "const itemGapBefore = () => (\n    <Example>\n        <Example.Item title={[\"gap: 4, 3rd item gapBefore: 10, direction: row\", \"increased gap\"]}>\n            <View direction=\"row\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={10}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 4, direction: row\", \"reduced gap\"]}>\n            <View direction=\"row\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={4}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 0, direction: row\", \"removed gap\"]}>\n            <View direction=\"row\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={0}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"gap: 4, direction: row, 2nd item gap: auto\">\n            <View direction=\"row\" gap={4}>\n                <Placeholder w={200} />\n                <View.Item gapBefore=\"auto\">\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"gap: 4, 3rd item gapBefore: 10, direction: column\", \"increased gap\"]}>\n            <View direction=\"column\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={10}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 4, direction: column\", \"reduced gap\"]}>\n            <View direction=\"column\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={4}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 0, direction: column\", \"removed gap\"]}>\n            <View direction=\"column\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={0}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"gap: 4, direction: column, height: 200px, 2nd item gap: auto\">\n            <View height=\"200px\" gap={4}>\n                <Placeholder />\n                <View.Item gapBefore=\"auto\">\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"responsive item gap\",\n                \"gap: 4, direction: row\",\n                \"[s] 3rd item gapBefore: 10\",\n                \"[m+] 3rd item gapBefore: 0\",\n            ]}\n        >\n            <View direction=\"row\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={{ s: 10, m: 0 }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemGrow",
+					"id": "utility-components-view--item-grow",
+					"name": "item, grow",
 					"snippet": "const itemGrow = () => (\n    <Example>\n        <Example.Item title=\"direction: row, 2nd item grow\">\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column, height: 200px, 2nd item grow\">\n            <View direction=\"column\" gap={3} height=\"200px\">\n                <Placeholder />\n                <View.Item grow>\n                    <Placeholder h=\"100%\" />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row, 2nd item grow, applied to View\">\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View grow>\n                    <Placeholder />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive item grow, direction: row\",\n                \"[s] 2nd item grow\",\n                \"[m+] 2nd item doesn't grow\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View.Item grow={{ s: true, m: false }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive item grow, direction: column, height: 200px\",\n                \"[s] 2nd item grow\",\n                \"[m+] 2nd item doesn't grow\",\n            ]}\n        >\n            <View direction=\"column\" gap={3} height=\"200px\">\n                <Placeholder />\n                <View.Item grow={{ s: true, m: false }}>\n                    <Placeholder h=\"100%\" />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemColumns",
+					"id": "utility-components-view--item-columns",
+					"name": "item, columns",
 					"snippet": "const itemColumns = () => (\n    <Example>\n        <Example.Item title=\"columns 6, 6, gap: 0\">\n            <View direction=\"row\">\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 3, 9, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={3}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, 9, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive columns\", \"[s] columns 6, 6, 12, gap: 4\", \"[m+]: 4, 4, 4\"]}>\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={{ s: 6, m: 4 }}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 6, m: 4 }}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 12, m: 4 }}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, 9, gap: 4, 2nd item gapBefore: 20\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6} gapBefore={20}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemOrder",
+					"id": "utility-components-view--item-order",
+					"name": "item, order",
 					"snippet": "const itemOrder = () => (\n    <Example>\n        <Example.Item title=\"order: 1 3 2\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={4}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={4} order={1}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={4}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive order\", \"[s] 1 2 3\", \"[m+] 1 3 2\"]}>\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={4}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={4} order={{ s: 0, m: 1 }}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={4}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive order\",\n                \"[s]: 1 3 2, 2 is full width on second row\",\n                \"[m+]: 1 2 3, 2 has grow in the center of the first row\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <View.Item columns={{ s: 6, m: \"auto\" }}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item\n                    grow={{ s: false, m: true }}\n                    order={{ s: 1, m: 0 }}\n                    columns={{ s: 12, m: \"auto\" }}\n                >\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 6, m: \"auto\" }}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "hiddenItem",
+					"id": "utility-components-view--hidden-item",
+					"name": "composition, Hidden item",
 					"snippet": "const hiddenItem = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"[s] 2nd item: visible, grow, 3rd item: !grow\",\n                \"[m+] 2nd item: hidden, 2nd item divider: hidden, 3rd item: grow\",\n            ]}\n        >\n            <View direction=\"row\" divided gap={3}>\n                <Placeholder />\n                <Hidden hide={{ s: false, m: true }}>\n                    <View.Item grow key=\"3\">\n                        <Placeholder />\n                    </View.Item>\n                </Hidden>\n                <View.Item grow={{ s: false, m: true }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"[s] 2nd item: visible, grow, 3rd item: !grow\",\n                \"[m+] 2nd item: hidden, 2nd item: grow doesn't push 3rd item, 3rd item: grow\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Placeholder />\n                <Hidden hide={{ s: false, m: true }}>\n                    <View.Item grow>\n                        <Placeholder />\n                    </View.Item>\n                </Hidden>\n                <View.Item grow={{ s: false, m: true }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "keys",
+					"id": "utility-components-view--keys",
+					"name": "item, key",
 					"snippet": "const keys = () => {\n    const toggle = useToggle();\n\n    return (\n        <View gap={2}>\n            <Button onClick={() => toggle.toggle()}>Toggle</Button>\n            <View.Item>Item 1</View.Item>\n            {toggle.active && <KeyItem>Item 2</KeyItem>}\n            <KeyItem>Item 3</KeyItem>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "nestedGaps",
+					"id": "utility-components-view--nested-gaps",
+					"name": "composition, nested gap",
 					"snippet": "const nestedGaps = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"direction: column, gap: 10\",\n                \"Child 1: direction: column, gap: 2\",\n                \"Child 2: direction column, gap: 6\",\n                \"Child 3: gapBefore: 0\",\n                \"Child 3 view: direction: row, gap: 2\",\n            ]}\n        >\n            <View gap={10}>\n                <View gap={2}>\n                    <Placeholder>Child 1</Placeholder>\n                    <Placeholder>Child 1</Placeholder>\n                </View>\n\n                <View gap={6}>\n                    <Placeholder>Child 2</Placeholder>\n                    <Placeholder>Child 2</Placeholder>\n                </View>\n\n                <View.Item gapBefore={0}>\n                    <View direction=\"row\" gap={2}>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "utility-components-view--test-composition",
+					"name": "composition, edge cases",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item>\n            <View direction=\"row\" align=\"center\" gap={4} padding={4}>\n                <View width=\"80px\" height=\"60px\" backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n\n                <View direction=\"row\" align=\"center\" gap={1} grow>\n                    <View.Item shrink>\n                        <Text>Text (like Jeff's Puzzles)</Text>\n                    </View.Item>\n\n                    <View minWidth=\"auto\" grow>\n                        <Button size=\"small\" color=\"neutral\" icon={IconPlus} />\n                    </View>\n                </View>\n\n                <Button color=\"primary\" rounded>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"View.Item, MenuItem, Aspect ratio\",\n                \"ratio should increase height on viewport change\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <View.Item>\n                    <Placeholder />\n                </View.Item>\n                <MenuItem selected roundedCorners>\n                    Menu\n                </MenuItem>\n                <View.Item grow>\n                    <View aspectRatio={16 / 9}>\n                        <Placeholder h=\"100%\" />\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"Scrollable tabs inside View.Item with grow\">\n            <View direction=\"row\" align=\"center\" gap={3}>\n                <Placeholder />\n                <View.Item grow>\n                    <View padding={0} align=\"center\">\n                        <Tabs variant=\"pills\">\n                            <Tabs.List>\n                                <Tabs.Item value=\"1\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"2\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"3\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"4\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"5\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"6\">Very long item</Tabs.Item>\n                            </Tabs.List>\n                            {[1, 2, 3, 5, 6].map((i) => (\n                                <Tabs.Panel key={i} value={i.toString()} />\n                            ))}\n                        </Tabs>\n                    </View>\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"2nd item has grow, Avatar stays circle\">\n            <View direction=\"row\" gap={3}>\n                <Avatar initials=\"DB\" />\n                <View.Item grow>\n                    Veggies sunt bona vobis, proinde vos postulo esse magis grape pea sprouts horseradish\n                    courgette maize spinach prairie turnip jícama coriander quandong gourd broccoli seakale\n                    gumbo. Parsley corn lentil zucchini radicchio maize burdock avocado sea lettuce.\n                    Garbanzo tigernut earthnut pea fennel.\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"item gapBefore from parent doesn't affect the child view\",\n                \"columns should take full width\",\n            ]}\n        >\n            <View>\n                <View.Item gapBefore={20}>\n                    <View direction=\"row\" gap={4}>\n                        <View.Item columns={6}>\n                            <Placeholder />\n                        </View.Item>\n                        <View.Item columns={6}>\n                            <Placeholder />\n                        </View.Item>\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"View becomes flexbox if there is a child with grow\">\n            <View height=\"300px\" borderColor=\"neutral-faded\">\n                <View height=\"50px\" />\n                <View grow backgroundColor=\"neutral-faded\" padding={4}>\n                    Grow\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "asProp",
+					"id": "utility-components-view--as-prop",
+					"name": "as",
 					"snippet": "const asProp = () => (\n    <View as=\"ul\">\n        <View.Item as=\"li\">Content</View.Item>\n    </View>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-view--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <View className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </View>\n    </div>\n);"
 				},
 				{
-					"name": "itemClassName",
+					"id": "utility-components-view--item-class-name",
+					"name": "item className, attributes",
 					"snippet": "const itemClassName = () => (\n    <div data-testid=\"root\">\n        <View.Item className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </View.Item>\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Button, Example, Hidden, MenuItem, Placeholder, Tabs, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/View/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "View",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/View/View.tsx",
-				"actualName": "View",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"divided": {
+						"defaultValue": null,
+						"description": "Render a divider between each child",
+						"name": "divided",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Flex direction for the content",
+						"name": "direction",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Direction>" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between children, base unit token number multiplier",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"wrap": {
+						"defaultValue": null,
+						"description": "Flex wrap for the content",
+						"name": "wrap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Flex align-items for the content",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Flex justify-content for the content",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width style, literal string value or a base unit token number multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"aspectRatio": {
+						"defaultValue": null,
+						"description": "Aspect ratio style, represented as width / height",
+						"name": "aspectRatio",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height style, literal string value or a base unit token number multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Maximum width style, literal string value or a base unit token number multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"minHeight": {
+						"defaultValue": null,
+						"description": "Minimum height style, literal string value or a base unit token number multiplier",
+						"name": "minHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"minWidth": {
+						"defaultValue": null,
+						"description": "Minimum width style, literal string value or a base unit token number multiplier",
+						"name": "minWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Padding style for all sides, base unit token number multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingTop": {
+						"defaultValue": null,
+						"description": "Padding top, base unit token number multiplier",
+						"name": "paddingTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingBottom": {
+						"defaultValue": null,
+						"description": "Padding bottom, base unit token number multiplier",
+						"name": "paddingBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingStart": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "paddingStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingEnd": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "paddingEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingInline": {
+						"defaultValue": null,
+						"description": "Padding inline, base unit token number multiplier",
+						"name": "paddingInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingBlock": {
+						"defaultValue": null,
+						"description": "Padding block, base unit token number multiplier",
+						"name": "paddingBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margin and remove side borders, base unit token number multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"textAlign": {
+						"defaultValue": null,
+						"description": "Text align for the content",
+						"name": "textAlign",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<TextAlign>" }
+					},
+					"backgroundColor": {
+						"defaultValue": null,
+						"description": "Background color, based on the color tokens",
+						"name": "backgroundColor",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"critical-faded\" | \"warning\" | \"warning-faded\" | \"positive-faded\" | \"primary-faded\" | \"elevation-base\" | \"elevation-raised\" | \"elevation-overlay\" | \"page\" | \"page-faded\" | \"disabled-faded\" | \"brand\" | \"white\" | \"black\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"critical-faded\"" },
+								{ "value": "\"warning\"" },
+								{ "value": "\"warning-faded\"" },
+								{ "value": "\"positive-faded\"" },
+								{ "value": "\"primary-faded\"" },
+								{ "value": "\"elevation-base\"" },
+								{ "value": "\"elevation-raised\"" },
+								{ "value": "\"elevation-overlay\"" },
+								{ "value": "\"page\"" },
+								{ "value": "\"page-faded\"" },
+								{ "value": "\"disabled-faded\"" },
+								{ "value": "\"brand\"" },
+								{ "value": "\"white\"" },
+								{ "value": "\"black\"" }
+							]
+						}
+					},
+					"borderColor": {
+						"defaultValue": null,
+						"description": "Border color, based on the color tokens",
+						"name": "borderColor",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<BorderColor>" }
+					},
+					"border": {
+						"defaultValue": null,
+						"description": "Add border to all sides",
+						"name": "border",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderTop": {
+						"defaultValue": null,
+						"description": "Add border to the top side",
+						"name": "borderTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderBottom": {
+						"defaultValue": null,
+						"description": "Add border to the bottom side",
+						"name": "borderBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderStart": {
+						"defaultValue": null,
+						"description": "Add border to the inline start side",
+						"name": "borderStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderEnd": {
+						"defaultValue": null,
+						"description": "Add border to the inline end side",
+						"name": "borderEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderInline": {
+						"defaultValue": null,
+						"description": "Add border to the inline direction",
+						"name": "borderInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderBlock": {
+						"defaultValue": null,
+						"description": "Add border to the block direction",
+						"name": "borderBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Radius>" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Position style",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Position>" }
+					},
+					"inset": {
+						"defaultValue": null,
+						"description": "Inset style, base unit token number multiplier when used as a number",
+						"name": "inset",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetStart": {
+						"defaultValue": null,
+						"description": "Inset start, base unit token number multiplier when used as a number",
+						"name": "insetStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetEnd": {
+						"defaultValue": null,
+						"description": "Inset end, base unit token number multiplier when used as a number",
+						"name": "insetEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetTop": {
+						"defaultValue": null,
+						"description": "Inset top, base unit token number multiplier when used as a number",
+						"name": "insetTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetBottom": {
+						"defaultValue": null,
+						"description": "Inset bottom, base unit token number multiplier when used as a number",
+						"name": "insetBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"zIndex": {
+						"defaultValue": null,
+						"description": "z-index style",
+						"name": "zIndex",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"shadow": {
+						"defaultValue": null,
+						"description": "Shadow style, based on the shadow tokens",
+						"name": "shadow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Overflow style",
+						"name": "overflow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"auto\"",
+							"value": [{ "value": "\"hidden\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"animated": {
+						"defaultValue": null,
+						"description": "Add transition for the properties",
+						"name": "animated",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					},
+					"grow": {
+						"defaultValue": null,
+						"description": "Apply flex-grow, using it on View.Item applies additional styles on the parent View",
+						"name": "grow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"shrink": {
+						"defaultValue": null,
+						"description": "Apply flex-shrink",
+						"name": "shrink",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "View"
 			}
 		},
 		"hooks-useelementid": {
@@ -3131,7 +16482,8 @@
 			"path": "./src/hooks/tests/useElementId.stories.tsx",
 			"stories": [
 				{
-					"name": "id",
+					"id": "hooks-useelementid--id",
+					"name": "passed id",
 					"snippet": "const id = () => {\n    return <Component id=\"hey\" />;\n};"
 				}
 			],
@@ -3148,6 +16500,7 @@
 			"path": "./src/hooks/tests/useHandlerRef.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usehandlerref--base",
 					"name": "base",
 					"snippet": "const base = (args) => {\n    const [count, setCount] = React.useState(0);\n\n    // Creating a new handler on each render\n    const handleEffect = () => {\n        args.handleEffect(0);\n    };\n\n    return (\n        <View gap={4}>\n            <Button onClick={() => setCount((prev) => prev + 1)}>Increase count</Button>\n            <Component onEffect={handleEffect} count={count} />\n        </View>\n    );\n};"
 				}
@@ -3165,43 +16518,53 @@
 			"path": "./src/hooks/tests/useHotkeys.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usehotkeys--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const { checkHotkeyState } = useHotkeys({\n        \"shift + b + n\": () => console.log(\"pressed\"),\n        \"c + v\": () => console.log(\"c + v\"),\n        \"Meta + k\": () => console.log(\"meta + k\"),\n        \"Meta + f\": () => console.log(\"meta + f\"),\n        \"Meta + v\": () => console.log(\"meta + v\"),\n        \"Meta + b\": () => console.log(\"meta + b\"),\n        \"control + enter\": () => console.log(\"control + enter\"),\n        \"meta + enter\": () => console.log(\"meta + enter\"),\n        \"mod + enter\": () => console.log(\"mod + enter\"),\n        \"mod + ArrowRight\": () => console.log(\"right\"),\n        \"mod + ArrowUp\": () => console.log(\"top\"),\n        \"shift + ArrowRight\": () => console.log(\"right\"),\n        \"shift + ArrowUp\": () => console.log(\"top\"),\n        \"alt+shift+n\": () => console.log(\"alt+shift+n\"),\n        \"shift+alt+n\": () => console.log(\"shift+alt+n\"),\n        \"alt+shiftLeft+n\": () => console.log(\"alt+shiftLeft+n\"),\n    });\n    const active = checkHotkeyState(\"shift + b + n\");\n    const shiftActive = checkHotkeyState(\"shift\");\n    const bActive = checkHotkeyState(\"b\");\n    const nActive = checkHotkeyState(\"n\");\n\n    return (\n        <View\n            animated\n            gap={2}\n            direction=\"row\"\n            backgroundColor={active ? \"positive-faded\" : undefined}\n            padding={2}\n            borderRadius=\"small\"\n        >\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={shiftActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={shiftActive ? undefined : \"raised\"}\n            >\n                Shift\n            </View>\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={bActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={bActive ? undefined : \"raised\"}\n            >\n                b\n            </View>\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={nActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={nActive ? undefined : \"raised\"}\n            >\n                n\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "singleKey",
+					"id": "hooks-usehotkeys--single-key",
+					"name": "single key",
 					"snippet": "const singleKey = (args) => <Component hotkeys={{ a: args.handleHotkey }} />;"
 				},
 				{
-					"name": "modKey",
+					"id": "hooks-usehotkeys--mod-key",
+					"name": "mod key",
 					"snippet": "const modKey = (args) => <Component hotkeys={{ mod: args.handleHotkey }} />;"
 				},
 				{
-					"name": "modKeyHold",
+					"id": "hooks-usehotkeys--mod-key-hold",
+					"name": "mod key on hold",
 					"snippet": "const modKeyHold = (args) => <Component hotkeys={{ \"Meta + b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyList",
+					"id": "hooks-usehotkeys--key-list",
+					"name": "key list",
 					"snippet": "const keyList = (args) => <Component hotkeys={{ \"a,b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombination",
+					"id": "hooks-usehotkeys--key-combination",
+					"name": "key combination",
 					"snippet": "const keyCombination = (args) => <Component hotkeys={{ \"a+b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationFormat",
+					"id": "hooks-usehotkeys--key-combination-format",
+					"name": "key combination without formatting",
 					"snippet": "const keyCombinationFormat = (args) => <Component hotkeys={{ \"A  + b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationOrder",
+					"id": "hooks-usehotkeys--key-combination-order",
+					"name": "key combination without order",
 					"snippet": "const keyCombinationOrder = (args) => <Component hotkeys={{ \"b+a\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationMoreThanRequired",
+					"id": "hooks-usehotkeys--key-combination-more-than-required",
+					"name": "key combination, more keys pressed",
 					"snippet": "const keyCombinationMoreThanRequired = (args) => <Component hotkeys={{ \"z + x\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "optionModified",
+					"id": "hooks-usehotkeys--option-modified",
+					"name": "modified with alt/option",
 					"snippet": "const optionModified = (args) => (\n    <Component hotkeys={{ \"alt+n\": args.handleHotkeyModified, \"alt+shift\": args.handleHotkey }} />\n);"
 				}
 			],
@@ -3218,22 +16581,27 @@
 			"path": "./src/hooks/tests/useKeyboardArrowNavigation.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usekeyboardarrownavigation--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "horizontal",
+					"id": "hooks-usekeyboardarrownavigation--horizontal",
+					"name": "orientation: horizontal",
 					"snippet": "const horizontal = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, orientation: \"horizontal\" });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "vertical",
+					"id": "hooks-usekeyboardarrownavigation--vertical",
+					"name": "orientation: vertical",
 					"snippet": "const vertical = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, orientation: \"vertical\" });\n\n    return (\n        <View gap={2} direction=\"column\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-usekeyboardarrownavigation--circular",
 					"name": "circular",
 					"snippet": "const circular = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, circular: true });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-usekeyboardarrownavigation--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, disabled: true });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				}
@@ -3249,7 +16617,13 @@
 			"id": "hooks-usekeyboardmode",
 			"name": "useKeyboardMode",
 			"path": "./src/hooks/tests/useKeyboardMode.stories.tsx",
-			"stories": [{ "name": "base", "snippet": "const base = () => <Component />;" }],
+			"stories": [
+				{
+					"id": "hooks-usekeyboardmode--base",
+					"name": "base",
+					"snippet": "const base = () => <Component />;"
+				}
+			],
 			"import": "import { Button, View } from \"reshaped\";",
 			"jsDocTags": {},
 			"error": {
@@ -3263,19 +16637,23 @@
 			"path": "./src/hooks/tests/useOnClickOutside.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-useonclickoutside--base",
 					"name": "base",
 					"snippet": "const base = (args) => {\n    const ref = React.useRef(null);\n    const [target, setTarget] = React.useState<\"inside\" | \"outside\" | null>(null);\n\n    useOnClickOutside([ref], () => {\n        args.handleOutsideClick();\n        setTarget(\"outside\");\n    });\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }} onClick={() => setTarget(\"inside\")}>\n                Trigger\n            </Button>\n            {target && `Clicked ${target}`}\n        </View>\n    );\n};"
 				},
 				{
-					"name": "refs",
+					"id": "hooks-useonclickoutside--refs",
+					"name": "multiple refs",
 					"snippet": "const refs = (args) => {\n    const ref = React.useRef(null);\n    const ref2 = React.useRef(null);\n\n    useOnClickOutside([ref, ref2], () => {\n        args.handleOutsideClick();\n    });\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }}>Trigger</Button>\n            <Button attributes={{ ref: ref2 }}>Trigger 2</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-useonclickoutside--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = (args) => {\n    const ref = React.useRef(null);\n\n    useOnClickOutside(\n        [ref],\n        () => {\n            args.handleOutsideClick();\n        },\n        {\n            disabled: true,\n        }\n    );\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }}>Trigger</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "deps",
+					"id": "hooks-useonclickoutside--deps",
+					"name": "test: handler uses latest state",
 					"snippet": "const deps = (args) => {\n    const ref = React.useRef(null);\n    const [count, setCount] = React.useState(0);\n\n    useOnClickOutside([ref], () => {\n        args.handleOutsideClick({ count });\n    });\n\n    return (\n        <Button attributes={{ ref }} onClick={() => setCount((prev) => prev + 1)}>\n            Trigger\n        </Button>\n    );\n};"
 				}
 			],
@@ -3290,7 +16668,13 @@
 			"id": "hooks-usertl",
 			"name": "useRTL",
 			"path": "./src/hooks/tests/useRTL.stories.tsx",
-			"stories": [{ "name": "setRTL", "snippet": "const setRTL = () => <Component />;" }],
+			"stories": [
+				{
+					"id": "hooks-usertl--set-rtl",
+					"name": "setRTL",
+					"snippet": "const setRTL = () => <Component />;"
+				}
+			],
 			"import": "",
 			"jsDocTags": {},
 			"error": {
@@ -3304,10 +16688,12 @@
 			"path": "./src/hooks/tests/useResponsiveClientValue.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-useresponsiveclientvalue--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const value = useResponsiveClientValue<ViewProps[\"backgroundColor\"]>({\n        s: \"neutral\",\n        m: \"critical\",\n        l: \"positive\",\n    });\n\n    return <View width={25} height={25} backgroundColor={value} />;\n};"
 				},
 				{
+					"id": "hooks-useresponsiveclientvalue--boolean",
 					"name": "boolean",
 					"snippet": "const boolean = () => {\n    const value = useResponsiveClientValue<boolean>({\n        s: true,\n        l: false,\n    });\n\n    return <div>{value?.toString()}</div>;\n};"
 				}
@@ -3325,19 +16711,23 @@
 			"path": "./src/hooks/tests/useScrollLock.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usescrolllock--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock();\n\n    return (\n        <React.Fragment>\n            <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n            <div style={{ height: \"150vh\" }} />\n        </React.Fragment>\n    );\n};"
 				},
 				{
-					"name": "origin",
+					"id": "hooks-usescrolllock--origin",
+					"name": "originRef",
 					"snippet": "const origin = () => {\n    const originRef = React.useRef<HTMLDivElement>(null);\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock({ originRef });\n\n    return (\n        <View overflow=\"auto\" height={25} attributes={{ ref: originRef, \"data-testid\": \"root\" }}>\n            <View height={50} padding={4} backgroundColor=\"neutral-faded\" borderRadius=\"medium\">\n                <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "container",
+					"id": "hooks-usescrolllock--container",
+					"name": "containerRef",
 					"snippet": "const container = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock({ containerRef });\n\n    return (\n        <View height={25} attributes={{ ref: containerRef, \"data-testid\": \"root\" }}>\n            <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testContainerAsync",
+					"id": "hooks-usescrolllock--test-container-async",
+					"name": "test: containerRef locked count",
 					"snippet": "const testContainerAsync = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const globalLock = useScrollLock();\n    const scopedLock = useScrollLock({ containerRef });\n\n    return (\n        <Example>\n            <Example.Item title=\"calling regular lock and lock with a container only requires a single unlock to remove overflow\">\n                <View attributes={{ ref: containerRef }} gap={4} direction=\"row\">\n                    <Button\n                        onClick={globalLock.scrollLocked ? globalLock.unlockScroll : globalLock.lockScroll}\n                    >\n                        Toggle\n                    </Button>\n                    <Button\n                        onClick={scopedLock.scrollLocked ? scopedLock.unlockScroll : scopedLock.lockScroll}\n                    >\n                        Toggle\n                    </Button>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
@@ -3354,14 +16744,17 @@
 			"path": "./src/hooks/tests/useToggle.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usetoggle--toggle",
 					"name": "toggle",
 					"snippet": "const toggle = () => {\n    const { toggle, active } = useToggle();\n\n    return (\n        <Button onClick={() => toggle()} attributes={{ \"data-active\": active }}>\n            {active ? \"Deactivate\" : \"Activate\"}\n        </Button>\n    );\n};"
 				},
 				{
+					"id": "hooks-usetoggle--activate",
 					"name": "activate",
 					"snippet": "const activate = () => {\n    const { activate, active } = useToggle();\n\n    return (\n        <React.Fragment>\n            <Button onClick={activate} attributes={{ \"data-active\": active }}>\n                Activate\n            </Button>\n        </React.Fragment>\n    );\n};"
 				},
 				{
+					"id": "hooks-usetoggle--deactivate",
 					"name": "deactivate",
 					"snippet": "const deactivate = () => {\n    const { deactivate, active } = useToggle(true);\n\n    return (\n        <Button onClick={deactivate} attributes={{ \"data-active\": active }}>\n            Deactivate\n        </Button>\n    );\n};"
 				}
@@ -3379,39 +16772,48 @@
 			"path": "./src/utilities/a11y/tests/TrapFocus.stories.tsx",
 			"stories": [
 				{
-					"name": "modeDialog",
+					"id": "utilities-trapfocus--mode-dialog",
+					"name": "mode: dialog",
 					"snippet": "const modeDialog = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, { mode: \"dialog\" });\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\"mode: dialog\", \"tab navigation, always stays inside until released\"]}\n            >\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View.Item>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeActionMenu",
+					"id": "utilities-trapfocus--mode-action-menu",
+					"name": "mode: action-menu",
 					"snippet": "const modeActionMenu = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"action-menu\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: action-menu\",\n                    \"up/down arrow navigation, tab and shift+tab release the focus and follows natural tab order\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeActionBar",
+					"id": "utilities-trapfocus--mode-action-bar",
+					"name": "mode: action-bar",
 					"snippet": "const modeActionBar = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"action-bar\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: action-bar\",\n                    \"left/right arrow navigation, tab and shift+tab release the focus and follows natural tab order\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeContentMenu",
+					"id": "utilities-trapfocus--mode-content-menu",
+					"name": "mode: content-menu",
 					"snippet": "const modeContentMenu = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"content-menu\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: content-menu\",\n                    \"tab navigation, tabbing outside the content will trigger the release\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utilities-trapfocus--include-trigger",
 					"name": "includeTrigger",
 					"snippet": "const includeTrigger = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n            includeTrigger: true,\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utilities-trapfocus--initial-focus-el",
 					"name": "initialFocusEl",
 					"snippet": "const initialFocusEl = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const initialFocusRef = React.useRef<HTMLButtonElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n            initialFocusEl: initialFocusRef.current,\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View\n                            gap={4}\n                            direction=\"row\"\n                            padding={4}\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            attributes={{ ref: rootRef }}\n                        >\n                            <Button onClick={() => {}}>Action 1</Button>\n                            <Button onClick={() => {}} attributes={{ ref: initialFocusRef }}>\n                                Action 2\n                            </Button>\n                            <Button onClick={() => {}}>Action 3</Button>\n                            <Button onClick={trapToggle.deactivate}>Release</Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "focusableElements",
+					"id": "utilities-trapfocus--focusable-elements",
+					"name": "test: focusable elements",
 					"snippet": "const focusableElements = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current);\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title=\"test with all types of focusable elements\">\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={trapToggle.activate}>Activate</Button>\n                    </View.Item>\n\n                    {trapToggle.active && (\n                        <View\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            padding={4}\n                            gap={4}\n                            attributes={{ ref: rootRef }}\n                            align=\"start\"\n                        >\n                            <Link href=\"#\" attributes={{ \"data-testid\": \"test-link\" }}>\n                                Link\n                            </Link>\n\n                            <TextField\n                                name=\"input\"\n                                placeholder=\"Input\"\n                                inputAttributes={{ \"data-testid\": \"test-text-field\" }}\n                            />\n\n                            <TextArea name=\"textarea\" inputAttributes={{ \"data-testid\": \"test-text-area\" }} />\n\n                            <Select\n                                name=\"select\"\n                                options={[\n                                    { label: \"Option 1\", value: \"1\" },\n                                    { label: \"Option 2\", value: \"2\" },\n                                ]}\n                                inputAttributes={{ \"data-testid\": \"test-select\" }}\n                            />\n\n                            <RadioGroup name=\"radio\">\n                                <Radio value=\"1\" inputAttributes={{ \"data-testid\": \"test-radio-1\" }}>\n                                    Option 1\n                                </Radio>\n                                <Radio value=\"2\" inputAttributes={{ \"data-testid\": \"test-radio-2\" }}>\n                                    Option 2\n                                </Radio>\n                            </RadioGroup>\n\n                            <Editor />\n\n                            <div tabIndex={0} role=\"button\" data-testid=\"test-tabindex\">\n                                div with tabIndex\n                            </div>\n\n                            <div style={{ display: \"none\" }}>\n                                <Button onClick={() => {}} attributes={{ \"data-testid\": \"test-hidden-button\" }}>\n                                    Hidden\n                                </Button>\n                            </div>\n\n                            <Button\n                                onClick={() => {}}\n                                attributes={{ tabIndex: -1, \"data-testid\": \"test-button-negative-tabindex\" }}\n                            >\n                                Excluded\n                            </Button>\n\n                            <input type=\"hidden\" data-testid=\"test-input-hidden\" />\n\n                            <Button\n                                onClick={trapToggle.deactivate}\n                                attributes={{ \"data-testid\": \"test-button\" }}\n                            >\n                                Release button\n                            </Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "nested",
+					"id": "utilities-trapfocus--nested",
+					"name": "test: nested",
 					"snippet": "const nested = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const innerRootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n    const innerTrapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    React.useEffect(() => {\n        if (!innerTrapToggle.active) return;\n        if (!innerRootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(innerRootRef.current, {\n            mode: \"dialog\",\n        });\n\n        return () => trapFocus.release();\n    }, [innerTrapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"nested, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View gap={4}>\n                            <View\n                                gap={4}\n                                direction=\"row\"\n                                padding={4}\n                                backgroundColor=\"neutral-faded\"\n                                borderRadius=\"medium\"\n                                attributes={{ ref: rootRef }}\n                            >\n                                <Button onClick={() => {}}>Action</Button>\n                                <Button onClick={innerTrapToggle.activate}>Inner trap focus</Button>\n                                <Button onClick={trapToggle.deactivate}>Release</Button>\n                            </View>\n\n                            {innerTrapToggle.active && (\n                                <View\n                                    gap={4}\n                                    direction=\"row\"\n                                    padding={4}\n                                    backgroundColor=\"neutral-faded\"\n                                    borderRadius=\"medium\"\n                                    attributes={{ ref: innerRootRef }}\n                                >\n                                    <Button onClick={() => {}}>Action</Button>\n                                    <Button onClick={innerTrapToggle.deactivate}>Release</Button>\n                                </View>\n                            )}\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "mutationObserver",
+					"id": "utilities-trapfocus--mutation-observer",
+					"name": "test: mutation observer",
 					"snippet": "const mutationObserver = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n    const [mutated, setMutated] = React.useState(false);\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n        });\n\n        setTimeout(() => {\n            setMutated(true);\n        }, 50);\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View\n                            gap={4}\n                            direction=\"row\"\n                            padding={4}\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            attributes={{ ref: rootRef }}\n                        >\n                            {!mutated && (\n                                <>\n                                    <Button onClick={() => {}}>Action 1</Button>\n                                    <Button onClick={() => {}}>Action 2</Button>\n                                </>\n                            )}\n                            <Button onClick={() => {}}>Action 3</Button>\n                            <Button onClick={trapToggle.deactivate}>Release</Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
@@ -3428,15 +16830,35 @@
 			"path": "./src/components/_private/Portal/tests/Portal.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "internal-portal--base",
+					"name": "Base",
 					"snippet": "const base = () => {\n\tconst ref = React.useRef<HTMLDivElement>(null);\n\tconst [mounted, setMounted] = React.useState(false);\n\n\tReact.useEffect(() => {\n\t\tsetMounted(true);\n\t}, []);\n\n\treturn (\n\t\t<>\n\t\t\t<div style={{ border: \"2px solid #333\", padding: 16 }}>\n\t\t\t\tApp\n\t\t\t\t{mounted && <Portal targetRef={ref}>Ported to green</Portal>}\n\t\t\t</div>\n\t\t\t<div ref={ref} style={{ border: \"2px solid green\", padding: 16 }} />\n\t\t</>\n\t);\n};"
 				}
 			],
 			"import": "import { Portal } from \"reshaped\";",
 			"jsDocTags": {},
-			"error": {
-				"name": "No component definition found",
-				"message": "File: /Users/shilman/projects/design-systems/reshaped/src/components/_private/Portal/index.ts\nError:\nNo suitable component definition found.\nYou can debug your component file in this playground: https://react-docgen.dev/playground\nCode:\nimport Portal, { PortalScope } from \"./Portal\";\n\nconst PortalRoot = Portal as typeof Portal & {\n\tScope: typeof PortalScope;\n};\n\nPortalRoot.Scope = PortalScope;\n\nexport default PortalRoot;\nexport type { Props as PortalProps } from \"./Portal.types\";\n\n\nFile: /Users/shilman/projects/design-systems/reshaped/src/components/_private/Portal/Portal.types.ts\nError:\nNo suitable component definition found.\nYou can debug your component file in this playground: https://react-docgen.dev/playground\nCode:\nimport React from \"react\";\n\nexport type Props = {\n\tchildren?: React.ReactNode;\n\ttargetRef?: React.RefObject<HTMLElement | ShadowRoot | null>;\n};\n\nexport type ScopeProps<T extends HTMLElement> = {\n\tchildren: (ref: React.RefObject<T | null>) => React.ReactNode;\n};\n\nexport type Context = {\n\tscopeRef: React.RefObject<HTMLElement | null>;\n};\n"
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/_private/Portal/index.ts",
+				"description": "",
+				"displayName": "Portal",
+				"methods": [],
+				"props": {
+					"targetRef": {
+						"defaultValue": null,
+						"description": "",
+						"name": "targetRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/_private/Portal/Portal.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | ShadowRoot | null>" }
+					}
+				},
+				"exportName": "Portal"
 			}
 		},
 		"internal-usedrag": {
@@ -3444,24 +16866,33 @@
 			"name": "useDrag",
 			"path": "./src/hooks/tests/useDrag.stories.tsx",
 			"stories": [
-				{ "name": "base", "snippet": "const base = () => <Example />;" },
 				{
-					"name": "mouseEvents",
+					"id": "internal-usedrag--base",
+					"name": "base",
+					"snippet": "const base = () => <Example />;"
+				},
+				{
+					"id": "internal-usedrag--mouse-events",
+					"name": "onDrag, mouse events",
 					"snippet": "const mouseEvents = () => {\n    return <Demo onDrag={fn()} />;\n};"
 				},
 				{
-					"name": "touchEvents",
+					"id": "internal-usedrag--touch-events",
+					"name": "onDrag, touch events",
 					"snippet": "const touchEvents = () => {\n    return <Demo onDrag={fn()} />;\n};"
 				},
 				{
-					"name": "orientationHorizontal",
+					"id": "internal-usedrag--orientation-horizontal",
+					"name": "orientation horizontal",
 					"snippet": "const orientationHorizontal = () => {\n    return <Demo onDrag={fn()} orientation=\"horizontal\" />;\n};"
 				},
 				{
-					"name": "orientationVertical",
+					"id": "internal-usedrag--orientation-vertical",
+					"name": "orientation vertical",
 					"snippet": "const orientationVertical = () => {\n    return <Demo onDrag={fn()} orientation=\"vertical\" />;\n};"
 				},
 				{
+					"id": "internal-usedrag--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => {\n    return <Demo onDrag={fn()} disabled />;\n};"
 				}
@@ -3479,7 +16910,8 @@
 			"path": "./src/tests/ShadowDOM.stories.tsx",
 			"stories": [
 				{
-					"name": "behavior",
+					"id": "internal-shadowdom--behavior",
+					"name": "Behavior",
 					"snippet": "const behavior = () => (\n\t<Example>\n\t\t<Example.Item title=\"base\">\n\t\t\t<Component />\n\t\t</Example.Item>\n\t</Example>\n);"
 				}
 			],
@@ -3496,30 +16928,94 @@
 			"path": "./src/tests/themes.stories.tsx",
 			"stories": [
 				{
-					"name": "test",
+					"id": "internal-themes--test",
+					"name": "Test",
 					"snippet": "const test = () => {\n\tconst { colorMode } = useTheme();\n\tconst [activeColor, setColor] = useState(colors[0]);\n\tconst [theme, setTheme] = useState(\"\");\n\tconst [algo, setAlgo] = useState<\"wcag\" | \"apca\">(\"wcag\");\n\n\tuseLayoutEffect(() => {\n\t\tsetTheme(\n\t\t\tgetThemeCSS(\n\t\t\t\t\"test\",\n\t\t\t\t{\n\t\t\t\t\tcolor: generateThemeColors({\n\t\t\t\t\t\tprimary: activeColor === colors[0] ? undefined : activeColor,\n\t\t\t\t\t}),\n\t\t\t\t},\n\t\t\t\t{\n\t\t\t\t\tcolorContrastAlgorithm: algo,\n\t\t\t\t}\n\t\t\t)\n\t\t);\n\t}, [activeColor, algo]);\n\n\treturn (\n\t\t<>\n\t\t\t<style>{theme}</style>\n\t\t\t<Theme name=\"test\">\n\t\t\t\t<View gap={4}>\n\t\t\t\t\t<View direction=\"row\" align=\"center\" gap={4}>\n\t\t\t\t\t\t{colors.map((color) => {\n\t\t\t\t\t\t\tconst hex = colorMode === \"dark\" && color === \"#000000\" ? \"#ffffff\" : color;\n\n\t\t\t\t\t\t\treturn (\n\t\t\t\t\t\t\t\t<Actionable key={color} onClick={() => setColor(color)} borderRadius=\"inherit\">\n\t\t\t\t\t\t\t\t\t<View\n\t\t\t\t\t\t\t\t\t\twidth={5}\n\t\t\t\t\t\t\t\t\t\theight={5}\n\t\t\t\t\t\t\t\t\t\tborderRadius=\"circular\"\n\t\t\t\t\t\t\t\t\t\tattributes={{\n\t\t\t\t\t\t\t\t\t\t\tstyle: {\n\t\t\t\t\t\t\t\t\t\t\t\ttransition: `box-shadow var(--rs-duration-fast) var(--rs-easing-standard)`,\n\t\t\t\t\t\t\t\t\t\t\t\tbackground: hex,\n\t\t\t\t\t\t\t\t\t\t\t\tboxShadow:\n\t\t\t\t\t\t\t\t\t\t\t\t\tcolor === activeColor\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t? `0 0 0 3px var(--rs-color-background-elevation-base), 0 0 0 5px ${hex}`\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t: undefined,\n\t\t\t\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t\t\t\t}}\n\t\t\t\t\t\t\t\t\t/>\n\t\t\t\t\t\t\t\t</Actionable>\n\t\t\t\t\t\t\t);\n\t\t\t\t\t\t})}\n\t\t\t\t\t\t<View.Item gapBefore=\"auto\">\n\t\t\t\t\t\t\t<Switch name=\"algo\" onChange={(args) => setAlgo(args.checked ? \"apca\" : \"wcag\")}>\n\t\t\t\t\t\t\t\tUse APCA\n\t\t\t\t\t\t\t</Switch>\n\t\t\t\t\t\t</View.Item>\n\t\t\t\t\t</View>\n\n\t\t\t\t\t<ThemePlayground />\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</>\n\t);\n};"
 				},
 				{
-					"name": "base",
+					"id": "internal-themes--base",
+					"name": "Base",
 					"snippet": "const base = () => (\n\t<Example>\n\t\t<Example.Item title=\"custom runtime theme\">\n\t\t\t<style>{css}</style>\n\t\t\t<Theme name=\"green\">\n\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"on colors generation\">\n\t\t\t<style>{css2}</style>\n\t\t\t<Theme name=\"peach\">\n\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "generation",
+					"id": "internal-themes--generation",
+					"name": "Generation",
 					"snippet": "const generation = () => (\n\t<div>\n\t\t<style>{cssGenerated}</style>\n\t\t<Theme name=\"generated\">{componentExamples}</Theme>\n\t</div>\n);"
 				},
 				{
-					"name": "onColors",
+					"id": "internal-themes--on-colors",
+					"name": "On Colors",
 					"snippet": "const onColors = () => (\n\t<Example>\n\t\t<Example.Item title=\"custom on color values\">\n\t\t\t<style>{onColorsCss}</style>\n\t\t\t<Theme name=\"on-color\">\n\t\t\t\t<View gap={2} direction=\"row\">\n\t\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t\t\t<Button color=\"critical\">Critical button</Button>\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"custom on color values, apca\">\n\t\t\t<style>{onColorsCssApca}</style>\n\t\t\t<Theme name=\"on-color-apca\">\n\t\t\t\t<View gap={2} direction=\"row\">\n\t\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t\t\t<Button color=\"critical\">Critical button</Button>\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t</Example>\n);"
 				}
 			],
 			"import": "import {\n    Actionable,\n    Alert,\n    Avatar,\n    Badge,\n    Button,\n    Card,\n    DropdownMenu,\n    Example,\n    Link,\n    Switch,\n    Text,\n    TextField,\n    Theme,\n    ThemePlayground,\n    View,\n} from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Theme/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Theme",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Theme/Theme.tsx",
-				"actualName": "Theme",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the theme to use, enables controlled mode",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"defaultName": {
+						"defaultValue": null,
+						"description": "Default name of the theme to use, enables uncontrolled mode",
+						"name": "defaultName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode to use",
+						"name": "colorMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode | \"inverted\"",
+							"value": [
+								{ "value": "\"light\"" },
+								{ "value": "\"dark\"" },
+								{ "value": "\"inverted\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -3529,7 +17025,8 @@
 			"path": "./src/Sandbox.stories.tsx",
 			"stories": [
 				{
-					"name": "preview",
+					"id": "sandbox--preview",
+					"name": "Preview",
 					"snippet": "const preview = () => {\n\treturn (\n\t\t<Preview>\n\t\t\t<Component />\n\t\t</Preview>\n\t);\n};"
 				}
 			],
@@ -3540,5 +17037,6 @@
 				"message": "We could not detect the component from your story file. Specify meta.component.\n   7 | import MenuItem from \"components/MenuItem\";\n   8 |\n>  9 | export default {\n     | ^\n  10 | \ttitle: \"Sandbox\",\n  11 | \tchromatic: { disableSnapshot: true },\n  12 | };\n\n./src/Sandbox.stories.tsx:\nimport View from \"components/View\";\nimport Image from \"components/Image\";\nimport React from \"react\";\nimport Select from \"components/Select\";\nimport useToggle from \"hooks/useToggle\";\nimport Modal from \"components/Modal\";\nimport MenuItem from \"components/MenuItem\";\n\nexport default {\n\ttitle: \"Sandbox\",\n\tchromatic: { disableSnapshot: true },\n};\n\nconst Preview: React.FC<{ children: React.ReactNode }> = (props) => {\n\treturn (\n\t\t<View padding={20} gap={6}>\n\t\t\t<View position=\"absolute\" insetTop={0} insetStart={0}>\n\t\t\t\t<Image src=\"./logo.svg\" />\n\t\t\t</View>\n\n\t\t\t{props.children}\n\t\t</View>\n\t);\n};\n\nexport const preview = () => {\n\treturn (\n\t\t<Preview>\n\t\t\t<Component />\n\t\t</Preview>\n\t);\n};\n\nconst Component = () => {\n\tconst toggle = useToggle();\n\tconst [value, setValue] = React.useState(\"Dog\");\n\n\tconst handleClick = () => {\n\t\ttoggle.toggle();\n\t};\n\n\treturn (\n\t\t<>\n\t\t\t<Select name=\"animal\" placeholder=\"Select an animal\" onClick={handleClick}>\n\t\t\t\t{value}\n\t\t\t</Select>\n\t\t\t<Modal active={toggle.active} onClose={toggle.deactivate} position=\"bottom\" padding={2}>\n\t\t\t\t<MenuItem\n\t\t\t\t\troundedCorners\n\t\t\t\t\tonClick={() => {\n\t\t\t\t\t\tsetValue(\"Dog\");\n\t\t\t\t\t\ttoggle.deactivate();\n\t\t\t\t\t}}\n\t\t\t\t\tattributes={{\n\t\t\t\t\t\trole: \"option\",\n\t\t\t\t\t}}\n\t\t\t\t>\n\t\t\t\t\tDog\n\t\t\t\t</MenuItem>\n\t\t\t\t<MenuItem\n\t\t\t\t\troundedCorners\n\t\t\t\t\tattributes={{\n\t\t\t\t\t\trole: \"option\",\n\t\t\t\t\t}}\n\t\t\t\t\tonClick={() => {\n\t\t\t\t\t\tsetValue(\"Turtle\");\n\t\t\t\t\t\ttoggle.deactivate();\n\t\t\t\t\t}}\n\t\t\t\t>\n\t\t\t\t\tTurtle\n\t\t\t\t</MenuItem>\n\t\t\t</Modal>\n\t\t</>\n\t);\n};\n"
 			}
 		}
-	}
+	},
+	"meta": { "docgen": "react-docgen-typescript", "durationMs": 2919 }
 }

--- a/eval/tasks/904-create-component-async-module-reshaped/manifests/components.json
+++ b/eval/tasks/904-create-component-async-module-reshaped/manifests/components.json
@@ -7,46 +7,201 @@
 			"path": "./src/components/ActionBar/tests/ActionBar.stories.tsx",
 			"stories": [
 				{
-					"name": "positionRelative",
+					"id": "components-actionbar--position-relative",
+					"name": "position, positionType: relative",
 					"snippet": "const positionRelative = () => (\n    <Example>\n        <Example.Item title=\"position: top\">\n            <ActionBar position=\"top\">\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <ActionBar position=\"bottom\">\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positionAbsolute",
+					"id": "components-actionbar--position-absolute",
+					"name": "position, positionType: absolute",
 					"snippet": "const positionAbsolute = () => (\n    <Example>\n        <Example.Item title=\"position: top-start\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top-start\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: top\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: top-end\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top-end\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom-start\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom-start\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom-end\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positionFixed",
+					"id": "components-actionbar--position-fixed",
+					"name": "position, positionType: fixed",
 					"snippet": "const positionFixed = () => (\n    <>\n        <ActionBar padding={2} position=\"top-start\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"top\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"top-end\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom-start\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom-end\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <div style={{ height: 2000 }} />\n    </>\n);"
 				},
 				{
+					"id": "components-actionbar--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated, position: top\">\n            <ActionBar position=\"top\" elevated>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"elevated, position: bottom\">\n            <ActionBar elevated>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"auto elevated, position: bottom\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-actionbar--offset",
 					"name": "offset",
 					"snippet": "const offset = () => (\n    <Example>\n        <Example.Item title=\"offset 2, position: top\">\n            <Fixtures.Container>\n                <ActionBar position=\"top\" positionType=\"absolute\" offset={2}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"offset 2, position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\" offset={2}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"offset s: 2, m: 4, position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\" offset={{ s: 2, m: 4 }}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-actionbar--active",
 					"name": "active",
 					"snippet": "const active = () => {\n    const barToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => barToggle.toggle()}>Toggle</Button>\n            <ActionBar active={barToggle.active} positionType=\"fixed\" position=\"top-end\">\n                <Fixtures.Actions />\n            </ActionBar>\n        </>\n    );\n};"
 				},
 				{
-					"name": "padding",
+					"id": "components-actionbar--padding",
+					"name": "padding, paddingBlock, paddingInline",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 6\">\n            <ActionBar padding={6}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"paddingBlock: 2, paddingInline: 4\">\n            <ActionBar paddingBlock={2} paddingInline={4}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"padding: [s] 4, [m+] 6\">\n            <ActionBar padding={{ s: 4, m: 6 }}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-actionbar--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ActionBar className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </ActionBar>\n    </div>\n);"
 				}
 			],
 			"import": "import { ActionBar, Button, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ActionBar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ActionBar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ActionBar/ActionBar.tsx",
-				"actualName": "ActionBar",
+				"methods": [],
+				"props": {
+					"paddingBlock": {
+						"defaultValue": null,
+						"description": "Padding block, base unit token number multiplier",
+						"name": "paddingBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingInline": {
+						"defaultValue": null,
+						"description": "Padding inline, base unit token number multiplier",
+						"name": "paddingInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Padding style for all sides, base unit token number multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Show or hide the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"offset": {
+						"defaultValue": null,
+						"description": "Offset from the container bounds",
+						"name": "offset",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"position": {
+						"defaultValue": { "value": "\"bottom\"" },
+						"description": "Position based on the container bounds",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"top-end\" | \"top-start\" | \"bottom\" | \"bottom-start\" | \"bottom-end\"",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" }
+							]
+						}
+					},
+					"positionType": {
+						"defaultValue": null,
+						"description": "CSS position style",
+						"name": "positionType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"relative\" | \"absolute\" | \"fixed\">" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Display above the content with elevated shadow and background",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -56,30 +211,138 @@
 			"path": "./src/components/Alert/tests/Alert.stories.tsx",
 			"stories": [
 				{
+					"id": "components-alert--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        {([\"neutral\", \"primary\", \"critical\", \"positive\", \"warning\"] as const).map((color) => (\n            <Example.Item title={`color: ${color}`} key={color}>\n                <Alert\n                    color={color}\n                    title=\"Alert title goes here\"\n                    icon={IconZap}\n                    actionsSlot={\n                        <>\n                            <Link\n                                variant=\"plain\"\n                                color={color === \"neutral\" ? \"primary\" : color}\n                                onClick={() => {}}\n                            >\n                                View now\n                            </Link>\n                            <Link\n                                variant=\"plain\"\n                                color={color === \"neutral\" ? \"primary\" : color}\n                                onClick={() => {}}\n                            >\n                                Dismiss\n                            </Link>\n                        </>\n                    }\n                >\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard\n                </Alert>\n            </Example.Item>\n        ))}\n    </Example>\n);"
 				},
 				{
+					"id": "components-alert--inline",
 					"name": "inline",
 					"snippet": "const inline = () => (\n    <Example>\n        <Example.Item title=\"inline: true\">\n            <Alert\n                inline\n                title=\"Alert title goes here\"\n                icon={IconZap}\n                actionsSlot={\n                    <>\n                        <Link variant=\"plain\" onClick={() => {}}>\n                            View now\n                        </Link>\n                        <Link variant=\"plain\" onClick={() => {}}>\n                            Dismiss\n                        </Link>\n                    </>\n                }\n            >\n                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has\n                been the industry's standard\n            </Alert>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-alert--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4\">\n            <Alert bleed={4} icon={IconZap}>\n                Content\n            </Alert>\n        </Example.Item>\n        <Example.Item title=\"bleed: [s] 4, [m+] 0\">\n            <Alert bleed={{ s: 4, m: 0 }} icon={IconZap}>\n                Content\n            </Alert>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-alert--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Alert className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </Alert>\n    </div>\n);"
 				}
 			],
 			"import": "import { Alert, Example, Link, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Alert/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Alert",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Alert/Alert.tsx",
-				"actualName": "Alert",
+				"methods": [],
+				"props": {
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"title": {
+						"defaultValue": null,
+						"description": "Title slot",
+						"name": "title",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Slot for rendering the main content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"actionsSlot": {
+						"defaultValue": null,
+						"description": "Actions slot, usually used for Buttons and Links, automatically adds a gap between the actions",
+						"name": "actionsSlot",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Color scheme of the alert elements",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"inline": {
+						"defaultValue": null,
+						"description": "Display action to the right of the content",
+						"name": "inline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margin and remove side borders, base unit token number multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -89,35 +352,573 @@
 			"path": "./src/components/Autocomplete/tests/Autocomplete.stories.tsx",
 			"stories": [
 				{
-					"name": "active",
+					"id": "components-autocomplete--active",
+					"name": "active, onOpen, onClose",
 					"snippet": "const active = (args) => {\n    const toggle = useToggle(true);\n\n    return (\n        <Example>\n            <Example.Item title=\"active, onOpen, onClose\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete\n                        name=\"fruit\"\n                        placeholder=\"Pick your food\"\n                        active={toggle.active}\n                        onOpen={() => {\n                            args.handleOpen();\n                            toggle.activate();\n                        }}\n                        onClose={() => {\n                            args.handleClose();\n                            toggle.deactivate();\n                        }}\n                        onChange={(args) => console.log(args)}\n                    >\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "base",
+					"id": "components-autocomplete--base",
+					"name": "onInput, onItemSelect, onBackspace",
 					"snippet": "const base = () => {\n    const [value, setValue] = React.useState(\"\");\n\n    return (\n        <Example>\n            <Example.Item title=\"Base\">\n                <FormControl>\n                    <FormControl.Label>Food</FormControl.Label>\n                    <Autocomplete\n                        name=\"fruit\"\n                        placeholder=\"Pick your food\"\n                        value={value}\n                        onChange={(args) => setValue(args.value)}\n                        onBackspace={fn()}\n                        onItemSelect={fn()}>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "itemData",
+					"id": "components-autocomplete--item-data",
+					"name": "item data",
 					"snippet": "const itemData = () => {\n    return (\n        <Example>\n            <Example.Item title=\"item data\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete name=\"fruit\" placeholder=\"Pick your food\" onItemSelect={fn()} active>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v} data={i === 1 ? { foo: true } : undefined}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "itemDisabled",
+					"id": "components-autocomplete--item-disabled",
+					"name": "item disabled",
 					"snippet": "const itemDisabled = () => {\n    return (\n        <Example>\n            <Example.Item title=\"item disabled\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete name=\"fruit\" placeholder=\"Pick your food\" active>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v} disabled={i === 1}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "multiselect",
+					"id": "components-autocomplete--multiselect",
+					"name": "test: multiselect",
 					"snippet": "const multiselect = () => {\n    const options = [\n        \"Pizza\",\n        \"Pie\",\n        \"Ice-cream\",\n        \"Fries\",\n        \"Salad\",\n        \"Option 4\",\n        \"Option 5\",\n        \"Option 6\",\n    ];\n\n    const inputRef = React.useRef<HTMLInputElement>(null);\n    const [values, setValues] = React.useState<string[]>([\n        \"Option 4\",\n        \"Option 5\",\n        \"Option 6\",\n        \"Pizza\",\n        \"Ice-cream\",\n    ]);\n    const [query, setQuery] = React.useState(\"\");\n\n    const handleDismiss = (dismissedValue: string) => {\n        const nextValues = values.filter((value) => value !== dismissedValue);\n        setValues(nextValues);\n        inputRef.current?.focus();\n    };\n\n    const valuesNode = values.map((value) => (\n        <Badge dismissAriaLabel=\"Dismiss value\" onDismiss={() => handleDismiss(value)} key={value}>\n            {value}\n        </Badge>\n    ));\n\n    return (\n        <FormControl>\n            <FormControl.Label>Food</FormControl.Label>\n            <Autocomplete\n                name=\"fruit\"\n                value={query}\n                placeholder=\"Pick your food\"\n                startSlot={valuesNode}\n                multiline\n                inputAttributes={{ ref: inputRef }}\n                onChange={(args) => setQuery(args.value)}\n                onBackspace={() => {\n                    if (query.length === 0) {\n                        setValues((prev) => prev.slice(0, -1));\n                    }\n                }}\n                onItemSelect={(args) => {\n                    setQuery(\"\");\n                    setValues((prev) => [...prev, args.value]);\n                }}\n            >\n                {options.map((v) => {\n                    if (!v.toLowerCase().includes(query.toLowerCase())) return;\n                    if (values.includes(v)) return;\n\n                    return (\n                        <Autocomplete.Item key={v} value={v}>\n                            {v}\n                        </Autocomplete.Item>\n                    );\n                })}\n            </Autocomplete>\n        </FormControl>\n    );\n};"
 				}
 			],
 			"import": "import { Autocomplete, Badge, Example, FormControl } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Autocomplete/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Autocomplete",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Autocomplete/Autocomplete.tsx",
-				"actualName": "Autocomplete",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"multiline": {
+						"defaultValue": null,
+						"description": "Enable multiline text field wrapping",
+						"name": "multiline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to be fully rounded",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content after the text field value",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text field value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the text field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the text field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"onInput": {
+						"defaultValue": null,
+						"description": "Callback for when value changes from user input",
+						"name": "onInput",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onItemSelect": {
+						"defaultValue": null,
+						"description": "Callback for when an item is selected in the dropdown",
+						"name": "onItemSelect",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: SelectArgs) => void)" }
+					},
+					"onBackspace": {
+						"defaultValue": null,
+						"description": "Callback for when the backspace key is pressed while the input is focused",
+						"name": "onBackspace",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onEnter": {
+						"defaultValue": null,
+						"description": "Callback for when the enter key is pressed while the input is focused",
+						"name": "onEnter",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Slot for rendering the Autocomplete.Item components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					}
+				},
+				"exportName": "Autocomplete"
 			}
 		},
 		"components-avatar": {
@@ -126,46 +927,230 @@
 			"path": "./src/components/Avatar/tests/Avatar.stories.tsx",
 			"stories": [
 				{
-					"name": "src",
+					"id": "components-avatar--src",
+					"name": "src, alt",
 					"snippet": "const src = () => (\n    <Example>\n        <Example.Item title=\"src, alt\">\n            <Avatar\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n                alt=\"Amsterdam canal\"\n                size={12}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"src\">\n            <Avatar src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "initials",
+					"id": "components-avatar--initials",
+					"name": "initials, icon",
 					"snippet": "const initials = () => (\n    <Example>\n        <Example.Item title=\"initials\">\n            <Avatar initials=\"RS\" />\n        </Example.Item>\n\n        <Example.Item title=\"icon\">\n            <Avatar icon={IconZap} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-avatar--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: 6\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={6} icon={IconZap} />\n                <Avatar size={6} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: 15\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={15} icon={IconZap} />\n                <Avatar size={15} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: 40\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={40} icon={IconZap} />\n                <Avatar size={40} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] 10\", \"[m+] 20\"]}>\n            <View direction=\"row\" gap={3}>\n                <Avatar size={{ s: 10, m: 20 }} icon={IconZap} />\n                <Avatar size={{ s: 10, m: 20 }} icon={IconZap} squared />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-avatar--squared",
 					"name": "squared",
 					"snippet": "const squared = () => (\n    <Example>\n        <Example.Item title=\"squared, with image\">\n            <Avatar\n                squared\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n            />\n        </Example.Item>\n        <Example.Item title=\"squared, with initials\">\n            <Avatar squared initials=\"RS\" />\n        </Example.Item>\n        <Example.Item title=\"squared, with initials\">\n            <Avatar squared icon={IconZap} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "colors",
+					"id": "components-avatar--colors",
+					"name": "color, variant",
 					"snippet": "const colors = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"neutral\" icon={IconZap} />\n                <Avatar color=\"neutral\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"primary\" icon={IconZap} />\n                <Avatar color=\"primary\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"positive\" icon={IconZap} />\n                <Avatar color=\"positive\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"warning\" icon={IconZap} />\n                <Avatar color=\"warning\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"critical\" icon={IconZap} />\n                <Avatar color=\"critical\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "fallback",
+					"id": "components-avatar--fallback",
+					"name": "test: fallback",
 					"snippet": "const fallback = (args) => {\n    const [error, setError] = useState(false);\n\n    return (\n        <Avatar\n            src={error ? undefined : \"/foo\"}\n            icon={IconZap}\n            imageAttributes={{\n                onError: () => {\n                    setError(true);\n                    args.handleError();\n                },\n            }}\n        />\n    );\n};"
 				},
 				{
+					"id": "components-avatar--render-image",
 					"name": "renderImage",
 					"snippet": "const renderImage = () => (\n    <Example>\n        <Example.Item title=\"renderImage\">\n            <Avatar\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n                alt=\"Amsterdam canal\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image\" />}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-avatar--class-name",
+					"name": "className, attributes, imageAttributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Avatar\n            src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            imageAttributes={{ id: \"test-image-id\", alt: \"test image\" }}\n        />\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Avatar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Avatar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Avatar/Avatar.tsx",
-				"actualName": "Avatar",
+				"methods": [],
+				"props": {
+					"src": {
+						"defaultValue": null,
+						"description": "Image URL",
+						"name": "src",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"alt": {
+						"defaultValue": null,
+						"description": "Image alt text",
+						"name": "alt",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"imageAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the image element",
+						"name": "imageAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"img\">" }
+					},
+					"renderImage": {
+						"defaultValue": null,
+						"description": "Render prop for the image element, useful for integrating with the Image component from third party frameworks",
+						"name": "renderImage",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Omit<Attributes<\"img\">, \"src\" | \"alt\"> & { src: string; alt: string; }) => ReactNode)"
+						}
+					},
+					"initials": {
+						"defaultValue": null,
+						"description": "Initials to display if no image is provided",
+						"name": "initials",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon, used when no image is provided",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"squared": {
+						"defaultValue": null,
+						"description": "Change the shape to rounded square",
+						"name": "squared",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"faded\"",
+							"value": [{ "value": "\"solid\"" }, { "value": "\"faded\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "12" },
+						"description": "Size of the component, base unit token number multiplier",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -175,63 +1160,273 @@
 			"path": "./src/components/Badge/tests/Badge.stories.tsx",
 			"stories": [
 				{
+					"id": "components-badge--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Badge>Badge</Badge>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <Badge variant=\"faded\">Badge</Badge>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <Badge variant=\"outline\">Badge</Badge>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"primary\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"primary\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"primary\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: positive, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"positive\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"positive\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"positive\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: critical, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"critical\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"critical\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"critical\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: warning, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"warning\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"warning\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"warning\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"small\">Badge</Badge>\n                <Badge rounded size=\"small\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge>Badge</Badge>\n                <Badge rounded>Badge</Badge>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"large\">Badge</Badge>\n                <Badge rounded size=\"large\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={3} direction=\"row\">\n                <Badge icon={IconCheckmark} endIcon={IconChevronRight} size=\"small\">\n                    Badge\n                </Badge>\n                <Badge icon={IconCheckmark} size=\"small\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={3} direction=\"row\">\n                <Badge icon={IconCheckmark} endIcon={IconChevronRight}>\n                    Badge\n                </Badge>\n                <Badge icon={IconCheckmark} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"large\" icon={IconCheckmark} endIcon={IconChevronRight}>\n                    Badge\n                </Badge>\n\n                <Badge icon={IconCheckmark} size=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onDismiss",
+					"id": "components-badge--on-dismiss",
+					"name": "onDismiss, dismissAriaLabel",
 					"snippet": "const onDismiss = () => <Example>\n    <Example.Item title=\"onDismiss\">\n        <Badge onDismiss={fn()} dismissAriaLabel=\"Dismiss\">Badge\n                            </Badge>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-badge--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded>Badge</Badge>\n                <Badge rounded variant=\"faded\">\n                    Badge\n                </Badge>\n                <Badge rounded variant=\"outline\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"rounded, all sizes, color: critical\", \"one character, renders as circle\"]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Badge rounded color=\"critical\" size=\"small\">\n                    2\n                </Badge>\n                <Badge rounded color=\"critical\">\n                    2\n                </Badge>\n                <Badge rounded color=\"critical\" size=\"large\">\n                    2\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--empty",
 					"name": "empty",
 					"snippet": "const empty = () => (\n    <Example>\n        <Example.Item title=\"empty, not rounded, all sizes, color: critical\">\n            <View direction=\"row\" gap={3}>\n                <Badge size=\"small\" color=\"critical\" />\n                <Badge color=\"critical\" />\n                <Badge size=\"large\" color=\"critical\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"empty, rounded, all sizes, color: critical\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded size=\"small\" color=\"critical\" />\n                <Badge rounded color=\"critical\" />\n                <Badge rounded size=\"large\" color=\"critical\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"empty, rounded, all sizes, color: neutral\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded size=\"small\" color=\"neutral\" />\n                <Badge rounded />\n                <Badge rounded size=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--highlighted",
 					"name": "highlighted",
 					"snippet": "const highlighted = () => (\n    <Example>\n        <Example.Item title=\"highlighted, color: neutral\">\n            <View gap={3} direction=\"row\">\n                <Badge highlighted>Badge</Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--container",
 					"name": "container",
 					"snippet": "const container = () => {\n    const [hidden, setHidden] = React.useState(false);\n\n    return (\n        <Example title={<Button onClick={() => setHidden(!hidden)}>Toggle badges</Button>}>\n            <Example.Item title=\"position: top-end\">\n                <Badge.Container>\n                    <Badge color=\"primary\" hidden={hidden}>\n                        5\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: bottom-end\">\n                <Badge.Container position=\"bottom-end\">\n                    <Badge color=\"primary\" hidden={hidden}>\n                        5\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: top-end, rounded, multiple digits\">\n                <Badge.Container>\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        123\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: top-end, rounded, empty\">\n                <Badge.Container>\n                    <Badge color=\"primary\" rounded hidden={hidden} />\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: top-end, overlap\", \"should cover the circular avatar\"]}>\n                <Badge.Container overlap>\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        2\n                    </Badge>\n                    <Avatar initials=\"A\" />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: bottom-end, overlap\", \"should cover the circular avatar\"]}>\n                <Badge.Container overlap position=\"bottom-end\">\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        2\n                    </Badge>\n                    <Avatar initials=\"A\" />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: top-end, overlap\", \"should cover the icon\"]}>\n                <Badge.Container overlap position=\"top-end\">\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden} />\n                    <Icon svg={IconCheckmark} size={5} />\n                </Badge.Container>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-badge--href",
 					"name": "href",
 					"snippet": "const href = () => (\n    <Badge href=\"https://reshaped.so\" dismissAriaLabel=\"Dismiss\">\n        Badge\n    </Badge>\n);"
 				},
 				{
+					"id": "components-badge--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Badge onClick={fn()}>Badge</Badge>;"
 				},
 				{
-					"name": "className",
+					"id": "components-badge--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Badge color=\"primary\" className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Badge, Button, Example, Icon, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Badge/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Badge",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Badge/Badge.tsx",
-				"actualName": "Badge",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"large\" | \"medium\"",
+							"value": [
+								{ "value": "\"small\"" },
+								{ "value": "\"large\"" },
+								{ "value": "\"medium\"" }
+							]
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "highlighted",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hidden": {
+						"defaultValue": null,
+						"description": "Transition the component to hidden state",
+						"name": "hidden",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting text or other content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"onDismiss": {
+						"defaultValue": null,
+						"description": "Callback triggered when the dismiss button is pressed",
+						"name": "onDismiss",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"dismissAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the dismiss button",
+						"name": "dismissAriaLabel",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "Badge"
 			}
 		},
 		"components-breadcrumbs": {
@@ -240,51 +1435,185 @@
 			"path": "./src/components/Breadcrumbs/tests/Breadcrumbs.stories.tsx",
 			"stories": [
 				{
+					"id": "components-breadcrumbs--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <Breadcrumbs ariaLabel=\"breadcrumb neutral\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"color: primary\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb primary\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "item",
+					"id": "components-breadcrumbs--item",
+					"name": "item, disabled",
 					"snippet": "const item = () => (\n    <Example>\n        <Example.Item title=\"disabled item\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb disabled\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}} disabled>\n                    Disabled item 2\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "icon",
+					"id": "components-breadcrumbs--icon",
+					"name": "item, icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"item with icon\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb with icon\">\n                <Breadcrumbs.Item icon={IconZap} onClick={() => {}}>\n                    Item 1\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "slots",
+					"id": "components-breadcrumbs--slots",
+					"name": "separator, children",
 					"snippet": "const slots = () => (\n    <Example>\n        <Example.Item title=\"slot: separator\">\n            <Breadcrumbs color=\"primary\" separator=\"/\" ariaLabel=\"breadcrumb with separator\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"custom child content\">\n            <Breadcrumbs ariaLabel=\"breadcrumb with custom children\">\n                <Breadcrumbs.Item onClick={() => {}}>\n                    <Badge>Item 1</Badge>\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>\n                    <Badge>Item 2</Badge>\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-breadcrumbs--collapsed",
 					"name": "collapsed",
 					"snippet": "const collapsed = () => (\n    <Example>\n        <Example.Item title=\"collapsed, 3 items shown by default\">\n            <Breadcrumbs\n                defaultVisibleItems={3}\n                ariaLabel=\"breadcrumbs one\"\n                expandAriaLabel=\"Expand items\"\n            >\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"collapsed, 4 items shown by default\">\n            <Breadcrumbs\n                defaultVisibleItems={4}\n                ariaLabel=\"breadcrumb two\"\n                expandAriaLabel=\"Expand items\"\n            >\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"collapsed, 3 items shown by default, not expandable\">\n            <Breadcrumbs defaultVisibleItems={3} ariaLabel=\"breadcrumb three\" disableExpand>\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "multiline",
+					"id": "components-breadcrumbs--multiline",
+					"name": "composition, multiline",
 					"snippet": "const multiline = () => (\n    <Example>\n        <Example.Item title=\"wraps content when multiline\">\n            <Breadcrumbs ariaLabel=\"breadcrumb multiline\">\n                {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((i) => (\n                    <Breadcrumbs.Item onClick={() => {}} key={i}>\n                        Item {i}\n                    </Breadcrumbs.Item>\n                ))}\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onClick",
+					"id": "components-breadcrumbs--on-click",
+					"name": "item, onClick, disabled",
 					"snippet": "const onClick = () => <Breadcrumbs>\n    <Breadcrumbs.Item onClick={fn()}>Trigger</Breadcrumbs.Item>\n    <Breadcrumbs.Item onClick={fn()} disabled>Trigger\n                    </Breadcrumbs.Item>\n</Breadcrumbs>;"
 				},
 				{
-					"name": "href",
+					"id": "components-breadcrumbs--href",
+					"name": "item, href",
 					"snippet": "const href = () => (\n    <Breadcrumbs>\n        <Breadcrumbs.Item href=\"https://reshaped.so\">Trigger</Breadcrumbs.Item>\n    </Breadcrumbs>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-breadcrumbs--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Breadcrumbs className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Breadcrumbs.Item>Trigger</Breadcrumbs.Item>\n        </Breadcrumbs>\n    </div>\n);"
 				}
 			],
 			"import": "import { Badge, Breadcrumbs, Example } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Breadcrumbs/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Breadcrumbs",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Breadcrumbs/Breadcrumbs.tsx",
-				"actualName": "Breadcrumbs",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children to position items",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ReactElement<unknown, string | JSXElementConstructor<any>>[]"
+						}
+					},
+					"separator": {
+						"defaultValue": null,
+						"description": "Node for defining custom separator between items",
+						"name": "separator",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"neutral\"",
+							"value": [{ "value": "\"primary\"" }, { "value": "\"neutral\"" }]
+						}
+					},
+					"defaultVisibleItems": {
+						"defaultValue": null,
+						"description": "Number of items to show by default, others will be hidden and can be expanded",
+						"name": "defaultVisibleItems",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"expandAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the expand button",
+						"name": "expandAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disableExpand": {
+						"defaultValue": null,
+						"description": "Turn expand button into static text and disable the expand functionality",
+						"name": "disableExpand",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the component",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"nav\">" }
+					}
+				},
+				"exportName": "Breadcrumbs"
 			}
 		},
 		"components-button": {
@@ -293,87 +1622,599 @@
 			"path": "./src/components/Button/tests/Button.stories.tsx",
 			"stories": [
 				{
-					"name": "variantAndColor",
+					"id": "components-button--variant-and-color",
+					"name": "variant, color",
 					"snippet": "const variantAndColor = () => (\n    <Example>\n        <Example.Item title=\"variant: solid\">\n            <View gap={4} direction=\"row\">\n                <Button onClick={() => {}}>Button</Button>\n                <Button onClick={() => {}} color=\"primary\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"faded\">\n                    Button\n                </Button>\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"outline\">\n                    Button\n                </Button>\n\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: ghost\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"ghost\">\n                    Button\n                </Button>\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: media\">\n            <View backgroundColor=\"primary\" borderRadius=\"medium\" padding={4} direction=\"row\" gap={4}>\n                <Button onClick={() => {}} color=\"media\">\n                    Button\n                </Button>\n\n                <Button onClick={() => {}} color=\"media\" variant=\"faded\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Button onClick={() => {}} icon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"endIcon\">\n            <Button onClick={() => {}} endIcon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"icon, endIcon\">\n            <Button onClick={() => {}} icon={IconZap} endIcon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"icon only\">\n            <Button onClick={() => {}} icon={IconZap} attributes={{ \"aria-label\": \"Action\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"small\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"small\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Button icon={IconZap}>Button</Button>\n                <Button variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"large\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"large\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"xlarge\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"xlarge\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"xlarge\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large, [m+] medium\">\n            <Button size={{ s: \"large\", m: \"medium\" }} icon={IconZap}>\n                Responsive\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated, color: neutral\">\n            <View direction=\"row\" gap={4}>\n                <Button elevated onClick={() => {}}>\n                    Button\n                </Button>\n                <Button elevated variant=\"outline\" onClick={() => {}}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"elevated, color\">\n            <View direction=\"row\" gap={4}>\n                <Button elevated color=\"primary\">\n                    Button\n                </Button>\n                <Button elevated variant=\"outline\" color=\"primary\">\n                    Button\n                </Button>\n                <View backgroundColor=\"primary\" padding={4} borderRadius=\"medium\">\n                    <Button color=\"media\" elevated>\n                        Button\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded, size: small, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, size: medium, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, size: large, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, icon only, all sizes\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"small\" icon={IconZap} />\n                <Button rounded icon={IconZap} />\n                <Button rounded size=\"large\" icon={IconZap} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--full-width",
 					"name": "fullWidth",
 					"snippet": "const fullWidth = () => (\n    <Example>\n        <Example.Item title=\"fullWidth, all variants\">\n            <View gap={3}>\n                <Button fullWidth>Neutral</Button>\n                <Button fullWidth variant=\"faded\">\n                    Faded\n                </Button>\n                <Button fullWidth variant=\"outline\">\n                    Outline\n                </Button>\n                <Button fullWidth variant=\"ghost\">\n                    Ghost\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive fullWidth\", \"[s] true\", \"[m+] false\"]}>\n            <Button fullWidth={{ s: true, m: false }}>Button</Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--loading",
 					"name": "loading",
 					"snippet": "const loading = () => (\n    <Example>\n        <Example.Item title=\"loading, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"loading, color critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"loading, color positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"loading, color: media\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n\n                <div style={{ position: \"absolute\", top: 16, left: 16 }}>\n                    <View gap={3} direction=\"row\">\n                        <Button color=\"media\" loading loadingAriaLabel=\"Loading\">\n                            Button\n                        </Button>\n                        <Button color=\"media\" variant=\"faded\" loading loadingAriaLabel=\"Loading\">\n                            Button\n                        </Button>\n                    </View>\n                </div>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"loading, long button text\", \"button size should stay the same\"]}>\n            <Button loading loadingAriaLabel=\"Loading\" color=\"primary\">\n                Long button text\n            </Button>\n        </Example.Item>\n\n        <Example.Item title={[\"loading, icon only\", \"button keep square 1/1 ratio\"]}>\n            <Button icon={IconZap} rounded loading loadingAriaLabel=\"Loading\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--highlighted",
 					"name": "highlighted",
 					"snippet": "const highlighted = () => (\n    <Example>\n        <Example.Item title=\"highlighted, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"highlighted, color: critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted color=\"critical\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"highlighted, color: positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted color=\"positive\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled icon={IconZap} onClick={() => {}}>\n                    Button\n                </Button>\n                <Button disabled variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"disabled, color: critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled color=\"critical\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"disabled, color: positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled color=\"positive\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"disabled, color: media\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n\n                <div style={{ position: \"absolute\", top: 16, left: 16 }}>\n                    <View gap={3} direction=\"row\">\n                        <Button color=\"media\" disabled>\n                            Button\n                        </Button>\n                        <Button color=\"media\" variant=\"faded\" disabled>\n                            Button\n                        </Button>\n                    </View>\n                </div>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner: all\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>Content</View.Item>\n                <Button.Aligner>\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: top\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"top\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: top and end\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side={[\"top\", \"end\"]}>\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: bottom\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2} align=\"end\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"bottom\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: start\">\n            <View padding={4} borderColor=\"neutral-faded\" gap={2} align=\"start\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"start\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: end\">\n            <View padding={4} borderColor=\"neutral-faded\" gap={2} align=\"end\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"end\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "components-button--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"slot gap\">\n            <Button variant=\"outline\">\n                <Avatar size={6} initials=\"RS\" />\n                Label\n                <Hotkey>B</Hotkey>\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--href",
 					"name": "href",
 					"snippet": "const href = () => <Button href=\"https://reshaped.so\">Trigger</Button>;"
 				},
 				{
+					"id": "components-button--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Button onClick={fn()}>Trigger</Button>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-button--href-on-click",
+					"name": "href, onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <Button\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </Button>\n);"
 				},
 				{
+					"id": "components-button--as",
 					"name": "as",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"as: span\">\n            <Button onClick={() => {}} as=\"span\">\n                Trigger\n            </Button>\n        </Example.Item>\n        <Example.Item title=\"render, disabled\">\n            <Button\n                disabled\n                onClick={() => {}}\n                render={(props) => <section {...props} />}\n                attributes={{ \"data-testid\": \"render-el\" }}\n            >\n                Trigger\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-button--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Button className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Button>\n    </div>\n);"
 				},
 				{
+					"id": "components-button--group",
 					"name": "group",
 					"snippet": "const group = () => (\n    <Example>\n        <Example.Item title=\"with icon\">\n            <Button.Group>\n                <Button rounded>Submit</Button>\n                <Button rounded icon={IconZap} />\n            </Button.Group>\n        </Example.Item>\n        <Example.Item title=\"variant: solid\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\", \"media\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color}>One</Button>\n                        <Button color={color}>Two</Button>\n                        <Button color={color}>Three</Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"outline\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"outline\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"outline\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\", \"media\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"faded\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"faded\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"faded\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"variant: ghost\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"ghost\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"ghost\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"ghost\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "groupClassName",
+					"id": "components-button--group-class-name",
+					"name": "group className, attributes",
 					"snippet": "const groupClassName = () => (\n    <div data-testid=\"root\">\n        <Button.Group className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Button>Trigger</Button>\n        </Button.Group>\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Button, Example, Hotkey, Image, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Button/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Button",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Button/Button.tsx",
-				"actualName": "Button",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"ghost\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"ghost\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loading": {
+						"defaultValue": null,
+						"description": "Show loading state",
+						"name": "loading",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loadingAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the loading indicator",
+						"name": "loadingAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Make the component take the full width of the parent element",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "highlighted",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Button"
 			}
 		},
 		"components-calendar": {
@@ -382,54 +2223,363 @@
 			"path": "./src/components/Calendar/tests/Calendar.stories.tsx",
 			"stories": [
 				{
+					"id": "components-calendar--default-month",
 					"name": "defaultMonth",
 					"snippet": "const defaultMonth = () => (\n    <Example>\n        <Example.Item title=\"defaultMonth: 2020 January\">\n            <Calendar defaultMonth={new Date(2020, 0)} range />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "uncontrolled",
+					"id": "components-calendar--uncontrolled",
+					"name": "defaultValue, range",
 					"snippet": "const uncontrolled = () => <Example>\n    <Example.Item title=\"defaultValue\">\n        <Calendar\n            defaultMonth={new Date(2020, 0)}\n            defaultValue={new Date(2020, 0, 10)}\n            onChange={fn()} />\n    </Example.Item>\n    <Example.Item title=\"defaultValue, range\">\n        <Calendar\n            range\n            defaultMonth={new Date(2020, 0)}\n            defaultValue={{ start: new Date(2020, 0, 10), end: new Date(2020, 0, 15) }}\n            onChange={fn()} />\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "controlled",
+					"id": "components-calendar--controlled",
+					"name": "value, range",
 					"snippet": "const controlled = () => <Example>\n    <Example.Item title=\"value\">\n        <Calendar\n            defaultMonth={new Date(2020, 0)}\n            value={new Date(2020, 0, 10)}\n            onChange={fn()} />\n    </Example.Item>\n    <Example.Item title=\"defaultValue, range\">\n        <Calendar\n            range\n            defaultMonth={new Date(2020, 0)}\n            value={{ start: new Date(2020, 0, 10), end: new Date(2020, 0, 15) }}\n            onChange={fn()} />\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-calendar--selected-dates",
 					"name": "selectedDates",
 					"snippet": "const selectedDates = () => (\n    <Example>\n        <Example.Item title=\"selectedDates: [4,8]\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                value={null}\n                selectedDates={[new Date(2020, 0, 4), new Date(2020, 0, 8)]}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "minMax",
+					"id": "components-calendar--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <Example>\n        <Example.Item title=\"min: 4, max: 20\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                min={new Date(2020, 0, 4)}\n                max={new Date(2020, 0, 20)}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-calendar--first-week-day",
 					"name": "firstWeekDay",
 					"snippet": "const firstWeekDay = () => (\n    <Example>\n        <Example.Item title=\"firstWeekDay: 3 (Wed)\">\n            <Calendar defaultMonth={new Date(2020, 0)} firstWeekDay={3} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "translation",
+					"id": "components-calendar--translation",
+					"name": "render functions",
 					"snippet": "const translation = () => (\n    <Example>\n        <Example.Item title=\"translated to NL\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                renderMonthLabel={({ date }) => date.toLocaleDateString(\"nl\", { month: \"short\" })}\n                renderSelectedMonthLabel={({ date }) =>\n                    date.toLocaleDateString(\"nl\", { month: \"long\", year: \"numeric\" })\n                }\n                renderWeekDay={({ date }) => date.toLocaleDateString(\"nl\", { weekday: \"short\" })}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "ariaLabels",
+					"id": "components-calendar--aria-labels",
+					"name": "aria labels",
 					"snippet": "const ariaLabels = () => (\n    <Example>\n        <Example.Item title=\"aria labels\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                nextYearAriaLabel=\"Test next year\"\n                nextMonthAriaLabel=\"Test next month\"\n                renderDateAriaLabel={() => \"Test date\"}\n                renderMonthAriaLabel={() => \"Test month\"}\n                previousYearAriaLabel=\"Test previous year\"\n                previousMonthAriaLabel=\"Test previous month\"\n                monthSelectionAriaLabel=\"Test month selection\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "monthSelection",
+					"id": "components-calendar--month-selection",
+					"name": "test: month selection",
 					"snippet": "const monthSelection = () => (\n    <Example>\n        <Example.Item title=\"month selection\">\n            <Calendar defaultMonth={new Date(2020, 1)} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "keyboardNavigation",
+					"id": "components-calendar--keyboard-navigation",
+					"name": "test: keyboard navigation",
 					"snippet": "const keyboardNavigation = () => (\n    <Example>\n        <Example.Item title=\"keyboard navigation\">\n            <Calendar defaultMonth={new Date(2020, 0)} />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Calendar, Example } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Calendar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Calendar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Calendar/Calendar.tsx",
-				"actualName": "Calendar",
+				"methods": [],
+				"props": {
+					"range": {
+						"defaultValue": null,
+						"description": "Disable range selection\nEnable range selection",
+						"name": "range",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Current selected date value, enables controlled mode\nCurrent selected range value, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date | RangeValue | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default selected date value, enables uncontrolled mode\nDefault selected range value, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date | RangeValue" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when date selection changes\nCallback when range selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { value: Date; }) => void) | ((args: { value: Date; }) => void) | ((args: { value: RangeValue; }) => void) | ((args: { value: RangeValue; }) => void)"
+						}
+					},
+					"defaultMonth": {
+						"defaultValue": { "value": "Date.now()" },
+						"description": "Default month to display",
+						"name": "defaultMonth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum date that can be selected",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum date that can be selected",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"firstWeekDay": {
+						"defaultValue": { "value": "1, Monday" },
+						"description": "First day of the week",
+						"name": "firstWeekDay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"selectedDates": {
+						"defaultValue": null,
+						"description": "Dates that are selected",
+						"name": "selectedDates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date[]" }
+					},
+					"renderWeekDay": {
+						"defaultValue": null,
+						"description": "Render a custom weekday label, can be used for localization",
+						"name": "renderWeekDay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { weekDay: number; date: Date; }) => string)" }
+					},
+					"renderSelectedMonthLabel": {
+						"defaultValue": null,
+						"description": "Render a custom month label, can be used for localization",
+						"name": "renderSelectedMonthLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { date: Date; }) => string)" }
+					},
+					"renderMonthLabel": {
+						"defaultValue": null,
+						"description": "Render a custom month label, can be used for localization",
+						"name": "renderMonthLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { month: number; date: Date; }) => string)" }
+					},
+					"previousMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the previous month button",
+						"name": "previousMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"nextMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "",
+						"name": "nextMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"previousYearAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the previous year button",
+						"name": "previousYearAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"nextYearAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the next year button",
+						"name": "nextYearAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"monthSelectionAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the month selection button",
+						"name": "monthSelectionAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"renderDateAriaLabel": {
+						"defaultValue": null,
+						"description": "Dynamic aria label applied to each date cell based on the arguments",
+						"name": "renderDateAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { date: Date; }) => string)" }
+					},
+					"renderMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "Dynamic aria label applied to each month element based on the arguments",
+						"name": "renderMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { month: number; }) => string)" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -439,50 +2589,356 @@
 			"path": "./src/components/Card/tests/Card.stories.tsx",
 			"stories": [
 				{
+					"id": "components-card--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: default\">\n            <Card>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title=\"padding: 2\">\n            <Card padding={2}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title=\"padding: 0\">\n            <Card padding={0}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive padding\", \"[s] 4\", \"[m+] 8\"]}>\n            <Card padding={{ s: 4, m: 8 }}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--selected",
 					"name": "selected",
 					"snippet": "const selected = () => (\n    <Example>\n        <Example.Item title=\"selected\">\n            <Card selected>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated\">\n            <Card elevated>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4\">\n            <Card bleed={4}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n        <Example.Item title={[\"responsive bleed\", \"[s] 4\", \"[m+] 0\"]}>\n            <Card bleed={{ s: 4, m: 0 }}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--height",
 					"name": "height",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"height: 200px\">\n            <Card height=\"200px\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Card onClick={fn()}>Trigger</Card>;"
 				},
 				{
+					"id": "components-card--href",
 					"name": "href",
 					"snippet": "const href = () => <Card href=\"https://reshaped.so\">Trigger</Card>;"
 				},
 				{
+					"id": "components-card--as",
 					"name": "as",
 					"snippet": "const as = () => <Card as=\"span\" attributes={{ \"data-testid\": \"root\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-card--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Card className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Card, Example, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Card/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Card",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Card/Card.tsx",
-				"actualName": "Card",
+				"methods": [],
+				"props": {
+					"padding": {
+						"defaultValue": null,
+						"description": "Component padding, base unit multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Remove side borders and apply negative margins, base unit multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"selected": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "selected",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when the component is clicked, turns component into a button",
+						"name": "onClick",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL to navigate to when the component is clicked, turns component into a link",
+						"name": "href",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"as": {
+						"defaultValue": { "value": "\"div\"" },
+						"description": "Custom component tag name",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(Attributes<keyof IntrinsicElements> & (Attributes))" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -492,56 +2948,181 @@
 			"path": "./src/components/Carousel/tests/Carousel.stories.tsx",
 			"stories": [
 				{
+					"id": "components-carousel--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Carousel attributes={{ \"data-testid\": \"test-id\" }} visibleItems={3}>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n    </Carousel>\n);"
 				},
 				{
+					"id": "components-carousel--visible-items",
 					"name": "visibleItems",
 					"snippet": "const visibleItems = () => (\n    <Example>\n        <Example.Item title=\"visibleItems: 3\">\n            <Carousel visibleItems={3}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive visibleItems\", \"s: 2, m+ 3\"]}>\n            <Carousel visibleItems={{ s: 2, m: 3 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title=\"visibleItems: auto\">\n            <Carousel>\n                <Placeholder h={100} />\n                <Placeholder h={100} w={200} />\n                <Placeholder h={100} w={300} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 2, visibleItems 3\">\n            <Carousel visibleItems={3} gap={2}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"gap: responsive, visibleItems: 3\", \"s: 2, l: 8\"]}>\n            <Carousel visibleItems={3} gap={{ s: 2, l: 8 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4, visibleItems: 3\">\n            <Carousel visibleItems={3} bleed={4}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive bleed, visibleItems: 3\", \"[s] 4, [l+] 0\"]}>\n            <Carousel visibleItems={3} bleed={{ s: 4, l: 0 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--navigation-display",
 					"name": "navigationDisplay",
 					"snippet": "const navigationDisplay = () => (\n    <Example>\n        <Example.Item title=\"navigationDisplay: hidden\">\n            <Carousel\n                visibleItems={3}\n                navigationDisplay=\"hidden\"\n                attributes={{ \"data-testid\": \"test-id\" }}\n            >\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "instanceRef",
+					"id": "components-carousel--instance-ref",
+					"name": "instanceRef, onChange",
 					"snippet": "const instanceRef = (args) => {\n    const carouselRef = React.useRef<CarouselInstanceRef>(null);\n    const [index, setIndex] = React.useState(0);\n\n    return (\n        <Example>\n            <Example.Item title=\"instanceRef, onChange\">\n                <View gap={3}>\n                    <View gap={3} direction=\"row\" align=\"center\">\n                        <Button onClick={() => carouselRef.current?.navigateBack()}>Back</Button>\n                        <Button onClick={() => carouselRef.current?.navigateForward()}>Forward</Button>\n                        <Button onClick={() => carouselRef.current?.navigateTo(3)}>To 3</Button>\n                        <View.Item>Index: {index}</View.Item>\n                    </View>\n                    <Carousel\n                        visibleItems={2}\n                        instanceRef={carouselRef}\n                        navigationDisplay=\"hidden\"\n                        onChange={(changeArgs) => {\n                            args.handleChange(changeArgs);\n                            setIndex(changeArgs.index);\n                        }}\n                    >\n                        <Placeholder h={100}>Item 0</Placeholder>\n                        <Placeholder h={100}>Item 1</Placeholder>\n                        <Placeholder h={100}>Item 2</Placeholder>\n                        <Placeholder h={100}>Item 3</Placeholder>\n                        <Placeholder h={100}>Item 4</Placeholder>\n                        <Placeholder h={100}>Item 5</Placeholder>\n                    </Carousel>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-carousel--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Carousel visibleItems={2} className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder h={100}>Item 0</Placeholder>\n            <Placeholder h={100}>Item 1</Placeholder>\n            <Placeholder h={100}>Item 2</Placeholder>\n            <Placeholder h={100}>Item 3</Placeholder>\n            <Placeholder h={100}>Item 4</Placeholder>\n            <Placeholder h={100}>Item 5</Placeholder>\n        </Carousel>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Carousel, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Carousel/index.ts",
 				"description": "",
-				"methods": [
-					{
-						"name": "navigateTo",
-						"docblock": null,
-						"modifiers": [],
-						"params": [
+				"displayName": "Carousel",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, each child is rendered as a carousel item",
+						"name": "children",
+						"declarations": [
 							{
-								"name": "index",
-								"optional": false,
-								"type": { "name": "number" }
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
 							}
 						],
-						"returns": null
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"visibleItems": {
+						"defaultValue": null,
+						"description": "Number of items visible at once in the container",
+						"name": "visibleItems",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between items in the container, base unit multiplier",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margins, base unit multiplier, can be used to make sure the items don't get clipped when scrolling",
+						"name": "bleed",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"navigationDisplay": {
+						"defaultValue": null,
+						"description": "Hide navigation controls",
+						"name": "navigationDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"hidden\"", "value": [{ "value": "\"hidden\"" }] }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the carousel methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the first visible carousel index changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { index: number; }) => void)" }
+					},
+					"onScroll": {
+						"defaultValue": null,
+						"description": "Callback when the carousel scrolls",
+						"name": "onScroll",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: UIEvent<HTMLUListElement, UIEvent>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
 					}
-				],
-				"displayName": "Carousel",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Carousel/Carousel.tsx",
-				"actualName": "Carousel",
+				},
 				"exportName": "default"
 			}
 		},
@@ -551,46 +3132,259 @@
 			"path": "./src/components/Checkbox/tests/Checkbox.stories.tsx",
 			"stories": [
 				{
-					"name": "render",
+					"id": "components-checkbox--render",
+					"name": "name, value",
 					"snippet": "const render = () => (\n    <Checkbox name=\"test-name\" value=\"test-value\">\n        Content\n    </Checkbox>\n);"
 				},
 				{
+					"id": "components-checkbox--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"small\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"small\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"medium\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"medium\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"large\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"large\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: responsive, s: small, m: large\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size={{ s: \"small\", m: \"large\" }} defaultChecked>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-checkbox--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Checkbox name=\"animal\" value=\"dog\" hasError>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-checkbox--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n        <Example.Item title=\"disabled, checked\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled checked>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n        <Example.Item title=\"disabled, indeterminate\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled indeterminate>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "checked",
+					"id": "components-checkbox--checked",
+					"name": "checked, controlled",
 					"snippet": "const checked = () => <Checkbox name=\"test-name\" value=\"test-value\" checked onChange={fn()}>Content\n            </Checkbox>;"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-checkbox--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Checkbox name=\"test-name\" value=\"test-value\" defaultChecked onChange={fn()}>Content\n            </Checkbox>;"
 				},
 				{
+					"id": "components-checkbox--indeterminate",
 					"name": "indeterminate",
 					"snippet": "const indeterminate = () => (\n    <Checkbox name=\"test-name\" value=\"test-value\" indeterminate>\n        Content\n    </Checkbox>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-checkbox--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Checkbox className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Checkbox>\n    </div>\n);"
 				}
 			],
 			"import": "import { Checkbox, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Checkbox/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Checkbox",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Checkbox/Checkbox.tsx",
-				"actualName": "Checkbox",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the label",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Component name attribute",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the component",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Component value used for form submission",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"indeterminate": {
+						"defaultValue": null,
+						"description": "Show a indeterminate state, used for \"select all\" checkboxes with some of the individual checkboxes selected",
+						"name": "indeterminate",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the component is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the component is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Component checked state, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default checked state, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -600,26 +3394,143 @@
 			"path": "./src/components/CheckboxGroup/tests/CheckboxGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "value",
+					"id": "components-checkboxgroup--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <View gap={2}>\n    <CheckboxGroup name=\"test-name\" value={[\"1\"]} onChange={fn()}>\n        {/* checked should be ignored */}\n        <Checkbox value=\"1\" checked={false}>Content\n                            </Checkbox>\n        <Checkbox value=\"2\">Content 2</Checkbox>\n    </CheckboxGroup>\n</View>;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-checkboxgroup--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <View gap={2}>\n    <CheckboxGroup name=\"test-name\" defaultValue={[\"1\"]} onChange={fn()}>\n        {/* checked should be ignored */}\n        <Checkbox value=\"1\" checked={false}>Content\n                            </Checkbox>\n        <Checkbox value=\"2\">Content 2</Checkbox>\n    </CheckboxGroup>\n</View>;"
 				},
 				{
+					"id": "components-checkboxgroup--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <CheckboxGroup name=\"test-name\" disabled>\n        <Checkbox value=\"test-value\">Item 1</Checkbox>\n        <Checkbox value=\"test-value-2\">Item 2</Checkbox>\n    </CheckboxGroup>\n);"
 				}
 			],
 			"import": "import { Checkbox, CheckboxGroup, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/CheckboxGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "CheckboxGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/CheckboxGroup/CheckboxGroup.tsx",
-				"actualName": "CheckboxGroup",
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Component id attribute",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting checkboxes or custom layout components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the component from form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Component name attribute",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string[], ChangeEvent<HTMLInputElement>>" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Component value, enables controlled mode\nComponent value, enables uncontrolled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -629,23 +3540,346 @@
 			"path": "./src/components/ContextMenu/tests/ContextMenu.stories.tsx",
 			"stories": [
 				{
+					"id": "components-contextmenu--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"base\">\n            <div style={{ height: 200, overflow: \"auto\" }}>\n                <ContextMenu>\n                    <View height=\"400px\" backgroundColor=\"neutral-faded\" borderRadius=\"medium\" />\n\n                    <ContextMenu.Content>\n                        <ContextMenu.Item>Item 1</ContextMenu.Item>\n                        <ContextMenu.Item>Item 2</ContextMenu.Item>\n                    </ContextMenu.Content>\n                </ContextMenu>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "components-contextmenu--handlers",
+					"name": "handleOpen, handleClose",
 					"snippet": "const handlers = () => <div style={{ height: 200, overflow: \"auto\" }} data-testid=\"scroll\">\n    <ContextMenu onOpen={fn()} onClose={fn()}>\n        <View\n            height=\"400px\"\n            backgroundColor=\"neutral-faded\"\n            borderRadius=\"medium\"\n            attributes={{ \"data-testid\": \"root\" }} />\n        <ContextMenu.Content>\n            <ContextMenu.Item>Item</ContextMenu.Item>\n        </ContextMenu.Content>\n    </ContextMenu>\n</div>;"
 				}
 			],
 			"import": "import { ContextMenu, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ContextMenu/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ContextMenu",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ContextMenu/ContextMenu.tsx",
-				"actualName": "ContextMenu",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/DropdownMenu/DropdownMenu.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | \"action-menu\" | \"selection-menu\"" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					}
+				},
+				"exportName": "ContextMenu"
 			}
 		},
 		"components-divider": {
@@ -654,30 +3888,118 @@
 			"path": "./src/components/Divider/tests/Divider.stories.tsx",
 			"stories": [
 				{
-					"name": "rendering",
+					"id": "components-divider--rendering",
+					"name": "base",
 					"snippet": "const rendering = () => (\n    <Example>\n        <Example.Item title=\"default rendering\">\n            <Divider />\n        </Example.Item>\n\n        <Example.Item title={[\"blank rendering\", \"box should overlap with divider\"]}>\n            <View width=\"40px\" height=\"10px\" backgroundColor=\"primary\" />\n            <Divider blank />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-divider--vertical",
 					"name": "vertical",
 					"snippet": "const vertical = () => (\n    <Example>\n        <Example.Item title=\"vertical\">\n            <View gap={3} direction=\"row\" align=\"stretch\">\n                <Placeholder />\n                <View.Item>\n                    <Divider vertical />\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive vertical\", \"[s] true\", \"[m+]: false\"]}>\n            <View gap={3} direction={{ s: \"row\", m: \"column\" }} align=\"stretch\">\n                <Placeholder />\n                <View.Item>\n                    <Divider vertical={{ s: true, m: false }} />\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "label",
+					"id": "components-divider--label",
+					"name": "children, contentPosition",
 					"snippet": "const label = () => {\n    return (\n        <Example>\n            <Example.Item title=\"alignment\">\n                <View gap={4}>\n                    <Divider>Centered label</Divider>\n                    <Divider contentPosition=\"start\">Start label</Divider>\n                    <Divider contentPosition=\"end\">End label</Divider>\n                </View>\n            </Example.Item>\n\n            <Example.Item title=\"responsive\">\n                <View gap={3} direction={{ s: \"column\", m: \"row\" }} align=\"stretch\">\n                    <Placeholder />\n                    <View.Item>\n                        <Divider vertical={{ s: false, m: true }}>or pick second option</Divider>\n                    </View.Item>\n                    <Placeholder />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-divider--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Divider className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Divider, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Divider/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Divider",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Divider/Divider.tsx",
-				"actualName": "Divider",
+				"methods": [],
+				"props": {
+					"blank": {
+						"defaultValue": null,
+						"description": "Change component to take no space, useful for using it as a border in components like Tabs",
+						"name": "blank",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"vertical": {
+						"defaultValue": null,
+						"description": "Change component to render vertically",
+						"name": "vertical",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"contentPosition": {
+						"defaultValue": null,
+						"description": "Position for rendering children",
+						"name": "contentPosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"center\" | \"start\" | \"end\"",
+							"value": [{ "value": "\"center\"" }, { "value": "\"start\"" }, { "value": "\"end\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting text labels or custom components as a part of divider",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"hr\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -687,51 +4009,415 @@
 			"path": "./src/components/DropdownMenu/tests/DropdownMenu.stories.tsx",
 			"stories": [
 				{
+					"id": "components-dropdownmenu--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: default\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <DropdownMenu position=\"end\">\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n\n        <Example.Item title={[\"position: top-start\", \"should change to top-start to fit viewport\"]}>\n            <DropdownMenu position=\"top-end\">\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n        <div style={{ height: 2000 }} />\n    </Example>\n);"
 				},
 				{
+					"id": "components-dropdownmenu--sections",
 					"name": "sections",
 					"snippet": "const sections = () => (\n    <Example>\n        <Example.Item title=\"2 sections\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Section>\n                        <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                    </DropdownMenu.Section>\n\n                    <DropdownMenu.Section>\n                        <DropdownMenu.Item>Item 3</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 4</DropdownMenu.Item>\n                    </DropdownMenu.Section>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-dropdownmenu--submenu",
 					"name": "submenu",
 					"snippet": "const submenu = () => (\n    <Example>\n        <Example.Item title=\"submenu\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item onClick={() => {}}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger>Item 2</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger>Item 3</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2-1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2-2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger disabled>Item 4, disabled</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 3-1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 3-2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-dropdownmenu--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <DropdownMenu onOpen={fn()} onClose={fn()} defaultActive>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "active",
+					"id": "components-dropdownmenu--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <DropdownMenu onOpen={fn()} onClose={fn()} active>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "components-dropdownmenu--active-false",
+					"name": "active false, controlled",
 					"snippet": "const activeFalse = () => <DropdownMenu onOpen={fn()} onClose={fn()} active={false}>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "className",
+					"id": "components-dropdownmenu--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <DropdownMenu active>\n            <DropdownMenu.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </DropdownMenu.Trigger>\n            <DropdownMenu.Content className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n                <DropdownMenu.Item>Item</DropdownMenu.Item>\n            </DropdownMenu.Content>\n        </DropdownMenu>\n    </div>\n);"
 				},
 				{
-					"name": "testScroll",
+					"id": "components-dropdownmenu--test-scroll",
+					"name": "test: scroll",
 					"snippet": "const testScroll = () => (\n    <Example>\n        <Example.Item title=\"Scrolls on page mount to the dropdown\">\n            <div style={{ height: 1000 }} />\n            <DropdownMenu position=\"end\" key=\"scroll\" defaultActive>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testTheme",
+					"id": "components-dropdownmenu--test-theme",
+					"name": "test: theme",
 					"snippet": "const testTheme = () => (\n    <Example>\n        <Example.Item title=\"switch color mode while dropdown is active and check that it still works\">\n            <ThemeSwitching />\n        </Example.Item>\n        <Example.Item title=\"dropdown inherits multiple themes\">\n            <ThemeMultiple />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, DropdownMenu, Example, Theme, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/DropdownMenu/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "DropdownMenu",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/DropdownMenu/DropdownMenu.tsx",
-				"actualName": "DropdownMenu",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/DropdownMenu/DropdownMenu.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | \"action-menu\" | \"selection-menu\"" }
+					}
+				},
+				"exportName": "DropdownMenu"
 			}
 		},
 		"components-fileupload": {
@@ -740,35 +4426,165 @@
 			"path": "./src/components/FileUpload/tests/FileUpload.stories.tsx",
 			"stories": [
 				{
+					"id": "components-fileupload--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"Base upload with previews\">\n            <Demo />\n        </Example.Item>\n        <Example.Item title=\"With trigger\">\n            <FileUpload name=\"file\">\n                <div>\n                    Drop files to attach, or{\" \"}\n                    <FileUpload.Trigger>\n                        <Link variant=\"plain\">browse</Link>\n                    </FileUpload.Trigger>\n                </div>\n            </FileUpload>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "inline",
+					"id": "components-fileupload--inline",
+					"name": "inline, variant, render props",
 					"snippet": "const inline = () => {\n    return (\n        <Example>\n            <Example.Item title=\"inline\">\n                <FileUpload name=\"file\" inline onChange={console.log}>\n                    <View padding={2} paddingInline={3}>\n                        Upload\n                    </View>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"variant headless\">\n                <FileUpload name=\"file2\" variant=\"headless\" onChange={console.log}>\n                    <Button variant=\"outline\" fullWidth>\n                        Upload\n                    </Button>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"variant headless, inline\">\n                <FileUpload name=\"file2\" variant=\"headless\" inline onChange={console.log}>\n                    <Button>Upload</Button>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"inline, render props\">\n                <FileUpload name=\"file3\" variant=\"headless\" inline onChange={console.log}>\n                    {(props) => <Button highlighted={props.highlighted}>Upload</Button>}\n                </FileUpload>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-fileupload--height",
 					"name": "height",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"Custom height\">\n            <FileUpload name=\"file\" height=\"300px\">\n                <View gap={3}>\n                    <Icon svg={IconMic} size={8} />\n                    Drop files to attach\n                </View>\n            </FileUpload>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onChange",
+					"id": "components-fileupload--on-change",
+					"name": "name, onChange",
 					"snippet": "const onChange = () => <div data-testid=\"root\">\n    <FileUpload name=\"test-name\" onChange={fn()}>Content\n                    </FileUpload>\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "components-fileupload--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <FileUpload\n            name=\"name\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ id: \"test-input-id\" }}\n        >\n            Content\n        </FileUpload>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, FileUpload, Icon, Image, Link, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/FileUpload/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "FileUpload",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/FileUpload/FileUpload.tsx",
-				"actualName": "FileUpload",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, can be a render function that receives component state",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode | ((props: { highlighted?: boolean; }) => ReactNode)" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component value is changed",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ChangeHandler<File[], ChangeEvent<HTMLInputElement> | DragEvent<HTMLDivElement>>"
+						}
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Component height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component variant, headless variant is useful for rendering custom triggers like a Button",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"headless\"",
+							"value": [{ "value": "\"outline\"" }, { "value": "\"headless\"" }]
+						}
+					},
+					"inline": {
+						"defaultValue": null,
+						"description": "Change component to render inline making it more compact",
+						"name": "inline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					}
+				},
+				"exportName": "FileUpload"
 			}
 		},
 		"components-hotkey": {
@@ -777,22 +4593,78 @@
 			"path": "./src/components/Hotkey/tests/Hotkey.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "components-hotkey--base",
+					"name": "Base",
 					"snippet": "const base = () => (\n\t<Example>\n\t\t<Example.Item title=\"Base\">\n\t\t\t<Demo />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"Active\">\n\t\t\t<Hotkey active>⌘K</Hotkey>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"Inside input slot\">\n\t\t\t<View width=\"300px\">\n\t\t\t\t<TextField\n\t\t\t\t\tname=\"hey\"\n\t\t\t\t\tendSlot={<Demo />}\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"hotkey test\" }}\n\t\t\t\t/>\n\t\t\t</View>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-hotkey--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Hotkey className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            ⌘K\n        </Hotkey>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Hotkey, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Hotkey/Hotkey.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Hotkey",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Hotkey/Hotkey.tsx",
-				"actualName": "Hotkey",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Highlight the component, can be used to show when hotkey is pressed",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -802,54 +4674,241 @@
 			"path": "./src/components/Link/tests/Link.stories.tsx",
 			"stories": [
 				{
+					"id": "components-link--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: underline\">\n            <Link href=\"http://reshaped.so\" attributes={{ target: \"_blank\" }}>\n                Reshaped\n            </Link>\n        </Example.Item>\n        <Example.Item title=\"variant: plain\">\n            <Link onClick={() => {}} variant=\"plain\">\n                Link\n            </Link>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary\">\n            <Link color=\"primary\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Link color=\"critical\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Link color=\"positive\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <Link color=\"warning\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <Link color=\"inherit\">Link</Link>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon, variant: underline\">\n            <Link icon={IconZap}>Link</Link>\n        </Example.Item>\n        <Example.Item title=\"icon, variant: plain\">\n            <Link icon={IconZap} variant=\"plain\">\n                Link\n            </Link>\n        </Example.Item>\n        <Example.Item\n            title={[\"icon, variant: underline\", \"should inherit display-1 size from the parent\"]}\n        >\n            <Text variant=\"title-3\">\n                <Link icon={IconZap} variant=\"underline\">\n                    Instant delivery\n                </Link>\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--href",
 					"name": "href",
 					"snippet": "const href = () => <Link href=\"https://reshaped.so\">Trigger</Link>;"
 				},
 				{
+					"id": "components-link--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Link onClick={fn()}>Trigger</Link>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-link--href-on-click",
+					"name": "href + onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <Link\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </Link>\n);"
 				},
 				{
+					"id": "components-link--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Link disabled onClick={() => {}}>\n        Trigger\n    </Link>\n);"
 				},
 				{
+					"id": "components-link--render",
 					"name": "render",
 					"snippet": "const render = () => <Link render={(props) => <section {...props} />}>Trigger</Link>;"
 				},
 				{
-					"name": "className",
+					"id": "components-link--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Link className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Link>\n    </div>\n);"
 				},
 				{
-					"name": "testMultilineInText",
+					"id": "components-link--test-multiline-in-text",
+					"name": "test: multiline",
 					"snippet": "const testMultilineInText = () => (\n    <Example>\n        <Example.Item title=\"should wrap inside the text\">\n            <div>\n                Someone asked me to write this text that is boring to ready for everyone and to add&nbsp;\n                <Link href=\"/\">this very very long link</Link> to it.\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Link, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Link/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Link",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Link/Link.tsx",
-				"actualName": "Link",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon at the start position",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"primary\"" },
+						"description": "Link color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"inherit\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"inherit\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"underline\"" },
+						"description": "Link render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"plain\" | \"underline\"",
+							"value": [{ "value": "\"plain\"" }, { "value": "\"underline\"" }]
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -859,30 +4918,110 @@
 			"path": "./src/components/Loader/tests/Loader.stories.tsx",
 			"stories": [
 				{
+					"id": "components-loader--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: medium\">\n                <Loader size=\"medium\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title=\"size: small\">\n                <Loader size=\"small\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title=\"size: large\">\n                <Loader size=\"large\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title={[\"responsive size\", \"[s] small\", \"[m+] medium\"]}>\n                <Loader size={{ s: \"small\", m: \"medium\" }} ariaLabel=\"Loading\" />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-loader--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary\">\n            <Loader ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Loader color=\"critical\" ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Loader color=\"positive\" ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <Loader color=\"inherit\" ariaLabel=\"Loading\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-loader--aria-label",
 					"name": "ariaLabel",
 					"snippet": "const ariaLabel = () => <Loader ariaLabel=\"Loading\" attributes={{ \"data-testid\": \"root\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-loader--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Loader className=\"test-classname\" attributes={{ id: \"test-id\" }} ariaLabel=\"Loading\" />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Loader } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Loader/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Loader",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Loader/Loader.tsx",
-				"actualName": "Loader",
+				"methods": [],
+				"props": {
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"inherit\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -892,67 +5031,504 @@
 			"path": "./src/components/MenuItem/tests/MenuItem.stories.tsx",
 			"stories": [
 				{
+					"id": "components-menuitem--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <MenuItem size=\"small\" icon={IconZap} onClick={() => {}} endSlot={<Hotkey>⌘K</Hotkey>}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <MenuItem icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <MenuItem size=\"large\" icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title={[\"responsive size\", \"[s] small\", \"[m] medium\", \"[l+] large\"]}>\n            <MenuItem size={{ s: \"small\", m: \"medium\", l: \"large\" }} icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <MenuItem color=\"neutral\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <MenuItem color=\"primary\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <MenuItem color=\"critical\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--selected",
 					"name": "selected",
 					"snippet": "const selected = () => (\n    <Example>\n        <Example.Item title=\"selected, color: neutral\">\n            <MenuItem color=\"neutral\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"selected, color: primary\">\n            <MenuItem color=\"primary\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"selected, color: critical\">\n            <MenuItem color=\"critical\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--rounded-corners",
 					"name": "roundedCorners",
 					"snippet": "const roundedCorners = () => (\n    <Example>\n        <Example.Item title=\"roundedCorners\">\n            <MenuItem roundedCorners selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive roundedCorners\", \"[s]: false\", \"[m+]: true\"]}>\n            <MenuItem roundedCorners={{ s: false, m: true }} selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "slots",
+					"id": "components-menuitem--slots",
+					"name": "startSlot, endSlot",
 					"snippet": "const slots = () => (\n    <Example>\n        <Example.Item title=\"startSlot, endSlot, selected\">\n            <MenuItem startSlot={<Placeholder h={20} />} endSlot={<Placeholder h={20} />} selected>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem size=\"small\" selected onClick={() => {}}>\n                        Menu item\n                    </MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem selected>Menu item</MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem size=\"large\" selected>\n                        Menu item\n                    </MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--href",
 					"name": "href",
 					"snippet": "const href = () => <MenuItem href=\"https://reshaped.so\">Trigger</MenuItem>;"
 				},
 				{
+					"id": "components-menuitem--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <MenuItem onClick={fn()}>Trigger</MenuItem>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-menuitem--href-on-click",
+					"name": "href + onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <MenuItem\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </MenuItem>\n);"
 				},
 				{
+					"id": "components-menuitem--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <MenuItem disabled onClick={() => {}}>\n        Trigger\n    </MenuItem>\n);"
 				},
 				{
-					"name": "as",
+					"id": "components-menuitem--as",
+					"name": "as, render",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"render, disabled\">\n            <MenuItem\n                disabled\n                onClick={() => {}}\n                render={(props) => <section {...props} />}\n                attributes={{ \"data-testid\": \"render-el\" }}\n            >\n                Trigger\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-menuitem--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <MenuItem className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </MenuItem>\n    </div>\n);"
 				},
 				{
-					"name": "alignerClassName",
+					"id": "components-menuitem--aligner-class-name",
+					"name": "aligner, className, attributes",
 					"snippet": "const alignerClassName = () => (\n    <div data-testid=\"root\">\n        <MenuItem.Aligner className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <MenuItem>Trigger</MenuItem>\n        </MenuItem.Aligner>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Hotkey, MenuItem, Placeholder, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/MenuItem/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "MenuItem",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/MenuItem/MenuItem.tsx",
-				"actualName": "MenuItem",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content\nNode for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"neutral\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"neutral\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content at the start side of the component",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content at the end side of the component",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component as hovered or focused. For example, when displaying currently focused item in Autocomplete",
+						"name": "highlighted",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"selected": {
+						"defaultValue": null,
+						"description": "Highlight the component as selected",
+						"name": "selected",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"roundedCorners": {
+						"defaultValue": null,
+						"description": "Round the corners of the component",
+						"name": "roundedCorners",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					}
+				},
+				"exportName": "MenuItem"
 			}
 		},
 		"components-modal": {
@@ -961,67 +5537,301 @@
 			"path": "./src/components/Modal/tests/Modal.stories.tsx",
 			"stories": [
 				{
+					"id": "components-modal--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title={[\"responsive position\", \"[s] full-screen\", \"[m] center\", \"[l] end\"]}>\n            <Demo position={{ s: \"full-screen\", m: \"center\", l: \"end\" }} />\n        </Example.Item>\n        <Example.Item title=\"position: center\">\n            <Demo position=\"center\" />\n        </Example.Item>\n        <Example.Item title=\"position: bottom\">\n            <Demo position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"position: start\">\n            <Demo position=\"start\" />\n        </Example.Item>\n        <Example.Item title=\"position: end\">\n            <Demo position=\"end\" />\n        </Example.Item>\n        <Example.Item title=\"position: full-screen\">\n            <Demo position=\"full-screen\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: default\">\n                <Demo />\n            </Example.Item>\n            <Example.Item title=\"size: 300px\">\n                <Demo size=\"300px\" />\n            </Example.Item>\n            <Example.Item\n                title={[\"size: 800px\", \"should have max width of 100% minus gaps on the sides\"]}\n            >\n                <Demo size=\"800px\" />\n            </Example.Item>\n            <Example.Item\n                title={[\n                    \"responsive size, responsive position\",\n                    \"[s] auto\",\n                    \"[m+] 600px\",\n                    \"bottom position changes height instead of width\",\n                ]}\n            >\n                <Demo\n                    position={{ s: \"bottom\", m: \"center\", l: \"end\" }}\n                    size={{ s: \"auto\", m: \"600px\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-modal--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 0\">\n            <Demo padding={0} />\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <Demo padding={6} />\n        </Example.Item>\n        <Example.Item title={[\"responsive padding\", \"[s] 2\", \"[m+]: 6\"]}>\n            <Demo padding={{ s: 2, m: 6 }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--overflow",
 					"name": "overflow",
 					"snippet": "const overflow = () => (\n    <Example>\n        <Example.Item title=\"default overflow\">\n            <Demo>\n                <div\n                    style={{\n                        position: \"absolute\",\n                        top: -32,\n                        left: -32,\n                        height: 100,\n                        width: 100,\n                        background: \"tomato\",\n                    }}\n                />\n            </Demo>\n        </Example.Item>\n\n        <Example.Item title=\"overflow: visible\">\n            <Demo overflow=\"visible\">\n                <div\n                    style={{\n                        position: \"absolute\",\n                        top: -32,\n                        left: -32,\n                        height: 100,\n                        width: 100,\n                        background: \"tomato\",\n                    }}\n                />\n            </Demo>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--composition",
 					"name": "composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"title, subtitle, dismissible\">\n            <Demo title=\"Modal title\" subtitle=\"Modal subtitle\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--overlay",
 					"name": "overlay",
 					"snippet": "const overlay = () => (\n    <Example>\n        <Example.Item title=\"transparentOverlay, doesn't lock scroll\">\n            <Demo transparentOverlay />\n        </Example.Item>\n        <Example.Item title=\"blurredOverlay\">\n            <Demo blurredOverlay />\n        </Example.Item>\n        <View height=\"1000px\" />\n    </Example>\n);"
 				},
 				{
-					"name": "flags",
+					"id": "components-modal--flags",
+					"name": "disableCloseOnOutsideClick",
 					"snippet": "const flags = () => {\n    return (\n        <Example>\n            <Example.Item title=\"disableCloseOnOutsideClick\">\n                <Demo disableCloseOnOutsideClick onClose={fn()} active />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-modal--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const containerRef2 = React.useRef<HTMLDivElement>(null);\n    const toggle = useToggle();\n    const toggle2 = useToggle();\n\n    return (\n        <Example>\n            <Example.Item title={[\"in scrollable container\", \"scroll and then open\"]}>\n                <View\n                    attributes={{ ref: containerRef2 }}\n                    borderRadius=\"medium\"\n                    height=\"400px\"\n                    overflow=\"auto\"\n                    backgroundColor=\"neutral-faded\"\n                    padding={4}\n                >\n                    <View gap={4} align=\"start\">\n                        <Button onClick={toggle2.activate}>Open modal</Button>\n                        <View height=\"500px\" backgroundColor=\"primary\" width=\"500px\" borderRadius=\"medium\" />\n                    </View>\n                    <Modal\n                        containerRef={containerRef2}\n                        active={toggle2.active}\n                        onClose={toggle2.deactivate}\n                        position=\"end\"\n                    >\n                        <Placeholder />\n                    </Modal>\n                </View>\n            </Example.Item>\n            <Example.Item title=\"in static container\">\n                <View\n                    attributes={{ ref: containerRef }}\n                    borderRadius=\"medium\"\n                    height=\"400px\"\n                    overflow=\"hidden\"\n                    backgroundColor=\"neutral-faded\"\n                    padding={4}\n                >\n                    <Button onClick={toggle.activate}>Open modal</Button>\n                    <Modal\n                        containerRef={containerRef}\n                        active={toggle.active}\n                        onClose={toggle.deactivate}\n                        position=\"end\"\n                    >\n                        <Placeholder />\n                    </Modal>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "renderProps",
+					"id": "components-modal--render-props",
+					"name": "children, render props",
 					"snippet": "const renderProps = () => (\n    <Modal active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        <Modal.Title>Title</Modal.Title>\n        Content\n    </Modal>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "components-modal--handlers",
+					"name": "onOpen, onClose, onAfterOpen, onAfterClose",
 					"snippet": "const handlers = () => {\n    const overlayToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => overlayToggle.toggle()}>Open overlay</Button>\n            <Modal\n                active={overlayToggle.active}\n                onClose={(closeArgs) => {\n                    overlayToggle.deactivate();\n                    args.handleClose(closeArgs);\n                }}\n                onOpen={fn()}\n                onAfterOpen={fn()}\n                onAfterClose={fn()}>\n                <Modal.Title>Title</Modal.Title>Content\n                                </Modal>\n        </>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-modal--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <Modal active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        <Modal.Title>Title</Modal.Title>\n        Content\n    </Modal>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-modal--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => {\n    const menuModalToggle = useToggle();\n    const menuModalToggleInner = useToggle();\n    const scrollModalToggle = useToggle();\n    const inputRef = React.useRef<HTMLInputElement>(null);\n\n    return (\n        <Example>\n            <Example.Item title=\"Scrolls with long content on touch devices\">\n                <Demo position=\"center\">\n                    <Button onClick={() => {}}>Action</Button>\n                    <View height=\"2000px\" backgroundColor=\"primary-faded\" />\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"keyboard focus stays on the modal first\">\n                <Demo title=\"Modal title\" autoFocus={false} />\n            </Example.Item>\n            <Example.Item title=\"trap focus works with custom children components\">\n                <Demo title=\"Modal title\">\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <Switch name=\"switch\" />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"focus moves to the input\">\n                <Demo\n                    title=\"Modal title\"\n                    onOpen={() => {\n                        inputRef.current?.focus();\n                    }}\n                >\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <TextField name=\"name\" inputAttributes={{ ref: inputRef }} />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"Focus moves to the input with autoFocus\">\n                <Demo title=\"Modal title\">\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <TextField\n                            name=\"name\"\n                            placeholder=\"autofocus\"\n                            inputAttributes={{ autoFocus: true }}\n                        />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"scrollable area in modal ignores swipe-to-close\">\n                <View gap={3} direction=\"row\">\n                    <Button onClick={scrollModalToggle.activate}>Open</Button>\n                    <Modal\n                        active={scrollModalToggle.active}\n                        onClose={scrollModalToggle.deactivate}\n                        size=\"300px\"\n                        position=\"bottom\"\n                    >\n                        <View\n                            height=\"1000px\"\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            padding={4}\n                        >\n                            Content\n                        </View>\n                    </Modal>\n                </View>\n            </Example.Item>\n            <Example.Item\n                title={[\n                    \"trap focus works correctly when it was already trapped\",\n                    \"focus return back to the dropdown trigger on modal close\",\n                    \"closing dropdown inside the modal doesn't close the modal\",\n                ]}\n            >\n                <DropdownMenu>\n                    <DropdownMenu.Trigger>\n                        {(attributes) => <Button attributes={attributes}>Open menu</Button>}\n                    </DropdownMenu.Trigger>\n                    <DropdownMenu.Content>\n                        <DropdownMenu.Item onClick={menuModalToggle.activate}>Open dialog</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                    </DropdownMenu.Content>\n                </DropdownMenu>\n                <Modal active={menuModalToggle.active} onClose={menuModalToggle.deactivate}>\n                    <View gap={3}>\n                        <DropdownMenu>\n                            <DropdownMenu.Trigger>\n                                {(attributes) => <Button attributes={attributes}>Open menu</Button>}\n                            </DropdownMenu.Trigger>\n                            <DropdownMenu.Content>\n                                <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                                <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                            </DropdownMenu.Content>\n                        </DropdownMenu>\n                        <Button onClick={menuModalToggleInner.activate}>Open dialog</Button>\n                        <Button onClick={menuModalToggle.deactivate}>Close</Button>\n                        <Modal active={menuModalToggleInner.active} onClose={menuModalToggleInner.deactivate}>\n                            <Button onClick={menuModalToggleInner.deactivate}>Close</Button>\n                        </Modal>\n                    </View>\n                </Modal>\n            </Example.Item>\n\n            <Example.Item title=\"disableSwipeGesture\">\n                <Demo disableSwipeGesture position=\"start\" />\n            </Example.Item>\n\n            <Example.Item title=\"scroll locks on open\">\n                <Demo />\n                <View height=\"1000px\" />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "trapFocusEdgeCases",
+					"id": "components-modal--trap-focus-edge-cases",
+					"name": "test: trap focus edge cases",
 					"snippet": "const trapFocusEdgeCases = () => {\n    const toggle = useToggle();\n\n    return (\n        <Example>\n            <Example.Item title=\"Radio should be navigatable with arrow keys\">\n                <Button onClick={toggle.activate}>Open modal</Button>\n                <Modal active={toggle.active} onClose={toggle.deactivate}>\n                    <View gap={2}>\n                        <Button onClick={() => {}}>Action 1</Button>\n                        <Radio name=\"radio\" value=\"1\">\n                            Option 1\n                        </Radio>\n                        <Radio name=\"radio\" value=\"2\">\n                            Option 2\n                        </Radio>\n                        <Button onClick={() => {}}>Action 2</Button>\n                    </View>\n                </Modal>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import {\n    Button,\n    Dismissible,\n    DropdownMenu,\n    Example,\n    Modal,\n    Placeholder,\n    Radio,\n    Switch,\n    TextField,\n    View,\n} from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Modal/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Modal",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Modal/Modal.tsx",
-				"actualName": "Modal",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Component position on the screen",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<\"bottom\" | \"center\" | \"start\" | \"end\" | \"full-screen\">"
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size, literal css value",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Component padding, unit token multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Remove overflow from the component content",
+						"name": "overflow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"visible\"", "value": [{ "value": "\"visible\"" }] }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is closed",
+						"name": "onClose",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((args: { reason: CloseReason | \"drag\"; }) => void)" }
+					},
+					"transparentOverlay": {
+						"defaultValue": null,
+						"description": "Make the overlay transparent",
+						"name": "transparentOverlay",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"blurredOverlay": {
+						"defaultValue": null,
+						"description": "Make the overlay blurred",
+						"name": "blurredOverlay",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableSwipeGesture": {
+						"defaultValue": null,
+						"description": "Disable swipe gesture to close the component on touch devices",
+						"name": "disableSwipeGesture",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable closing the component on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Focus the first focusable element in the component when it is opened, when false, focus will be set on the component content container",
+						"name": "autoFocus",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element, useful when there is no visible title",
+						"name": "ariaLabel",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"overlayClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the overlay element",
+						"name": "overlayClassName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "(Attributes<\"div\"> & { ref?: RefObject<HTMLDivElement | null>; })"
+						}
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the visibility of the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the component is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"containerRef": {
+						"defaultValue": null,
+						"description": "Element to render the component in",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"onAfterOpen": {
+						"defaultValue": null,
+						"description": "Callback after the component open transition is complete",
+						"name": "onAfterOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onAfterClose": {
+						"defaultValue": null,
+						"description": "Callback after the component close transition is complete",
+						"name": "onAfterClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					}
+				},
+				"exportName": "Modal"
 			}
 		},
 		"components-numberfield": {
@@ -1030,54 +5840,450 @@
 			"path": "./src/components/NumberField/tests/NumberField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-numberfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => {\n    return (\n        <Example>\n            <Example.Item title=\"variant: outline\">\n                <NumberField\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"variant: faded\">\n                <NumberField\n                    variant=\"faded\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"variant: headless\">\n                <NumberField\n                    variant=\"headless\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-numberfield--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: small\">\n                <NumberField\n                    size=\"small\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    suffix=\"m2\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: medium\">\n                <NumberField\n                    size=\"medium\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: large\">\n                <NumberField\n                    size=\"large\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: xlarge\">\n                <NumberField\n                    size=\"xlarge\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-numberfield--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <NumberField\n    name=\"test-name\"\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    disabled\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-numberfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <NumberField\n    name=\"test-name\"\n    defaultValue={2}\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-numberfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <NumberField\n    name=\"test-name\"\n    value={2}\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "minMax",
+					"id": "components-numberfield--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <NumberField\n        name=\"test-name\"\n        defaultValue={6}\n        min={5}\n        max={10}\n        increaseAriaLabel=\"Increase\"\n        decreaseAriaLabel=\"Decrease\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-numberfield--step",
 					"name": "step",
 					"snippet": "const step = () => (\n    <NumberField\n        name=\"test-name\"\n        defaultValue={6}\n        step={0.5}\n        increaseAriaLabel=\"Increase\"\n        decreaseAriaLabel=\"Decrease\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-numberfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <NumberField\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n            increaseAriaLabel=\"Increase\"\n            decreaseAriaLabel=\"Decrease\"\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-numberfield--form-control",
+					"name": "test: FormControl",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"FormControl\">\n            <FormControl>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"FormControl, disabled\">\n            <FormControl disabled>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"FormControl, error\">\n            <FormControl hasError>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "valueChanges",
+					"id": "components-numberfield--value-changes",
+					"name": "test: keyboard",
 					"snippet": "const valueChanges = () => (\n    <Example>\n        <Example.Item title=\"keyboard\">\n            <NumberField\n                name=\"name\"\n                increaseAriaLabel=\"Increase\"\n                decreaseAriaLabel=\"Decrease\"\n                inputAttributes={{ \"aria-label\": \"Label\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, FormControl, NumberField } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/NumberField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "NumberField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/NumberField/NumberField.tsx",
-				"actualName": "NumberField",
+				"methods": [],
+				"props": {
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component value is changed",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<number, ChangeEvent<HTMLInputElement>>" }
+					},
+					"increaseAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the increase button",
+						"name": "increaseAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"decreaseAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the decrease button",
+						"name": "decreaseAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum value supported in the form field",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum value supported in the form field",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"step": {
+						"defaultValue": null,
+						"description": "Step at which the value will increase or decrease when clicking the button controls",
+						"name": "step",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the form field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the form field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1087,34 +6293,166 @@
 			"path": "./src/components/Pagination/tests/Pagination.stories.tsx",
 			"stories": [
 				{
+					"id": "components-pagination--truncate",
 					"name": "truncate",
 					"snippet": "const truncate = () => {\n    return (\n        <Example>\n            <Example.Item title=\"start\">\n                <Pagination\n                    total={10}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"middle\">\n                <Pagination\n                    total={10}\n                    defaultPage={5}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"end\">\n                <Pagination\n                    total={10}\n                    defaultPage={10}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"no truncation\">\n                <Pagination\n                    total={4}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "render",
+					"id": "components-pagination--render",
+					"name": "rendering",
 					"snippet": "const render = () => (\n    <div data-testid=\"root\">\n        <Pagination\n            total={10}\n            previousAriaLabel=\"Previous\"\n            nextAriaLabel=\"Next\"\n            pageAriaLabel={(args) => `Page ${args.page}`}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "defaultPage",
+					"id": "components-pagination--default-page",
+					"name": "defaultPage, uncontrolled",
 					"snippet": "const defaultPage = () => <div data-testid=\"root\">\n    <Pagination\n        total={10}\n        defaultPage={2}\n        onChange={fn()}\n        previousAriaLabel=\"Previous\"\n        nextAriaLabel=\"Next\" />\n</div>;"
 				},
 				{
-					"name": "page",
+					"id": "components-pagination--page",
+					"name": "page, controlled",
 					"snippet": "const page = () => <div data-testid=\"root\">\n    <Pagination\n        total={10}\n        page={2}\n        onChange={fn()}\n        previousAriaLabel=\"Previous\"\n        nextAriaLabel=\"Next\" />\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "components-pagination--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Pagination\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            total={10}\n            previousAriaLabel=\"Previous\"\n            nextAriaLabel=\"Next\"\n        />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Pagination } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Pagination/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Pagination",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Pagination/Pagination.tsx",
-				"actualName": "Pagination",
+				"methods": [],
+				"props": {
+					"total": {
+						"defaultValue": null,
+						"description": "Total number of pages available",
+						"name": "total",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "number" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the current page changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { page: number; }) => void)" }
+					},
+					"pageAriaLabel": {
+						"defaultValue": null,
+						"description": "Function to dynamically get an aria-label for each page",
+						"name": "pageAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { page: number; }) => string)" }
+					},
+					"previousAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the previous page button",
+						"name": "previousAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"nextAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the next page button",
+						"name": "nextAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"page": {
+						"defaultValue": null,
+						"description": "Currently selected page number, starts with 1, enables controlled mode",
+						"name": "page",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultPage": {
+						"defaultValue": null,
+						"description": "Default selected page number, starts with 1, enables uncontrolled mode",
+						"name": "defaultPage",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1124,54 +6462,229 @@
 			"path": "./src/components/PinField/tests/PinField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-pinfield--base",
 					"name": "base",
 					"snippet": "const base = () => <PinField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-pinfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <PinField name=\"pin\" variant=\"faded\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-pinfield--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <PinField name=\"pin\" size=\"small\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <PinField name=\"pin\" size=\"medium\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <PinField name=\"pin\" size=\"large\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <PinField name=\"pin\" size=\"xlarge\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: responsive, s: medium, m+: xlarge\">\n            <PinField\n                name=\"pin\"\n                size={{ s: \"medium\", m: \"xlarge\" }}\n                inputAttributes={{ \"aria-label\": \"Pin\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-pinfield--value-length",
 					"name": "valueLength",
 					"snippet": "const valueLength = () => (\n    <PinField name=\"test-name\" valueLength={6} inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-pinfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <PinField\n    name=\"test-name\"\n    onChange={fn()}\n    defaultValue=\"12\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-pinfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <PinField\n    name=\"test-name\"\n    onChange={fn()}\n    value=\"12\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-pinfield--pattern",
 					"name": "pattern",
 					"snippet": "const pattern = () => <PinField\n    name=\"test-name\"\n    pattern=\"alphabetic\"\n    defaultValue=\"ab\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-pinfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <PinField\n            name=\"test-name\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ \"aria-label\": \"Label\", id: \"test-input-id\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-pinfield--form-control",
+					"name": "test: with FormControl",
 					"snippet": "const formControl = () => (\n    <FormControl>\n        <FormControl.Label>Label</FormControl.Label>\n        <PinField name=\"test-name\" />\n    </FormControl>\n);"
 				},
 				{
-					"name": "keyboard",
+					"id": "components-pinfield--keyboard",
+					"name": "test: keyboard navigation",
 					"snippet": "const keyboard = () => <PinField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				}
 			],
 			"import": "import { Example, FormControl, PinField } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/PinField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "PinField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/PinField/PinField.tsx",
-				"actualName": "PinField",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"valueLength": {
+						"defaultValue": null,
+						"description": "Amount of characters in the pin",
+						"name": "valueLength",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"pattern": {
+						"defaultValue": null,
+						"description": "Character pattern used in the input value",
+						"name": "pattern",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"numeric\" | \"alphabetic\" | \"alphanumeric\"",
+							"value": [
+								{ "value": "\"numeric\"" },
+								{ "value": "\"alphabetic\"" },
+								{ "value": "\"alphanumeric\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Input fields render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\"",
+							"value": [{ "value": "\"outline\"" }, { "value": "\"faded\"" }]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the input element, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1181,75 +6694,514 @@
 			"path": "./src/components/Popover/tests/Popover.stories.tsx",
 			"stories": [
 				{
+					"id": "components-popover--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: bottom\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"bottom-start\" />\n                <Demo position=\"bottom\" />\n                <Demo position=\"bottom-end\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: top\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"top-start\" />\n                <Demo position=\"top\" />\n                <Demo position=\"top-end\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: start\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"start-top\" />\n                <Demo position=\"start\" />\n                <Demo position=\"start-bottom\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: end\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"end-top\" />\n                <Demo position=\"end\" />\n                <Demo position=\"end-bottom\" defaultActive />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "widthNumber",
+					"id": "components-popover--width-number",
+					"name": "width: px",
 					"snippet": "const widthNumber = () => <Demo width=\"400px\" defaultActive />;"
 				},
 				{
-					"name": "widthFull",
+					"id": "components-popover--width-full",
+					"name": "width: 100%",
 					"snippet": "const widthFull = () => <Demo width=\"100%\" defaultActive />;"
 				},
 				{
+					"id": "components-popover--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 0\">\n            <Demo padding={0} />\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <Demo padding={6} defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-popover--elevation",
 					"name": "elevation",
 					"snippet": "const elevation = () => (\n    <Example>\n        <Example.Item title=\"elevation: raised\">\n            <Demo elevation=\"raised\" defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-popover--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <Popover onOpen={fn()} onClose={fn()} defaultActive>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "active",
+					"id": "components-popover--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <Popover onOpen={fn()} onClose={fn()} active>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "components-popover--active-false",
+					"name": "active false, controlled",
 					"snippet": "const activeFalse = () => <Popover onOpen={fn()} onClose={fn()} active={false}>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "dismissible",
+					"id": "components-popover--dismissible",
+					"name": "dismissible, onClose, className, attributes, closeAriaLabel",
 					"snippet": "const dismissible = () => <Popover onClose={fn()} defaultActive>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>\n        <Popover.Dismissible\n            closeAriaLabel=\"Close\"\n            attributes={{ \"data-testid\": \"test-id\" }}\n            className=\"test-classname\">Content\n                            </Popover.Dismissible>\n    </Popover.Content>\n</Popover>;"
 				},
 				{
+					"id": "components-popover--auto-focus",
 					"name": "autoFocus",
 					"snippet": "const autoFocus = () => (\n    <Example>\n        <Example.Item title=\"autoFocus=false\">\n            <Demo autoFocus={false} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-popover--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Popover active>\n            <Popover.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </Popover.Trigger>\n            <Popover.Content className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n                Content\n            </Popover.Content>\n        </Popover>\n    </div>\n);"
 				},
 				{
-					"name": "testNested",
+					"id": "components-popover--test-nested",
+					"name": "test: nested",
 					"snippet": "const testNested = () => (\n    <Popover position=\"bottom\">\n        <Popover.Trigger>\n            {(attributes) => <Button attributes={attributes}>Open</Button>}\n        </Popover.Trigger>\n        <Popover.Content>\n            <View gap={2} align=\"start\">\n                Popover content\n                <Popover>\n                    <Popover.Trigger>\n                        {(attributes) => <Button attributes={attributes}>Open</Button>}\n                    </Popover.Trigger>\n                    <Popover.Content>Hello</Popover.Content>\n                </Popover>\n            </View>\n        </Popover.Content>\n    </Popover>\n);"
 				},
 				{
-					"name": "testWithTooltip",
+					"id": "components-popover--test-with-tooltip",
+					"name": "test: with tooltip",
 					"snippet": "const testWithTooltip = () => (\n    <View paddingTop={10}>\n        <Tooltip position=\"top\" text=\"Hello\">\n            {(tooltipAttributes) => (\n                <Popover position=\"bottom\">\n                    <Popover.Trigger>\n                        {(attributes) => (\n                            <Button\n                                attributes={{\n                                    ...attributes,\n                                    ...tooltipAttributes,\n                                }}\n                            >\n                                Open\n                            </Button>\n                        )}\n                    </Popover.Trigger>\n                    <Popover.Content>\n                        <View gap={2} align=\"start\">\n                            Popover content\n                            <Button onClick={() => {}}>Button</Button>\n                        </View>\n                    </Popover.Content>\n                </Popover>\n            )}\n        </Tooltip>\n    </View>\n);"
 				},
 				{
-					"name": "testContentEditable",
+					"id": "components-popover--test-content-editable",
+					"name": "test: contenteditable",
 					"snippet": "const testContentEditable = () => {\n    const [active, setActive] = useState(false);\n\n    return (\n        <Popover>\n            <Popover.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </Popover.Trigger>\n            <Popover.Content>\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={() => {}}>Hello</Button>\n                    </View.Item>\n\n                    <ScrollArea height=\"100px\">\n                        <div\n                            style={{ height: \"200px\" }}\n                            contentEditable\n                            tabIndex={0}\n                            onInput={(e) => {\n                                setActive(e.currentTarget.innerText.startsWith(\"@\"));\n                            }}\n                            onKeyDown={(e) => {\n                                console.log(e.key);\n                                if (e.key === \"Enter\" && active) {\n                                    e.preventDefault();\n                                    e.currentTarget.innerText = \"@hello\";\n                                    setActive(false);\n                                }\n                            }}\n                        />\n                    </ScrollArea>\n\n                    <Popover\n                        active={active}\n                        onClose={() => setActive(false)}\n                        originCoordinates={{ x: 300, y: 300 }}\n                        trapFocusMode=\"selection-menu\"\n                    >\n                        <Popover.Content>\n                            <View gap={4}>\n                                <MenuItem onClick={() => {}}>Action</MenuItem>\n                                <MenuItem onClick={() => {}}>Close</MenuItem>\n                            </View>\n                        </Popover.Content>\n                    </Popover>\n                </View>\n            </Popover.Content>\n        </Popover>\n    );\n};"
 				},
 				{
-					"name": "variant",
+					"id": "components-popover--variant",
+					"name": "variant [deprecated]",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: headless\">\n            <Popover variant=\"headless\" defaultActive position=\"bottom-start\">\n                <Popover.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </Popover.Trigger>\n                <Popover.Content>\n                    <View\n                        height=\"100px\"\n                        width=\"100px\"\n                        borderColor=\"primary\"\n                        borderRadius=\"medium\"\n                        backgroundColor=\"primary-faded\"\n                    />\n                </Popover.Content>\n            </Popover>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, MenuItem, Popover, ScrollArea, Tooltip, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Popover/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Popover",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Popover/Popover.tsx",
-				"actualName": "Popover",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Automatically focus the first focusable element in the content, when false the content container will be focused instead",
+						"name": "autoFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | TrapMode" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Content element padding, unit token multiplier",
+						"name": "padding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "@deprecated use Flyout utility instead, will be removed in v4",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"elevated\" | \"headless\"",
+							"value": [{ "value": "\"elevated\"" }, { "value": "\"headless\"" }]
+						}
+					}
+				},
+				"exportName": "Popover"
 			}
 		},
 		"components-progress": {
@@ -1258,38 +7210,177 @@
 			"path": "./src/components/Progress/tests/Progress.stories.tsx",
 			"stories": [
 				{
+					"id": "components-progress--value",
 					"name": "value",
 					"snippet": "const value = () => (\n    <Example>\n        <Example.Item title=\"value: 50\">\n            <Progress value={50} ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"value: 20, min: 0, max: 40\">\n            <Progress value={20} min={0} max={40} ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"value: 50, min: 0, max: 40\">\n            <Progress value={50} min={0} max={40} ariaLabel=\"rating value\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small, value: 50\">\n            <Progress value={50} size=\"small\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"size: medium, value: 50\">\n            <Progress value={50} size=\"medium\" ariaLabel=\"rating value\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: critical, value: 50\">\n            <Progress value={50} color=\"critical\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: warning, value: 50\">\n            <Progress value={50} color=\"warning\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive, value: 50\">\n            <Progress value={50} color=\"positive\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: media, value: 50\">\n            <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                <Progress value={50} color=\"media\" ariaLabel=\"rating value\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--duration",
 					"name": "duration",
 					"snippet": "const duration = () => {\n    const [active, setActive] = React.useState(false);\n\n    const handleChange = () => {\n        setActive((state) => !state);\n    };\n\n    return (\n        <Example>\n            <Example.Item title=\"duration: 2000\">\n                <View gap={3}>\n                    <View.Item>\n                        <Button onClick={handleChange}>Change</Button>\n                    </View.Item>\n\n                    <Progress value={active ? 100 : 0} duration={2000} ariaLabel=\"rating value\" />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "render",
+					"id": "components-progress--render",
+					"name": "rendering",
 					"snippet": "const render = () => <Progress value={75} min={50} max={100} ariaLabel=\"progress\" />;"
 				},
 				{
-					"name": "className",
+					"id": "components-progress--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Progress className=\"test-classname\" attributes={{ id: \"test-id\" }} ariaLabel=\"progress\" />\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, Progress, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Progress/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Progress",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Progress/Progress.tsx",
-				"actualName": "Progress",
+				"methods": [],
+				"props": {
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the progress bar controlling the size of the fill",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Lower value boundary of the progress bar",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Upper value boundary of the progress bar",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"warning\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"duration": {
+						"defaultValue": null,
+						"description": "Duration of the progress bar animation in milliseconds",
+						"name": "duration",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1299,30 +7390,135 @@
 			"path": "./src/components/ProgressIndicator/tests/ProgressIndicator.stories.tsx",
 			"stories": [
 				{
+					"id": "components-progressindicator--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const [activeIndex, setActiveIndex] = React.useState(0);\n    const total = 10;\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <View gap={4}>\n                    <View direction=\"row\" gap={2} align=\"center\">\n                        <Button\n                            onClick={() => {\n                                setActiveIndex((prev) => Math.max(0, prev - 1));\n                            }}\n                        >\n                            Previous\n                        </Button>\n                        <Button\n                            onClick={() => {\n                                setActiveIndex((prev) => Math.min(total - 1, prev + 1));\n                            }}\n                        >\n                            Next\n                        </Button>\n                        <Text weight=\"medium\">Index: {activeIndex}</Text>\n                    </View>\n\n                    <View borderRadius=\"medium\" overflow=\"hidden\" width=\"300px\">\n                        <Scrim\n                            position=\"bottom\"\n                            backgroundSlot={<View aspectRatio={16 / 9} backgroundColor=\"neutral-faded\" />}\n                        >\n                            <View align=\"center\">\n                                <ProgressIndicator total={total} activeIndex={activeIndex} color=\"media\" />\n                            </View>\n                        </Scrim>\n                    </View>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-progressindicator--color",
 					"name": "color",
 					"snippet": "const color = () => {\n    return (\n        <Example>\n            <Example.Item title=\"color: primary\">\n                <ProgressIndicator total={10} activeIndex={5} color=\"primary\" />\n            </Example.Item>\n            <Example.Item title=\"color: media\">\n                <View borderRadius=\"medium\" overflow=\"hidden\" width=\"300px\">\n                    <Scrim\n                        position=\"bottom\"\n                        backgroundSlot={<View aspectRatio={16 / 9} backgroundColor=\"neutral-faded\" />}\n                    >\n                        <View align=\"center\">\n                            <ProgressIndicator total={10} activeIndex={5} color=\"media\" />\n                        </View>\n                    </Scrim>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-progressindicator--aria-label",
 					"name": "ariaLabel",
 					"snippet": "const ariaLabel = () => <ProgressIndicator total={10} className=\"test-classname\" ariaLabel=\"Progress\" />;"
 				},
 				{
-					"name": "className",
+					"id": "components-progressindicator--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ProgressIndicator total={10} className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, ProgressIndicator, Scrim, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ProgressIndicator/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ProgressIndicator",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ProgressIndicator/ProgressIndicator.tsx",
-				"actualName": "ProgressIndicator",
+				"methods": [],
+				"props": {
+					"total": {
+						"defaultValue": null,
+						"description": "Total amount of progress indicator dots",
+						"name": "total",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "number" }
+					},
+					"activeIndex": {
+						"defaultValue": null,
+						"description": "Index of the active progress indicator dot",
+						"name": "activeIndex",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\"",
+							"value": [{ "value": "\"media\"" }, { "value": "\"primary\"" }]
+						}
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1332,50 +7528,203 @@
 			"path": "./src/components/Radio/tests/Radio.stories.tsx",
 			"stories": [
 				{
+					"id": "components-radio--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"small\" defaultChecked>\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"medium\">\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"large\">\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: responsive, s: small, m: large\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size={{ s: \"small\", m: \"large\" }}>\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-radio--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Radio name=\"error\" value=\"dog\" hasError>\n                Radio\n            </Radio>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-radio--render",
+					"name": "name, value",
 					"snippet": "const render = () => (\n    <Radio name=\"test-name\" value=\"test-value\">\n        Content\n    </Radio>\n);"
 				},
 				{
-					"name": "checked",
+					"id": "components-radio--checked",
+					"name": "checked, controlled",
 					"snippet": "const checked = () => <Radio name=\"test-name\" value=\"test-value\" checked onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "checkedFalse",
+					"id": "components-radio--checked-false",
+					"name": "checked false, controlled",
 					"snippet": "const checkedFalse = () => <Radio name=\"test-name\" value=\"test-value\" checked={false} onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-radio--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Radio name=\"test-name\" value=\"test-value\" defaultChecked onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "defaultCheckedFalse",
+					"id": "components-radio--default-checked-false",
+					"name": "defaultChecked false, uncontrolled",
 					"snippet": "const defaultCheckedFalse = () => <Radio name=\"test-name\" value=\"test-value\" onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
+					"id": "components-radio--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Radio name=\"test-name\" value=\"test-value\" disabled>\n        Content\n    </Radio>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-radio--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Radio className=\"test-classname\" attributes={{ id: \"test-id\" }} value=\"value\">\n            Content\n        </Radio>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Radio, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Radio/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Radio",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Radio/Radio.tsx",
-				"actualName": "Radio",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the form field from the form submission",
+						"name": "disabled",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Indicate that the form field has an error",
+						"name": "hasError",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element",
+						"name": "value",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the input is focused",
+						"name": "onFocus",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the input is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "",
+						"name": "checked",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultChecked",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1385,26 +7734,169 @@
 			"path": "./src/components/RadioGroup/tests/RadioGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "value",
+					"id": "components-radiogroup--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <RadioGroup name=\"test-name\" value=\"1\" onChange={fn()}>\n    {/* checked should be ignored */}\n    <Radio value=\"1\" checked={false}>Content\n                    </Radio>\n    <Radio value=\"2\">Content 2</Radio>\n</RadioGroup>;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-radiogroup--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <RadioGroup name=\"test-name\" defaultValue=\"1\" onChange={fn()}>\n    {/* checked should be ignored */}\n    <Radio value=\"1\" checked={false}>Content\n                    </Radio>\n    <Radio value=\"2\">Content 2</Radio>\n</RadioGroup>;"
 				},
 				{
+					"id": "components-radiogroup--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <RadioGroup name=\"test-name\" disabled>\n        <Radio value=\"test-value\">Content</Radio>\n    </RadioGroup>\n);"
 				}
 			],
 			"import": "import { Radio, RadioGroup } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/RadioGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "RadioGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/RadioGroup/RadioGroup.tsx",
-				"actualName": "RadioGroup",
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the radio group",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the form field from the form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Indicate that the form field has an error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the input element, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1414,39 +7906,131 @@
 			"path": "./src/components/Resizable/tests/Resizable.stories.tsx",
 			"stories": [
 				{
+					"id": "components-resizable--direction",
 					"name": "direction",
 					"snippet": "const direction = () => {\n    return (\n        <Example>\n            <Example.Item title=\"row\">\n                <Resizable height=\"200px\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n            <Example.Item title=\"column\">\n                <Resizable height=\"400px\" direction=\"column\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n\n            {/* Test that page doesn't scroll on dragging */}\n            <div style={{ height: 2000 }} />\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-resizable--children",
 					"name": "children",
 					"snippet": "const children = () => {\n    return (\n        <Example>\n            <Example.Item title=\"render props, row\">\n                <Resizable height=\"200px\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n            <Example.Item title=\"render props, column\">\n                <Resizable height=\"400px\" direction=\"column\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-resizable--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"bordered, row\">\n            <Resizable height=\"200px\" variant=\"bordered\">\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n            </Resizable>\n        </Example.Item>\n        <Example.Item title=\"bordered, column\">\n            <Resizable height=\"400px\" direction=\"column\" variant=\"bordered\">\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n            </Resizable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "components-resizable--size",
+					"name": "minSize, maxSize, defaultSize",
 					"snippet": "const size = () => (\n    <Resizable className=\"test-classname\" attributes={{ id: \"test-id\" }} height=\"200px\">\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n        <Resizable.Handle />\n        <Resizable.Item minSize=\"200px\" maxSize=\"500px\" defaultSize=\"300px\">\n            <Panel />\n        </Resizable.Item>\n    </Resizable>\n);"
 				},
 				{
-					"name": "layout",
+					"id": "components-resizable--layout",
+					"name": "height, gap",
 					"snippet": "const layout = () => (\n    <Resizable height=\"100px\" gap={8}>\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n        <Resizable.Handle />\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n    </Resizable>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-resizable--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Resizable className=\"test-classname\" attributes={{ id: \"test-id\" }} height=\"200px\">\n            <Resizable.Item>\n                <Panel />\n            </Resizable.Item>\n            <Resizable.Handle />\n            <Resizable.Item>\n                <Panel />\n            </Resizable.Item>\n        </Resizable>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, Resizable, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Resizable/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Resizable",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Resizable/Resizable.tsx",
-				"actualName": "Resizable",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Resizable/Resizable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"bordered\" | \"borderless\"",
+							"value": [{ "value": "\"bordered\"" }, { "value": "\"borderless\"" }]
+						}
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Component content direction with the resize handle rendered in between the chidlren",
+						"name": "direction",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Resizable/Resizable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between children, base unit token number multiplier",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					}
+				},
+				"exportName": "Resizable"
 			}
 		},
 		"components-scrim": {
@@ -1455,26 +8039,101 @@
 			"path": "./src/components/Scrim/tests/Scrim.stories.tsx",
 			"stories": [
 				{
+					"id": "components-scrim--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: center\">\n            <Scrim backgroundSlot={<Placeholder h={200} />}>Scrim</Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <Scrim position=\"bottom\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: top\">\n            <Scrim position=\"top\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: start\">\n            <Scrim position=\"start\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <Scrim position=\"end\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-scrim--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Scrim className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Scrim>\n    </div>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "components-scrim--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"without backgroundSlot, size is based on the parent component\">\n            <div style={{ height: 300, position: \"relative\" }}>\n                <Scrim>Text</Scrim>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Placeholder, Scrim } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Scrim/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Scrim",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Scrim/Scrim.tsx",
-				"actualName": "Scrim",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"backgroundSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting background content behind the scrim",
+						"name": "backgroundSlot",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Component content position",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"bottom\" | \"start\" | \"end\" | \"full\"",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"full\"" }
+							]
+						}
+					},
+					"scrimClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the scrim element",
+						"name": "scrimClassName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1484,79 +8143,398 @@
 			"path": "./src/components/Select/tests/Select.stories.tsx",
 			"stories": [
 				{
-					"name": "nativeRender",
+					"id": "components-select--native-render",
+					"name": "native rendering, options, name, id",
 					"snippet": "const nativeRender = () => (\n    <Example>\n        <Example.Item title=\"native with options prop\">\n            <Select\n                name=\"animal\"\n                id=\"animal-1\"\n                placeholder=\"Select an animal\"\n                options={[\n                    { label: \"Dog\", value: \"dog\" },\n                    { label: \"Turtle\", value: \"turtle\" },\n                ]}\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            />\n        </Example.Item>\n        <Example.Item title=\"native with option tags\">\n            <Select\n                name=\"animal\"\n                id=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "customRender",
+					"id": "components-select--custom-render",
+					"name": "custom rendering, name, id, option groups",
 					"snippet": "const customRender = () => (\n    <Example>\n        <Example.Item title=\"custom with options\">\n            <Select.Custom\n                name=\"animal\"\n                id=\"animal-1\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"native with option tags\">\n            <Select.Custom\n                name=\"animal-2\"\n                id=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Group label=\"Birds\">\n                    <Select.Option value=\"pigeon\">Pigeon</Select.Option>\n                    <Select.Option value=\"parrot\">Parrot</Select.Option>\n                </Select.Group>\n                <Select.Group label=\"Sea Mammals\">\n                    <Select.Option value=\"whale\">Whale</Select.Option>\n                    <Select.Option value=\"dolphin\">Dolphin</Select.Option>\n                </Select.Group>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "nativeHandlers",
+					"id": "components-select--native-handlers",
+					"name": "native, controlled, uncontrolled, onFocus, onBlur, onChange",
 					"snippet": "const nativeHandlers = () => <Example>\n    <Example.Item title=\"native, uncontrolled, onChange\">\n        <Select\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n    <Example.Item title=\"native, controlled, onChange\">\n        <Select\n            name=\"animal-2\"\n            placeholder=\"Select an animal\"\n            value=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n    <Example.Item title=\"native, onFocus, onBlur, onClick\">\n        <Select\n            name=\"animal-3\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onFocus={fn()}\n            onBlur={fn()}\n            onClick={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "customHandlers",
+					"id": "components-select--custom-handlers",
+					"name": "custom, controlled, uncontrolled, onFocus, onBlur, onChange",
 					"snippet": "const customHandlers = () => <Example>\n    <Example.Item title=\"custom, uncontrolled, onChange\">\n        <Select.Custom\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n    <Example.Item title=\"custom, controlled, onChange\">\n        <Select.Custom\n            name=\"animal-2\"\n            placeholder=\"Select an animal\"\n            value=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n    <Example.Item title=\"native, onFocus, onBlur, onClick\">\n        <Select.Custom\n            name=\"animal-3\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onFocus={fn()}\n            onBlur={fn()}\n            onClick={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "triggerOnly",
+					"id": "components-select--trigger-only",
+					"name": "trigger only, onClick",
 					"snippet": "const triggerOnly = (args) => {\n    const toggle = useToggle();\n    const [value, setValue] = React.useState(\"Dog\");\n\n    const handleClick: SelectProps[\"onClick\"] = (e) => {\n        args.handleClick(e);\n        toggle.toggle();\n    };\n\n    return (\n        <Example>\n            <Example.Item title=\"trigger only, onClick\">\n                <Select\n                    name=\"animal\"\n                    placeholder=\"Select an animal\"\n                    onClick={handleClick}\n                    value=\"dog\"\n                    inputAttributes={{\n                        \"aria-label\": \"Select an animal\",\n                    }}\n                >\n                    {value}\n                </Select>\n                <Modal\n                    active={toggle.active}\n                    onClose={toggle.deactivate}\n                    position=\"bottom\"\n                    padding={2}\n                    attributes={{ \"aria-label\": \"Select an animal\" }}\n                >\n                    <div role=\"listbox\" aria-label=\"Select an animal\">\n                        <MenuItem\n                            roundedCorners\n                            onClick={() => {\n                                setValue(\"Dog\");\n                                toggle.deactivate();\n                            }}\n                            attributes={{\n                                role: \"option\",\n                            }}\n                        >\n                            Dog\n                        </MenuItem>\n                        <MenuItem\n                            roundedCorners\n                            attributes={{\n                                role: \"option\",\n                            }}\n                            onClick={() => {\n                                setValue(\"Turtle\");\n                                toggle.deactivate();\n                            }}\n                        >\n                            Turtle\n                        </MenuItem>\n                    </div>\n                </Modal>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-select--multiple",
 					"name": "multiple",
 					"snippet": "const multiple = () => <Example>\n    <Example.Item title=\"multiple\">\n        <Select.Custom\n            multiple\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue={[\"dog\"]}\n            onChange={fn()}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-select--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded, native\">\n            <Select\n                variant=\"faded\"\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n\n        <Example.Item title=\"variant: faded, custom\">\n            <Select.Custom\n                variant=\"faded\"\n                name=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless, native\">\n            <Select\n                variant=\"headless\"\n                name=\"animal-3\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless, custom\">\n            <Select.Custom\n                variant=\"headless\"\n                name=\"animal-4\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <Select.Custom size=\"small\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <Select.Custom size=\"medium\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <Select.Custom size=\"large\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: xlarge\">\n            <Select.Custom size=\"xlarge\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "startSlot",
+					"id": "components-select--start-slot",
+					"name": "icon,startSlot",
 					"snippet": "const startSlot = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Select.Custom name=\"animal\" placeholder=\"Select an animal\" icon={IconZap}>\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n\n        <Example.Item title=\"startSlot\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                startSlot={<Placeholder h={20} />}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--render-value",
 					"name": "renderValue",
 					"snippet": "const renderValue = () => {\n    const options = [\n        {\n            value: \"1\",\n            label: \"Title 1\",\n            subtitle: \"Subtitle 1\",\n        },\n        {\n            value: \"2\",\n            label: \"Title 2\",\n            subtitle: \"Subtitle 2\",\n        },\n    ];\n\n    return (\n        <Example>\n            <Example.Item title=\"default renderer, single\">\n                <Select.Custom name=\"animal\" defaultValue=\"1\" placeholder=\"Nothing selected\">\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"default renderer, multiple\">\n                <Select.Custom name=\"animal\" defaultValue={[\"1\"]} multiple placeholder=\"Nothing selected\">\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"renderValue, single\">\n                <Select.Custom\n                    name=\"animal\"\n                    defaultValue=\"1\"\n                    placeholder=\"Nothing selected\"\n                    renderValue={(args) => <Badge>Title {args.value}</Badge>}\n                >\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"renderValue, multiple\">\n                <Select.Custom\n                    name=\"animal\"\n                    defaultValue={[\"1\"]}\n                    multiple\n                    placeholder=\"Nothing selected\"\n                    renderValue={(args) => <Badge>Titles {args.value.join(\", \")}</Badge>}\n                >\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-select--error",
 					"name": "error",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Select.Custom name=\"animal\" placeholder=\"Select an animal\" hasError>\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, native\">\n            <Select\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                disabled\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n        <Example.Item title=\"disabled, custom\">\n            <Select.Custom\n                name=\"animal-2\"\n                placeholder=\"Select an animal\"\n                disabled\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-select--class-name",
+					"name": "className, attributes, inputAttributes",
 					"snippet": "const className = () => (\n    <Example>\n        <Example.Item title=\"native, className, attributes, inputAttributes\">\n            <Select\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                className=\"native-class\"\n                attributes={{ id: \"test-id\" }}\n                inputAttributes={{ \"aria-label\": \"test-label\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n        <Example.Item title=\"custom, className, attributes, inputAttributes\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                className=\"custom-class\"\n                attributes={{ id: \"test-id\" }}\n                inputAttributes={{ \"aria-label\": \"test-label\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "fallback",
+					"id": "components-select--fallback",
+					"name": "test: fallbackAdjustLayout",
 					"snippet": "const fallback = () => (\n    <Example>\n        <Example.Item title=\"fallback\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                {[...Array(100)].map((_, index) => (\n                    <Select.Option key={index} value={`item-${index}`}>\n                        Item {index + 1}\n                    </Select.Option>\n                ))}\n            </Select.Custom>\n            <div style={{ height: \"1000px\" }}></div>\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                {[...Array(100)].map((_, index) => (\n                    <Select.Option key={index} value={`item-${index}`}>\n                        Item {index + 1}\n                    </Select.Option>\n                ))}\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-select--form-control",
+					"name": "test: with FormControl",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"FormControl\">\n            <FormControl hasError>\n                <FormControl.Label>Animal</FormControl.Label>\n                <Select.Custom name=\"animal\" placeholder=\"Select an animal\">\n                    <Select.Option value=\"dog\">Dog</Select.Option>\n                    <Select.Option value=\"turtle\">Turtle</Select.Option>\n                </Select.Custom>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "components-select--test-composition",
+					"name": "test: composition",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item title=\"custom with options\">\n            <Select.Custom\n                name=\"animal\"\n                id=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Group>\n                    <Select.Option value=\"dog\">Dog</Select.Option>\n                    <Select.Option value=\"turtle\">Turtle</Select.Option>\n                </Select.Group>\n                <Select.Group>Hello</Select.Group>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Badge, Example, FormControl, MenuItem, Modal, Placeholder, Select, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Select/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Select",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Select/Select.tsx",
-				"actualName": "Select",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the select user interaction and form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value selected",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon to display in the select start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the select value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when the trigger is clicked",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"options": {
+						"defaultValue": null,
+						"description": "@deprecated Use <option /> children instead",
+						"name": "options",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NativeOption[]" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the input is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLSelectElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the input is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLSelectElement, Element>) => void)" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"select\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"renderValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "renderValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "undefined" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLSelectElement>>" }
+					}
+				},
+				"exportName": "Select"
 			}
 		},
 		"components-skeleton": {
@@ -1565,26 +8543,87 @@
 			"path": "./src/components/Skeleton/tests/Skeleton.stories.tsx",
 			"stories": [
 				{
+					"id": "components-skeleton--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"text\">\n            <Skeleton />\n        </Example.Item>\n\n        <Example.Item title=\"view, rectangle\">\n            <Skeleton width=\"100px\" height=\"100px\" />\n        </Example.Item>\n\n        <Example.Item title=\"view, circle\">\n            <Skeleton width=\"100px\" height=\"100px\" borderRadius=\"circular\" />\n        </Example.Item>\n\n        <Example.Item title=\"view, rectangle, responsive\">\n            <Skeleton width={{ s: \"100px\", m: \"200px\" }} height={{ s: \"100px\", m: \"200px\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-skeleton--radius",
 					"name": "radius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius=small\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"small\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=medium\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"medium\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=large\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"large\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=circular\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"circular\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-skeleton--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Skeleton className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Skeleton } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Skeleton/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Skeleton",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Skeleton/Skeleton.tsx",
-				"actualName": "Skeleton",
+				"methods": [],
+				"props": {
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width style, literal string value or a base unit token number multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Radius>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Skeleton/Skeleton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Skeleton/Skeleton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1594,66 +8633,421 @@
 			"path": "./src/components/Slider/tests/Slider.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "components-slider--base",
+					"name": "name, minName, maxName, range",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"single, name\">\n            <Slider name=\"slider-single\" defaultValue={30} />\n        </Example.Item>\n        <Example.Item title=\"range, name\">\n            <Slider range name=\"slider-range\" defaultMinValue={30} defaultMaxValue={85} />\n        </Example.Item>\n        <Example.Item title=\"range, minName, maxName\">\n            <Slider\n                range\n                minName=\"slider-min\"\n                maxName=\"slider-max\"\n                defaultMinValue={30}\n                defaultMaxValue={85}\n            />\n        </Example.Item>\n        <div style={{ height: 2000 }} />\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--orientation",
 					"name": "orientation",
 					"snippet": "const orientation = () => (\n    <Example>\n        <Example.Item title=\"orientation: vertical\">\n            <View height=\"200px\">\n                <Slider\n                    range\n                    name=\"slider\"\n                    defaultMinValue={30}\n                    defaultMaxValue={85}\n                    orientation=\"vertical\"\n                />\n            </View>\n        </Example.Item>\n        <View height=\"2000px\" />\n    </Example>\n);"
 				},
 				{
-					"name": "minMax",
+					"id": "components-slider--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <Example>\n        <Example.Item title=\"min, max\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={60} />\n        </Example.Item>\n        <Example.Item title=\"min, max, value < min\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={30} />\n        </Example.Item>\n        <Example.Item title=\"min, max, value > max\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={80} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--step",
 					"name": "step",
 					"snippet": "const step = () => (\n    <Example>\n        <Example.Item title=\"step: 5\">\n            <Slider name=\"slider\" defaultValue={30} step={5} />\n        </Example.Item>\n\n        <Example.Item title=\"step: 5, defaultValue: 31, rounded down to 30\">\n            <Slider name=\"slider\" defaultValue={31} step={5} />\n        </Example.Item>\n\n        <Example.Item title=\"step: 0.01, float\">\n            <Slider name=\"slider\" defaultValue={30} step={0.01} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <Slider name=\"slider\" defaultValue={30} disabled />\n        </Example.Item>\n\n        <Example.Item title=\"disabled, range\">\n            <Slider name=\"slider\" range defaultMinValue={30} defaultMaxValue={80} disabled />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--render-value",
 					"name": "renderValue",
 					"snippet": "const renderValue = () => (\n    <Example>\n        <Example.Item title=\"renderValue: $\">\n            <Slider name=\"name\" defaultValue={50} renderValue={(args) => `$${args.value}`} />\n        </Example.Item>\n        <Example.Item title=\"renderValue: false\">\n            <Slider name=\"name\" defaultValue={50} renderValue={false} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-slider--default-value",
+					"name": "defaultValue, onChange, onChangeCommit",
 					"snippet": "const defaultValue = () => <View paddingTop={10}>\n    <Slider name=\"test-name\" defaultValue={50} onChange={fn()} onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "value",
+					"id": "components-slider--value",
+					"name": "value, onChange, onChangeCommit",
 					"snippet": "const value = () => <View paddingTop={10}>\n    <Slider name=\"test-name\" value={50} onChange={fn()} onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "rangeDefaultValue",
+					"id": "components-slider--range-default-value",
+					"name": "range, defaultValue, onChange, onChangeCommit",
 					"snippet": "const rangeDefaultValue = () => <View paddingTop={10}>\n    <Slider\n        range\n        name=\"test-name\"\n        defaultMinValue={50}\n        defaultMaxValue={70}\n        onChange={fn()}\n        onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "rangeValue",
+					"id": "components-slider--range-value",
+					"name": "range, value, onChange, onChangeCommit, minName, maxName",
 					"snippet": "const rangeValue = () => <View paddingTop={10}>\n    <Slider\n        range\n        minName=\"test-name-min\"\n        maxName=\"test-name-max\"\n        minValue={50}\n        maxValue={70}\n        onChange={fn()}\n        onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "className",
+					"id": "components-slider--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Slider name=\"name\" className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				},
 				{
-					"name": "testForm",
+					"id": "components-slider--test-form",
+					"name": "test: form onChange",
 					"snippet": "const testForm = (args) => {\n    const formRef = React.useRef<HTMLFormElement>(null);\n    const [data, setData] = React.useState<[string, FormDataEntryValue][]>([]);\n\n    const handleChange = (e: React.FormEvent<HTMLFormElement>) => {\n        const formData = new FormData(e.currentTarget);\n        const nextState = [...formData.entries()];\n\n        args.handleFormChange({ formData: nextState });\n        setData(nextState);\n    };\n\n    return (\n        <View paddingTop={10} gap={4}>\n            <form onChange={handleChange} ref={formRef}>\n                <Slider\n                    range\n                    minName=\"slider-min\"\n                    maxName=\"slider-max\"\n                    defaultMinValue={30}\n                    defaultMaxValue={50}\n                />\n            </form>\n\n            {data.map((v) => v.join(\": \")).join(\", \")}\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testSwipe",
+					"id": "components-slider--test-swipe",
+					"name": "test: prevents parent swipe",
 					"snippet": "const testSwipe = () => {\n    const toggle = useToggle(true);\n\n    return (\n        <Modal active={toggle.active} onClose={toggle.deactivate} position=\"end\">\n            <View gap={4}>\n                <Modal.Title>Modal</Modal.Title>\n                <Slider name=\"slider\" defaultValue={30} />\n            </View>\n        </Modal>\n    );\n};"
 				}
 			],
 			"import": "import { Example, Modal, Slider, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Slider/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Slider",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Slider/Slider.tsx",
-				"actualName": "Slider",
+				"methods": [],
+				"props": {
+					"step": {
+						"defaultValue": null,
+						"description": "Step of the slider",
+						"name": "step",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the slider user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum value of the slider",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum value of the slider",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"orientation": {
+						"defaultValue": null,
+						"description": "Orientation of the slider",
+						"name": "orientation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"vertical\" | \"horizontal\"",
+							"value": [{ "value": "\"vertical\"" }, { "value": "\"horizontal\"" }]
+						}
+					},
+					"renderValue": {
+						"defaultValue": null,
+						"description": "Render a custom value in the thumb tooltip",
+						"name": "renderValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | ((args: { value: number; }) => string)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the slider, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the slider, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"range": {
+						"defaultValue": null,
+						"description": "Enables range slider with two thumbs",
+						"name": "range",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the slider input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"minName": {
+						"defaultValue": null,
+						"description": "Name of the slider min value input element, overrides the name",
+						"name": "minName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"maxName": {
+						"defaultValue": null,
+						"description": "Name of the slider max value input element, overrides the name",
+						"name": "maxName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the slider value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: SingleChangeArgs) => void) | ((args: RangeChangeArgs) => void) | ((args: RangeChangeArgs) => void)"
+						}
+					},
+					"onChangeCommit": {
+						"defaultValue": null,
+						"description": "Callback when the user commits the change by releasing the thumb\nCallback when the user commits the change by releasing the thumbs",
+						"name": "onChangeCommit",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: SingleChangeArgs) => void) | ((args: RangeChangeArgs) => void) | ((args: RangeChangeArgs) => void)"
+						}
+					},
+					"minValue": {
+						"defaultValue": null,
+						"description": "Minimum value of the slider",
+						"name": "minValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"maxValue": {
+						"defaultValue": null,
+						"description": "Maximum value of the slider",
+						"name": "maxValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultMinValue": {
+						"defaultValue": null,
+						"description": "Default minimum value of the slider, enables uncontrolled mode",
+						"name": "defaultMinValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultMaxValue": {
+						"defaultValue": null,
+						"description": "Default maximum value of the slider, enables uncontrolled mode",
+						"name": "defaultMaxValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1663,35 +9057,137 @@
 			"path": "./src/components/Stepper/tests/Stepper.stories.tsx",
 			"stories": [
 				{
+					"id": "components-stepper--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example>\n        <Example.Item title=\"direction: row\">\n            <Stepper activeId=\"1\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <Stepper activeId=\"1\" direction=\"column\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-stepper--label-display",
 					"name": "labelDisplay",
 					"snippet": "const labelDisplay = () => (\n    <Example>\n        <Example.Item title=\"direction: row, labels hidden\">\n            <Stepper activeId=\"1\" labelDisplay=\"hidden\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: column, labels hiden\">\n            <Stepper activeId=\"1\" direction=\"column\" labelDisplay=\"hidden\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: row, labels hidden on s\">\n            <Stepper activeId=\"1\" labelDisplay={{ s: \"hidden\", m: \"inline\" }}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-stepper--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 6, direction: row\">\n            <Stepper activeId=\"1\" gap={6}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"gap: 6, direction: column\">\n            <Stepper activeId=\"1\" direction=\"column\" gap={6}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap\", \"[s] 2\", \"[m+] 5\"]}>\n            <Stepper activeId=\"1\" gap={{ s: 2, m: 5 }}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-stepper--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Stepper className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Stepper.Item attributes={{ id: \"test-item-id\" }} className=\"test-item-classname\" />\n        </Stepper>\n    </div>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-stepper--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"multiline subtitle\",\n                \"should wrap the text correctly\",\n                \"should display the connector correctly\",\n            ]}\n        >\n            <Demo\n                activeId={0}\n                subtitle=\"It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, Placeholder, Stepper, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Stepper/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Stepper",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Stepper/Stepper.tsx",
-				"actualName": "Stepper",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"activeId": {
+						"defaultValue": null,
+						"description": "Id of the item to display as active",
+						"name": "activeId",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string | number" }
+					},
+					"labelDisplay": {
+						"defaultValue": null,
+						"description": "Display variant for the item label",
+						"name": "labelDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"hidden\" | \"inline\">" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Direction of the stepper",
+						"name": "direction",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between items (default: 3)",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
+				"exportName": "Stepper"
 			}
 		},
 		"components-switch": {
@@ -1700,38 +9196,236 @@
 			"path": "./src/components/Switch/tests/Switch.stories.tsx",
 			"stories": [
 				{
-					"name": "size",
+					"id": "components-switch--size",
+					"name": "Size",
 					"snippet": "const size = () => (\n\t<Example>\n\t\t<Example.Item title=\"size: medium\">\n\t\t\t<Switch name=\"active\" size=\"medium\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: small\">\n\t\t\t<Switch name=\"active\" size=\"small\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: large\">\n\t\t\t<Switch name=\"active\" size=\"large\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: responsive, s: small, m: large\">\n\t\t\t<Switch\n\t\t\t\tname=\"active\"\n\t\t\t\tsize={{ s: \"small\", m: \"large\" }}\n\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t/>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "label",
+					"id": "components-switch--label",
+					"name": "Label",
 					"snippet": "const label = () => (\n\t<Example>\n\t\t<Example.Item title=\"size: medium\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch reversed name=\"active\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: small\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" size=\"small\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch\n\t\t\t\t\treversed\n\t\t\t\t\tname=\"active\"\n\t\t\t\t\tsize=\"small\"\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t\t>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\n\t\t<Example.Item title=\"size: large\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" size=\"large\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch\n\t\t\t\t\treversed\n\t\t\t\t\tname=\"active\"\n\t\t\t\t\tsize=\"large\"\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t\t>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-switch--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Switch name=\"test-name\" defaultChecked onChange={fn()}>Label\n            </Switch>;"
 				},
 				{
-					"name": "checked",
+					"id": "components-switch--checked",
+					"name": "checked, uncontrolled",
 					"snippet": "const checked = () => <Switch name=\"test-name\" checked onChange={fn()}>Label\n            </Switch>;"
 				},
 				{
+					"id": "components-switch--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, unselected\">\n            <Switch name=\"active\" disabled inputAttributes={{ \"aria-label\": \"test switch\" }} />\n        </Example.Item>\n        <Example.Item title=\"disabled, selected\">\n            <Switch\n                name=\"active\"\n                disabled\n                defaultChecked\n                inputAttributes={{ \"aria-label\": \"test switch\" }}\n            />\n        </Example.Item>\n        <Example.Item title=\"disabled, with label\">\n            <Switch name=\"active\" disabled>\n                Switch\n            </Switch>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-switch--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Switch\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ \"aria-label\": \"test select\", id: \"test-input-id\" }}\n            name=\"name\"\n        >\n            Label\n        </Switch>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Switch, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Switch/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Switch",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Switch/Switch.tsx",
-				"actualName": "Switch",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the switch",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the switch input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the switch user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"reversed": {
+						"defaultValue": null,
+						"description": "Reverse the children position",
+						"name": "reversed",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the switch value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the switch is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the switch is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default value of the switch, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Value of the switch, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1741,51 +9435,112 @@
 			"path": "./src/components/Table/tests/Table.stories.tsx",
 			"stories": [
 				{
-					"name": "layout",
+					"id": "components-table--layout",
+					"name": "base",
 					"snippet": "const layout = () => (\n    <Example>\n        <Example.Item title=\"base\">\n            <Table>\n                <Table.Head>\n                    <Table.Row>\n                        <Table.Heading>Column 1</Table.Heading>\n                        <Table.Heading>Column 2</Table.Heading>\n                    </Table.Row>\n                </Table.Head>\n                <Table.Body>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell>Cell 2</Table.Cell>\n                    </Table.Row>\n                </Table.Body>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"colspan: 2 for col 2, rowspan: 2 for cell 3\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading colSpan={2}>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                    <Table.Cell rowSpan={2}>Cell 3</Table.Cell>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"align: center for heading 1, align: end for heading 2\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading align=\"center\">Column 1</Table.Heading>\n                    <Table.Heading align=\"end\">Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"valign: center for cell 2, valign: end for cell 3\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>\n                        <View height={15} backgroundColor=\"neutral-faded\" />\n                    </Table.Cell>\n                    <Table.Cell verticalAlign=\"center\">Cell 2</Table.Cell>\n                    <Table.Cell verticalAlign=\"end\">Cell 3</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"width: 40%, minWidth: 200px for col 1\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"40%\" minWidth=\"200px\">\n                        Column 1\n                    </Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-table--border",
 					"name": "border",
 					"snippet": "const border = () => (\n    <Example>\n        <Example.Item title=\"border: true\">\n            <Table border>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"columnBorder: true\">\n            <Table columnBorder>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"columnBorder: true, border: true\">\n            <Table columnBorder border>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-table--rows",
 					"name": "rows",
 					"snippet": "const rows = () => (\n    <Example>\n        <Example.Item title=\"highlighted for row 2\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row highlighted>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"clickable row 2, focus ring\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row onClick={() => {}}>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-table--render",
+					"name": "rendering",
 					"snippet": "const render = () => (\n    <Table>\n        <Table.Head>\n            <Table.Row>\n                <Table.Heading>Heading</Table.Heading>\n                <Table.Heading>Heading</Table.Heading>\n            </Table.Row>\n        </Table.Head>\n        <Table.Body>\n            <Table.Row>\n                <Table.Cell>Content</Table.Cell>\n                <Table.Cell>Content</Table.Cell>\n            </Table.Row>\n        </Table.Body>\n    </Table>\n);"
 				},
 				{
-					"name": "tbody",
+					"id": "components-table--tbody",
+					"name": "tbody rendering",
 					"snippet": "const tbody = () => (\n    <Table>\n        <Table.Row>\n            <Table.Heading>Heading</Table.Heading>\n            <Table.Heading>Heading</Table.Heading>\n        </Table.Row>\n    </Table>\n);"
 				},
 				{
-					"name": "tabIndex",
+					"id": "components-table--tab-index",
+					"name": "adds tabIndex for clickable rows",
 					"snippet": "const tabIndex = () => (\n    <Table>\n        <Table.Row>\n            <Table.Cell />\n        </Table.Row>\n        <Table.Row onClick={() => {}}>\n            <Table.Cell />\n        </Table.Row>\n        <Table.Row attributes={{ onClick: () => {} }}>\n            <Table.Cell />\n        </Table.Row>\n    </Table>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-table--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Table className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Table.Row attributes={{ id: \"test-row-id\" }}>\n                <Table.Cell attributes={{ id: \"test-cell-id\" }}></Table.Cell>\n            </Table.Row>\n        </Table>\n    </div>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-table--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"scroll fade\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"500px\">Column 1</Table.Heading>\n                    <Table.Heading width=\"500px\">Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"card with highlighted heading\">\n            <Card elevated padding={0}>\n                <Table>\n                    <Table.Row highlighted>\n                        <Table.Heading width=\"50%\" minWidth=\"200px\">\n                            Column 1\n                        </Table.Heading>\n                        <Table.Heading colSpan={2} align=\"end\">\n                            Column 2\n                        </Table.Heading>\n                    </Table.Row>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell align=\"center\">Cell 2</Table.Cell>\n                        <Table.Cell align=\"end\">Cell 3</Table.Cell>\n                    </Table.Row>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell align=\"center\">Cell 2</Table.Cell>\n                        <Table.Cell align=\"end\">Cell 3</Table.Cell>\n                    </Table.Row>\n                </Table>\n            </Card>\n        </Example.Item>\n        <Example.Item title=\"width: auto, nowrap\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"50%\">Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                    <Table.Heading>Column 3</Table.Heading>\n                    <Table.Heading width=\"auto\">Long heading title</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                    <Table.Cell>Cell 3</Table.Cell>\n                    <Table.Cell>Cell 4</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "examples",
+					"id": "components-table--examples",
+					"name": "test: selectable",
 					"snippet": "const examples = () => (\n    <Example>\n        <Example.Item title=\"selectable\">\n            <SelectionDemo />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Card, Checkbox, Example, Table, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Table/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Table",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Table/Table.tsx",
-				"actualName": "Table",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"border": {
+						"defaultValue": null,
+						"description": "Add border around the table",
+						"name": "border",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"columnBorder": {
+						"defaultValue": null,
+						"description": "Add border between the table columns",
+						"name": "columnBorder",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
+				"exportName": "Table"
 			}
 		},
 		"components-tabs": {
@@ -1794,71 +9549,196 @@
 			"path": "./src/components/Tabs/tests/Tabs.stories.tsx",
 			"stories": [
 				{
+					"id": "components-tabs--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Tabs>\n        <Tabs.List>\n            <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n            <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n        </Tabs.List>\n\n        <Tabs.Panel value=\"1\">\n            <View padding={4}>Content 1</View>\n        </Tabs.Panel>\n        <Tabs.Panel value=\"2\">\n            <View padding={4}>Content 2</View>\n        </Tabs.Panel>\n    </Tabs>\n);"
 				},
 				{
+					"id": "components-tabs--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Tabs defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills\">\n            <Tabs variant=\"pills\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills-elevated\">\n            <Tabs variant=\"pills-elevated\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: borderless\">\n            <Tabs variant=\"borderless\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"variant: default, size: large\">\n            <Tabs size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills, size: large\">\n            <Tabs variant=\"pills\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills-elevated, size: large\">\n            <Tabs variant=\"pills-elevated\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: borderless, size: large\">\n            <Tabs variant=\"borderless\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example>\n        <Example.Item title=\"direction: column, variant: underline\">\n            <Tabs direction=\"column\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: pills\">\n            <Tabs direction=\"column\" variant=\"pills\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: pills-elevated\">\n            <Tabs direction=\"column\" variant=\"pills-elevated\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: borderless\">\n            <Tabs direction=\"column\" variant=\"borderless\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Tabs>\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"1\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"icon only\">\n            <Tabs variant=\"pills-elevated\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap} attributes={{ \"aria-label\": \"Tab 1\" }} />\n                    <Tabs.Item value=\"1\" icon={IconZap} attributes={{ \"aria-label\": \"Tab 2\" }} />\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "equalWidth",
+					"id": "components-tabs--equal-width",
+					"name": "itemWidth",
 					"snippet": "const equalWidth = () => (\n    <Example>\n        <Example.Item title=\"equal width items\">\n            <Tabs onChange={console.log} itemWidth=\"equal\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"1\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                    <Tabs.Item value=\"2\" icon={IconZap}>\n                        Very long item 3\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--href",
 					"name": "href",
 					"snippet": "const href = () => (\n    <Example>\n        <Example.Item title=\"href, no onChange\">\n            <Tabs value=\"2\">\n                <Tabs.List>\n                    <Tabs.Item value=\"1\" href=\"#item-1\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"2\" href=\"#item-2\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                    <Tabs.Item value=\"3\" href=\"#item-3\" icon={IconZap}>\n                        Very long item 3\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "disabled",
+					"id": "components-tabs--disabled",
+					"name": "item, disabled",
 					"snippet": "const disabled = () => {\n    return (\n        <Example>\n            <Example.Item title=\"disabled\">\n                <Tabs defaultValue=\"1\">\n                    <Tabs.List>\n                        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"2\" disabled icon={IconZap}>\n                            Item 2\n                        </Tabs.Item>\n                        <Tabs.Item value=\"3\">Item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"1\">\n                        <View padding={4}>Content 1</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <View padding={4}>Content 2</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"3\">\n                        <View padding={4}>Content 3</View>\n                    </Tabs.Panel>\n                </Tabs>\n            </Example.Item>\n\n            <Example.Item title=\"disabled, href\">\n                <Tabs defaultValue=\"1\">\n                    <Tabs.List>\n                        <Tabs.Item href=\"#item1\" value=\"1\">\n                            Item 1\n                        </Tabs.Item>\n                        <Tabs.Item href=\"#item2\" value=\"2\" disabled icon={IconZap}>\n                            Item 2\n                        </Tabs.Item>\n                        <Tabs.Item href=\"#item3\" value=\"3\">\n                            Item 3\n                        </Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"1\">\n                        <View padding={4}>Content 1</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <View padding={4}>Content 2</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"3\">\n                        <View padding={4}>Content 3</View>\n                    </Tabs.Panel>\n                </Tabs>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-tabs--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <Tabs defaultValue=\"2\" onChange={fn()}>\n    <Tabs.List>\n        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n        <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n    </Tabs.List>\n    <Tabs.Panel value=\"1\">Content 1</Tabs.Panel>\n    <Tabs.Panel value=\"2\">Content 2</Tabs.Panel>\n</Tabs>;"
 				},
 				{
-					"name": "value",
+					"id": "components-tabs--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <Tabs value=\"2\" onChange={fn()}>\n    <Tabs.List>\n        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n        <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n    </Tabs.List>\n    <Tabs.Panel value=\"1\">Content 1</Tabs.Panel>\n    <Tabs.Panel value=\"2\">Content 2</Tabs.Panel>\n</Tabs>;"
 				},
 				{
-					"name": "className",
+					"id": "components-tabs--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Tabs>\n            <Tabs.List attributes={{ id: \"test-list-id\" }} className=\"test-list-classname\">\n                <Tabs.Item attributes={{ id: \"test-item-id\" }} value=\"1\">\n                    Item\n                </Tabs.Item>\n            </Tabs.List>\n\n            <Tabs.Panel\n                attributes={{ \"data-testid\": \"test-panel-id\" }}\n                className=\"test-panel-classname\"\n                value=\"1\"\n            />\n        </Tabs>\n    </div>\n);"
 				},
 				{
-					"name": "testFocusableContent",
+					"id": "components-tabs--test-focusable-content",
+					"name": "test: focusable content",
 					"snippet": "const testFocusableContent = () => (\n    <Example>\n        <Example.Item title=\"panels without focusable content\">\n            <Tabs>\n                <View gap={4}>\n                    <Tabs.List>\n                        <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                        <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"0\">Tab 1</Tabs.Panel>\n                    <Tabs.Panel value=\"1\">Tab 2</Tabs.Panel>\n                    <Tabs.Panel value=\"2\">Tab 3</Tabs.Panel>\n                </View>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"panels with focusable content\">\n            <Tabs>\n                <View gap={4}>\n                    <Tabs.List>\n                        <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                        <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"0\">\n                        <Button onClick={() => {}}>Tab 1 action</Button>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"1\">\n                        <Button onClick={() => {}}>Tab 2 action</Button>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <Button onClick={() => {}}>Tab 3 action</Button>\n                    </Tabs.Panel>\n                </View>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "components-tabs--test-composition",
+					"name": "test: composition",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item title=\"Viewport overflow\">\n            <Tabs>\n                <Tabs.List>\n                    {[...Array(8)].map((_, i) => (\n                        <Tabs.Item value={`${i}`} key={i} icon={IconZap}>\n                            Very long item {i}\n                        </Tabs.Item>\n                    ))}\n                </Tabs.List>\n\n                {[...Array(8)].map((_, i) => (\n                    <Tabs.Panel value={`${i}`} key={i}>\n                        Tab {i}\n                    </Tabs.Panel>\n                ))}\n            </Tabs>\n        </Example.Item>\n        <Example.Item>\n            <Tabs onChange={console.log} variant=\"pills-elevated\" name=\"hey\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">\n                        <View borderColor=\"neutral-faded\" padding={5}>\n                            Item 3\n                        </View>\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"Custom non-interactive list children\">\n            <Tabs direction=\"column\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <View height={6} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testEdgeCaseDom",
+					"id": "components-tabs--test-edge-case-dom",
+					"name": "test: scroll subscription",
 					"snippet": "const testEdgeCaseDom = () => {\n    const [activeItem, setActiveItem] = React.useState(\"1\");\n    const sectionsRef = React.useRef(null);\n\n    return (\n        <Example>\n            <Example.Item title=\"active item changes on scroll\">\n                <View justify=\"center\" align=\"center\" padding={10}>\n                    <View width={60} gap={2}>\n                        <Tabs value={activeItem} onChange={(args) => setActiveItem(args.value)}>\n                            <Tabs.List>\n                                <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                                <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n                                <Tabs.Item value=\"3\">Item 3</Tabs.Item>\n                                <Tabs.Item value=\"4\">Item 4</Tabs.Item>\n                            </Tabs.List>\n                        </Tabs>\n\n                        <ScrollArea\n                            attributes={{ ref: sectionsRef }}\n                            height={70}\n                            onScroll={(args) => {\n                                setActiveItem(Math.min(4, Math.floor(args.y * 10) + 1).toString());\n                            }}\n                        >\n                            <View gap={4}>\n                                <View gap={2}>\n                                    <Text>Section 1</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View grow height=\"100px\" backgroundColor=\"neutral-faded\" key={i} />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 2</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 3</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 4</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n                            </View>\n                        </ScrollArea>\n                    </View>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Example, ScrollArea, Tabs, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Tabs/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Tabs",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Tabs/Tabs.tsx",
-				"actualName": "Tabs",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Direction of the tab buttons",
+						"name": "direction",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"itemWidth": {
+						"defaultValue": null,
+						"description": "Equal width for the tab buttons",
+						"name": "itemWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"equal\"", "value": [{ "value": "\"equal\"" }] }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Render variant for component",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"bordered\" | \"borderless\" | \"pills\" | \"pills-elevated\"",
+							"value": [
+								{ "value": "\"bordered\"" },
+								{ "value": "\"borderless\"" },
+								{ "value": "\"pills\"" },
+								{ "value": "\"pills-elevated\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"large\" | \"medium\"",
+							"value": [{ "value": "\"large\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the tab buttons group when used as a form control",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the active tab value changes",
+						"name": "onChange",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((args: { value: string; name?: string; }) => void)" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the active tab, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the active tab, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "Tabs"
 			}
 		},
 		"components-textarea": {
@@ -1867,71 +9747,315 @@
 			"path": "./src/components/TextArea/tests/TextArea.stories.tsx",
 			"stories": [
 				{
-					"name": "variants",
+					"id": "components-textarea--variants",
+					"name": "variant",
 					"snippet": "const variants = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <TextArea variant=\"faded\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless\">\n            <TextArea variant=\"headless\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: medium\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"medium\" />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"large\" />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"xlarge\" />\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] large\", \"[m+] medium\"]}>\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size={{ s: \"xlarge\", m: \"medium\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--resize",
 					"name": "resize",
 					"snippet": "const resize = () => (\n    <Example>\n        <Example.Item title=\"resize: none\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" resize=\"none\" />\n        </Example.Item>\n        <Example.Item title=\"resize: auto\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" resize=\"auto\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-textarea--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" hasError />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner\">\n            <View gap={2}>\n                <Text variant=\"featured-2\">What problem are you trying to solve?</Text>\n                <TextArea.Aligner>\n                    <TextArea\n                        variant=\"headless\"\n                        placeholder=\"Try something like 'I have a job'\"\n                        name=\"description\"\n                    />\n                </TextArea.Aligner>\n                <View.Item>\n                    <Button>Next</Button>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-textarea--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"long value without breaks\">\n            <TextArea\n                name=\"hey\"\n                defaultValue={`<div style=\"position:relative;width:100%;padding-top:calc(150% + 72px)\">\n<iframe src=\"nskjdfdsdkjfsjkdfhbsjlhdfbsjlhfbs;jhbsdljfhsbljhfsbljhfbsjlfdhbsljhfbsdljhfbsljhfbslufbhsdlfds\" />\n</div>`}\n                resize=\"auto\"\n                placeholder=\"Placeholder\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-textarea--render",
+					"name": "base",
 					"snippet": "const render = () => <TextArea name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-textarea--placeholder",
 					"name": "placeholder",
 					"snippet": "const placeholder = () => (\n    <TextArea\n        name=\"test-name\"\n        placeholder=\"Placeholder\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-textarea--id",
 					"name": "id",
 					"snippet": "const id = () => (\n    <TextArea name=\"test-name\" id=\"test-id\" inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
+					"id": "components-textarea--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <TextArea name=\"test-name\" disabled inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-textarea--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <TextArea\n    name=\"test-name\"\n    defaultValue=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-textarea--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <TextArea\n    name=\"test-name\"\n    value=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-textarea--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <TextArea\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-textarea--form-control",
+					"name": "test: form control",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"with helper\">\n            <FormControl>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextArea name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n        <Example.Item title=\"with error\">\n            <FormControl hasError>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextArea name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, FormControl, Text, TextArea, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/TextArea/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "TextArea",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/TextArea/TextArea.tsx",
-				"actualName": "TextArea",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text area",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text area input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text area user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text area value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLTextAreaElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text area is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLTextAreaElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text area is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLTextAreaElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"textarea\">" }
+					},
+					"resize": {
+						"defaultValue": null,
+						"description": "Enable or disable the text area resizing, supports auto-sizing",
+						"name": "resize",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"none\" | \"auto\"",
+							"value": [{ "value": "\"none\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "TextArea"
 			}
 		},
 		"components-textfield": {
@@ -1940,71 +10064,445 @@
 			"path": "./src/components/TextField/tests/TextField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-textfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <TextField variant=\"faded\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless\">\n            <TextField variant=\"headless\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded\">\n            <TextField\n                rounded\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                icon={IconZap}\n                prefix=\"+31\"\n                endSlot={<Button rounded size=\"small\" icon={IconZap} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"rounded, variant: faded\">\n            <View direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <TextField\n                        rounded\n                        variant=\"faded\"\n                        name=\"Name\"\n                        placeholder=\"Enter your name\"\n                        startSlot={\n                            <Badge rounded size=\"small\">\n                                Hello\n                            </Badge>\n                        }\n                    />\n                </View.Item>\n                <Button rounded>Submit</Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-textfield--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" hasError />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "attachments",
+					"id": "components-textfield--attachments",
+					"name": "icon, endIcon, suffix, prefix, startSlot, endSlot, startSlotPadding, endSlotPadding",
 					"snippet": "const attachments = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" value=\"Reshaped\" icon={IconZap} />\n        </Example.Item>\n        <Example.Item title=\"endIcon\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" value=\"Reshaped\" endIcon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title={[\"startSlot\", \"vertical and horizontal padding aligned\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title={[\"endSlot\", \"vertical and horizontal padding aligned\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                endSlot={\n                    <Button\n                        icon={IconZap}\n                        size=\"small\"\n                        onClick={() => {}}\n                        attributes={{ \"aria-label\": \"Action\" }}\n                    />\n                }\n            />\n        </Example.Item>\n\n        <Example.Item title=\"paddingSlotStart=4, paddingSlotEnd=2\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlotPadding={4}\n                endSlotPadding={2}\n                startSlot={<Placeholder h={20} />}\n                endSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"with all affixes\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                endIcon={IconZap}\n                icon={IconZap}\n                prefix=\"Estimated value\"\n                suffix=\"m2\"\n                startSlot={<Placeholder h={20} />}\n                endSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"multiline wrap\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlot={[...Array(10).keys()].map((i) => (\n                    <Badge size=\"small\" key={i}>\n                        Item {i + 1}\n                    </Badge>\n                ))}\n                multiline\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"small\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"medium\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"large\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"xlarge\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] xlarge\", \"[m+] medium\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                size={{ s: \"xlarge\", m: \"medium\" }}\n                icon={IconZap}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner\">\n            <View gap={2}>\n                <Text variant=\"featured-2\">What problem are you trying to solve?</Text>\n                <TextField.Aligner>\n                    <TextField\n                        variant=\"headless\"\n                        placeholder=\"Try something like 'I have a job'\"\n                        name=\"description\"\n                    />\n                </TextField.Aligner>\n                <View.Item>\n                    <Button>Next</Button>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-textfield--render",
+					"name": "base",
 					"snippet": "const render = () => <TextField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-textfield--placeholder",
 					"name": "placeholder",
 					"snippet": "const placeholder = () => (\n    <TextField\n        name=\"test-name\"\n        placeholder=\"Placeholder\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-textfield--id",
 					"name": "id",
 					"snippet": "const id = () => (\n    <TextField name=\"test-name\" id=\"test-id\" inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
+					"id": "components-textfield--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <TextField name=\"test-name\" disabled inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-textfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <TextField\n    name=\"test-name\"\n    defaultValue=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-textfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <TextField\n    name=\"test-name\"\n    value=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-textfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <TextField\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-textfield--form-control",
+					"name": "test: form control",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"with helper\">\n            <FormControl>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextField name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n        <Example.Item title=\"with error\">\n            <FormControl hasError>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextField name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Badge, Button, Example, FormControl, Placeholder, Text, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/TextField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "TextField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/TextField/TextField.tsx",
-				"actualName": "TextField",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"multiline": {
+						"defaultValue": null,
+						"description": "Enable multiline text field wrapping",
+						"name": "multiline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to be fully rounded",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content after the text field value",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text field value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the text field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the text field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "TextField"
 			}
 		},
 		"components-timeline": {
@@ -2013,27 +10511,71 @@
 			"path": "./src/components/Timeline/tests/Timeline.stories.tsx",
 			"stories": [
 				{
+					"id": "components-timeline--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"children passed directly\">\n            <Timeline>\n                <Placeholder />\n                <Placeholder />\n                <Placeholder />\n            </Timeline>\n        </Example.Item>\n        <Example.Item title=\"children wrapped with Timeline.Item\">\n            <Timeline>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "marker",
+					"id": "components-timeline--marker",
+					"name": "markerSlot",
 					"snippet": "const marker = () => (\n    <Example>\n        <Example.Item title=\"slot\">\n            <Timeline>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n\n        <Example.Item title=\"null marker\">\n            <Timeline>\n                <Timeline.Item markerSlot={null}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={null}>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-timeline--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Timeline className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Timeline.Item className=\"test-item-classname\" attributes={{ id: \"test-item-id\" }}>\n                Content\n            </Timeline.Item>\n            <Timeline.Item>Content</Timeline.Item>\n        </Timeline>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Placeholder, Timeline } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Timeline/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Timeline",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Timeline/Timeline.tsx",
-				"actualName": "Timeline",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"ul\">" }
+					}
+				},
+				"exportName": "Timeline"
 			}
 		},
 		"components-toast": {
@@ -2041,32 +10583,54 @@
 			"name": "Toast",
 			"path": "./src/components/Toast/tests/Toast.stories.tsx",
 			"stories": [
-				{ "name": "size", "snippet": "const size = () => <Size />;" },
 				{
+					"id": "components-toast--size",
+					"name": "size",
+					"snippet": "const size = () => <Size />;"
+				},
+				{
+					"id": "components-toast--position",
 					"name": "position",
 					"snippet": "const position = () => <Position />;"
 				},
-				{ "name": "color", "snippet": "const color = () => <Color />;" },
-				{ "name": "timeout", "snippet": "const timeout = () => <Timeout />;" },
 				{
-					"name": "regionOptions",
+					"id": "components-toast--color",
+					"name": "color",
+					"snippet": "const color = () => <Color />;"
+				},
+				{
+					"id": "components-toast--timeout",
+					"name": "timeout",
+					"snippet": "const timeout = () => <Timeout />;"
+				},
+				{
+					"id": "components-toast--region-options",
+					"name": "expanded",
 					"snippet": "const regionOptions = () => <Expanded />;"
 				},
-				{ "name": "slots", "snippet": "const slots = () => <Slots />;" },
 				{
+					"id": "components-toast--slots",
+					"name": "slots",
+					"snippet": "const slots = () => <Slots />;"
+				},
+				{
+					"id": "components-toast--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const toast = useToast();\n\n    return (\n        <Button\n            onClick={() => {\n                const id = toast.show({\n                    title: \"Title\",\n                    text: \"Text\",\n                    children: \"Children\",\n                    startSlot: \"Slot\",\n                    actionsSlot: (\n                        <Button attributes={{ \"data-testid\": \"trigger-id\" }} onClick={() => toast.hide(id)}>\n                            Trigger\n                        </Button>\n                    ),\n                });\n            }}\n        >\n            Show toast\n        </Button>\n    );\n};"
 				},
 				{
-					"name": "nested",
+					"id": "components-toast--nested",
+					"name": "ToastProvider",
 					"snippet": "const nested = () => {\n    return (\n        <div data-testid=\"test-container-id\">\n            <ToastProvider>\n                <NestedDemo />\n            </ToastProvider>\n        </div>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-toast--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => {\n    const toast = useToast();\n\n    return (\n        <Button\n            onClick={() => {\n                const id = toast.show({\n                    text: \"Content\",\n                    attributes: { \"data-testid\": \"test-id\" },\n                    className: \"test-classname\",\n                });\n            }}\n        >\n            Show toast\n        </Button>\n    );\n};"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-toast--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"Multiline, should support dynamic height\">\n            <Multiline />\n        </Example.Item>\n        <Example.Item title=\"Nested ToastProvider\">\n            <ToastProvider>\n                <Nested />\n            </ToastProvider>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
@@ -2083,30 +10647,601 @@
 			"path": "./src/components/ToggleButton/tests/ToggleButton.stories.tsx",
 			"stories": [
 				{
+					"id": "components-togglebutton--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"outline\">\n            <ToggleButton>Button</ToggleButton>\n        </Example.Item>\n        <Example.Item title=\"ghost\">\n            <ToggleButton variant=\"ghost\">Button</ToggleButton>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-togglebutton--selected-color",
 					"name": "selectedColor",
 					"snippet": "const selectedColor = () => (\n    <Example>\n        <Example.Item title=\"selectedColor: primary\">\n            <ToggleButton selectedColor=\"primary\" defaultChecked>\n                Button\n            </ToggleButton>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onChange",
+					"id": "components-togglebutton--on-change",
+					"name": "checked, defaultChecked, onChange",
 					"snippet": "const onChange = () => <Example>\n    <Example.Item title=\"defaultChecked, onChange\">\n        <ToggleButton defaultChecked onChange={fn()} value=\"1\">Button\n                                </ToggleButton>\n    </Example.Item>\n    <Example.Item title=\"checked, onChange\">\n        <ToggleButton checked onChange={fn()} value=\"2\">Button\n                                </ToggleButton>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-togglebutton--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <ToggleButton onClick={fn()}>Button</ToggleButton>;"
 				}
 			],
 			"import": "import { Example, ToggleButton } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ToggleButton/ToggleButton.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "ToggleButton",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ToggleButton/ToggleButton.tsx",
-				"actualName": "ToggleButton",
+				"methods": [],
+				"props": {
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loading": {
+						"defaultValue": null,
+						"description": "Show loading state",
+						"name": "loading",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loadingAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the loading indicator",
+						"name": "loadingAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Make the component take the full width of the parent element",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"ghost\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"ghost\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"selectedColor": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme when selected",
+						"name": "selectedColor",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the toggle button, enables controlled mode for the ToggleButtonGroup",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the toggle button value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { checked: boolean; value: string; event: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>; }) => void)"
+						}
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default value of the toggle button, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Value of the toggle button, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2116,34 +11251,194 @@
 			"path": "./src/components/ToggleButtonGroup/tests/ToggleButtonGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "single",
+					"id": "components-togglebuttongroup--single",
+					"name": "checked, defaultChecked, onChange",
 					"snippet": "const single = () => <Example>\n    <Example.Item title=\"single, uncontrolled, onChange\">\n        <ToggleButtonGroup onChange={fn()}>\n            <ToggleButton value=\"1\" onChange={fn()}>Button\n                                    </ToggleButton>\n            <ToggleButton value=\"2\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n    <Example.Item title=\"single, controlled, onChange\">\n        <ToggleButtonGroup onChange={fn()} value={[]}>\n            <ToggleButton value=\"3\" onChange={fn()}>Button\n                                    </ToggleButton>\n            <ToggleButton value=\"4\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "multiple",
+					"id": "components-togglebuttongroup--multiple",
+					"name": "selectionMode, checked, defaultChecked, onChange",
 					"snippet": "const multiple = () => <Example>\n    <Example.Item title=\"multiple, uncontrolled, onChange\">\n        <ToggleButtonGroup onChange={fn()} selectionMode=\"multiple\">\n            <ToggleButton value=\"1\">Button</ToggleButton>\n            <ToggleButton value=\"2\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n    <Example.Item title=\"multiple, controlled, onChange\">\n        <ToggleButtonGroup onChange={fn()} value={[]} selectionMode=\"multiple\">\n            <ToggleButton value=\"3\">Button</ToggleButton>\n            <ToggleButton value=\"4\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "selectedColor",
+					"id": "components-togglebuttongroup--selected-color",
+					"name": "color,selectedColor",
 					"snippet": "const selectedColor = () => (\n    <Example>\n        <Example.Item title=\"selectedColor: primary\">\n            <ToggleButtonGroup selectedColor=\"primary\" defaultValue={[\"2\"]}>\n                <ToggleButton value=\"1\">Button</ToggleButton>\n                <ToggleButton value=\"2\">Button</ToggleButton>\n                <ToggleButton value=\"3\">Button</ToggleButton>\n            </ToggleButtonGroup>\n        </Example.Item>\n        <Example.Item title=\"color: primary, selectedColor: critical\">\n            <ToggleButtonGroup color=\"primary\" selectedColor=\"critical\" defaultValue={[\"2\"]}>\n                <ToggleButton value=\"1\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n                <ToggleButton value=\"2\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n                <ToggleButton value=\"3\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n            </ToggleButtonGroup>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-togglebuttongroup--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ToggleButtonGroup className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <ToggleButton>Button 1</ToggleButton>\n            <ToggleButton>Button 1</ToggleButton>\n        </ToggleButtonGroup>\n    </div>\n);"
 				},
 				{
-					"name": "testIcon",
+					"id": "components-togglebuttongroup--test-icon",
+					"name": "test: icon only",
 					"snippet": "const testIcon = () => (\n    <Example>\n        <Example.Item title=\"icon only\">\n            <ToggleButtonGroup selectedColor=\"primary\">\n                <ToggleButton value=\"1\" icon={IconPlus} />\n                <ToggleButton value=\"2\" icon={IconMinus} />\n                <ToggleButton value=\"3\" icon={IconCheckmark} />\n            </ToggleButtonGroup>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, ToggleButton, ToggleButtonGroup } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ToggleButtonGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ToggleButtonGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx",
-				"actualName": "ToggleButtonGroup",
+				"methods": [],
+				"props": {
+					"selectionMode": {
+						"defaultValue": { "value": "\"single\"" },
+						"description": "Selection mode for the toggle button group",
+						"name": "selectionMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"single\" | \"multiple\"",
+							"value": [{ "value": "\"single\"" }, { "value": "\"multiple\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme applied to each button",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"selectedColor": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme for the selected button",
+						"name": "selectedColor",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the toggle button group value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { value: string[]; event: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>; }) => void)"
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting child Button components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Selected values in the group, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default selected values in the group, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2153,30 +11448,269 @@
 			"path": "./src/components/Tooltip/tests/Tooltip.stories.tsx",
 			"stories": [
 				{
+					"id": "components-tooltip--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: bottom-start\">\n            <View direction=\"row\" gap={2}>\n                <Demo position=\"bottom-start\" text=\"Tooltip 1\" />\n                <Demo position=\"bottom-start\" text=\"Tooltip 2\" />\n                <Demo position=\"bottom-start\" text=\"Tooltip 3\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: bottom\">\n            <Demo position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"position: bottom-end\">\n            <Demo position=\"bottom-end\" />\n        </Example.Item>\n        <Example.Item title=\"position: top-start\">\n            <Demo position=\"top-start\" />\n        </Example.Item>\n        <Example.Item title=\"position: top\">\n            <Demo position=\"top\" />\n        </Example.Item>\n        <Example.Item title=\"position: top-end\">\n            <Demo position=\"top-end\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: start\">\n            <View align=\"end\">\n                <Demo position=\"start\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: start-top\">\n            <View align=\"end\">\n                <Demo position=\"start-top\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: start-bottom\">\n            <View align=\"end\">\n                <Demo position=\"start-bottom\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <Demo position=\"end\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: end-top\">\n            <Demo position=\"end-top\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: end-bottom\">\n            <Demo position=\"end-bottom\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tooltip--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: inverted\">\n            <Demo color=\"inverted\" position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"color: dark\">\n            <Demo color=\"dark\" position=\"bottom\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-tooltip--default-active",
+					"name": "uncontrolled",
 					"snippet": "const defaultActive = () => <Tooltip text=\"Content\" onOpen={fn()} onClose={fn()}>\n    {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n</Tooltip>;"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-tooltip--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"responsive visibility\">\n            <DemoResponsive text=\"Responsive\" />\n        </Example.Item>\n\n        <Example.Item title=\"without text\">\n            <Tooltip>{() => <Button>Button</Button>}</Tooltip>\n        </Example.Item>\n\n        <Example.Item title=\"tooltip with popover\">\n            <Tooltip text=\"Tooltip\" position=\"top\">\n                {(attributes) => (\n                    <Popover position=\"bottom\">\n                        <Popover.Trigger>\n                            {(popoverAttributes) => (\n                                <Button attributes={{ ...attributes, ...popoverAttributes }}>Action</Button>\n                            )}\n                        </Popover.Trigger>\n                        <Popover.Content>Popover</Popover.Content>\n                    </Popover>\n                )}\n            </Tooltip>\n        </Example.Item>\n\n        <Example.Item title=\"nested popovers inside a tooltip\">\n            <View direction=\"row\" gap={2}>\n                <Tooltip position=\"top\" text=\"Hello\">\n                    {(tooltipAttributes) => (\n                        <Popover position=\"bottom\" width=\"300px\">\n                            <Popover.Trigger>\n                                {(attributes) => (\n                                    <Button attributes={{ ...tooltipAttributes, ...attributes }}>\n                                        Tooltip with popover\n                                    </Button>\n                                )}\n                            </Popover.Trigger>\n                            <Popover.Content>\n                                <View gap={2} align=\"center\" direction=\"row\" justify=\"space-between\">\n                                    Popover content\n                                    <Popover position=\"bottom\" width=\"300px\">\n                                        <Popover.Trigger>\n                                            {(attributes) => <Button attributes={attributes}>Open</Button>}\n                                        </Popover.Trigger>\n                                        <Popover.Content>\n                                            <Popover.Dismissible align=\"center\" closeAriaLabel=\"Close\">\n                                                Another popover content\n                                            </Popover.Dismissible>\n                                        </Popover.Content>\n                                    </Popover>\n                                </View>\n                            </Popover.Content>\n                        </Popover>\n                    )}\n                </Tooltip>\n                <Tooltip position=\"top\" text=\"Hello\">\n                    {(tooltipAttributes) => <Button attributes={tooltipAttributes}>Just a tooltip</Button>}\n                </Tooltip>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, Popover, Tooltip, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Tooltip/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Tooltip",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Tooltip/Tooltip.tsx",
-				"actualName": "Tooltip",
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the flyout content interactivity",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"contentAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the content element",
+						"name": "contentAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"contentClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the content element",
+						"name": "contentClassName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "(attributes: TriggerAttributes) => ReactNode" }
+					},
+					"text": {
+						"defaultValue": null,
+						"description": "Text content for the tooltip",
+						"name": "text",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"inverted\"" },
+						"description": "Color of the tooltip",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"dark\" | \"inverted\"",
+							"value": [{ "value": "\"dark\"" }, { "value": "\"inverted\"" }]
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2186,51 +11720,191 @@
 			"path": "./src/components/Accordion/tests/Accordion.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-accordion--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Accordion defaultActive>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--icon-size",
 					"name": "iconSize",
 					"snippet": "const iconSize = () => (\n    <Accordion iconSize={6}>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--icon-position",
 					"name": "iconPosition",
 					"snippet": "const iconPosition = () => (\n    <Accordion iconPosition=\"start\">\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Accordion defaultActive gap={4}>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <Placeholder />\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--on-toggle",
 					"name": "onToggle",
 					"snippet": "const onToggle = () => <Accordion onToggle={fn()}>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
+					"id": "utility-components-accordion--active",
 					"name": "active",
 					"snippet": "const active = () => <Accordion onToggle={fn()} active>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
+					"id": "utility-components-accordion--default-active",
 					"name": "defaultActive",
 					"snippet": "const defaultActive = () => <Accordion onToggle={fn()} defaultActive>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
-					"name": "renderProps",
+					"id": "utility-components-accordion--render-props",
+					"name": "children: render props",
 					"snippet": "const renderProps = () => <Accordion onToggle={fn()}>\n    <Accordion.Trigger>\n        {(attributes, { active }) => (\n            <Button attributes={{ ...attributes, \"data-active\": active }}>Trigger</Button>\n        )}\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-accordion--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Accordion className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Accordion.Trigger>\n                <Placeholder>Trigger</Placeholder>\n            </Accordion.Trigger>\n            <Accordion.Content>\n                <View paddingTop={2}>\n                    <Placeholder />\n                </View>\n            </Accordion.Content>\n        </Accordion>\n    </div>\n);"
 				}
 			],
 			"import": "import { Accordion, Button, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Accordion/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Accordion",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Accordion/Accordion.tsx",
-				"actualName": "Accordion",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"iconSize": {
+						"defaultValue": null,
+						"description": "Expand / collapse icon size in units",
+						"name": "iconSize",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"iconPosition": {
+						"defaultValue": null,
+						"description": "Position of the expand / collapse icon",
+						"name": "iconPosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"start\" | \"end\"",
+							"value": [{ "value": "\"start\"" }, { "value": "\"end\"" }]
+						}
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between the trigger and the content",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the trigger and the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onToggle": {
+						"defaultValue": null,
+						"description": "Callback when the accordion is expanded or collapsed",
+						"name": "onToggle",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((active: boolean) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control whether the accordion is expanded or collapsed, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control whether the accordion is expanded or collapsed by default, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Accordion"
 			}
 		},
 		"utility-components-actionable": {
@@ -2239,54 +11913,456 @@
 			"path": "./src/components/Actionable/tests/Actionable.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "utility-components-actionable--base",
+					"name": "href, onClick",
 					"snippet": "const base = () => <Example>\n    <Example.Item title=\"span\">\n        <Actionable>Span</Actionable>\n    </Example.Item>\n    <Example.Item title=\"onClick\">\n        <Actionable onClick={fn()}>Button</Actionable>\n    </Example.Item>\n    <Example.Item title=\"href\">\n        <Actionable href=\"https://reshaped.so\" attributes={{ target: \"_blank\" }}>Link\n                            </Actionable>\n    </Example.Item>\n    <Example.Item title=\"attributes.href\">\n        <Actionable attributes={{ href: \"https://reshaped.so\" }}>Link with attributes</Actionable>\n    </Example.Item>\n    <Example.Item title=\"href, onClick\">\n        <Actionable\n            onClick={(e) => {\n                e.preventDefault();\n                args.handleSecondClick(e);\n            }}\n            href=\"https://reshaped.so\">Link with onClick\n                            </Actionable>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "utility-components-actionable--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, button\">\n            <Actionable disabled onClick={() => {}}>\n                Button\n            </Actionable>\n        </Example.Item>\n        <Example.Item title=\"disabled, link\">\n            <Actionable disabled href=\"https://reshaped.so\">\n                Link\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--full-width",
 					"name": "fullWidth",
 					"snippet": "const fullWidth = () => (\n    <Example>\n        <Example.Item title=\"fullWidth\">\n            <Actionable fullWidth href=\"https://reshaped.so\">\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--inset-focus",
 					"name": "insetFocus",
 					"snippet": "const insetFocus = () => (\n    <Example>\n        <Example.Item title=\"insetFocus\">\n            <Actionable insetFocus onClick={() => {}}>\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--disable-focus-ring",
 					"name": "disableFocusRing",
 					"snippet": "const disableFocusRing = () => (\n    <Example>\n        <Example.Item title=\"disableFocusRing\">\n            <Actionable disableFocusRing onClick={() => {}}>\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--border-radius",
 					"name": "borderRadius",
 					"snippet": "const borderRadius = () => (\n    <Example>\n        <Example.Item title=\"borderRadius: inherit\">\n            <Actionable borderRadius=\"inherit\" onClick={() => {}}>\n                <View borderRadius=\"large\">Actionable</View>\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--type",
 					"name": "type",
 					"snippet": "const type = (args) => (\n    <Example>\n        <Example.Item title=\"type: submit\">\n            <form\n                onSubmit={(e) => {\n                    e.preventDefault();\n                    args.handleSubmit();\n                }}\n            >\n                <Actionable onClick={() => {}} type=\"submit\">\n                    Submit\n                </Actionable>\n            </form>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "as",
+					"id": "utility-components-actionable--as",
+					"name": "as, render",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"as: span\">\n            <Actionable onClick={() => {}} as=\"span\">\n                Trigger\n            </Actionable>\n        </Example.Item>\n        <Example.Item title=\"render, disabled\">\n            <Actionable disabled onClick={() => {}} render={(props) => <section {...props} />}>\n                Trigger\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--stop-propagation",
 					"name": "stopPropagation",
 					"snippet": "const stopPropagation = () => <div onClick={fn()}>\n    <Actionable stopPropagation onClick={() => {}}>Trigger\n                    </Actionable>\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-actionable--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Actionable className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Actionable>\n    </div>\n);"
 				}
 			],
 			"import": "import { Actionable, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Actionable/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Actionable",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Actionable/Actionable.tsx",
-				"actualName": "Actionable",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"touchHitbox": {
+						"defaultValue": null,
+						"description": "Enable a minimum required touch hitbox",
+						"name": "touchHitbox",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Take up the full width of its parent",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"insetFocus": {
+						"defaultValue": null,
+						"description": "Enable a focus ring inside the element bounds",
+						"name": "insetFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableFocusRing": {
+						"defaultValue": null,
+						"description": "Don't show a focus ring on focus, can be used when it is within a container with a focus ring",
+						"name": "disableFocusRing",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Apply the focus ring to the child and rely on its border radius",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"inherit\"", "value": [{ "value": "\"inherit\"" }] }
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2296,30 +12372,149 @@
 			"path": "./src/components/Container/tests/Container.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-container--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: default\">\n            <Container>\n                <Placeholder />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"padding: 0\">\n            <Container padding={0}>\n                <Placeholder />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "utility-components-container--size",
+					"name": "width, height, maxHeight",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"width: 200px, height: 200px\">\n            <Container width=\"200px\" height=\"200px\">\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width: 200px, height: 200px, maxHeight: 100px\">\n            <Container width=\"200px\" height=\"200px\" maxHeight=\"100px\">\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width, height: [s] 100px, [m+] 200px\">\n            <Container width={{ s: \"100px\", m: \"200px\" }} height={{ s: \"100px\", m: \"200px\" }}>\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width, height: [s] 100px, [m+] 200px, maxHeight: [s] 50px, [m+]: 100px\">\n            <Container\n                width={{ s: \"100px\", m: \"200px\" }}\n                height={{ s: \"100px\", m: \"200px\" }}\n                maxHeight={{ s: \"50px\", m: \"100px\" }}\n            >\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "flex",
+					"id": "utility-components-container--flex",
+					"name": "align, justify",
 					"snippet": "const flex = () => (\n    <Example>\n        <Example.Item title=\"align: center, justify: center\">\n            <Container align=\"center\" justify=\"center\" height=\"200px\">\n                <Placeholder />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-container--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Container className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </Container>\n    </div>\n);"
 				}
 			],
 			"import": "import { Container, Example, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Container/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Container",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Container/Container.tsx",
-				"actualName": "Container",
+				"methods": [],
+				"props": {
+					"align": {
+						"defaultValue": null,
+						"description": "Flex align-items for the content",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Flex justify-content for the content",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier\nComponent height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" },
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height style, literal string value or a base unit token number multiplier\nComponent max height, literal css value or unit token multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" },
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Component inline padding",
+						"name": "padding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Component width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2329,34 +12524,157 @@
 			"path": "./src/components/Dismissible/tests/Dismissible.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-dismissible--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Dismissible closeAriaLabel=\"Close banner\" onClose={() => {}}>\n                <Placeholder />\n            </Dismissible>\n        </Example.Item>\n        <Example.Item title=\"variant: media\">\n            <View width=\"300px\">\n                <Dismissible variant=\"media\" closeAriaLabel=\"Close banner\" onClose={() => {}}>\n                    <View aspectRatio={16 / 9}>\n                        <Image\n                            height=\"100%\"\n                            src=\"https://images.unsplash.com/photo-1607030529528-ca6923e27f77?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1867&q=80)\"\n                        />\n                    </View>\n                </Dismissible>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-dismissible--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: center\">\n            <Dismissible align=\"center\" closeAriaLabel=\"Close\" onClose={() => {}}>\n                <Placeholder />\n            </Dismissible>\n        </Example.Item>\n\n        <Example.Item title=\"align: center, variant: media\">\n            <Dismissible align=\"center\" closeAriaLabel=\"Close\" variant=\"media\" onClose={() => {}}>\n                <View aspectRatio={16 / 9}>\n                    <Image\n                        height=\"100%\"\n                        src=\"https://images.unsplash.com/photo-1607030529528-ca6923e27f77?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1867&q=80)\"\n                    />\n                </View>\n            </Dismissible>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-dismissible--hide-close-button",
 					"name": "hideCloseButton",
 					"snippet": "const hideCloseButton = () => (\n    <Example>\n        <Example.Item title=\"hide close button\">\n            <div id=\"root\">\n                <Dismissible hideCloseButton>\n                    <Placeholder />\n                </Dismissible>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "closeAriaLabel",
+					"id": "utility-components-dismissible--close-aria-label",
+					"name": "onClose, closeAriaLabel",
 					"snippet": "const closeAriaLabel = () => <Dismissible closeAriaLabel=\"Close\" onClose={fn()}>\n    <Placeholder />\n</Dismissible>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-dismissible--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Dismissible\n            closeAriaLabel=\"Close\"\n            onClose={() => {}}\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n        >\n            <Placeholder />\n        </Dismissible>\n    </div>\n);"
 				}
 			],
 			"import": "import { Dismissible, Example, Image, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Dismissible/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Dismissible",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Dismissible/Dismissible.tsx",
-				"actualName": "Dismissible",
+				"methods": [],
+				"props": {
+					"hideCloseButton": {
+						"defaultValue": null,
+						"description": "Hide the close button\nShow the close button",
+						"name": "hideCloseButton",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"closeAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the close button",
+						"name": "closeAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"media\"", "value": [{ "value": "\"media\"" }] }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Close button alignment",
+						"name": "align",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"center\"",
+							"value": [{ "value": "\"top\"" }, { "value": "\"center\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is dismissed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2366,135 +12684,577 @@
 			"path": "./src/components/Flyout/tests/Flyout.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-flyout--position",
 					"name": "position",
 					"snippet": "const position = () => {\n    return (\n        <View gap={4} padding={50} align=\"center\" justify=\"center\" height=\"100vh\" width=\"120%\">\n            <View gap={4} direction=\"row\">\n                <Demo position=\"top-start\" defaultActive />\n                <Demo position=\"top\" />\n                <Demo position=\"top-end\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"end-top\" />\n                <Demo position=\"end\" />\n                <Demo position=\"end-bottom\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"start-top\" />\n                <Demo position=\"start\" />\n                <Demo position=\"start-bottom\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"bottom-start\" />\n                <Demo position=\"bottom\" />\n                <Demo position=\"bottom-end\" />\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "defaultActive",
+					"id": "utility-components-flyout--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <Flyout onOpen={fn()} onClose={fn()} defaultActive>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "active",
+					"id": "utility-components-flyout--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <Flyout onOpen={fn()} onClose={fn()} active>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "utility-components-flyout--active-false",
+					"name": "active: false, controlled",
 					"snippet": "const activeFalse = () => <Flyout onOpen={fn()} onClose={fn()} active={false}>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "modes",
+					"id": "utility-components-flyout--modes",
+					"name": "triggerType, trapFocusMode",
 					"snippet": "const modes = () => {\n    return (\n        <Example>\n            <Example.Item title=\"triggerType: click\">\n                <View direction=\"row\" gap={4}>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"dialog\" text=\"dialog\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"action-menu\" text=\"action-menu\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"action-bar\" text=\"action-bar\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"content-menu\" text=\"content-menu\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode={false} text=\"false\">\n                        {modeContent}\n                    </Demo>\n                </View>\n            </Example.Item>\n\n            <Example.Item title=\"triggerType: hover\">\n                <View direction=\"row\" gap={4}>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"dialog\" triggerType=\"hover\" text=\"dialog\">\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"action-menu\"\n                        triggerType=\"hover\"\n                        text=\"action-menu\"\n                    >\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"action-bar\"\n                        triggerType=\"hover\"\n                        text=\"action-bar\"\n                    >\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"content-menu\"\n                        triggerType=\"hover\"\n                        text=\"content-menu\"\n                    >\n                        {modeContent}\n                    </Demo>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "positionFallbacks",
+					"id": "utility-components-flyout--position-fallbacks",
+					"name": "fallbackPositions",
 					"snippet": "const positionFallbacks = () => {\n    return (\n        <Example>\n            <Example.Item title=\"position: top, default fallbacks\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" />\n                </View>\n            </Example.Item>\n            <Example.Item title=\"position: top, fallbackPositions: [start]\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" fallbackPositions={[\"start\"]} contentHeight={200} defaultActive />\n                </View>\n            </Example.Item>\n            <Example.Item title=\"position: top, fallbackPositions: false\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" fallbackPositions={false} contentHeight={400} />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--fallback-adjust-layout",
 					"name": "fallbackAdjustLayout",
 					"snippet": "const fallbackAdjustLayout = () => {\n    return (\n        <Demo\n            contentHeight={false}\n            position=\"bottom-start\"\n            width=\"200px\"\n            fallbackAdjustLayout\n            defaultActive\n        >\n            <div style={{ height: \"600px\" }}>Content</div>\n        </Demo>\n    );\n};"
 				},
 				{
-					"name": "fallbackAdjustLayoutShift",
+					"id": "utility-components-flyout--fallback-adjust-layout-shift",
+					"name": "fallbackAdjustLayout, shift",
 					"snippet": "const fallbackAdjustLayoutShift = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={10}>\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    attributes={{ ref: containerRef }}\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls containerRef={containerRef} />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <FallbackAdjustLayoutControls />\n            <div style={{ height: \"100vh\", width: \"250%\" }} />\n        </View>\n    );\n};"
 				},
 				{
-					"name": "fallbackAdjustLayoutSize",
+					"id": "utility-components-flyout--fallback-adjust-layout-size",
+					"name": "fallbackAdjustLayout, size",
 					"snippet": "const fallbackAdjustLayoutSize = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={10}>\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls large />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    attributes={{ ref: containerRef }}\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls containerRef={containerRef} large />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <FallbackAdjustLayoutControls large />\n            <div style={{ height: \"100vh\", width: \"250%\" }} />\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--origin-coordinates",
 					"name": "originCoordinates",
 					"snippet": "const originCoordinates = () => {\n    return (\n        <View gap={4} direction=\"row\">\n            <Demo position=\"bottom-start\" originCoordinates={{ x: 150, y: 150 }} defaultActive />\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--width",
 					"name": "width",
 					"snippet": "const width = () => (\n    <Example>\n        <Example.Item title=\"width: 300px\">\n            <Demo width=\"300px\" position=\"bottom\" />\n        </Example.Item>\n\n        <Example.Item title=\"width: trigger\">\n            <Demo width=\"trigger\" contentWidth={false} defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-flyout--content-gap",
 					"name": "contentGap",
 					"snippet": "const contentGap = () => <Demo contentGap={10} defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--content-shift",
 					"name": "contentShift",
 					"snippet": "const contentShift = () => <Demo contentShift={10} defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-content-hover",
 					"name": "disableContentHover",
 					"snippet": "const disableContentHover = () => <Demo triggerType=\"hover\" disableContentHover />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-close-on-outside-click",
 					"name": "disableCloseOnOutsideClick",
 					"snippet": "const disableCloseOnOutsideClick = () => <Demo disableCloseOnOutsideClick />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-hide-animation",
 					"name": "disableHideAnimation",
 					"snippet": "const disableHideAnimation = () => <Demo disableHideAnimation defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Flyout disabled>\n        <Flyout.Trigger>\n            {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n        </Flyout.Trigger>\n        <Flyout.Content>\n            <Content />\n        </Flyout.Content>\n    </Flyout>\n);"
 				},
 				{
+					"id": "utility-components-flyout--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const portalRef = React.useRef<HTMLDivElement>(null);\n    const portalRef2 = React.useRef<HTMLDivElement>(null);\n    const portalRef3 = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={4} direction=\"row\">\n            <View\n                grow\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef, \"data-testid\": \"container\" }}\n                justify=\"end\"\n                align=\"start\"\n                padding={4}\n            >\n                <Demo containerRef={portalRef} position=\"bottom-start\" defaultActive />\n            </View>\n            <View\n                grow\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef2 }}\n                justify=\"start\"\n                align=\"end\"\n                padding={4}\n            >\n                <Demo containerRef={portalRef2} position=\"top-end\" />\n            </View>\n            <View\n                width={50}\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef3 }}\n                padding={4}\n                overflow=\"auto\"\n            >\n                <View height={120} width=\"120%\" justify=\"center\" align=\"center\">\n                    <Demo containerRef={portalRef3} position=\"bottom-end\" />\n                </View>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--initial-focus-ref",
 					"name": "initialFocusRef",
 					"snippet": "const initialFocusRef = () => {\n    const initialFocusRef = React.useRef<HTMLInputElement>(null);\n\n    return (\n        <Demo initialFocusRef={initialFocusRef}>\n            <View gap={4}>\n                <Button onClick={() => {}}>Action 1</Button>\n                <TextField name=\"foo\" inputAttributes={{ ref: initialFocusRef }} />\n            </View>\n        </Demo>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--instance-ref",
 					"name": "instanceRef",
 					"snippet": "const instanceRef = () => {\n    const flyoutRef = React.useRef<FlyoutInstance>(null);\n\n    return (\n        <View direction=\"row\" gap={4}>\n            <Demo\n                instanceRef={flyoutRef}\n                disableCloseOnOutsideClick\n                onOpen={fn()}\n                onClose={fn()} />\n            <Button onClick={() => flyoutRef.current?.open()}>Open</Button>\n            <Button onClick={() => flyoutRef.current?.close()}>Close</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "contentAttributes",
+					"id": "utility-components-flyout--content-attributes",
+					"name": "content: className, attributes",
 					"snippet": "const contentAttributes = () => {\n    return (\n        <Flyout position=\"bottom\" defaultActive>\n            <Flyout.Trigger>\n                {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n            </Flyout.Trigger>\n            <Flyout.Content attributes={{ \"data-testid\": \"test-id\" }} className=\"test-classname\">\n                <Content />\n            </Flyout.Content>\n        </Flyout>\n    );\n};"
 				},
 				{
-					"name": "testShadowDom",
+					"id": "utility-components-flyout--test-shadow-dom",
+					"name": "test: shadow dom",
 					"snippet": "const testShadowDom = () => <custom-element-flyout />;"
 				},
 				{
-					"name": "testInsideFixed",
+					"id": "utility-components-flyout--test-inside-fixed",
+					"name": "test: inside position fixed",
 					"snippet": "const testInsideFixed = () => (\n    <React.Fragment>\n        <View\n            position=\"fixed\"\n            insetBottom={2}\n            insetStart={2}\n            insetEnd={2}\n            backgroundColor=\"elevation-overlay\"\n            borderColor=\"neutral-faded\"\n            borderRadius=\"small\"\n            padding={4}\n            zIndex={10}\n            attributes={{ \"data-testid\": \"container\" }}\n            height={20}\n        >\n            <Demo defaultActive position=\"top-start\" />\n        </View>\n        <View paddingTop={18} gap={4}>\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n        </View>\n    </React.Fragment>\n);"
 				},
 				{
-					"name": "testInsideSticky",
+					"id": "utility-components-flyout--test-inside-sticky",
+					"name": "test: inside position sticky",
 					"snippet": "const testInsideSticky = () => (\n    <React.Fragment>\n        <View\n            position=\"sticky\"\n            insetTop={4}\n            insetStart={0}\n            insetEnd={0}\n            backgroundColor=\"elevation-overlay\"\n            borderColor=\"neutral-faded\"\n            borderRadius=\"small\"\n            padding={4}\n            zIndex={10}\n            attributes={{ \"data-testid\": \"container\" }}\n        >\n            <Demo defaultActive />\n        </View>\n        <View gap={4} paddingTop={2}>\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n        </View>\n    </React.Fragment>\n);"
 				},
 				{
-					"name": "testInsideScrollable",
+					"id": "utility-components-flyout--test-inside-scrollable",
+					"name": "test: inside scrollable",
 					"snippet": "const testInsideScrollable = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View padding={20}>\n            <View height={30} overflow=\"auto\" backgroundColor=\"neutral-faded\" borderRadius=\"small\">\n                <View height={50} attributes={{ ref: containerRef }} padding={20} paddingBottom={30}>\n                    <Demo position=\"bottom\" />\n                </View>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testInsideModal",
+					"id": "utility-components-flyout--test-inside-modal",
+					"name": "test: inside modal",
 					"snippet": "const testInsideModal = () => {\n    return (\n        <Modal active position=\"end\">\n            <View gap={4} align=\"start\">\n                <Modal.Title>Title</Modal.Title>\n                <Demo position=\"bottom-start\" />\n                <View height={300} width={25} backgroundColor=\"neutral-faded\" />\n                <Demo position=\"start\" />\n                <View height={300} width={25} backgroundColor=\"neutral-faded\" />\n                <Demo position=\"bottom-start\" />\n            </View>\n        </Modal>\n    );\n};"
 				},
 				{
-					"name": "testDynamicBounds",
+					"id": "utility-components-flyout--test-dynamic-bounds",
+					"name": "test: auto position update",
 					"snippet": "const testDynamicBounds = () => {\n    const [left, setLeft] = React.useState(50);\n    const [top, setTop] = React.useState(50);\n    const [size, setSize] = React.useState<\"medium\" | \"large\">(\"medium\");\n    const flyoutRef = React.useRef<FlyoutInstance>(null);\n\n    React.useEffect(() => {\n        flyoutRef.current?.updatePosition();\n    }, [left, top]);\n\n    return (\n        <View gap={4}>\n            <View direction=\"row\" gap={2}>\n                <Button onClick={() => setLeft((prev) => prev - 10)}>Left</Button>\n                <Button onClick={() => setLeft((prev) => prev + 10)}>Right</Button>\n                <Button onClick={() => setTop((prev) => prev - 10)}>Up</Button>\n                <Button onClick={() => setTop((prev) => prev + 10)}>Down</Button>\n                <Button\n                    onClick={() => {\n                        setLeft(50);\n                        setTop(50);\n                    }}\n                >\n                    Center\n                </Button>\n                <Button onClick={() => setSize(\"large\")}>Large button</Button>\n                <Button onClick={() => setSize(\"medium\")}>Small button</Button>\n            </View>\n            <View height={100}>\n                <Flyout\n                    position=\"bottom\"\n                    instanceRef={flyoutRef}\n                    disableCloseOnOutsideClick\n                    defaultActive\n                >\n                    <Flyout.Trigger>\n                        {(attributes) => (\n                            <div style={{ position: \"absolute\", left: `${left}%`, top: `${top}%` }}>\n                                <Button color=\"primary\" attributes={attributes} size={size}>\n                                    Open\n                                </Button>\n                            </div>\n                        )}\n                    </Flyout.Trigger>\n                    <Flyout.Content>\n                        <Content />\n                    </Flyout.Content>\n                </Flyout>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testScopedTheming",
+					"id": "utility-components-flyout--test-scoped-theming",
+					"name": "test: content uses scope theme",
 					"snippet": "const testScopedTheming = () => (\n    <View gap={3} align=\"start\">\n        <Button color=\"primary\">Slate button</Button>\n        <Theme name=\"reshaped\">\n            <Flyout triggerType=\"click\" active position=\"bottom-start\">\n                <Flyout.Trigger>\n                    {(attributes) => (\n                        <Button color=\"primary\" attributes={attributes}>\n                            Reshaped button\n                        </Button>\n                    )}\n                </Flyout.Trigger>\n                <Flyout.Content>\n                    <Content>\n                        <View gap={1}>\n                            <View.Item>Portal content, rendered in body</View.Item>\n                            <Button color=\"primary\">Reshaped button</Button>\n                        </View>\n                    </Content>\n                </Flyout.Content>\n            </Flyout>\n        </Theme>\n    </View>\n);"
 				},
 				{
-					"name": "testWithoutFocusable",
+					"id": "utility-components-flyout--test-without-focusable",
+					"name": "test: without focusable content",
 					"snippet": "const testWithoutFocusable = () => <Demo position=\"bottom-start\" />;"
 				},
 				{
-					"name": "testChangeSize",
+					"id": "utility-components-flyout--test-change-size",
+					"name": "test: size updates",
 					"snippet": "const testChangeSize = () => {\n    const [position, setPosition] = React.useState<FlyoutProps[\"position\"]>(\"bottom-start\");\n    const [updatedHeight, setUpdatedHeight] = React.useState(false);\n\n    return (\n        <>\n            <View direction=\"row\" gap={4} align=\"center\">\n                <Select\n                    name=\"position\"\n                    options={[\n                        \"bottom-start\",\n                        \"bottom\",\n                        \"bottom-end\",\n                        \"top-start\",\n                        \"top\",\n                        \"top-end\",\n                        \"start-top\",\n                        \"start\",\n                        \"start-bottom\",\n                        \"end-top\",\n                        \"end\",\n                        \"end-bottom\",\n                    ].map((p) => ({ label: p, value: p }))}\n                    onChange={(args) => setPosition(args.value as FlyoutProps[\"position\"])}\n                    value={position}\n                />\n                <Switch name=\"height\" onChange={(args) => setUpdatedHeight(args.checked)}>\n                    Change height\n                </Switch>\n            </View>\n            <div\n                style={{\n                    position: \"fixed\",\n                    top: \"50%\",\n                    left: \"50%\",\n                    transform: \"translate(-50%, -50%)\",\n                }}\n            >\n                <Demo position={position} disableCloseOnOutsideClick active contentHeight={false}>\n                    <View\n                        backgroundColor=\"neutral-faded\"\n                        borderRadius=\"small\"\n                        height={updatedHeight ? 50 : 25}\n                        attributes={{ style: { transition: \"0.2s ease-in-out\" } }}\n                    />\n                </Demo>\n            </div>\n        </>\n    );\n};"
 				}
 			],
 			"import": "import {\n    Button,\n    Example,\n    Flyout,\n    Modal,\n    Reshaped,\n    Select,\n    Switch,\n    TextField,\n    Theme,\n    View,\n} from \"reshaped\";\nimport React from \"react\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Flyout/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Flyout",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Flyout/Flyout.tsx",
-				"actualName": "Flyout",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"groupTimeouts": {
+						"defaultValue": null,
+						"description": "Removes the content display delay if another flyout is already active",
+						"name": "groupTimeouts",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | TrapMode" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the flyout content interactivity",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Automatically focus the first focusable element in the content, when false the content container will be focused instead",
+						"name": "autoFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the content element",
+						"name": "contentClassName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"contentAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the content element",
+						"name": "contentAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Flyout"
 			}
 		},
 		"utility-components-formcontrol": {
@@ -2503,43 +13263,147 @@
 			"path": "./src/components/FormControl/tests/FormControl.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-formcontrol--status",
 					"name": "status",
 					"snippet": "const status = () => (\n    <Example>\n        <Example.Item title=\"status: default\">\n            <FormControl>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"status: error\">\n            <FormControl hasError>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: medium\">\n            <FormControl size=\"medium\">\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <FormControl size=\"large\">\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" size=\"large\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <FormControl disabled>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--required",
 					"name": "required",
 					"snippet": "const required = () => (\n    <Example>\n        <Example.Item title=\"required\">\n            <FormControl required>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "utility-components-formcontrol--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"horizontal\">\n            <FormControl>\n                <View direction=\"row\" gap={10} align=\"center\">\n                    <View width=\"100px\">\n                        <FormControl.Label>Label</FormControl.Label>\n                    </View>\n                    <View.Item grow>\n                        <TextField name=\"name\" placeholder=\"Enter value\" />\n                    </View.Item>\n                </View>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-formcontrol--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <FormControl id=\"test-id\" hasError>\n        <FormControl.Label>Label</FormControl.Label>\n        <TextField name=\"name\" />\n        <FormControl.Helper>Caption</FormControl.Helper>\n        <FormControl.Error>Error</FormControl.Error>\n    </FormControl>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--group",
 					"name": "group",
 					"snippet": "const group = () => (\n    <FormControl group>\n        <FormControl.Label>Label</FormControl.Label>\n        <RadioGroup name=\"name\">\n            <View gap={2}>\n                <Radio value=\"1\">One</Radio>\n                <Radio value=\"2\">Two</Radio>\n            </View>\n        </RadioGroup>\n    </FormControl>\n);"
 				}
 			],
 			"import": "import { Example, FormControl, Radio, RadioGroup, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/FormControl/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "FormControl",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/FormControl/FormControl.tsx",
-				"actualName": "FormControl",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size, to be used together with the other form component sizes",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"large\" | \"medium\"",
+							"value": [{ "value": "\"large\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"required": {
+						"defaultValue": null,
+						"description": "Change component to show a required indicator",
+						"name": "required",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Apply disabled styles",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"group": {
+						"defaultValue": null,
+						"description": "Apply semantic html markup when used for displaying multiple form fields together with a single label",
+						"name": "group",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Custom id for the form control",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "FormControl"
 			}
 		},
 		"utility-components-grid": {
@@ -2548,43 +13412,421 @@
 			"path": "./src/components/Grid/tests/Grid.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "utility-components-grid--base",
+					"name": "gap, columnGap, rowGap, align, justify, maxWidth, width, height",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"gap: 2\">\n            <Grid gap={2} columns={2}>\n                {[1, 2].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"columnGap: 2, rowGap: 4\">\n            <Grid columnGap={2} rowGap={4} columns={2}>\n                {[1, 2, 3, 4].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"align: center\">\n            <Grid gap={2} columns={2} align=\"center\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={8}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"justify: center\">\n            <Grid gap={2} columns=\"200px 200px\" justify=\"center\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"maxWidth: 400px\">\n            <Grid gap={2} columns=\"200px 200px\" maxWidth=\"400px\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"width: 400px, height: 200px\">\n            <Grid gap={2} columns={2} width=\"400px\" height=\"200px\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "layout",
+					"id": "utility-components-grid--layout",
+					"name": "rows, columns",
 					"snippet": "const layout = () => (\n    <Example>\n        <Example.Item title=\"simple: 2 rows, 3 columns\">\n            <Grid gap={4} columns={3} rows={2}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"columns template, 1fr 2fr 1fr\">\n            <Grid gap={4} columns=\"1fr 2fr 1fr\" rows={2}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"rows template, 1fr 2fr\">\n            <Grid gap={4} columns={3} rows=\"1fr 2fr\">\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"responsive\">\n            <Grid gap={4} columns={{ s: 3, m: \"1fr 2fr 1fr\" }} rows={{ s: 2, m: \"1fr 2fr\" }}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemLayout",
+					"id": "utility-components-grid--item-layout",
+					"name": "colStart, colEnd, rowStart, rowEnd",
 					"snippet": "const itemLayout = () => (\n    <Example>\n        <Example.Item title=\"column, start 1, end 3\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item colStart={1} colEnd={3}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"column, start 1, span 2\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item colStart={1} colSpan={2}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"row, start 1, end 3\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowEnd={3}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"row, start 1, span 2\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowSpan={2}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"responsive\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowSpan={{ s: 1, m: 2 }} colStart={1} colSpan={{ s: 1, m: 2 }}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-grid--areas",
 					"name": "areas",
 					"snippet": "const areas = () => (\n    <Example>\n        <Example.Item title=\"simple: 2 rows, 3 columns\">\n            <Grid gap={4} rows={2} areas={[\"a .\", \"a b\"]}>\n                {[\"a\", \"b\"].map((area) => (\n                    <Grid.Item area={area} key={area}>\n                        <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                            {area}\n                        </View>\n                    </Grid.Item>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "auto",
+					"id": "utility-components-grid--auto",
+					"name": "autoFlow, autoColumns, autoRows",
 					"snippet": "const auto = () => (\n    <Example>\n        <Example.Item title=\"auto flow: column\">\n            <Grid gap={4} autoFlow=\"column\" rows={2} columns={2}>\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"auto rows\">\n            <Grid gap={4} autoRows=\"100px\" columns={2}>\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"auto columns\">\n            <Grid gap={4} autoColumns=\"100px\" autoFlow=\"column\">\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-grid--as",
 					"name": "as",
 					"snippet": "const as = () => (\n    <Grid as=\"ul\">\n        <Grid.Item as=\"li\">Content</Grid.Item>\n    </Grid>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-grid--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Grid className=\"test-class\" attributes={{ id: \"test-id\" }}>\n            <Grid.Item className=\"test-item-class\" attributes={{ id: \"test-item-id\" }}>\n                Content\n            </Grid.Item>\n        </Grid>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Grid, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Grid/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Grid",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Grid/Grid.tsx",
-				"actualName": "Grid",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between grid items",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"columnGap": {
+						"defaultValue": null,
+						"description": "Horizontal gap between grid items",
+						"name": "columnGap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"rowGap": {
+						"defaultValue": null,
+						"description": "Vertical gap between grid items",
+						"name": "rowGap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Align grid items vertically",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Justify grid items horizontally",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"rows": {
+						"defaultValue": null,
+						"description": "Grid template rows",
+						"name": "rows",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<number | \"inherit\" | \"none\" | \"auto\" | (string & {}) | \"-moz-initial\" | \"initial\" | \"revert\" | \"revert-layer\" | \"unset\" | \"max-content\" | \"min-content\" | \"subgrid\">"
+						}
+					},
+					"columns": {
+						"defaultValue": null,
+						"description": "Grid template columns",
+						"name": "columns",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<number | \"inherit\" | \"none\" | \"auto\" | (string & {}) | \"-moz-initial\" | \"initial\" | \"revert\" | \"revert-layer\" | \"unset\" | \"max-content\" | \"min-content\" | \"subgrid\">"
+						}
+					},
+					"areas": {
+						"defaultValue": null,
+						"description": "Grid areas for template syntax",
+						"name": "areas",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string[]>" }
+					},
+					"autoFlow": {
+						"defaultValue": null,
+						"description": "Grid auto flow",
+						"name": "autoFlow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoFlow>" }
+					},
+					"autoColumns": {
+						"defaultValue": null,
+						"description": "Grid auto columns",
+						"name": "autoColumns",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoColumns<0 | (string & {})>>" }
+					},
+					"autoRows": {
+						"defaultValue": null,
+						"description": "Grid auto rows",
+						"name": "autoRows",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoRows<0 | (string & {})>>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Maximum width of the grid container, literal css value or unit token multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width of the grid container, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height of the grid container, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Custom root element html tag",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					}
+				},
+				"exportName": "Grid"
 			}
 		},
 		"utility-components-hidden": {
@@ -2593,22 +13835,261 @@
 			"path": "./src/components/Hidden/tests/Hidden.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-hidden--visibility",
 					"name": "visibility",
 					"snippet": "const visibility = () => (\n    <Example>\n        <Example.Item title=\"hide: always\">\n            <Hidden hide={true}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on s\">\n            <Hidden hide={{ s: false, m: true }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on l/xl\">\n            <Hidden hide={{ s: true, l: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on m/l/xl\">\n            <Hidden hide={{ s: true, m: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on m\">\n            <Hidden hide={{ s: true, m: false, l: true }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on s/xl\">\n            <Hidden hide={{ s: false, m: true, xl: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"hide: always, visibility\">\n            <Hidden hide visibility>\n                Content\n            </Hidden>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-hidden--as",
 					"name": "as",
 					"snippet": "const as = () => <Hidden as=\"span\">Content</Hidden>;"
 				}
 			],
 			"import": "import { Example, Hidden } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Hidden/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Hidden",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Hidden/Hidden.tsx",
-				"actualName": "Hidden",
+				"methods": [],
+				"props": {
+					"hide": {
+						"defaultValue": null,
+						"description": "Pick at which viewport sizes to hide the children",
+						"name": "hide",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"visibility": {
+						"defaultValue": null,
+						"description": "Use visibility hidden instead of display none",
+						"name": "visibility",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Custom root element html tag",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2618,22 +14099,39 @@
 			"path": "./src/components/HiddenVisually/tests/HiddenVisually.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-hiddenvisually--visibility",
 					"name": "visibility",
 					"snippet": "const visibility = () => (\n    <Example>\n        <Example.Item title=\"pronounced by screen readers\">\n            <HiddenVisually>Screen-reader only</HiddenVisually>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-hiddenvisually--children",
 					"name": "children",
 					"snippet": "const children = () => <HiddenVisually>Content</HiddenVisually>;"
 				}
 			],
 			"import": "import { Example, HiddenVisually } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/HiddenVisually/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "HiddenVisually",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/HiddenVisually/HiddenVisually.tsx",
-				"actualName": "HiddenVisually",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/HiddenVisually/HiddenVisually.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2643,34 +14141,115 @@
 			"path": "./src/components/Icon/tests/Icon.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-icon--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: 4\">\n            <Icon svg={IconZap} size={4} />\n        </Example.Item>\n        <Example.Item title=\"size: 8\">\n            <Icon svg={IconZap} size={8} />\n        </Example.Item>\n        <Example.Item title=\"size: 100%\">\n            <View width={25} height={25}>\n                <Icon svg={IconZap} size=\"100%\" />\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive size\", \"[s] 5\", \"[m]: 10\"]}>\n            <Icon svg={IconZap} size={{ s: 5, m: 10 }} />\n        </Example.Item>\n        <Example.Item title=\"size: inherit from font\">\n            <Text variant=\"title-6\">\n                <View direction=\"row\" align=\"center\" gap={2}>\n                    <Icon svg={IconZap} />\n                    <View.Item>Reshaped</View.Item>\n                </View>\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-icon--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <Icon svg={IconZap} color=\"neutral\" />\n        </Example.Item>\n        <Example.Item title=\"color: neutral-faded\">\n            <Icon svg={IconZap} color=\"neutral-faded\" />\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <Icon svg={IconZap} color=\"primary\" />\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Icon svg={IconZap} color=\"critical\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Icon svg={IconZap} color=\"positive\" />\n        </Example.Item>\n        <Example.Item title=\"color: disabled\">\n            <Icon svg={IconZap} color=\"disabled\" />\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <div style={{ color: \"tomato\" }}>\n                <Icon svg={IconZap} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "autoWidth",
+					"id": "utility-components-icon--auto-width",
+					"name": "autoWidth, blank",
 					"snippet": "const autoWidth = () => (\n    <Example>\n        <Example.Item title=\"square boundaries\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={IconMic} size={10} />\n            </div>\n        </Example.Item>\n        <Example.Item title=\"auto width boundaries\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={IconMic} size={10} autoWidth />\n            </div>\n        </Example.Item>\n        <Example.Item title=\"blank\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={null} size={10} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-icon--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Icon svg={IconZap} className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				},
 				{
-					"name": "render",
+					"id": "utility-components-icon--render",
+					"name": "test: hidden from sr",
 					"snippet": "const render = () => (\n    <div data-testid=\"root\">\n        <Icon svg={IconZap} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Icon, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Icon/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Icon",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Icon/Icon.tsx",
-				"actualName": "Icon",
+				"methods": [],
+				"props": {
+					"svg": {
+						"defaultValue": null,
+						"description": "Icon svg component or node",
+						"name": "svg",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Icon size, literal css value or unit token multiplier",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Icon color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"warning\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"autoWidth": {
+						"defaultValue": null,
+						"description": "Use the width of the svg asset instead of providing a square bounding box",
+						"name": "autoWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2680,54 +14259,230 @@
 			"path": "./src/components/Image/tests/Image.stories.tsx",
 			"stories": [
 				{
-					"name": "src",
+					"id": "utility-components-image--src",
+					"name": "src, alt",
 					"snippet": "const src = () => (\n    <Example>\n        <Example.Item title=\"src, alt\">\n            <Image src={imgUrl} alt=\"Image alt\" />\n        </Example.Item>\n\n        <Example.Item title=\"src\">\n            <Image src={imgUrl} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "utility-components-image--size",
+					"name": "width, height, maxWidth, aspectRatio",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"width: 200px\">\n            <Image src={imgUrl} width=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"height: 200px\">\n            <Image src={imgUrl} height=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"maxWidth: 200px\">\n            <Image src={imgUrl} maxWidth=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"aspectRatio: 1/1\">\n            <Image src={imgUrl} aspectRatio={1 / 1} width=\"300px\" />\n        </Example.Item>\n        <Example.Item title={[\"responsive width\", \"[s] 200px\", \"[m+] 300px\"]}>\n            <Image src={imgUrl} width={{ s: \"200px\", m: \"300px\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "radius",
+					"id": "utility-components-image--radius",
+					"name": "borderRadius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius: small\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"small\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"radius: medium\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"medium\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"radius: large\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--display-mode",
 					"name": "displayMode",
 					"snippet": "const displayMode = () => (\n    <Example>\n        <Example.Item title=\"mode: cover\">\n            <Image src={imgUrl} height=\"200px\" width=\"100%\" displayMode=\"cover\" />\n        </Example.Item>\n        <Example.Item title=\"mode: contain\">\n            <Image src={imgUrl} height=\"200px\" width=\"100%\" displayMode=\"contain\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--on-load",
 					"name": "onLoad",
 					"snippet": "const onLoad = () => <Image src={imgUrl} alt=\"photo\" onLoad={fn()} />;"
 				},
 				{
+					"id": "utility-components-image--on-error",
 					"name": "onError",
 					"snippet": "const onError = () => <Image src=\"/invalid.png\" alt=\"photo\" onError={fn()} />;"
 				},
 				{
+					"id": "utility-components-image--fallback",
 					"name": "fallback",
 					"snippet": "const fallback = () => (\n    <Example>\n        <Example.Item title=\"fallback, background, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"fallback, image, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback={imgUrl} />\n                </View>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"fallback, icon, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback={<Icon svg={IconZap} size={10} />} />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"fallback, icon, no url\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image fallback={<Icon svg={IconZap} size={10} />} />\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--render-image",
 					"name": "renderImage",
 					"snippet": "const renderImage = () => (\n    <Example>\n        <Example.Item title=\"renderImage\">\n            <Image\n                src={imgUrl}\n                alt=\"Amsterdam canal\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image\" />}\n            />\n        </Example.Item>\n        <Example.Item title=\"renderImage, fallback\">\n            <Image\n                src=\"error\"\n                fallback={imgUrl}\n                alt=\"Amsterdam canal 2\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image-fallback\" />}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "imageAttributes",
+					"id": "utility-components-image--image-attributes",
+					"name": "className, attributes,imageAttributes",
 					"snippet": "const imageAttributes = () => (\n    <div data-testid=\"root\">\n        <Image\n            src={imgUrl}\n            alt=\"photo\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            imageAttributes={{ \"data-testid\": \"test-img-id\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "ratio",
+					"id": "utility-components-image--ratio",
+					"name": "test: aspectRatio",
 					"snippet": "const ratio = () => (\n    <Example>\n        <Example.Item title=\"ratio: 16/9\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"ratio: 16/9, displayMode: contain\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} displayMode=\"contain\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Icon, Image, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Image/Image.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Image",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Image/Image.tsx",
-				"actualName": "Image",
+				"methods": [],
+				"props": {
+					"src": {
+						"defaultValue": null,
+						"description": "Image URL",
+						"name": "src",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"alt": {
+						"defaultValue": null,
+						"description": "Image alt text",
+						"name": "alt",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Image width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Image height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Image max width, literal css value or unit token multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"aspectRatio": {
+						"defaultValue": null,
+						"description": "Image aspect ratio, width / height",
+						"name": "aspectRatio",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Image border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"large\" | \"medium\"",
+							"value": [
+								{ "value": "\"small\"" },
+								{ "value": "\"large\"" },
+								{ "value": "\"medium\"" }
+							]
+						}
+					},
+					"displayMode": {
+						"defaultValue": null,
+						"description": "Image display mode for controlling how it fits into the provided boundaries",
+						"name": "displayMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"cover\" | \"contain\"",
+							"value": [{ "value": "\"cover\"" }, { "value": "\"contain\"" }]
+						}
+					},
+					"onLoad": {
+						"defaultValue": null,
+						"description": "Image on load event",
+						"name": "onLoad",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: SyntheticEvent<Element, Event>) => void)" }
+					},
+					"onError": {
+						"defaultValue": null,
+						"description": "Image on error event",
+						"name": "onError",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: SyntheticEvent<Element, Event>) => void)" }
+					},
+					"fallback": {
+						"defaultValue": null,
+						"description": "Image fallback content if the image fails to load or was not provided",
+						"name": "fallback",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"renderImage": {
+						"defaultValue": null,
+						"description": "Image render function, can be used for integrating with Image component in 3rd party frameworks",
+						"name": "renderImage",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Omit<Attributes<\"img\">, \"src\" | \"alt\"> & { src: string; alt: string; }) => ReactNode)"
+						}
+					},
+					"imageAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the image element",
+						"name": "imageAttributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"img\">" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(Attributes<\"div\"> & Attributes<\"img\">)" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2737,46 +14492,229 @@
 			"path": "./src/components/Overlay/tests/Overlay.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-overlay--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate}>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--transparent",
 					"name": "transparent",
 					"snippet": "const transparent = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate} transparent>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--blurred",
 					"name": "blurred",
 					"snippet": "const blurred = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate} blurred>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "renderProps",
+					"id": "utility-components-overlay--render-props",
+					"name": "children, render props",
 					"snippet": "const renderProps = () => (\n    <Overlay active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        {(args) => (args.active ? \"Opened\" : \"Closed\")}\n    </Overlay>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "utility-components-overlay--handlers",
+					"name": "onOpen, onClose, onAfterOpen, onAfterClose",
 					"snippet": "const handlers = () => {\n    const overlayToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => overlayToggle.toggle()}>Open overlay</Button>\n            <Overlay\n                active={overlayToggle.active}\n                onClose={(closeArgs) => {\n                    overlayToggle.deactivate();\n                    args.handleClose(closeArgs);\n                }}\n                onOpen={fn()}\n                onAfterOpen={fn()}\n                onAfterClose={fn()}>Content\n                                </Overlay>\n        </>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--disable-close-on-click",
 					"name": "disableCloseOnClick",
 					"snippet": "const disableCloseOnClick = (args) => (\n    <Overlay\n        active\n        disableCloseOnClick\n        onClose={(closeArgs) => {\n            args.handleClose(closeArgs);\n        }}\n    >\n        Content\n    </Overlay>\n);"
 				},
 				{
+					"id": "utility-components-overlay--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <>\n            <div ref={containerRef} data-testid=\"test-id\" style={{ height: 200 }} />\n            <Overlay active containerRef={containerRef}>\n                Content\n            </Overlay>\n        </>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-overlay--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <Overlay active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        Content\n    </Overlay>\n);"
 				}
 			],
 			"import": "import { Button, Example, Overlay } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Overlay/index.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Overlay",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Overlay/Overlay.tsx",
-				"actualName": "Overlay",
+				"methods": [],
+				"props": {
+					"transparent": {
+						"defaultValue": null,
+						"description": "Make the overlay transparent",
+						"name": "transparent",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number | boolean" }
+					},
+					"blurred": {
+						"defaultValue": null,
+						"description": "Make the overlay blurred",
+						"name": "blurred",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Control the overflow of the component content",
+						"name": "overflow",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"auto\"",
+							"value": [{ "value": "\"hidden\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, render function receives the state of the component as an argument",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode | ((props: { active: boolean; }) => ReactNode)" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the visibility of the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason: CloseReason; }) => void)" }
+					},
+					"onAfterClose": {
+						"defaultValue": null,
+						"description": "Callback after the component close transition is complete",
+						"name": "onAfterClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the component is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onAfterOpen": {
+						"defaultValue": null,
+						"description": "Callback after the component open transition is complete",
+						"name": "onAfterOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"disableCloseOnClick": {
+						"defaultValue": null,
+						"description": "Disable closing the component on outside click",
+						"name": "disableCloseOnClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": null,
+						"description": "Element to render the component in",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2786,42 +14724,213 @@
 			"path": "./src/components/Reshaped/tests/Reshaped.stories.tsx",
 			"stories": [
 				{
-					"name": "rtl",
+					"id": "utility-components-reshaped--rtl",
+					"name": "defaultRTL",
 					"snippet": "const rtl = () => (\n    <Reshaped defaultRTL theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				},
 				{
-					"name": "controlledMode",
+					"id": "utility-components-reshaped--controlled-mode",
+					"name": "colorMode, controlled",
 					"snippet": "const controlledMode = () => {\n    const [mode, setMode] = useState<G.ColorMode>(\"dark\");\n\n    return (\n        <Reshaped theme=\"reshaped\" colorMode={mode}>\n            <Button\n                onClick={() => {\n                    setMode(mode === \"dark\" ? \"light\" : \"dark\");\n                }}\n            >\n                Toggle color mode\n            </Button>\n        </Reshaped>\n    );\n};"
 				},
 				{
-					"name": "lightMode",
+					"id": "utility-components-reshaped--light-mode",
+					"name": "defaultColorMode=light",
 					"snippet": "const lightMode = () => <Reshaped theme=\"reshaped\">Hello</Reshaped>;"
 				},
 				{
-					"name": "darkMode",
+					"id": "utility-components-reshaped--dark-mode",
+					"name": "defaultColorMode=dark",
 					"snippet": "const darkMode = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				},
 				{
+					"id": "utility-components-reshaped--scoped",
 					"name": "scoped",
 					"snippet": "const scoped = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\" scoped>\n        Hello\n    </Reshaped>\n);"
 				},
 				{
-					"name": "testScoped",
+					"id": "utility-components-reshaped--test-scoped",
+					"name": "test: scoped switch",
 					"snippet": "const testScoped = () => (\n    <Reshaped theme=\"reshaped\">\n        <Reshaped theme=\"slate\" scoped>\n            <ScopedComponent />\n        </Reshaped>\n    </Reshaped>\n);"
 				},
 				{
-					"name": "keyboardMode",
+					"id": "utility-components-reshaped--keyboard-mode",
+					"name": "test: keyboard mode",
 					"snippet": "const keyboardMode = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				}
 			],
 			"import": "import { Button, Reshaped } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Reshaped/Reshaped.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Reshaped",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Reshaped/Reshaped.tsx",
-				"actualName": "Reshaped",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"theme": {
+						"defaultValue": null,
+						"description": "Theme of the application, enables controlled mode",
+						"name": "theme",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NonNullable<Theme>" }
+					},
+					"defaultTheme": {
+						"defaultValue": null,
+						"description": "Default theme of the application, enables uncontrolled mode",
+						"name": "defaultTheme",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NonNullable<Theme>" }
+					},
+					"defaultRTL": {
+						"defaultValue": null,
+						"description": "Default content direction of the application",
+						"name": "defaultRTL",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode of the application, enables controlled mode",
+						"name": "colorMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode",
+							"value": [{ "value": "\"light\"" }, { "value": "\"dark\"" }]
+						}
+					},
+					"defaultColorMode": {
+						"defaultValue": null,
+						"description": "Default color mode of the application, enables uncontrolled mode",
+						"name": "defaultColorMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode",
+							"value": [{ "value": "\"light\"" }, { "value": "\"dark\"" }]
+						}
+					},
+					"defaultViewport": {
+						"defaultValue": null,
+						"description": "Default viewport size of the application",
+						"name": "defaultViewport",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Viewport",
+							"value": [
+								{ "value": "\"s\"" },
+								{ "value": "\"m\"" },
+								{ "value": "\"l\"" },
+								{ "value": "\"xl\"" }
+							]
+						}
+					},
+					"toastOptions": {
+						"defaultValue": null,
+						"description": "Global options for the ToastProvider",
+						"name": "toastOptions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "Partial<Record<Position, { width?: string; expanded?: boolean; }>> | undefined"
+						}
+					},
+					"scoped": {
+						"defaultValue": null,
+						"description": "Enable scoped mode for applications not using Reshaped provider at the application root",
+						"name": "scoped",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2831,42 +14940,150 @@
 			"path": "./src/components/ScrollArea/tests/ScrollArea.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-scrollarea--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"vertical scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"horizontal scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\" height=\"100px\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"horizontal and vertical scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-scrollarea--scrollbar-display",
 					"name": "scrollbarDisplay",
 					"snippet": "const scrollbarDisplay = () => (\n    <Example>\n        <Example.Item title=\"scrollbarDisplay: hover\">\n            <ScrollArea height=\"100px\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"scrollbarDisplay: hidden\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"hidden\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"scrollbarDisplay: visible\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "height",
+					"id": "utility-components-scrollarea--height",
+					"name": "height, maxHeight",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"height: 80px\">\n            <ScrollArea height=\"80px\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"responsive height: s 80px, m: 120px\">\n            <ScrollArea height={{ s: \"80px\", m: \"120px\" }}>\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"maxHeight: 80px\">\n            <ScrollArea maxHeight=\"80px\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"responsive max height: s 80px, m: 200px\">\n            <ScrollArea maxHeight={{ s: \"80px\", m: \"200px\" }}>\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onScroll",
+					"id": "utility-components-scrollarea--on-scroll",
+					"name": "ref, onScroll",
 					"snippet": "const onScroll = () => {\n    const ref = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={4}>\n            <View.Item>\n                <Button onClick={() => ref.current?.scrollBy({ top: 50, left: 50 })}>Scroll</Button>\n            </View.Item>\n            <ScrollArea height=\"100px\" ref={ref} scrollbarDisplay=\"visible\" onScroll={fn()}>\n                <View backgroundColor=\"neutral-faded\" padding={4} width=\"1000px\" height=\"200px\">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                                            has been the industry's standard dummy text ever since the 1500s, when an unknown\n                                            printer took a galley of type and scrambled it to make a type specimen book. It has\n                                            survived not only five centuries, but also the leap into electronic typesetting,\n                                            remaining essentially unchanged. It was popularised in the 1960s with the release of\n                                            Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                                            publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                                        </View>\n            </ScrollArea>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-scrollarea--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ScrollArea className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </ScrollArea>\n    </div>\n);"
 				},
 				{
-					"name": "testNested",
+					"id": "utility-components-scrollarea--test-nested",
+					"name": "test: nested",
 					"snippet": "const testNested = () => (\n    <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n        <View padding={4} paddingInline={16}>\n            <ScrollArea height=\"200px\" scrollbarDisplay=\"visible\">\n                {Array(20)\n                    .fill(\"\")\n                    .map((_, index) => {\n                        return <div key={index}>Item {index + 1}</div>;\n                    })}\n            </ScrollArea>\n        </View>\n    </ScrollArea>\n);"
 				},
 				{
-					"name": "testDynamicHeight",
+					"id": "utility-components-scrollarea--test-dynamic-height",
+					"name": "test: dynamic height change",
 					"snippet": "const testDynamicHeight = () => {\n    const [count, setCount] = React.useState(10);\n\n    return (\n        <View gap={4}>\n            <View.Item>\n                <Button onClick={() => setCount((prev) => prev + 10)}>Add more items</Button>\n            </View.Item>\n\n            <ScrollArea height=\"200px\" scrollbarDisplay=\"visible\">\n                <View gap={2}>\n                    {new Array(count).fill(\"\").map((_, i) => (\n                        <View.Item key={i}>Item {i + 1}</View.Item>\n                    ))}\n                </View>\n            </ScrollArea>\n        </View>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Example, ScrollArea, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ScrollArea/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ScrollArea",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ScrollArea/ScrollArea.tsx",
-				"actualName": "ScrollArea",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"scrollbarDisplay": {
+						"defaultValue": null,
+						"description": "Scrollbar visibility behavior based on the user interaction",
+						"name": "scrollbarDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"hover\" | \"visible\"",
+							"value": [
+								{ "value": "\"hidden\"" },
+								{ "value": "\"hover\"" },
+								{ "value": "\"visible\"" }
+							]
+						}
+					},
+					"onScroll": {
+						"defaultValue": null,
+						"description": "Callback when the scroll area is scrolled",
+						"name": "onScroll",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: Coordinates) => void)" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height of the scroll area, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height of the scroll area, literal css value or unit token multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2876,54 +15093,387 @@
 			"path": "./src/components/Text/tests/Text.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-text--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: title-1\">\n            <Text variant=\"title-1\">Title 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-2\">\n            <Text variant=\"title-2\">Title 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-3\">\n            <Text variant=\"title-3\">Title 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-4\">\n            <Text variant=\"title-4\">Title 4</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-5\">\n            <Text variant=\"title-5\">Title 5</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-6\">\n            <Text variant=\"title-6\">Title 6</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-1\">\n            <Text variant=\"featured-1\">Featured 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-2\">\n            <Text variant=\"featured-2\">Featured 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-3\">\n            <Text variant=\"featured-3\">Featured 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-1\">\n            <Text variant=\"body-1\">Body 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-2\">\n            <Text variant=\"body-2\">Body 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-3\">\n            <Text variant=\"body-3\">Body 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: caption-1\">\n            <Text variant=\"caption-1\">Caption 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: caption-2\">\n            <Text variant=\"caption-2\">Caption 2</Text>\n        </Example.Item>\n        <Example.Item title={[\"responsive variant\", \"[s] body-3\", \"[m+] title-4\"]}>\n            <Text variant={{ s: \"body-3\", m: \"title-4\" }}>Responsive</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--weight",
 					"name": "weight",
 					"snippet": "const weight = () => (\n    <Example>\n        <Example.Item title=\"weight: regular\">\n            <Text weight=\"regular\">Regular</Text>\n        </Example.Item>\n        <Example.Item title=\"weight: medium\">\n            <Text weight=\"medium\">Medium</Text>\n        </Example.Item>\n        <Example.Item title=\"weight: bold\">\n            <Text weight=\"bold\">Bold</Text>\n        </Example.Item>\n        <Example.Item title={[\"responsive\", \"[s] weight: regular\", \"[m+] bold\"]}>\n            <Text weight={{ s: \"regular\", m: \"bold\" }}>Responsive</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: inherit\">\n            <Text>Neutral</Text>\n        </Example.Item>\n        <Example.Item title=\"color: neutral-faded\">\n            <Text color=\"neutral-faded\">Faded</Text>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Text color=\"positive\">Positive</Text>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <Text color=\"warning\">Warning</Text>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Text color=\"critical\">Critical</Text>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <Text color=\"primary\">Primary</Text>\n        </Example.Item>\n        <Example.Item title=\"color: disabled\">\n            <Text color=\"disabled\" attributes={{ \"aria-disabled\": true }}>\n                Disabled\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--decoration",
 					"name": "decoration",
 					"snippet": "const decoration = () => (\n    <Example>\n        <Example.Item title=\"decoration: line-through\">\n            <Text decoration=\"line-through\">Line through</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--wrap",
 					"name": "wrap",
 					"snippet": "const wrap = () => (\n    <Example>\n        <Example.Item title=\"wrap: balance\">\n            <Text wrap=\"balance\" variant=\"title-3\">\n                The design system you want to build\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "mono",
+					"id": "utility-components-text--mono",
+					"name": "monospace",
 					"snippet": "const mono = () => (\n    <Example>\n        <Example.Item title=\"monospace\">\n            <Text monospace>Content</Text>\n        </Example.Item>\n        <Example.Item title=\"monospace, variant, weight\">\n            <Text monospace variant=\"title-1\" weight=\"regular\">\n                Content\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--max-lines",
 					"name": "maxLines",
 					"snippet": "const maxLines = () => (\n    <Example>\n        <Example.Item title=\"maxLines: 2\">\n            <Text maxLines={2}>\n                There are many variations of passages of Lorem Ipsum available, but the majority have\n                suffered alteration in some form, by injected humour, or randomised words which don't look\n                even slightly believable. If you are going to use a passage of Lorem Ipsum, you need to be\n                sure there isn't anything embarrassing hidden in the middle of text. All the Lorem Ipsum\n                generators on the Internet tend to repeat predefined chunks as necessary, making this the\n                first true generator on the Internet. It uses a dictionary of over 200 Latin words,\n                combined with a handful of model sentence structures, to generate Lorem Ipsum which looks\n                reasonable. The generated Lorem Ipsum is therefore always free from repetition, injected\n                humour, or non-characteristic words etc.\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: start\">\n            <Text align=\"start\">Text content</Text>\n        </Example.Item>\n        <Example.Item title=\"align: center\">\n            <Text align=\"center\">Text content</Text>\n        </Example.Item>\n        <Example.Item title=\"align: end\">\n            <Text align=\"end\">Text content</Text>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive alignment\", \"[s]: center\", \"[m+] start\"]}>\n            <Text align={{ s: \"center\", m: \"start\" }}>Text content</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "asProp",
+					"id": "utility-components-text--as-prop",
+					"name": "as",
 					"snippet": "const asProp = () => (\n    <>\n        <Text as=\"h1\">Content</Text>\n        <Text variant=\"title-3\">Content</Text>\n        <Text variant={{ s: \"title-3\", m: \"title-4\" }}>Content</Text>\n    </>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-text--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Text className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Text>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Text/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Text",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Text/Text.tsx",
-				"actualName": "Text",
+				"methods": [],
+				"props": {
+					"variant": {
+						"defaultValue": null,
+						"description": "Text render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Variant>" }
+					},
+					"weight": {
+						"defaultValue": null,
+						"description": "Text font weight",
+						"name": "weight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"medium\" | \"bold\" | \"regular\">" }
+					},
+					"monospace": {
+						"defaultValue": null,
+						"description": "Render monospace font",
+						"name": "monospace",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Text color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"warning\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Text alignment",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"center\" | \"start\" | \"end\">" }
+					},
+					"wrap": {
+						"defaultValue": null,
+						"description": "CSS wrapping style",
+						"name": "wrap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"balance\"", "value": [{ "value": "\"balance\"" }] }
+					},
+					"decoration": {
+						"defaultValue": null,
+						"description": "CSS text decoration style",
+						"name": "decoration",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"line-through\"",
+							"value": [{ "value": "\"line-through\"" }]
+						}
+					},
+					"maxLines": {
+						"defaultValue": null,
+						"description": "Maximum number of lines to render, used for text truncation",
+						"name": "maxLines",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different html tag",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2933,46 +15483,114 @@
 			"path": "./src/components/Theme/tests/Theme.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-theme--scoped",
 					"name": "scoped",
 					"snippet": "const scoped = () => (\n    <Example>\n        <Example.Item title=\"scoped, single\">\n            <Theme name=\"reshaped\">\n                <Card attributes={{ \"data-testid\": \"test-id\" }}>\n                    <Button color=\"primary\">Action</Button>\n                </Card>\n            </Theme>\n        </Example.Item>\n\n        <Example.Item title=\"scoped, multiple\">\n            <Theme name={[\"reshaped\", \"figma\"]}>\n                <Card attributes={{ \"data-testid\": \"test-id-multi\" }}>\n                    <View direction=\"row\" gap={4}>\n                        <Button color=\"primary\">Action</Button>\n\n                        <Popover>\n                            <Popover.Trigger>\n                                {(attributes) => <Button attributes={attributes}>Popover</Button>}\n                            </Popover.Trigger>\n                            <Popover.Content>Content</Popover.Content>\n                        </Popover>\n                    </View>\n                </Card>\n            </Theme>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-theme--light",
 					"name": "light",
 					"snippet": "const light = () => (\n    <Theme name=\"reshaped\" colorMode=\"light\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--dark",
 					"name": "dark",
 					"snippet": "const dark = () => (\n    <Theme name=\"reshaped\" colorMode=\"dark\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--inherited",
 					"name": "inherited",
 					"snippet": "const inherited = () => (\n    <Theme name=\"reshaped\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--inverted",
 					"name": "inverted",
 					"snippet": "const inverted = () => (\n    <Theme name=\"reshaped\" colorMode=\"inverted\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--controlled",
 					"name": "controlled",
 					"snippet": "const controlled = () => {\n    const Internal = () => {\n        const { setTheme, theme } = useTheme();\n\n        return (\n            <Button color=\"primary\" onClick={() => setTheme(\"slate\")}>\n                Switch to slate\n            </Button>\n        );\n    };\n\n    return (\n        <div data-testid=\"root\">\n            <Theme name=\"reshaped\">\n                <Internal />\n            </Theme>\n        </div>\n    );\n};"
 				},
 				{
+					"id": "utility-components-theme--uncontrolled",
 					"name": "uncontrolled",
 					"snippet": "const uncontrolled = () => {\n    const Internal = () => {\n        const { setTheme } = useTheme();\n\n        return (\n            <Button color=\"primary\" onClick={() => setTheme(\"slate\")}>\n                Switch to slate\n            </Button>\n        );\n    };\n\n    return (\n        <div data-testid=\"root\">\n            <Theme defaultName=\"reshaped\">\n                <Internal />\n            </Theme>\n        </div>\n    );\n};"
 				},
 				{
-					"name": "disabledTransition",
+					"id": "utility-components-theme--disabled-transition",
+					"name": "disabled transitions",
 					"snippet": "const disabledTransition = () => {\n    const { invertColorMode } = useTheme();\n\n    return (\n        <Example>\n            <Example.Item title=\"should have no transitions while switching color mode\">\n                <View gap={3}>\n                    <Button onClick={invertColorMode}>Invert mode</Button>\n\n                    <MenuItem selected>Test transition</MenuItem>\n\n                    <Card>Default card</Card>\n\n                    <Theme colorMode=\"inverted\">\n                        <Card>Inverted card</Card>\n                    </Theme>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Card, Example, MenuItem, Popover, Theme, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Theme/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Theme",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Theme/Theme.tsx",
-				"actualName": "Theme",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the theme to use, enables controlled mode",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"defaultName": {
+						"defaultValue": null,
+						"description": "Default name of the theme to use, enables uncontrolled mode",
+						"name": "defaultName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode to use",
+						"name": "colorMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode | \"inverted\"",
+							"value": [
+								{ "value": "\"light\"" },
+								{ "value": "\"dark\"" },
+								{ "value": "\"inverted\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2982,147 +15600,880 @@
 			"path": "./src/components/View/tests/View.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-view--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example title=\"Border is used to highlight the padding value\">\n        <Example.Item title=\"padding: 4\">\n            <View padding={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <View padding={6} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: 0\">\n            <View padding={0} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: vertical 2, horizontal 4\">\n            <View paddingInline={4} paddingBlock={2} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingTop: 4\">\n            <View paddingTop={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingBottom: 4\">\n            <View paddingBottom={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingStart: 4\">\n            <View paddingStart={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingEnd: 4\">\n            <View paddingEnd={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive padding:\",\n                \"[s] vertical 2, horizontal 4\",\n                \"[m+] vertical 4, horizontal 8\",\n            ]}\n        >\n            <View paddingInline={{ s: 4, m: 8 }} paddingBlock={{ s: 2, m: 4 }} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"responsive padding:\", \"[s] top 2, bottom 4\", \"[m+] top 4, bottom 0, start: 8\"]}\n        >\n            <View\n                paddingTop={{ s: 2, m: 4 }}\n                paddingBottom={{ s: 4, m: 0 }}\n                paddingStart={{ s: 0, m: 8 }}\n                borderColor=\"neutral\"\n            >\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"nested padding, child view should have no horizontal padding\">\n            <View paddingStart={4} borderColor=\"neutral\">\n                <View borderColor=\"primary\" paddingBlock={4}>\n                    <Placeholder />\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example title=\"Item 1 is another component, Item 2 is View.Item, Item 3 is text\">\n        <Example.Item title=\"direction: column as default\">\n            <View gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <View gap={3} direction=\"column\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column-reverse\">\n            <View gap={3} direction=\"column-reverse\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row\">\n            <View gap={3} direction=\"row\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row-reverse\">\n            <View gap={3} direction=\"row-reverse\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"responsive direction\", \"[s] column-reverse\", \"[m] row-reverse\", \"[l+] row\"]}\n        >\n            <View direction={{ s: \"column-reverse\", m: \"row-reverse\", l: \"row\" }} gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 4, direction: row\">\n            <View direction=\"row\" gap={4} divided>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n                <Placeholder>Item 3</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 0, direction: row\">\n            <View direction=\"row\" gap={0}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap, direction: row\", \"[s] 4\", \"[m+] 8\"]}>\n            <View direction=\"row\" gap={{ s: 4, m: 8 }}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 4, direction: column\">\n            <View gap={4}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 0, direction: column\">\n            <View gap={0}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap, direction: column\", \"[s] 4\", \"[m+] 8\"]}>\n            <View gap={{ s: 4, m: 8 }}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--divided",
 					"name": "divided",
 					"snippet": "const divided = () => (\n    <Example>\n        <Example.Item title=\"direction: row\">\n            <View divided direction=\"row\" gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <View divided gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive divided\", \"[s] direction: row\", \"[m+] direction: column\"]}>\n            <View divided direction={{ s: \"row\", m: \"column\" }} gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row, columns\">\n            <View divided gap={3} direction=\"row\">\n                <View.Item columns={2}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={8}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={2}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"with React.Fragment\">\n            <View direction=\"row\" gap={4} divided>\n                <Placeholder>Item 1</Placeholder>\n                <>\n                    <Placeholder>Item 2</Placeholder>\n                    <Placeholder>Item 3</Placeholder>\n                </>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example title=\"Removes side borders and border radius when applied\">\n        <Example.Item title=\"bleed: 4\">\n            <View bleed={4} padding={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive bleed\", \"[s] 4\", \"[m+] 0\"]}>\n            <View bleed={{ s: 4, m: 0 }} padding={4} borderRadius=\"small\" borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--wrap",
 					"name": "wrap",
 					"snippet": "const wrap = () => (\n    <Example>\n        <Example.Item title=\"wrap: false\">\n            <View direction=\"row\" wrap={false} gap={3}>\n                <Placeholder w={600} h={100} />\n                <Placeholder w={600} h={100} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: start, direction: row\">\n            <View align=\"start\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: center, direction: row\">\n            <View align=\"center\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: end, direction: row\">\n            <View align=\"end\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"align: stretch, direction: row\",\n                \"2nd item is stretched based on the 1st item height\",\n            ]}\n        >\n            <View align=\"stretch\" direction=\"row\" gap={3}>\n                <Placeholder h={100} />\n                <Placeholder h=\"auto\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: baseline, direction: row\">\n            <View align=\"baseline\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Text variant=\"title-6\">Content</Text>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"align: start, direction: column\">\n            <View align=\"start\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: center, direction: column\">\n            <View align=\"center\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: end, direction: row\">\n            <View align=\"end\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"align: stretch, direction: column\",\n                \"1st item uses its own width, 2nd item is stretched to full width\",\n            ]}\n        >\n            <View align=\"stretch\" direction=\"column\" gap={3}>\n                <Placeholder w={100} />\n                <Placeholder w=\"auto\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--justify",
 					"name": "justify",
 					"snippet": "const justify = () => (\n    <Example>\n        <Example.Item title=\"justify: start, direction: row\">\n            <View justify=\"start\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: center, direction: row\">\n            <View justify=\"center\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: end, direction: row\">\n            <View justify=\"end\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: space-between, direction: row\">\n            <View justify=\"space-between\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"justify: start, direction: column, height: 200px\">\n            <View height=\"200px\" justify=\"start\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: center, direction: column, height: 200px\">\n            <View height=\"200px\" justify=\"center\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: end, direction: column, height: 200px\">\n            <View justify=\"end\" height=\"200px\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: space-between, direction: column, height: 200px\">\n            <View justify=\"space-between\" height=\"200px\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--text-align",
 					"name": "textAlign",
 					"snippet": "const textAlign = () => (\n    <Example>\n        <Example.Item title=\"textAlign: start\">\n            <View textAlign=\"start\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: center\">\n            <View textAlign=\"center\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: end\">\n            <View textAlign=\"end\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: [s] start, [m+] end\">\n            <View textAlign={{ s: \"start\", m: \"end\" }}>Content</View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"height: 100px, width: 100px\">\n            <View backgroundColor=\"neutral-faded\" height=\"100px\" width=\"100px\" />\n        </Example.Item>\n        <Example.Item title=\"height: 25, width: 25\">\n            <View backgroundColor=\"neutral-faded\" height={25} width={25} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive height and width\",\n                \"[s] height: 25, width: 25\",\n                \"[m+] height: 200px, width: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                height={{ s: 25, m: \"200px\" }}\n                width={{ s: 25, m: \"200px\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "ratio",
+					"id": "utility-components-view--ratio",
+					"name": "aspectRatio",
 					"snippet": "const ratio = () => (\n    <Example>\n        <Example.Item title=\"ratio: 16 / 9\">\n            <View backgroundColor=\"neutral-faded\" aspectRatio={16 / 9} width=\"200px\" />\n        </Example.Item>\n        <Example.Item title={[\"responsive ratio\", \"[s] 1/1\", \"[m+] 16/9\"]}>\n            <View backgroundColor=\"neutral-faded\" aspectRatio={{ s: 1, m: 16 / 9 }} width=\"200px\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "maxSize",
+					"id": "utility-components-view--max-size",
+					"name": "width, height, maxWidth, maxHeight",
 					"snippet": "const maxSize = () => (\n    <Example>\n        <Example.Item title=\"maxHeight: 150px, maxWidth: 150px, height: 300px\">\n            <View backgroundColor=\"neutral-faded\" maxHeight=\"150px\" maxWidth=\"150px\" height=\"300px\" />\n        </Example.Item>\n        <Example.Item title=\"maxHeight: 25, maxWidth: 25, height: 50\">\n            <View backgroundColor=\"neutral-faded\" maxHeight={25} maxWidth={25} height={50} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive maxHeight and maxWidth, height: 300\",\n                \"[s] maxHeight: 25, maxWidth: 25\",\n                \"[m+] maxHeight: 200px, maxWidth: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                maxHeight={{ s: 25, m: \"200px\" }}\n                maxWidth={{ s: 25, m: \"200px\" }}\n                height=\"300px\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "minSize",
+					"id": "utility-components-view--min-size",
+					"name": "width, height, minWidth, minHeight",
 					"snippet": "const minSize = () => (\n    <Example>\n        <Example.Item title=\"minHeight: 150px, minWidth: 150px, height: 50px, width: 50px\">\n            <View\n                backgroundColor=\"neutral-faded\"\n                minHeight=\"150px\"\n                minWidth=\"150px\"\n                height=\"50px\"\n                width=\"50px\"\n            />\n        </Example.Item>\n        <Example.Item title=\"minHeight: 25, minWidth: 25, height: 5, width: 5\">\n            <View backgroundColor=\"neutral-faded\" minHeight={25} minWidth={25} height={5} width={5} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive minHeight and minWidth, height: 50px, width: 50px\",\n                \"[s] minHeight: 25, minWidth: 25\",\n                \"[m+] minHeight: 200px, minWidth: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                minHeight={{ s: 25, m: \"200px\" }}\n                minWidth={{ s: 25, m: \"200px\" }}\n                height=\"50px\"\n                width=\"50px\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "background",
+					"id": "utility-components-view--background",
+					"name": "backgroundColor",
 					"snippet": "const background = () => (\n    <Example title=\"border is used to highlight the backround value when it's similar to the page background, text color changes based on the background\">\n        <Example.Item title=\"bg: page\">\n            <View backgroundColor=\"page\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: page-faded\">\n            <View backgroundColor=\"page-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: disabled\">\n            <View backgroundColor=\"disabled\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: disabled-faded\">\n            <View backgroundColor=\"disabled-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-base\">\n            <View backgroundColor=\"elevation-base\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-raised\">\n            <View backgroundColor=\"elevation-raised\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-overlay\">\n            <View backgroundColor=\"elevation-overlay\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: neutral\">\n            <View backgroundColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: neutral-faded\">\n            <View backgroundColor=\"neutral-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: primary\">\n            <View backgroundColor=\"primary\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: primary-faded\">\n            <View backgroundColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: critical\">\n            <View backgroundColor=\"critical\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: critical-faded\">\n            <View backgroundColor=\"critical-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: warning\">\n            <View backgroundColor=\"warning\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: warning-faded\">\n            <View backgroundColor=\"warning-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: positive\">\n            <View backgroundColor=\"positive\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: positive-faded\">\n            <View backgroundColor=\"positive-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--border-color",
 					"name": "borderColor",
 					"snippet": "const borderColor = () => (\n    <Example>\n        <Example.Item title=\"border: neutral\">\n            <View borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: neutral-faded\">\n            <View borderColor=\"neutral-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: primary\">\n            <View borderColor=\"primary\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: primary-faded\">\n            <View borderColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: critical\">\n            <View borderColor=\"critical\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: critical-faded\">\n            <View borderColor=\"critical-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: warning\">\n            <View borderColor=\"warning\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: warning-faded\">\n            <View borderColor=\"warning-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: positive\">\n            <View borderColor=\"positive\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: positive-faded\">\n            <View borderColor=\"positive-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: transparent, background: primary-faded\">\n            <View borderColor=\"transparent\" backgroundColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive\", \"[s] primary\", \"[m+] neutral\"]}>\n            <View borderColor={{ s: \"primary\", m: \"neutral\" }} padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--border",
 					"name": "border",
 					"snippet": "const border = () => (\n    <Example>\n        <Example.Item title=\"border: true\">\n            <View border borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderTop: true\">\n            <View borderTop borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderBottom: true\">\n            <View borderBottom borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderStart: true\">\n            <View borderStart borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderEnd: true\">\n            <View borderEnd borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderInline: true\">\n            <View borderInline borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderBlock: true\">\n            <View borderBlock borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderTop: true, borderStart: true, \">\n            <View borderColor=\"neutral\" borderTop borderStart padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"responsive\",\n                \"[s] borderTop: true, borderStart: true\",\n                \"[m+] borderBottom: true, borderEnd: true\",\n            ]}\n        >\n            <View\n                borderColor=\"neutral\"\n                borderTop={{ s: true, m: false }}\n                borderStart={{ s: true, m: false }}\n                borderBottom={{ s: false, m: true }}\n                borderEnd={{ s: false, m: true }}\n                padding={4}\n            >\n                Content\n            </View>\n        </Example.Item>\n\n        <div style={{ height: 100 }} />\n    </Example>\n);"
 				},
 				{
-					"name": "radius",
+					"id": "utility-components-view--radius",
+					"name": "borderRadius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius: small\">\n            <View borderRadius=\"small\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: medium\">\n            <View borderRadius=\"medium\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: large\">\n            <View borderRadius=\"large\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: circular\">\n            <View borderRadius=\"circular\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--shadow",
 					"name": "shadow",
 					"snippet": "const shadow = () => (\n    <Example>\n        <Example.Item title=\"shadow: raised, radius: medium\">\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                shadow=\"raised\"\n                borderRadius=\"medium\"\n                backgroundColor=\"elevation-raised\"\n            />\n        </Example.Item>\n        <Example.Item title=\"shadow: overlay, radius: medium\">\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                shadow=\"overlay\"\n                borderRadius=\"medium\"\n                backgroundColor=\"elevation-overlay\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--overflow",
 					"name": "overflow",
 					"snippet": "const overflow = () => (\n    <Example>\n        <Example.Item\n            title={[\"overflow: hidden, radius: medium\", \"child background should have radius\"]}\n        >\n            <View height=\"100px\" width=\"100px\" shadow=\"raised\" borderRadius=\"medium\" overflow=\"hidden\">\n                <View backgroundColor=\"primary\" height=\"100%\" width=\"100%\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positioning",
+					"id": "utility-components-view--positioning",
+					"name": "position",
 					"snippet": "const positioning = () => (\n    <Example>\n        <Example.Item title=\"position: relative + absolute\">\n            <View borderColor=\"neutral\" position=\"relative\">\n                <Placeholder />\n                <View\n                    position=\"absolute\"\n                    insetTop={0}\n                    insetEnd={0}\n                    backgroundColor=\"critical\"\n                    zIndex={5}\n                    height={10}\n                    width={10}\n                />\n                <View\n                    position=\"absolute\"\n                    insetTop={0}\n                    insetEnd={0}\n                    backgroundColor=\"primary\"\n                    height={15}\n                    width={15}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: sticky\">\n            <div style={{ overflow: \"auto\", height: 100 }} tabIndex={0}>\n                <View position=\"sticky\" borderColor=\"primary\" insetTop={0}>\n                    Content\n                </View>\n                <Placeholder h={1000} />\n            </div>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive\", \"[s] position: absolute\", \"[m+]: position: relative\"]}>\n            <div style={{ overflow: \"auto\", height: 100, position: \"relative\" }} tabIndex={0}>\n                <View position={{ s: \"absolute\", m: \"relative\" }} borderColor=\"primary\" insetTop={0}>\n                    Content\n                </View>\n                <Placeholder h={1000} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--inset",
 					"name": "inset",
 					"snippet": "const inset = () => (\n    <Example>\n        <Example.Item title=\"inset: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" inset={4} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetTop: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" insetTop={4} height={10} width={10} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetStart: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetStart={4}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetEnd: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" insetEnd={4} height={10} width={10} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetBottom: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetBottom={4}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"responsive, [s] insetBottom: 4 [m+] insetEnd: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetBottom={{ s: 4, m: \"auto\" }}\n                    insetEnd={{ s: \"auto\", m: 4 }}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--animated",
 					"name": "animated",
 					"snippet": "const animated = () => {\n    const [background, setBackground] = React.useState<ViewProps[\"backgroundColor\"]>(\"neutral\");\n\n    return (\n        <View gap={3} align=\"start\">\n            <Button\n                onClick={() => setBackground((prev) => (prev === \"neutral\" ? \"primary\" : \"neutral\"))}\n            >\n                Change background\n            </Button>\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                backgroundColor={background}\n                align=\"center\"\n                justify=\"center\"\n                animated\n            >\n                Content\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "itemGapBefore",
+					"id": "utility-components-view--item-gap-before",
+					"name": "item, gapBefore",
 					"snippet": "const itemGapBefore = () => (\n    <Example>\n        <Example.Item title={[\"gap: 4, 3rd item gapBefore: 10, direction: row\", \"increased gap\"]}>\n            <View direction=\"row\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={10}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 4, direction: row\", \"reduced gap\"]}>\n            <View direction=\"row\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={4}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 0, direction: row\", \"removed gap\"]}>\n            <View direction=\"row\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={0}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"gap: 4, direction: row, 2nd item gap: auto\">\n            <View direction=\"row\" gap={4}>\n                <Placeholder w={200} />\n                <View.Item gapBefore=\"auto\">\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"gap: 4, 3rd item gapBefore: 10, direction: column\", \"increased gap\"]}>\n            <View direction=\"column\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={10}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 4, direction: column\", \"reduced gap\"]}>\n            <View direction=\"column\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={4}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 0, direction: column\", \"removed gap\"]}>\n            <View direction=\"column\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={0}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"gap: 4, direction: column, height: 200px, 2nd item gap: auto\">\n            <View height=\"200px\" gap={4}>\n                <Placeholder />\n                <View.Item gapBefore=\"auto\">\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"responsive item gap\",\n                \"gap: 4, direction: row\",\n                \"[s] 3rd item gapBefore: 10\",\n                \"[m+] 3rd item gapBefore: 0\",\n            ]}\n        >\n            <View direction=\"row\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={{ s: 10, m: 0 }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemGrow",
+					"id": "utility-components-view--item-grow",
+					"name": "item, grow",
 					"snippet": "const itemGrow = () => (\n    <Example>\n        <Example.Item title=\"direction: row, 2nd item grow\">\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column, height: 200px, 2nd item grow\">\n            <View direction=\"column\" gap={3} height=\"200px\">\n                <Placeholder />\n                <View.Item grow>\n                    <Placeholder h=\"100%\" />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row, 2nd item grow, applied to View\">\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View grow>\n                    <Placeholder />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive item grow, direction: row\",\n                \"[s] 2nd item grow\",\n                \"[m+] 2nd item doesn't grow\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View.Item grow={{ s: true, m: false }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive item grow, direction: column, height: 200px\",\n                \"[s] 2nd item grow\",\n                \"[m+] 2nd item doesn't grow\",\n            ]}\n        >\n            <View direction=\"column\" gap={3} height=\"200px\">\n                <Placeholder />\n                <View.Item grow={{ s: true, m: false }}>\n                    <Placeholder h=\"100%\" />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemColumns",
+					"id": "utility-components-view--item-columns",
+					"name": "item, columns",
 					"snippet": "const itemColumns = () => (\n    <Example>\n        <Example.Item title=\"columns 6, 6, gap: 0\">\n            <View direction=\"row\">\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 3, 9, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={3}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, 9, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive columns\", \"[s] columns 6, 6, 12, gap: 4\", \"[m+]: 4, 4, 4\"]}>\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={{ s: 6, m: 4 }}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 6, m: 4 }}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 12, m: 4 }}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, 9, gap: 4, 2nd item gapBefore: 20\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6} gapBefore={20}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemOrder",
+					"id": "utility-components-view--item-order",
+					"name": "item, order",
 					"snippet": "const itemOrder = () => (\n    <Example>\n        <Example.Item title=\"order: 1 3 2\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={4}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={4} order={1}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={4}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive order\", \"[s] 1 2 3\", \"[m+] 1 3 2\"]}>\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={4}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={4} order={{ s: 0, m: 1 }}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={4}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive order\",\n                \"[s]: 1 3 2, 2 is full width on second row\",\n                \"[m+]: 1 2 3, 2 has grow in the center of the first row\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <View.Item columns={{ s: 6, m: \"auto\" }}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item\n                    grow={{ s: false, m: true }}\n                    order={{ s: 1, m: 0 }}\n                    columns={{ s: 12, m: \"auto\" }}\n                >\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 6, m: \"auto\" }}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "hiddenItem",
+					"id": "utility-components-view--hidden-item",
+					"name": "composition, Hidden item",
 					"snippet": "const hiddenItem = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"[s] 2nd item: visible, grow, 3rd item: !grow\",\n                \"[m+] 2nd item: hidden, 2nd item divider: hidden, 3rd item: grow\",\n            ]}\n        >\n            <View direction=\"row\" divided gap={3}>\n                <Placeholder />\n                <Hidden hide={{ s: false, m: true }}>\n                    <View.Item grow key=\"3\">\n                        <Placeholder />\n                    </View.Item>\n                </Hidden>\n                <View.Item grow={{ s: false, m: true }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"[s] 2nd item: visible, grow, 3rd item: !grow\",\n                \"[m+] 2nd item: hidden, 2nd item: grow doesn't push 3rd item, 3rd item: grow\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Placeholder />\n                <Hidden hide={{ s: false, m: true }}>\n                    <View.Item grow>\n                        <Placeholder />\n                    </View.Item>\n                </Hidden>\n                <View.Item grow={{ s: false, m: true }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "keys",
+					"id": "utility-components-view--keys",
+					"name": "item, key",
 					"snippet": "const keys = () => {\n    const toggle = useToggle();\n\n    return (\n        <View gap={2}>\n            <Button onClick={() => toggle.toggle()}>Toggle</Button>\n            <View.Item>Item 1</View.Item>\n            {toggle.active && <KeyItem>Item 2</KeyItem>}\n            <KeyItem>Item 3</KeyItem>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "nestedGaps",
+					"id": "utility-components-view--nested-gaps",
+					"name": "composition, nested gap",
 					"snippet": "const nestedGaps = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"direction: column, gap: 10\",\n                \"Child 1: direction: column, gap: 2\",\n                \"Child 2: direction column, gap: 6\",\n                \"Child 3: gapBefore: 0\",\n                \"Child 3 view: direction: row, gap: 2\",\n            ]}\n        >\n            <View gap={10}>\n                <View gap={2}>\n                    <Placeholder>Child 1</Placeholder>\n                    <Placeholder>Child 1</Placeholder>\n                </View>\n\n                <View gap={6}>\n                    <Placeholder>Child 2</Placeholder>\n                    <Placeholder>Child 2</Placeholder>\n                </View>\n\n                <View.Item gapBefore={0}>\n                    <View direction=\"row\" gap={2}>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "utility-components-view--test-composition",
+					"name": "composition, edge cases",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item>\n            <View direction=\"row\" align=\"center\" gap={4} padding={4}>\n                <View width=\"80px\" height=\"60px\" backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n\n                <View direction=\"row\" align=\"center\" gap={1} grow>\n                    <View.Item shrink>\n                        <Text>Text (like Jeff's Puzzles)</Text>\n                    </View.Item>\n\n                    <View minWidth=\"auto\" grow>\n                        <Button size=\"small\" color=\"neutral\" icon={IconPlus} />\n                    </View>\n                </View>\n\n                <Button color=\"primary\" rounded>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"View.Item, MenuItem, Aspect ratio\",\n                \"ratio should increase height on viewport change\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <View.Item>\n                    <Placeholder />\n                </View.Item>\n                <MenuItem selected roundedCorners>\n                    Menu\n                </MenuItem>\n                <View.Item grow>\n                    <View aspectRatio={16 / 9}>\n                        <Placeholder h=\"100%\" />\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"Scrollable tabs inside View.Item with grow\">\n            <View direction=\"row\" align=\"center\" gap={3}>\n                <Placeholder />\n                <View.Item grow>\n                    <View padding={0} align=\"center\">\n                        <Tabs variant=\"pills\">\n                            <Tabs.List>\n                                <Tabs.Item value=\"1\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"2\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"3\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"4\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"5\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"6\">Very long item</Tabs.Item>\n                            </Tabs.List>\n                            {[1, 2, 3, 5, 6].map((i) => (\n                                <Tabs.Panel key={i} value={i.toString()} />\n                            ))}\n                        </Tabs>\n                    </View>\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"2nd item has grow, Avatar stays circle\">\n            <View direction=\"row\" gap={3}>\n                <Avatar initials=\"DB\" />\n                <View.Item grow>\n                    Veggies sunt bona vobis, proinde vos postulo esse magis grape pea sprouts horseradish\n                    courgette maize spinach prairie turnip jícama coriander quandong gourd broccoli seakale\n                    gumbo. Parsley corn lentil zucchini radicchio maize burdock avocado sea lettuce.\n                    Garbanzo tigernut earthnut pea fennel.\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"item gapBefore from parent doesn't affect the child view\",\n                \"columns should take full width\",\n            ]}\n        >\n            <View>\n                <View.Item gapBefore={20}>\n                    <View direction=\"row\" gap={4}>\n                        <View.Item columns={6}>\n                            <Placeholder />\n                        </View.Item>\n                        <View.Item columns={6}>\n                            <Placeholder />\n                        </View.Item>\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"View becomes flexbox if there is a child with grow\">\n            <View height=\"300px\" borderColor=\"neutral-faded\">\n                <View height=\"50px\" />\n                <View grow backgroundColor=\"neutral-faded\" padding={4}>\n                    Grow\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "asProp",
+					"id": "utility-components-view--as-prop",
+					"name": "as",
 					"snippet": "const asProp = () => (\n    <View as=\"ul\">\n        <View.Item as=\"li\">Content</View.Item>\n    </View>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-view--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <View className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </View>\n    </div>\n);"
 				},
 				{
-					"name": "itemClassName",
+					"id": "utility-components-view--item-class-name",
+					"name": "item className, attributes",
 					"snippet": "const itemClassName = () => (\n    <div data-testid=\"root\">\n        <View.Item className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </View.Item>\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Button, Example, Hidden, MenuItem, Placeholder, Tabs, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/View/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "View",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/View/View.tsx",
-				"actualName": "View",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"divided": {
+						"defaultValue": null,
+						"description": "Render a divider between each child",
+						"name": "divided",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Flex direction for the content",
+						"name": "direction",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Direction>" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between children, base unit token number multiplier",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"wrap": {
+						"defaultValue": null,
+						"description": "Flex wrap for the content",
+						"name": "wrap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Flex align-items for the content",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Flex justify-content for the content",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width style, literal string value or a base unit token number multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"aspectRatio": {
+						"defaultValue": null,
+						"description": "Aspect ratio style, represented as width / height",
+						"name": "aspectRatio",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height style, literal string value or a base unit token number multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Maximum width style, literal string value or a base unit token number multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"minHeight": {
+						"defaultValue": null,
+						"description": "Minimum height style, literal string value or a base unit token number multiplier",
+						"name": "minHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"minWidth": {
+						"defaultValue": null,
+						"description": "Minimum width style, literal string value or a base unit token number multiplier",
+						"name": "minWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Padding style for all sides, base unit token number multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingTop": {
+						"defaultValue": null,
+						"description": "Padding top, base unit token number multiplier",
+						"name": "paddingTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingBottom": {
+						"defaultValue": null,
+						"description": "Padding bottom, base unit token number multiplier",
+						"name": "paddingBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingStart": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "paddingStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingEnd": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "paddingEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingInline": {
+						"defaultValue": null,
+						"description": "Padding inline, base unit token number multiplier",
+						"name": "paddingInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingBlock": {
+						"defaultValue": null,
+						"description": "Padding block, base unit token number multiplier",
+						"name": "paddingBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margin and remove side borders, base unit token number multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"textAlign": {
+						"defaultValue": null,
+						"description": "Text align for the content",
+						"name": "textAlign",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<TextAlign>" }
+					},
+					"backgroundColor": {
+						"defaultValue": null,
+						"description": "Background color, based on the color tokens",
+						"name": "backgroundColor",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"critical-faded\" | \"warning\" | \"warning-faded\" | \"positive-faded\" | \"primary-faded\" | \"elevation-base\" | \"elevation-raised\" | \"elevation-overlay\" | \"page\" | \"page-faded\" | \"disabled-faded\" | \"brand\" | \"white\" | \"black\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"critical-faded\"" },
+								{ "value": "\"warning\"" },
+								{ "value": "\"warning-faded\"" },
+								{ "value": "\"positive-faded\"" },
+								{ "value": "\"primary-faded\"" },
+								{ "value": "\"elevation-base\"" },
+								{ "value": "\"elevation-raised\"" },
+								{ "value": "\"elevation-overlay\"" },
+								{ "value": "\"page\"" },
+								{ "value": "\"page-faded\"" },
+								{ "value": "\"disabled-faded\"" },
+								{ "value": "\"brand\"" },
+								{ "value": "\"white\"" },
+								{ "value": "\"black\"" }
+							]
+						}
+					},
+					"borderColor": {
+						"defaultValue": null,
+						"description": "Border color, based on the color tokens",
+						"name": "borderColor",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<BorderColor>" }
+					},
+					"border": {
+						"defaultValue": null,
+						"description": "Add border to all sides",
+						"name": "border",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderTop": {
+						"defaultValue": null,
+						"description": "Add border to the top side",
+						"name": "borderTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderBottom": {
+						"defaultValue": null,
+						"description": "Add border to the bottom side",
+						"name": "borderBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderStart": {
+						"defaultValue": null,
+						"description": "Add border to the inline start side",
+						"name": "borderStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderEnd": {
+						"defaultValue": null,
+						"description": "Add border to the inline end side",
+						"name": "borderEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderInline": {
+						"defaultValue": null,
+						"description": "Add border to the inline direction",
+						"name": "borderInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderBlock": {
+						"defaultValue": null,
+						"description": "Add border to the block direction",
+						"name": "borderBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Radius>" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Position style",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Position>" }
+					},
+					"inset": {
+						"defaultValue": null,
+						"description": "Inset style, base unit token number multiplier when used as a number",
+						"name": "inset",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetStart": {
+						"defaultValue": null,
+						"description": "Inset start, base unit token number multiplier when used as a number",
+						"name": "insetStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetEnd": {
+						"defaultValue": null,
+						"description": "Inset end, base unit token number multiplier when used as a number",
+						"name": "insetEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetTop": {
+						"defaultValue": null,
+						"description": "Inset top, base unit token number multiplier when used as a number",
+						"name": "insetTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetBottom": {
+						"defaultValue": null,
+						"description": "Inset bottom, base unit token number multiplier when used as a number",
+						"name": "insetBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"zIndex": {
+						"defaultValue": null,
+						"description": "z-index style",
+						"name": "zIndex",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"shadow": {
+						"defaultValue": null,
+						"description": "Shadow style, based on the shadow tokens",
+						"name": "shadow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Overflow style",
+						"name": "overflow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"auto\"",
+							"value": [{ "value": "\"hidden\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"animated": {
+						"defaultValue": null,
+						"description": "Add transition for the properties",
+						"name": "animated",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					},
+					"grow": {
+						"defaultValue": null,
+						"description": "Apply flex-grow, using it on View.Item applies additional styles on the parent View",
+						"name": "grow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"shrink": {
+						"defaultValue": null,
+						"description": "Apply flex-shrink",
+						"name": "shrink",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "View"
 			}
 		},
 		"hooks-useelementid": {
@@ -3131,7 +16482,8 @@
 			"path": "./src/hooks/tests/useElementId.stories.tsx",
 			"stories": [
 				{
-					"name": "id",
+					"id": "hooks-useelementid--id",
+					"name": "passed id",
 					"snippet": "const id = () => {\n    return <Component id=\"hey\" />;\n};"
 				}
 			],
@@ -3148,6 +16500,7 @@
 			"path": "./src/hooks/tests/useHandlerRef.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usehandlerref--base",
 					"name": "base",
 					"snippet": "const base = (args) => {\n    const [count, setCount] = React.useState(0);\n\n    // Creating a new handler on each render\n    const handleEffect = () => {\n        args.handleEffect(0);\n    };\n\n    return (\n        <View gap={4}>\n            <Button onClick={() => setCount((prev) => prev + 1)}>Increase count</Button>\n            <Component onEffect={handleEffect} count={count} />\n        </View>\n    );\n};"
 				}
@@ -3165,43 +16518,53 @@
 			"path": "./src/hooks/tests/useHotkeys.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usehotkeys--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const { checkHotkeyState } = useHotkeys({\n        \"shift + b + n\": () => console.log(\"pressed\"),\n        \"c + v\": () => console.log(\"c + v\"),\n        \"Meta + k\": () => console.log(\"meta + k\"),\n        \"Meta + f\": () => console.log(\"meta + f\"),\n        \"Meta + v\": () => console.log(\"meta + v\"),\n        \"Meta + b\": () => console.log(\"meta + b\"),\n        \"control + enter\": () => console.log(\"control + enter\"),\n        \"meta + enter\": () => console.log(\"meta + enter\"),\n        \"mod + enter\": () => console.log(\"mod + enter\"),\n        \"mod + ArrowRight\": () => console.log(\"right\"),\n        \"mod + ArrowUp\": () => console.log(\"top\"),\n        \"shift + ArrowRight\": () => console.log(\"right\"),\n        \"shift + ArrowUp\": () => console.log(\"top\"),\n        \"alt+shift+n\": () => console.log(\"alt+shift+n\"),\n        \"shift+alt+n\": () => console.log(\"shift+alt+n\"),\n        \"alt+shiftLeft+n\": () => console.log(\"alt+shiftLeft+n\"),\n    });\n    const active = checkHotkeyState(\"shift + b + n\");\n    const shiftActive = checkHotkeyState(\"shift\");\n    const bActive = checkHotkeyState(\"b\");\n    const nActive = checkHotkeyState(\"n\");\n\n    return (\n        <View\n            animated\n            gap={2}\n            direction=\"row\"\n            backgroundColor={active ? \"positive-faded\" : undefined}\n            padding={2}\n            borderRadius=\"small\"\n        >\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={shiftActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={shiftActive ? undefined : \"raised\"}\n            >\n                Shift\n            </View>\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={bActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={bActive ? undefined : \"raised\"}\n            >\n                b\n            </View>\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={nActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={nActive ? undefined : \"raised\"}\n            >\n                n\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "singleKey",
+					"id": "hooks-usehotkeys--single-key",
+					"name": "single key",
 					"snippet": "const singleKey = (args) => <Component hotkeys={{ a: args.handleHotkey }} />;"
 				},
 				{
-					"name": "modKey",
+					"id": "hooks-usehotkeys--mod-key",
+					"name": "mod key",
 					"snippet": "const modKey = (args) => <Component hotkeys={{ mod: args.handleHotkey }} />;"
 				},
 				{
-					"name": "modKeyHold",
+					"id": "hooks-usehotkeys--mod-key-hold",
+					"name": "mod key on hold",
 					"snippet": "const modKeyHold = (args) => <Component hotkeys={{ \"Meta + b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyList",
+					"id": "hooks-usehotkeys--key-list",
+					"name": "key list",
 					"snippet": "const keyList = (args) => <Component hotkeys={{ \"a,b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombination",
+					"id": "hooks-usehotkeys--key-combination",
+					"name": "key combination",
 					"snippet": "const keyCombination = (args) => <Component hotkeys={{ \"a+b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationFormat",
+					"id": "hooks-usehotkeys--key-combination-format",
+					"name": "key combination without formatting",
 					"snippet": "const keyCombinationFormat = (args) => <Component hotkeys={{ \"A  + b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationOrder",
+					"id": "hooks-usehotkeys--key-combination-order",
+					"name": "key combination without order",
 					"snippet": "const keyCombinationOrder = (args) => <Component hotkeys={{ \"b+a\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationMoreThanRequired",
+					"id": "hooks-usehotkeys--key-combination-more-than-required",
+					"name": "key combination, more keys pressed",
 					"snippet": "const keyCombinationMoreThanRequired = (args) => <Component hotkeys={{ \"z + x\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "optionModified",
+					"id": "hooks-usehotkeys--option-modified",
+					"name": "modified with alt/option",
 					"snippet": "const optionModified = (args) => (\n    <Component hotkeys={{ \"alt+n\": args.handleHotkeyModified, \"alt+shift\": args.handleHotkey }} />\n);"
 				}
 			],
@@ -3218,22 +16581,27 @@
 			"path": "./src/hooks/tests/useKeyboardArrowNavigation.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usekeyboardarrownavigation--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "horizontal",
+					"id": "hooks-usekeyboardarrownavigation--horizontal",
+					"name": "orientation: horizontal",
 					"snippet": "const horizontal = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, orientation: \"horizontal\" });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "vertical",
+					"id": "hooks-usekeyboardarrownavigation--vertical",
+					"name": "orientation: vertical",
 					"snippet": "const vertical = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, orientation: \"vertical\" });\n\n    return (\n        <View gap={2} direction=\"column\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-usekeyboardarrownavigation--circular",
 					"name": "circular",
 					"snippet": "const circular = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, circular: true });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-usekeyboardarrownavigation--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, disabled: true });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				}
@@ -3249,7 +16617,13 @@
 			"id": "hooks-usekeyboardmode",
 			"name": "useKeyboardMode",
 			"path": "./src/hooks/tests/useKeyboardMode.stories.tsx",
-			"stories": [{ "name": "base", "snippet": "const base = () => <Component />;" }],
+			"stories": [
+				{
+					"id": "hooks-usekeyboardmode--base",
+					"name": "base",
+					"snippet": "const base = () => <Component />;"
+				}
+			],
 			"import": "import { Button, View } from \"reshaped\";",
 			"jsDocTags": {},
 			"error": {
@@ -3263,19 +16637,23 @@
 			"path": "./src/hooks/tests/useOnClickOutside.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-useonclickoutside--base",
 					"name": "base",
 					"snippet": "const base = (args) => {\n    const ref = React.useRef(null);\n    const [target, setTarget] = React.useState<\"inside\" | \"outside\" | null>(null);\n\n    useOnClickOutside([ref], () => {\n        args.handleOutsideClick();\n        setTarget(\"outside\");\n    });\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }} onClick={() => setTarget(\"inside\")}>\n                Trigger\n            </Button>\n            {target && `Clicked ${target}`}\n        </View>\n    );\n};"
 				},
 				{
-					"name": "refs",
+					"id": "hooks-useonclickoutside--refs",
+					"name": "multiple refs",
 					"snippet": "const refs = (args) => {\n    const ref = React.useRef(null);\n    const ref2 = React.useRef(null);\n\n    useOnClickOutside([ref, ref2], () => {\n        args.handleOutsideClick();\n    });\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }}>Trigger</Button>\n            <Button attributes={{ ref: ref2 }}>Trigger 2</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-useonclickoutside--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = (args) => {\n    const ref = React.useRef(null);\n\n    useOnClickOutside(\n        [ref],\n        () => {\n            args.handleOutsideClick();\n        },\n        {\n            disabled: true,\n        }\n    );\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }}>Trigger</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "deps",
+					"id": "hooks-useonclickoutside--deps",
+					"name": "test: handler uses latest state",
 					"snippet": "const deps = (args) => {\n    const ref = React.useRef(null);\n    const [count, setCount] = React.useState(0);\n\n    useOnClickOutside([ref], () => {\n        args.handleOutsideClick({ count });\n    });\n\n    return (\n        <Button attributes={{ ref }} onClick={() => setCount((prev) => prev + 1)}>\n            Trigger\n        </Button>\n    );\n};"
 				}
 			],
@@ -3290,7 +16668,13 @@
 			"id": "hooks-usertl",
 			"name": "useRTL",
 			"path": "./src/hooks/tests/useRTL.stories.tsx",
-			"stories": [{ "name": "setRTL", "snippet": "const setRTL = () => <Component />;" }],
+			"stories": [
+				{
+					"id": "hooks-usertl--set-rtl",
+					"name": "setRTL",
+					"snippet": "const setRTL = () => <Component />;"
+				}
+			],
 			"import": "",
 			"jsDocTags": {},
 			"error": {
@@ -3304,10 +16688,12 @@
 			"path": "./src/hooks/tests/useResponsiveClientValue.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-useresponsiveclientvalue--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const value = useResponsiveClientValue<ViewProps[\"backgroundColor\"]>({\n        s: \"neutral\",\n        m: \"critical\",\n        l: \"positive\",\n    });\n\n    return <View width={25} height={25} backgroundColor={value} />;\n};"
 				},
 				{
+					"id": "hooks-useresponsiveclientvalue--boolean",
 					"name": "boolean",
 					"snippet": "const boolean = () => {\n    const value = useResponsiveClientValue<boolean>({\n        s: true,\n        l: false,\n    });\n\n    return <div>{value?.toString()}</div>;\n};"
 				}
@@ -3325,19 +16711,23 @@
 			"path": "./src/hooks/tests/useScrollLock.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usescrolllock--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock();\n\n    return (\n        <React.Fragment>\n            <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n            <div style={{ height: \"150vh\" }} />\n        </React.Fragment>\n    );\n};"
 				},
 				{
-					"name": "origin",
+					"id": "hooks-usescrolllock--origin",
+					"name": "originRef",
 					"snippet": "const origin = () => {\n    const originRef = React.useRef<HTMLDivElement>(null);\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock({ originRef });\n\n    return (\n        <View overflow=\"auto\" height={25} attributes={{ ref: originRef, \"data-testid\": \"root\" }}>\n            <View height={50} padding={4} backgroundColor=\"neutral-faded\" borderRadius=\"medium\">\n                <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "container",
+					"id": "hooks-usescrolllock--container",
+					"name": "containerRef",
 					"snippet": "const container = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock({ containerRef });\n\n    return (\n        <View height={25} attributes={{ ref: containerRef, \"data-testid\": \"root\" }}>\n            <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testContainerAsync",
+					"id": "hooks-usescrolllock--test-container-async",
+					"name": "test: containerRef locked count",
 					"snippet": "const testContainerAsync = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const globalLock = useScrollLock();\n    const scopedLock = useScrollLock({ containerRef });\n\n    return (\n        <Example>\n            <Example.Item title=\"calling regular lock and lock with a container only requires a single unlock to remove overflow\">\n                <View attributes={{ ref: containerRef }} gap={4} direction=\"row\">\n                    <Button\n                        onClick={globalLock.scrollLocked ? globalLock.unlockScroll : globalLock.lockScroll}\n                    >\n                        Toggle\n                    </Button>\n                    <Button\n                        onClick={scopedLock.scrollLocked ? scopedLock.unlockScroll : scopedLock.lockScroll}\n                    >\n                        Toggle\n                    </Button>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
@@ -3354,14 +16744,17 @@
 			"path": "./src/hooks/tests/useToggle.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usetoggle--toggle",
 					"name": "toggle",
 					"snippet": "const toggle = () => {\n    const { toggle, active } = useToggle();\n\n    return (\n        <Button onClick={() => toggle()} attributes={{ \"data-active\": active }}>\n            {active ? \"Deactivate\" : \"Activate\"}\n        </Button>\n    );\n};"
 				},
 				{
+					"id": "hooks-usetoggle--activate",
 					"name": "activate",
 					"snippet": "const activate = () => {\n    const { activate, active } = useToggle();\n\n    return (\n        <React.Fragment>\n            <Button onClick={activate} attributes={{ \"data-active\": active }}>\n                Activate\n            </Button>\n        </React.Fragment>\n    );\n};"
 				},
 				{
+					"id": "hooks-usetoggle--deactivate",
 					"name": "deactivate",
 					"snippet": "const deactivate = () => {\n    const { deactivate, active } = useToggle(true);\n\n    return (\n        <Button onClick={deactivate} attributes={{ \"data-active\": active }}>\n            Deactivate\n        </Button>\n    );\n};"
 				}
@@ -3379,39 +16772,48 @@
 			"path": "./src/utilities/a11y/tests/TrapFocus.stories.tsx",
 			"stories": [
 				{
-					"name": "modeDialog",
+					"id": "utilities-trapfocus--mode-dialog",
+					"name": "mode: dialog",
 					"snippet": "const modeDialog = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, { mode: \"dialog\" });\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\"mode: dialog\", \"tab navigation, always stays inside until released\"]}\n            >\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View.Item>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeActionMenu",
+					"id": "utilities-trapfocus--mode-action-menu",
+					"name": "mode: action-menu",
 					"snippet": "const modeActionMenu = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"action-menu\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: action-menu\",\n                    \"up/down arrow navigation, tab and shift+tab release the focus and follows natural tab order\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeActionBar",
+					"id": "utilities-trapfocus--mode-action-bar",
+					"name": "mode: action-bar",
 					"snippet": "const modeActionBar = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"action-bar\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: action-bar\",\n                    \"left/right arrow navigation, tab and shift+tab release the focus and follows natural tab order\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeContentMenu",
+					"id": "utilities-trapfocus--mode-content-menu",
+					"name": "mode: content-menu",
 					"snippet": "const modeContentMenu = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"content-menu\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: content-menu\",\n                    \"tab navigation, tabbing outside the content will trigger the release\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utilities-trapfocus--include-trigger",
 					"name": "includeTrigger",
 					"snippet": "const includeTrigger = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n            includeTrigger: true,\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utilities-trapfocus--initial-focus-el",
 					"name": "initialFocusEl",
 					"snippet": "const initialFocusEl = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const initialFocusRef = React.useRef<HTMLButtonElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n            initialFocusEl: initialFocusRef.current,\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View\n                            gap={4}\n                            direction=\"row\"\n                            padding={4}\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            attributes={{ ref: rootRef }}\n                        >\n                            <Button onClick={() => {}}>Action 1</Button>\n                            <Button onClick={() => {}} attributes={{ ref: initialFocusRef }}>\n                                Action 2\n                            </Button>\n                            <Button onClick={() => {}}>Action 3</Button>\n                            <Button onClick={trapToggle.deactivate}>Release</Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "focusableElements",
+					"id": "utilities-trapfocus--focusable-elements",
+					"name": "test: focusable elements",
 					"snippet": "const focusableElements = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current);\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title=\"test with all types of focusable elements\">\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={trapToggle.activate}>Activate</Button>\n                    </View.Item>\n\n                    {trapToggle.active && (\n                        <View\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            padding={4}\n                            gap={4}\n                            attributes={{ ref: rootRef }}\n                            align=\"start\"\n                        >\n                            <Link href=\"#\" attributes={{ \"data-testid\": \"test-link\" }}>\n                                Link\n                            </Link>\n\n                            <TextField\n                                name=\"input\"\n                                placeholder=\"Input\"\n                                inputAttributes={{ \"data-testid\": \"test-text-field\" }}\n                            />\n\n                            <TextArea name=\"textarea\" inputAttributes={{ \"data-testid\": \"test-text-area\" }} />\n\n                            <Select\n                                name=\"select\"\n                                options={[\n                                    { label: \"Option 1\", value: \"1\" },\n                                    { label: \"Option 2\", value: \"2\" },\n                                ]}\n                                inputAttributes={{ \"data-testid\": \"test-select\" }}\n                            />\n\n                            <RadioGroup name=\"radio\">\n                                <Radio value=\"1\" inputAttributes={{ \"data-testid\": \"test-radio-1\" }}>\n                                    Option 1\n                                </Radio>\n                                <Radio value=\"2\" inputAttributes={{ \"data-testid\": \"test-radio-2\" }}>\n                                    Option 2\n                                </Radio>\n                            </RadioGroup>\n\n                            <Editor />\n\n                            <div tabIndex={0} role=\"button\" data-testid=\"test-tabindex\">\n                                div with tabIndex\n                            </div>\n\n                            <div style={{ display: \"none\" }}>\n                                <Button onClick={() => {}} attributes={{ \"data-testid\": \"test-hidden-button\" }}>\n                                    Hidden\n                                </Button>\n                            </div>\n\n                            <Button\n                                onClick={() => {}}\n                                attributes={{ tabIndex: -1, \"data-testid\": \"test-button-negative-tabindex\" }}\n                            >\n                                Excluded\n                            </Button>\n\n                            <input type=\"hidden\" data-testid=\"test-input-hidden\" />\n\n                            <Button\n                                onClick={trapToggle.deactivate}\n                                attributes={{ \"data-testid\": \"test-button\" }}\n                            >\n                                Release button\n                            </Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "nested",
+					"id": "utilities-trapfocus--nested",
+					"name": "test: nested",
 					"snippet": "const nested = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const innerRootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n    const innerTrapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    React.useEffect(() => {\n        if (!innerTrapToggle.active) return;\n        if (!innerRootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(innerRootRef.current, {\n            mode: \"dialog\",\n        });\n\n        return () => trapFocus.release();\n    }, [innerTrapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"nested, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View gap={4}>\n                            <View\n                                gap={4}\n                                direction=\"row\"\n                                padding={4}\n                                backgroundColor=\"neutral-faded\"\n                                borderRadius=\"medium\"\n                                attributes={{ ref: rootRef }}\n                            >\n                                <Button onClick={() => {}}>Action</Button>\n                                <Button onClick={innerTrapToggle.activate}>Inner trap focus</Button>\n                                <Button onClick={trapToggle.deactivate}>Release</Button>\n                            </View>\n\n                            {innerTrapToggle.active && (\n                                <View\n                                    gap={4}\n                                    direction=\"row\"\n                                    padding={4}\n                                    backgroundColor=\"neutral-faded\"\n                                    borderRadius=\"medium\"\n                                    attributes={{ ref: innerRootRef }}\n                                >\n                                    <Button onClick={() => {}}>Action</Button>\n                                    <Button onClick={innerTrapToggle.deactivate}>Release</Button>\n                                </View>\n                            )}\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "mutationObserver",
+					"id": "utilities-trapfocus--mutation-observer",
+					"name": "test: mutation observer",
 					"snippet": "const mutationObserver = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n    const [mutated, setMutated] = React.useState(false);\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n        });\n\n        setTimeout(() => {\n            setMutated(true);\n        }, 50);\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View\n                            gap={4}\n                            direction=\"row\"\n                            padding={4}\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            attributes={{ ref: rootRef }}\n                        >\n                            {!mutated && (\n                                <>\n                                    <Button onClick={() => {}}>Action 1</Button>\n                                    <Button onClick={() => {}}>Action 2</Button>\n                                </>\n                            )}\n                            <Button onClick={() => {}}>Action 3</Button>\n                            <Button onClick={trapToggle.deactivate}>Release</Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
@@ -3428,15 +16830,35 @@
 			"path": "./src/components/_private/Portal/tests/Portal.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "internal-portal--base",
+					"name": "Base",
 					"snippet": "const base = () => {\n\tconst ref = React.useRef<HTMLDivElement>(null);\n\tconst [mounted, setMounted] = React.useState(false);\n\n\tReact.useEffect(() => {\n\t\tsetMounted(true);\n\t}, []);\n\n\treturn (\n\t\t<>\n\t\t\t<div style={{ border: \"2px solid #333\", padding: 16 }}>\n\t\t\t\tApp\n\t\t\t\t{mounted && <Portal targetRef={ref}>Ported to green</Portal>}\n\t\t\t</div>\n\t\t\t<div ref={ref} style={{ border: \"2px solid green\", padding: 16 }} />\n\t\t</>\n\t);\n};"
 				}
 			],
 			"import": "import { Portal } from \"reshaped\";",
 			"jsDocTags": {},
-			"error": {
-				"name": "No component definition found",
-				"message": "File: /Users/shilman/projects/design-systems/reshaped/src/components/_private/Portal/index.ts\nError:\nNo suitable component definition found.\nYou can debug your component file in this playground: https://react-docgen.dev/playground\nCode:\nimport Portal, { PortalScope } from \"./Portal\";\n\nconst PortalRoot = Portal as typeof Portal & {\n\tScope: typeof PortalScope;\n};\n\nPortalRoot.Scope = PortalScope;\n\nexport default PortalRoot;\nexport type { Props as PortalProps } from \"./Portal.types\";\n\n\nFile: /Users/shilman/projects/design-systems/reshaped/src/components/_private/Portal/Portal.types.ts\nError:\nNo suitable component definition found.\nYou can debug your component file in this playground: https://react-docgen.dev/playground\nCode:\nimport React from \"react\";\n\nexport type Props = {\n\tchildren?: React.ReactNode;\n\ttargetRef?: React.RefObject<HTMLElement | ShadowRoot | null>;\n};\n\nexport type ScopeProps<T extends HTMLElement> = {\n\tchildren: (ref: React.RefObject<T | null>) => React.ReactNode;\n};\n\nexport type Context = {\n\tscopeRef: React.RefObject<HTMLElement | null>;\n};\n"
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/_private/Portal/index.ts",
+				"description": "",
+				"displayName": "Portal",
+				"methods": [],
+				"props": {
+					"targetRef": {
+						"defaultValue": null,
+						"description": "",
+						"name": "targetRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/_private/Portal/Portal.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | ShadowRoot | null>" }
+					}
+				},
+				"exportName": "Portal"
 			}
 		},
 		"internal-usedrag": {
@@ -3444,24 +16866,33 @@
 			"name": "useDrag",
 			"path": "./src/hooks/tests/useDrag.stories.tsx",
 			"stories": [
-				{ "name": "base", "snippet": "const base = () => <Example />;" },
 				{
-					"name": "mouseEvents",
+					"id": "internal-usedrag--base",
+					"name": "base",
+					"snippet": "const base = () => <Example />;"
+				},
+				{
+					"id": "internal-usedrag--mouse-events",
+					"name": "onDrag, mouse events",
 					"snippet": "const mouseEvents = () => {\n    return <Demo onDrag={fn()} />;\n};"
 				},
 				{
-					"name": "touchEvents",
+					"id": "internal-usedrag--touch-events",
+					"name": "onDrag, touch events",
 					"snippet": "const touchEvents = () => {\n    return <Demo onDrag={fn()} />;\n};"
 				},
 				{
-					"name": "orientationHorizontal",
+					"id": "internal-usedrag--orientation-horizontal",
+					"name": "orientation horizontal",
 					"snippet": "const orientationHorizontal = () => {\n    return <Demo onDrag={fn()} orientation=\"horizontal\" />;\n};"
 				},
 				{
-					"name": "orientationVertical",
+					"id": "internal-usedrag--orientation-vertical",
+					"name": "orientation vertical",
 					"snippet": "const orientationVertical = () => {\n    return <Demo onDrag={fn()} orientation=\"vertical\" />;\n};"
 				},
 				{
+					"id": "internal-usedrag--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => {\n    return <Demo onDrag={fn()} disabled />;\n};"
 				}
@@ -3479,7 +16910,8 @@
 			"path": "./src/tests/ShadowDOM.stories.tsx",
 			"stories": [
 				{
-					"name": "behavior",
+					"id": "internal-shadowdom--behavior",
+					"name": "Behavior",
 					"snippet": "const behavior = () => (\n\t<Example>\n\t\t<Example.Item title=\"base\">\n\t\t\t<Component />\n\t\t</Example.Item>\n\t</Example>\n);"
 				}
 			],
@@ -3496,30 +16928,94 @@
 			"path": "./src/tests/themes.stories.tsx",
 			"stories": [
 				{
-					"name": "test",
+					"id": "internal-themes--test",
+					"name": "Test",
 					"snippet": "const test = () => {\n\tconst { colorMode } = useTheme();\n\tconst [activeColor, setColor] = useState(colors[0]);\n\tconst [theme, setTheme] = useState(\"\");\n\tconst [algo, setAlgo] = useState<\"wcag\" | \"apca\">(\"wcag\");\n\n\tuseLayoutEffect(() => {\n\t\tsetTheme(\n\t\t\tgetThemeCSS(\n\t\t\t\t\"test\",\n\t\t\t\t{\n\t\t\t\t\tcolor: generateThemeColors({\n\t\t\t\t\t\tprimary: activeColor === colors[0] ? undefined : activeColor,\n\t\t\t\t\t}),\n\t\t\t\t},\n\t\t\t\t{\n\t\t\t\t\tcolorContrastAlgorithm: algo,\n\t\t\t\t}\n\t\t\t)\n\t\t);\n\t}, [activeColor, algo]);\n\n\treturn (\n\t\t<>\n\t\t\t<style>{theme}</style>\n\t\t\t<Theme name=\"test\">\n\t\t\t\t<View gap={4}>\n\t\t\t\t\t<View direction=\"row\" align=\"center\" gap={4}>\n\t\t\t\t\t\t{colors.map((color) => {\n\t\t\t\t\t\t\tconst hex = colorMode === \"dark\" && color === \"#000000\" ? \"#ffffff\" : color;\n\n\t\t\t\t\t\t\treturn (\n\t\t\t\t\t\t\t\t<Actionable key={color} onClick={() => setColor(color)} borderRadius=\"inherit\">\n\t\t\t\t\t\t\t\t\t<View\n\t\t\t\t\t\t\t\t\t\twidth={5}\n\t\t\t\t\t\t\t\t\t\theight={5}\n\t\t\t\t\t\t\t\t\t\tborderRadius=\"circular\"\n\t\t\t\t\t\t\t\t\t\tattributes={{\n\t\t\t\t\t\t\t\t\t\t\tstyle: {\n\t\t\t\t\t\t\t\t\t\t\t\ttransition: `box-shadow var(--rs-duration-fast) var(--rs-easing-standard)`,\n\t\t\t\t\t\t\t\t\t\t\t\tbackground: hex,\n\t\t\t\t\t\t\t\t\t\t\t\tboxShadow:\n\t\t\t\t\t\t\t\t\t\t\t\t\tcolor === activeColor\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t? `0 0 0 3px var(--rs-color-background-elevation-base), 0 0 0 5px ${hex}`\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t: undefined,\n\t\t\t\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t\t\t\t}}\n\t\t\t\t\t\t\t\t\t/>\n\t\t\t\t\t\t\t\t</Actionable>\n\t\t\t\t\t\t\t);\n\t\t\t\t\t\t})}\n\t\t\t\t\t\t<View.Item gapBefore=\"auto\">\n\t\t\t\t\t\t\t<Switch name=\"algo\" onChange={(args) => setAlgo(args.checked ? \"apca\" : \"wcag\")}>\n\t\t\t\t\t\t\t\tUse APCA\n\t\t\t\t\t\t\t</Switch>\n\t\t\t\t\t\t</View.Item>\n\t\t\t\t\t</View>\n\n\t\t\t\t\t<ThemePlayground />\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</>\n\t);\n};"
 				},
 				{
-					"name": "base",
+					"id": "internal-themes--base",
+					"name": "Base",
 					"snippet": "const base = () => (\n\t<Example>\n\t\t<Example.Item title=\"custom runtime theme\">\n\t\t\t<style>{css}</style>\n\t\t\t<Theme name=\"green\">\n\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"on colors generation\">\n\t\t\t<style>{css2}</style>\n\t\t\t<Theme name=\"peach\">\n\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "generation",
+					"id": "internal-themes--generation",
+					"name": "Generation",
 					"snippet": "const generation = () => (\n\t<div>\n\t\t<style>{cssGenerated}</style>\n\t\t<Theme name=\"generated\">{componentExamples}</Theme>\n\t</div>\n);"
 				},
 				{
-					"name": "onColors",
+					"id": "internal-themes--on-colors",
+					"name": "On Colors",
 					"snippet": "const onColors = () => (\n\t<Example>\n\t\t<Example.Item title=\"custom on color values\">\n\t\t\t<style>{onColorsCss}</style>\n\t\t\t<Theme name=\"on-color\">\n\t\t\t\t<View gap={2} direction=\"row\">\n\t\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t\t\t<Button color=\"critical\">Critical button</Button>\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"custom on color values, apca\">\n\t\t\t<style>{onColorsCssApca}</style>\n\t\t\t<Theme name=\"on-color-apca\">\n\t\t\t\t<View gap={2} direction=\"row\">\n\t\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t\t\t<Button color=\"critical\">Critical button</Button>\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t</Example>\n);"
 				}
 			],
 			"import": "import {\n    Actionable,\n    Alert,\n    Avatar,\n    Badge,\n    Button,\n    Card,\n    DropdownMenu,\n    Example,\n    Link,\n    Switch,\n    Text,\n    TextField,\n    Theme,\n    ThemePlayground,\n    View,\n} from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Theme/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Theme",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Theme/Theme.tsx",
-				"actualName": "Theme",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the theme to use, enables controlled mode",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"defaultName": {
+						"defaultValue": null,
+						"description": "Default name of the theme to use, enables uncontrolled mode",
+						"name": "defaultName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode to use",
+						"name": "colorMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode | \"inverted\"",
+							"value": [
+								{ "value": "\"light\"" },
+								{ "value": "\"dark\"" },
+								{ "value": "\"inverted\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -3529,7 +17025,8 @@
 			"path": "./src/Sandbox.stories.tsx",
 			"stories": [
 				{
-					"name": "preview",
+					"id": "sandbox--preview",
+					"name": "Preview",
 					"snippet": "const preview = () => {\n\treturn (\n\t\t<Preview>\n\t\t\t<Component />\n\t\t</Preview>\n\t);\n};"
 				}
 			],
@@ -3540,5 +17037,6 @@
 				"message": "We could not detect the component from your story file. Specify meta.component.\n   7 | import MenuItem from \"components/MenuItem\";\n   8 |\n>  9 | export default {\n     | ^\n  10 | \ttitle: \"Sandbox\",\n  11 | \tchromatic: { disableSnapshot: true },\n  12 | };\n\n./src/Sandbox.stories.tsx:\nimport View from \"components/View\";\nimport Image from \"components/Image\";\nimport React from \"react\";\nimport Select from \"components/Select\";\nimport useToggle from \"hooks/useToggle\";\nimport Modal from \"components/Modal\";\nimport MenuItem from \"components/MenuItem\";\n\nexport default {\n\ttitle: \"Sandbox\",\n\tchromatic: { disableSnapshot: true },\n};\n\nconst Preview: React.FC<{ children: React.ReactNode }> = (props) => {\n\treturn (\n\t\t<View padding={20} gap={6}>\n\t\t\t<View position=\"absolute\" insetTop={0} insetStart={0}>\n\t\t\t\t<Image src=\"./logo.svg\" />\n\t\t\t</View>\n\n\t\t\t{props.children}\n\t\t</View>\n\t);\n};\n\nexport const preview = () => {\n\treturn (\n\t\t<Preview>\n\t\t\t<Component />\n\t\t</Preview>\n\t);\n};\n\nconst Component = () => {\n\tconst toggle = useToggle();\n\tconst [value, setValue] = React.useState(\"Dog\");\n\n\tconst handleClick = () => {\n\t\ttoggle.toggle();\n\t};\n\n\treturn (\n\t\t<>\n\t\t\t<Select name=\"animal\" placeholder=\"Select an animal\" onClick={handleClick}>\n\t\t\t\t{value}\n\t\t\t</Select>\n\t\t\t<Modal active={toggle.active} onClose={toggle.deactivate} position=\"bottom\" padding={2}>\n\t\t\t\t<MenuItem\n\t\t\t\t\troundedCorners\n\t\t\t\t\tonClick={() => {\n\t\t\t\t\t\tsetValue(\"Dog\");\n\t\t\t\t\t\ttoggle.deactivate();\n\t\t\t\t\t}}\n\t\t\t\t\tattributes={{\n\t\t\t\t\t\trole: \"option\",\n\t\t\t\t\t}}\n\t\t\t\t>\n\t\t\t\t\tDog\n\t\t\t\t</MenuItem>\n\t\t\t\t<MenuItem\n\t\t\t\t\troundedCorners\n\t\t\t\t\tattributes={{\n\t\t\t\t\t\trole: \"option\",\n\t\t\t\t\t}}\n\t\t\t\t\tonClick={() => {\n\t\t\t\t\t\tsetValue(\"Turtle\");\n\t\t\t\t\t\ttoggle.deactivate();\n\t\t\t\t\t}}\n\t\t\t\t>\n\t\t\t\t\tTurtle\n\t\t\t\t</MenuItem>\n\t\t\t</Modal>\n\t\t</>\n\t);\n};\n"
 			}
 		}
-	}
+	},
+	"meta": { "docgen": "react-docgen-typescript", "durationMs": 2919 }
 }

--- a/eval/tasks/905-existing-component-write-story-reshaped/manifests/components.json
+++ b/eval/tasks/905-existing-component-write-story-reshaped/manifests/components.json
@@ -7,46 +7,201 @@
 			"path": "./src/components/ActionBar/tests/ActionBar.stories.tsx",
 			"stories": [
 				{
-					"name": "positionRelative",
+					"id": "components-actionbar--position-relative",
+					"name": "position, positionType: relative",
 					"snippet": "const positionRelative = () => (\n    <Example>\n        <Example.Item title=\"position: top\">\n            <ActionBar position=\"top\">\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <ActionBar position=\"bottom\">\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positionAbsolute",
+					"id": "components-actionbar--position-absolute",
+					"name": "position, positionType: absolute",
 					"snippet": "const positionAbsolute = () => (\n    <Example>\n        <Example.Item title=\"position: top-start\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top-start\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: top\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: top-end\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top-end\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom-start\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom-start\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom-end\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positionFixed",
+					"id": "components-actionbar--position-fixed",
+					"name": "position, positionType: fixed",
 					"snippet": "const positionFixed = () => (\n    <>\n        <ActionBar padding={2} position=\"top-start\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"top\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"top-end\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom-start\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom-end\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <div style={{ height: 2000 }} />\n    </>\n);"
 				},
 				{
+					"id": "components-actionbar--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated, position: top\">\n            <ActionBar position=\"top\" elevated>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"elevated, position: bottom\">\n            <ActionBar elevated>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"auto elevated, position: bottom\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-actionbar--offset",
 					"name": "offset",
 					"snippet": "const offset = () => (\n    <Example>\n        <Example.Item title=\"offset 2, position: top\">\n            <Fixtures.Container>\n                <ActionBar position=\"top\" positionType=\"absolute\" offset={2}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"offset 2, position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\" offset={2}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"offset s: 2, m: 4, position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\" offset={{ s: 2, m: 4 }}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-actionbar--active",
 					"name": "active",
 					"snippet": "const active = () => {\n    const barToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => barToggle.toggle()}>Toggle</Button>\n            <ActionBar active={barToggle.active} positionType=\"fixed\" position=\"top-end\">\n                <Fixtures.Actions />\n            </ActionBar>\n        </>\n    );\n};"
 				},
 				{
-					"name": "padding",
+					"id": "components-actionbar--padding",
+					"name": "padding, paddingBlock, paddingInline",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 6\">\n            <ActionBar padding={6}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"paddingBlock: 2, paddingInline: 4\">\n            <ActionBar paddingBlock={2} paddingInline={4}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"padding: [s] 4, [m+] 6\">\n            <ActionBar padding={{ s: 4, m: 6 }}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-actionbar--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ActionBar className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </ActionBar>\n    </div>\n);"
 				}
 			],
 			"import": "import { ActionBar, Button, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ActionBar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ActionBar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ActionBar/ActionBar.tsx",
-				"actualName": "ActionBar",
+				"methods": [],
+				"props": {
+					"paddingBlock": {
+						"defaultValue": null,
+						"description": "Padding block, base unit token number multiplier",
+						"name": "paddingBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingInline": {
+						"defaultValue": null,
+						"description": "Padding inline, base unit token number multiplier",
+						"name": "paddingInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Padding style for all sides, base unit token number multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Show or hide the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"offset": {
+						"defaultValue": null,
+						"description": "Offset from the container bounds",
+						"name": "offset",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"position": {
+						"defaultValue": { "value": "\"bottom\"" },
+						"description": "Position based on the container bounds",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"top-end\" | \"top-start\" | \"bottom\" | \"bottom-start\" | \"bottom-end\"",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" }
+							]
+						}
+					},
+					"positionType": {
+						"defaultValue": null,
+						"description": "CSS position style",
+						"name": "positionType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"relative\" | \"absolute\" | \"fixed\">" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Display above the content with elevated shadow and background",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -56,30 +211,138 @@
 			"path": "./src/components/Alert/tests/Alert.stories.tsx",
 			"stories": [
 				{
+					"id": "components-alert--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        {([\"neutral\", \"primary\", \"critical\", \"positive\", \"warning\"] as const).map((color) => (\n            <Example.Item title={`color: ${color}`} key={color}>\n                <Alert\n                    color={color}\n                    title=\"Alert title goes here\"\n                    icon={IconZap}\n                    actionsSlot={\n                        <>\n                            <Link\n                                variant=\"plain\"\n                                color={color === \"neutral\" ? \"primary\" : color}\n                                onClick={() => {}}\n                            >\n                                View now\n                            </Link>\n                            <Link\n                                variant=\"plain\"\n                                color={color === \"neutral\" ? \"primary\" : color}\n                                onClick={() => {}}\n                            >\n                                Dismiss\n                            </Link>\n                        </>\n                    }\n                >\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard\n                </Alert>\n            </Example.Item>\n        ))}\n    </Example>\n);"
 				},
 				{
+					"id": "components-alert--inline",
 					"name": "inline",
 					"snippet": "const inline = () => (\n    <Example>\n        <Example.Item title=\"inline: true\">\n            <Alert\n                inline\n                title=\"Alert title goes here\"\n                icon={IconZap}\n                actionsSlot={\n                    <>\n                        <Link variant=\"plain\" onClick={() => {}}>\n                            View now\n                        </Link>\n                        <Link variant=\"plain\" onClick={() => {}}>\n                            Dismiss\n                        </Link>\n                    </>\n                }\n            >\n                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has\n                been the industry's standard\n            </Alert>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-alert--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4\">\n            <Alert bleed={4} icon={IconZap}>\n                Content\n            </Alert>\n        </Example.Item>\n        <Example.Item title=\"bleed: [s] 4, [m+] 0\">\n            <Alert bleed={{ s: 4, m: 0 }} icon={IconZap}>\n                Content\n            </Alert>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-alert--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Alert className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </Alert>\n    </div>\n);"
 				}
 			],
 			"import": "import { Alert, Example, Link, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Alert/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Alert",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Alert/Alert.tsx",
-				"actualName": "Alert",
+				"methods": [],
+				"props": {
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"title": {
+						"defaultValue": null,
+						"description": "Title slot",
+						"name": "title",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Slot for rendering the main content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"actionsSlot": {
+						"defaultValue": null,
+						"description": "Actions slot, usually used for Buttons and Links, automatically adds a gap between the actions",
+						"name": "actionsSlot",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Color scheme of the alert elements",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"inline": {
+						"defaultValue": null,
+						"description": "Display action to the right of the content",
+						"name": "inline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margin and remove side borders, base unit token number multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -89,35 +352,573 @@
 			"path": "./src/components/Autocomplete/tests/Autocomplete.stories.tsx",
 			"stories": [
 				{
-					"name": "active",
+					"id": "components-autocomplete--active",
+					"name": "active, onOpen, onClose",
 					"snippet": "const active = (args) => {\n    const toggle = useToggle(true);\n\n    return (\n        <Example>\n            <Example.Item title=\"active, onOpen, onClose\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete\n                        name=\"fruit\"\n                        placeholder=\"Pick your food\"\n                        active={toggle.active}\n                        onOpen={() => {\n                            args.handleOpen();\n                            toggle.activate();\n                        }}\n                        onClose={() => {\n                            args.handleClose();\n                            toggle.deactivate();\n                        }}\n                        onChange={(args) => console.log(args)}\n                    >\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "base",
+					"id": "components-autocomplete--base",
+					"name": "onInput, onItemSelect, onBackspace",
 					"snippet": "const base = () => {\n    const [value, setValue] = React.useState(\"\");\n\n    return (\n        <Example>\n            <Example.Item title=\"Base\">\n                <FormControl>\n                    <FormControl.Label>Food</FormControl.Label>\n                    <Autocomplete\n                        name=\"fruit\"\n                        placeholder=\"Pick your food\"\n                        value={value}\n                        onChange={(args) => setValue(args.value)}\n                        onBackspace={fn()}\n                        onItemSelect={fn()}>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "itemData",
+					"id": "components-autocomplete--item-data",
+					"name": "item data",
 					"snippet": "const itemData = () => {\n    return (\n        <Example>\n            <Example.Item title=\"item data\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete name=\"fruit\" placeholder=\"Pick your food\" onItemSelect={fn()} active>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v} data={i === 1 ? { foo: true } : undefined}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "itemDisabled",
+					"id": "components-autocomplete--item-disabled",
+					"name": "item disabled",
 					"snippet": "const itemDisabled = () => {\n    return (\n        <Example>\n            <Example.Item title=\"item disabled\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete name=\"fruit\" placeholder=\"Pick your food\" active>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v} disabled={i === 1}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "multiselect",
+					"id": "components-autocomplete--multiselect",
+					"name": "test: multiselect",
 					"snippet": "const multiselect = () => {\n    const options = [\n        \"Pizza\",\n        \"Pie\",\n        \"Ice-cream\",\n        \"Fries\",\n        \"Salad\",\n        \"Option 4\",\n        \"Option 5\",\n        \"Option 6\",\n    ];\n\n    const inputRef = React.useRef<HTMLInputElement>(null);\n    const [values, setValues] = React.useState<string[]>([\n        \"Option 4\",\n        \"Option 5\",\n        \"Option 6\",\n        \"Pizza\",\n        \"Ice-cream\",\n    ]);\n    const [query, setQuery] = React.useState(\"\");\n\n    const handleDismiss = (dismissedValue: string) => {\n        const nextValues = values.filter((value) => value !== dismissedValue);\n        setValues(nextValues);\n        inputRef.current?.focus();\n    };\n\n    const valuesNode = values.map((value) => (\n        <Badge dismissAriaLabel=\"Dismiss value\" onDismiss={() => handleDismiss(value)} key={value}>\n            {value}\n        </Badge>\n    ));\n\n    return (\n        <FormControl>\n            <FormControl.Label>Food</FormControl.Label>\n            <Autocomplete\n                name=\"fruit\"\n                value={query}\n                placeholder=\"Pick your food\"\n                startSlot={valuesNode}\n                multiline\n                inputAttributes={{ ref: inputRef }}\n                onChange={(args) => setQuery(args.value)}\n                onBackspace={() => {\n                    if (query.length === 0) {\n                        setValues((prev) => prev.slice(0, -1));\n                    }\n                }}\n                onItemSelect={(args) => {\n                    setQuery(\"\");\n                    setValues((prev) => [...prev, args.value]);\n                }}\n            >\n                {options.map((v) => {\n                    if (!v.toLowerCase().includes(query.toLowerCase())) return;\n                    if (values.includes(v)) return;\n\n                    return (\n                        <Autocomplete.Item key={v} value={v}>\n                            {v}\n                        </Autocomplete.Item>\n                    );\n                })}\n            </Autocomplete>\n        </FormControl>\n    );\n};"
 				}
 			],
 			"import": "import { Autocomplete, Badge, Example, FormControl } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Autocomplete/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Autocomplete",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Autocomplete/Autocomplete.tsx",
-				"actualName": "Autocomplete",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"multiline": {
+						"defaultValue": null,
+						"description": "Enable multiline text field wrapping",
+						"name": "multiline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to be fully rounded",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content after the text field value",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text field value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the text field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the text field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"onInput": {
+						"defaultValue": null,
+						"description": "Callback for when value changes from user input",
+						"name": "onInput",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onItemSelect": {
+						"defaultValue": null,
+						"description": "Callback for when an item is selected in the dropdown",
+						"name": "onItemSelect",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: SelectArgs) => void)" }
+					},
+					"onBackspace": {
+						"defaultValue": null,
+						"description": "Callback for when the backspace key is pressed while the input is focused",
+						"name": "onBackspace",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onEnter": {
+						"defaultValue": null,
+						"description": "Callback for when the enter key is pressed while the input is focused",
+						"name": "onEnter",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Slot for rendering the Autocomplete.Item components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					}
+				},
+				"exportName": "Autocomplete"
 			}
 		},
 		"components-avatar": {
@@ -126,46 +927,230 @@
 			"path": "./src/components/Avatar/tests/Avatar.stories.tsx",
 			"stories": [
 				{
-					"name": "src",
+					"id": "components-avatar--src",
+					"name": "src, alt",
 					"snippet": "const src = () => (\n    <Example>\n        <Example.Item title=\"src, alt\">\n            <Avatar\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n                alt=\"Amsterdam canal\"\n                size={12}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"src\">\n            <Avatar src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "initials",
+					"id": "components-avatar--initials",
+					"name": "initials, icon",
 					"snippet": "const initials = () => (\n    <Example>\n        <Example.Item title=\"initials\">\n            <Avatar initials=\"RS\" />\n        </Example.Item>\n\n        <Example.Item title=\"icon\">\n            <Avatar icon={IconZap} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-avatar--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: 6\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={6} icon={IconZap} />\n                <Avatar size={6} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: 15\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={15} icon={IconZap} />\n                <Avatar size={15} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: 40\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={40} icon={IconZap} />\n                <Avatar size={40} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] 10\", \"[m+] 20\"]}>\n            <View direction=\"row\" gap={3}>\n                <Avatar size={{ s: 10, m: 20 }} icon={IconZap} />\n                <Avatar size={{ s: 10, m: 20 }} icon={IconZap} squared />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-avatar--squared",
 					"name": "squared",
 					"snippet": "const squared = () => (\n    <Example>\n        <Example.Item title=\"squared, with image\">\n            <Avatar\n                squared\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n            />\n        </Example.Item>\n        <Example.Item title=\"squared, with initials\">\n            <Avatar squared initials=\"RS\" />\n        </Example.Item>\n        <Example.Item title=\"squared, with initials\">\n            <Avatar squared icon={IconZap} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "colors",
+					"id": "components-avatar--colors",
+					"name": "color, variant",
 					"snippet": "const colors = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"neutral\" icon={IconZap} />\n                <Avatar color=\"neutral\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"primary\" icon={IconZap} />\n                <Avatar color=\"primary\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"positive\" icon={IconZap} />\n                <Avatar color=\"positive\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"warning\" icon={IconZap} />\n                <Avatar color=\"warning\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"critical\" icon={IconZap} />\n                <Avatar color=\"critical\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "fallback",
+					"id": "components-avatar--fallback",
+					"name": "test: fallback",
 					"snippet": "const fallback = (args) => {\n    const [error, setError] = useState(false);\n\n    return (\n        <Avatar\n            src={error ? undefined : \"/foo\"}\n            icon={IconZap}\n            imageAttributes={{\n                onError: () => {\n                    setError(true);\n                    args.handleError();\n                },\n            }}\n        />\n    );\n};"
 				},
 				{
+					"id": "components-avatar--render-image",
 					"name": "renderImage",
 					"snippet": "const renderImage = () => (\n    <Example>\n        <Example.Item title=\"renderImage\">\n            <Avatar\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n                alt=\"Amsterdam canal\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image\" />}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-avatar--class-name",
+					"name": "className, attributes, imageAttributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Avatar\n            src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            imageAttributes={{ id: \"test-image-id\", alt: \"test image\" }}\n        />\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Avatar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Avatar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Avatar/Avatar.tsx",
-				"actualName": "Avatar",
+				"methods": [],
+				"props": {
+					"src": {
+						"defaultValue": null,
+						"description": "Image URL",
+						"name": "src",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"alt": {
+						"defaultValue": null,
+						"description": "Image alt text",
+						"name": "alt",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"imageAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the image element",
+						"name": "imageAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"img\">" }
+					},
+					"renderImage": {
+						"defaultValue": null,
+						"description": "Render prop for the image element, useful for integrating with the Image component from third party frameworks",
+						"name": "renderImage",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Omit<Attributes<\"img\">, \"src\" | \"alt\"> & { src: string; alt: string; }) => ReactNode)"
+						}
+					},
+					"initials": {
+						"defaultValue": null,
+						"description": "Initials to display if no image is provided",
+						"name": "initials",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon, used when no image is provided",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"squared": {
+						"defaultValue": null,
+						"description": "Change the shape to rounded square",
+						"name": "squared",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"faded\"",
+							"value": [{ "value": "\"solid\"" }, { "value": "\"faded\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "12" },
+						"description": "Size of the component, base unit token number multiplier",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -175,63 +1160,273 @@
 			"path": "./src/components/Badge/tests/Badge.stories.tsx",
 			"stories": [
 				{
+					"id": "components-badge--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Badge>Badge</Badge>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <Badge variant=\"faded\">Badge</Badge>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <Badge variant=\"outline\">Badge</Badge>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"primary\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"primary\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"primary\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: positive, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"positive\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"positive\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"positive\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: critical, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"critical\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"critical\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"critical\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: warning, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"warning\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"warning\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"warning\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"small\">Badge</Badge>\n                <Badge rounded size=\"small\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge>Badge</Badge>\n                <Badge rounded>Badge</Badge>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"large\">Badge</Badge>\n                <Badge rounded size=\"large\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={3} direction=\"row\">\n                <Badge icon={IconCheckmark} endIcon={IconChevronRight} size=\"small\">\n                    Badge\n                </Badge>\n                <Badge icon={IconCheckmark} size=\"small\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={3} direction=\"row\">\n                <Badge icon={IconCheckmark} endIcon={IconChevronRight}>\n                    Badge\n                </Badge>\n                <Badge icon={IconCheckmark} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"large\" icon={IconCheckmark} endIcon={IconChevronRight}>\n                    Badge\n                </Badge>\n\n                <Badge icon={IconCheckmark} size=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onDismiss",
+					"id": "components-badge--on-dismiss",
+					"name": "onDismiss, dismissAriaLabel",
 					"snippet": "const onDismiss = () => <Example>\n    <Example.Item title=\"onDismiss\">\n        <Badge onDismiss={fn()} dismissAriaLabel=\"Dismiss\">Badge\n                            </Badge>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-badge--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded>Badge</Badge>\n                <Badge rounded variant=\"faded\">\n                    Badge\n                </Badge>\n                <Badge rounded variant=\"outline\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"rounded, all sizes, color: critical\", \"one character, renders as circle\"]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Badge rounded color=\"critical\" size=\"small\">\n                    2\n                </Badge>\n                <Badge rounded color=\"critical\">\n                    2\n                </Badge>\n                <Badge rounded color=\"critical\" size=\"large\">\n                    2\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--empty",
 					"name": "empty",
 					"snippet": "const empty = () => (\n    <Example>\n        <Example.Item title=\"empty, not rounded, all sizes, color: critical\">\n            <View direction=\"row\" gap={3}>\n                <Badge size=\"small\" color=\"critical\" />\n                <Badge color=\"critical\" />\n                <Badge size=\"large\" color=\"critical\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"empty, rounded, all sizes, color: critical\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded size=\"small\" color=\"critical\" />\n                <Badge rounded color=\"critical\" />\n                <Badge rounded size=\"large\" color=\"critical\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"empty, rounded, all sizes, color: neutral\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded size=\"small\" color=\"neutral\" />\n                <Badge rounded />\n                <Badge rounded size=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--highlighted",
 					"name": "highlighted",
 					"snippet": "const highlighted = () => (\n    <Example>\n        <Example.Item title=\"highlighted, color: neutral\">\n            <View gap={3} direction=\"row\">\n                <Badge highlighted>Badge</Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--container",
 					"name": "container",
 					"snippet": "const container = () => {\n    const [hidden, setHidden] = React.useState(false);\n\n    return (\n        <Example title={<Button onClick={() => setHidden(!hidden)}>Toggle badges</Button>}>\n            <Example.Item title=\"position: top-end\">\n                <Badge.Container>\n                    <Badge color=\"primary\" hidden={hidden}>\n                        5\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: bottom-end\">\n                <Badge.Container position=\"bottom-end\">\n                    <Badge color=\"primary\" hidden={hidden}>\n                        5\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: top-end, rounded, multiple digits\">\n                <Badge.Container>\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        123\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: top-end, rounded, empty\">\n                <Badge.Container>\n                    <Badge color=\"primary\" rounded hidden={hidden} />\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: top-end, overlap\", \"should cover the circular avatar\"]}>\n                <Badge.Container overlap>\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        2\n                    </Badge>\n                    <Avatar initials=\"A\" />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: bottom-end, overlap\", \"should cover the circular avatar\"]}>\n                <Badge.Container overlap position=\"bottom-end\">\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        2\n                    </Badge>\n                    <Avatar initials=\"A\" />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: top-end, overlap\", \"should cover the icon\"]}>\n                <Badge.Container overlap position=\"top-end\">\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden} />\n                    <Icon svg={IconCheckmark} size={5} />\n                </Badge.Container>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-badge--href",
 					"name": "href",
 					"snippet": "const href = () => (\n    <Badge href=\"https://reshaped.so\" dismissAriaLabel=\"Dismiss\">\n        Badge\n    </Badge>\n);"
 				},
 				{
+					"id": "components-badge--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Badge onClick={fn()}>Badge</Badge>;"
 				},
 				{
-					"name": "className",
+					"id": "components-badge--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Badge color=\"primary\" className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Badge, Button, Example, Icon, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Badge/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Badge",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Badge/Badge.tsx",
-				"actualName": "Badge",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"large\" | \"medium\"",
+							"value": [
+								{ "value": "\"small\"" },
+								{ "value": "\"large\"" },
+								{ "value": "\"medium\"" }
+							]
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "highlighted",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hidden": {
+						"defaultValue": null,
+						"description": "Transition the component to hidden state",
+						"name": "hidden",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting text or other content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"onDismiss": {
+						"defaultValue": null,
+						"description": "Callback triggered when the dismiss button is pressed",
+						"name": "onDismiss",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"dismissAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the dismiss button",
+						"name": "dismissAriaLabel",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "Badge"
 			}
 		},
 		"components-breadcrumbs": {
@@ -240,51 +1435,185 @@
 			"path": "./src/components/Breadcrumbs/tests/Breadcrumbs.stories.tsx",
 			"stories": [
 				{
+					"id": "components-breadcrumbs--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <Breadcrumbs ariaLabel=\"breadcrumb neutral\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"color: primary\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb primary\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "item",
+					"id": "components-breadcrumbs--item",
+					"name": "item, disabled",
 					"snippet": "const item = () => (\n    <Example>\n        <Example.Item title=\"disabled item\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb disabled\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}} disabled>\n                    Disabled item 2\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "icon",
+					"id": "components-breadcrumbs--icon",
+					"name": "item, icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"item with icon\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb with icon\">\n                <Breadcrumbs.Item icon={IconZap} onClick={() => {}}>\n                    Item 1\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "slots",
+					"id": "components-breadcrumbs--slots",
+					"name": "separator, children",
 					"snippet": "const slots = () => (\n    <Example>\n        <Example.Item title=\"slot: separator\">\n            <Breadcrumbs color=\"primary\" separator=\"/\" ariaLabel=\"breadcrumb with separator\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"custom child content\">\n            <Breadcrumbs ariaLabel=\"breadcrumb with custom children\">\n                <Breadcrumbs.Item onClick={() => {}}>\n                    <Badge>Item 1</Badge>\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>\n                    <Badge>Item 2</Badge>\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-breadcrumbs--collapsed",
 					"name": "collapsed",
 					"snippet": "const collapsed = () => (\n    <Example>\n        <Example.Item title=\"collapsed, 3 items shown by default\">\n            <Breadcrumbs\n                defaultVisibleItems={3}\n                ariaLabel=\"breadcrumbs one\"\n                expandAriaLabel=\"Expand items\"\n            >\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"collapsed, 4 items shown by default\">\n            <Breadcrumbs\n                defaultVisibleItems={4}\n                ariaLabel=\"breadcrumb two\"\n                expandAriaLabel=\"Expand items\"\n            >\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"collapsed, 3 items shown by default, not expandable\">\n            <Breadcrumbs defaultVisibleItems={3} ariaLabel=\"breadcrumb three\" disableExpand>\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "multiline",
+					"id": "components-breadcrumbs--multiline",
+					"name": "composition, multiline",
 					"snippet": "const multiline = () => (\n    <Example>\n        <Example.Item title=\"wraps content when multiline\">\n            <Breadcrumbs ariaLabel=\"breadcrumb multiline\">\n                {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((i) => (\n                    <Breadcrumbs.Item onClick={() => {}} key={i}>\n                        Item {i}\n                    </Breadcrumbs.Item>\n                ))}\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onClick",
+					"id": "components-breadcrumbs--on-click",
+					"name": "item, onClick, disabled",
 					"snippet": "const onClick = () => <Breadcrumbs>\n    <Breadcrumbs.Item onClick={fn()}>Trigger</Breadcrumbs.Item>\n    <Breadcrumbs.Item onClick={fn()} disabled>Trigger\n                    </Breadcrumbs.Item>\n</Breadcrumbs>;"
 				},
 				{
-					"name": "href",
+					"id": "components-breadcrumbs--href",
+					"name": "item, href",
 					"snippet": "const href = () => (\n    <Breadcrumbs>\n        <Breadcrumbs.Item href=\"https://reshaped.so\">Trigger</Breadcrumbs.Item>\n    </Breadcrumbs>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-breadcrumbs--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Breadcrumbs className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Breadcrumbs.Item>Trigger</Breadcrumbs.Item>\n        </Breadcrumbs>\n    </div>\n);"
 				}
 			],
 			"import": "import { Badge, Breadcrumbs, Example } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Breadcrumbs/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Breadcrumbs",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Breadcrumbs/Breadcrumbs.tsx",
-				"actualName": "Breadcrumbs",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children to position items",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ReactElement<unknown, string | JSXElementConstructor<any>>[]"
+						}
+					},
+					"separator": {
+						"defaultValue": null,
+						"description": "Node for defining custom separator between items",
+						"name": "separator",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"neutral\"",
+							"value": [{ "value": "\"primary\"" }, { "value": "\"neutral\"" }]
+						}
+					},
+					"defaultVisibleItems": {
+						"defaultValue": null,
+						"description": "Number of items to show by default, others will be hidden and can be expanded",
+						"name": "defaultVisibleItems",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"expandAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the expand button",
+						"name": "expandAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disableExpand": {
+						"defaultValue": null,
+						"description": "Turn expand button into static text and disable the expand functionality",
+						"name": "disableExpand",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the component",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"nav\">" }
+					}
+				},
+				"exportName": "Breadcrumbs"
 			}
 		},
 		"components-button": {
@@ -293,87 +1622,599 @@
 			"path": "./src/components/Button/tests/Button.stories.tsx",
 			"stories": [
 				{
-					"name": "variantAndColor",
+					"id": "components-button--variant-and-color",
+					"name": "variant, color",
 					"snippet": "const variantAndColor = () => (\n    <Example>\n        <Example.Item title=\"variant: solid\">\n            <View gap={4} direction=\"row\">\n                <Button onClick={() => {}}>Button</Button>\n                <Button onClick={() => {}} color=\"primary\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"faded\">\n                    Button\n                </Button>\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"outline\">\n                    Button\n                </Button>\n\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: ghost\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"ghost\">\n                    Button\n                </Button>\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: media\">\n            <View backgroundColor=\"primary\" borderRadius=\"medium\" padding={4} direction=\"row\" gap={4}>\n                <Button onClick={() => {}} color=\"media\">\n                    Button\n                </Button>\n\n                <Button onClick={() => {}} color=\"media\" variant=\"faded\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Button onClick={() => {}} icon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"endIcon\">\n            <Button onClick={() => {}} endIcon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"icon, endIcon\">\n            <Button onClick={() => {}} icon={IconZap} endIcon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"icon only\">\n            <Button onClick={() => {}} icon={IconZap} attributes={{ \"aria-label\": \"Action\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"small\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"small\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Button icon={IconZap}>Button</Button>\n                <Button variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"large\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"large\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"xlarge\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"xlarge\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"xlarge\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large, [m+] medium\">\n            <Button size={{ s: \"large\", m: \"medium\" }} icon={IconZap}>\n                Responsive\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated, color: neutral\">\n            <View direction=\"row\" gap={4}>\n                <Button elevated onClick={() => {}}>\n                    Button\n                </Button>\n                <Button elevated variant=\"outline\" onClick={() => {}}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"elevated, color\">\n            <View direction=\"row\" gap={4}>\n                <Button elevated color=\"primary\">\n                    Button\n                </Button>\n                <Button elevated variant=\"outline\" color=\"primary\">\n                    Button\n                </Button>\n                <View backgroundColor=\"primary\" padding={4} borderRadius=\"medium\">\n                    <Button color=\"media\" elevated>\n                        Button\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded, size: small, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, size: medium, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, size: large, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, icon only, all sizes\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"small\" icon={IconZap} />\n                <Button rounded icon={IconZap} />\n                <Button rounded size=\"large\" icon={IconZap} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--full-width",
 					"name": "fullWidth",
 					"snippet": "const fullWidth = () => (\n    <Example>\n        <Example.Item title=\"fullWidth, all variants\">\n            <View gap={3}>\n                <Button fullWidth>Neutral</Button>\n                <Button fullWidth variant=\"faded\">\n                    Faded\n                </Button>\n                <Button fullWidth variant=\"outline\">\n                    Outline\n                </Button>\n                <Button fullWidth variant=\"ghost\">\n                    Ghost\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive fullWidth\", \"[s] true\", \"[m+] false\"]}>\n            <Button fullWidth={{ s: true, m: false }}>Button</Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--loading",
 					"name": "loading",
 					"snippet": "const loading = () => (\n    <Example>\n        <Example.Item title=\"loading, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"loading, color critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"loading, color positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"loading, color: media\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n\n                <div style={{ position: \"absolute\", top: 16, left: 16 }}>\n                    <View gap={3} direction=\"row\">\n                        <Button color=\"media\" loading loadingAriaLabel=\"Loading\">\n                            Button\n                        </Button>\n                        <Button color=\"media\" variant=\"faded\" loading loadingAriaLabel=\"Loading\">\n                            Button\n                        </Button>\n                    </View>\n                </div>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"loading, long button text\", \"button size should stay the same\"]}>\n            <Button loading loadingAriaLabel=\"Loading\" color=\"primary\">\n                Long button text\n            </Button>\n        </Example.Item>\n\n        <Example.Item title={[\"loading, icon only\", \"button keep square 1/1 ratio\"]}>\n            <Button icon={IconZap} rounded loading loadingAriaLabel=\"Loading\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--highlighted",
 					"name": "highlighted",
 					"snippet": "const highlighted = () => (\n    <Example>\n        <Example.Item title=\"highlighted, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"highlighted, color: critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted color=\"critical\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"highlighted, color: positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted color=\"positive\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled icon={IconZap} onClick={() => {}}>\n                    Button\n                </Button>\n                <Button disabled variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"disabled, color: critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled color=\"critical\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"disabled, color: positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled color=\"positive\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"disabled, color: media\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n\n                <div style={{ position: \"absolute\", top: 16, left: 16 }}>\n                    <View gap={3} direction=\"row\">\n                        <Button color=\"media\" disabled>\n                            Button\n                        </Button>\n                        <Button color=\"media\" variant=\"faded\" disabled>\n                            Button\n                        </Button>\n                    </View>\n                </div>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner: all\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>Content</View.Item>\n                <Button.Aligner>\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: top\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"top\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: top and end\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side={[\"top\", \"end\"]}>\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: bottom\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2} align=\"end\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"bottom\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: start\">\n            <View padding={4} borderColor=\"neutral-faded\" gap={2} align=\"start\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"start\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: end\">\n            <View padding={4} borderColor=\"neutral-faded\" gap={2} align=\"end\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"end\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "components-button--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"slot gap\">\n            <Button variant=\"outline\">\n                <Avatar size={6} initials=\"RS\" />\n                Label\n                <Hotkey>B</Hotkey>\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--href",
 					"name": "href",
 					"snippet": "const href = () => <Button href=\"https://reshaped.so\">Trigger</Button>;"
 				},
 				{
+					"id": "components-button--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Button onClick={fn()}>Trigger</Button>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-button--href-on-click",
+					"name": "href, onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <Button\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </Button>\n);"
 				},
 				{
+					"id": "components-button--as",
 					"name": "as",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"as: span\">\n            <Button onClick={() => {}} as=\"span\">\n                Trigger\n            </Button>\n        </Example.Item>\n        <Example.Item title=\"render, disabled\">\n            <Button\n                disabled\n                onClick={() => {}}\n                render={(props) => <section {...props} />}\n                attributes={{ \"data-testid\": \"render-el\" }}\n            >\n                Trigger\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-button--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Button className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Button>\n    </div>\n);"
 				},
 				{
+					"id": "components-button--group",
 					"name": "group",
 					"snippet": "const group = () => (\n    <Example>\n        <Example.Item title=\"with icon\">\n            <Button.Group>\n                <Button rounded>Submit</Button>\n                <Button rounded icon={IconZap} />\n            </Button.Group>\n        </Example.Item>\n        <Example.Item title=\"variant: solid\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\", \"media\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color}>One</Button>\n                        <Button color={color}>Two</Button>\n                        <Button color={color}>Three</Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"outline\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"outline\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"outline\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\", \"media\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"faded\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"faded\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"faded\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"variant: ghost\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"ghost\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"ghost\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"ghost\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "groupClassName",
+					"id": "components-button--group-class-name",
+					"name": "group className, attributes",
 					"snippet": "const groupClassName = () => (\n    <div data-testid=\"root\">\n        <Button.Group className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Button>Trigger</Button>\n        </Button.Group>\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Button, Example, Hotkey, Image, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Button/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Button",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Button/Button.tsx",
-				"actualName": "Button",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"ghost\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"ghost\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loading": {
+						"defaultValue": null,
+						"description": "Show loading state",
+						"name": "loading",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loadingAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the loading indicator",
+						"name": "loadingAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Make the component take the full width of the parent element",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "highlighted",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Button"
 			}
 		},
 		"components-calendar": {
@@ -382,54 +2223,363 @@
 			"path": "./src/components/Calendar/tests/Calendar.stories.tsx",
 			"stories": [
 				{
+					"id": "components-calendar--default-month",
 					"name": "defaultMonth",
 					"snippet": "const defaultMonth = () => (\n    <Example>\n        <Example.Item title=\"defaultMonth: 2020 January\">\n            <Calendar defaultMonth={new Date(2020, 0)} range />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "uncontrolled",
+					"id": "components-calendar--uncontrolled",
+					"name": "defaultValue, range",
 					"snippet": "const uncontrolled = () => <Example>\n    <Example.Item title=\"defaultValue\">\n        <Calendar\n            defaultMonth={new Date(2020, 0)}\n            defaultValue={new Date(2020, 0, 10)}\n            onChange={fn()} />\n    </Example.Item>\n    <Example.Item title=\"defaultValue, range\">\n        <Calendar\n            range\n            defaultMonth={new Date(2020, 0)}\n            defaultValue={{ start: new Date(2020, 0, 10), end: new Date(2020, 0, 15) }}\n            onChange={fn()} />\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "controlled",
+					"id": "components-calendar--controlled",
+					"name": "value, range",
 					"snippet": "const controlled = () => <Example>\n    <Example.Item title=\"value\">\n        <Calendar\n            defaultMonth={new Date(2020, 0)}\n            value={new Date(2020, 0, 10)}\n            onChange={fn()} />\n    </Example.Item>\n    <Example.Item title=\"defaultValue, range\">\n        <Calendar\n            range\n            defaultMonth={new Date(2020, 0)}\n            value={{ start: new Date(2020, 0, 10), end: new Date(2020, 0, 15) }}\n            onChange={fn()} />\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-calendar--selected-dates",
 					"name": "selectedDates",
 					"snippet": "const selectedDates = () => (\n    <Example>\n        <Example.Item title=\"selectedDates: [4,8]\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                value={null}\n                selectedDates={[new Date(2020, 0, 4), new Date(2020, 0, 8)]}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "minMax",
+					"id": "components-calendar--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <Example>\n        <Example.Item title=\"min: 4, max: 20\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                min={new Date(2020, 0, 4)}\n                max={new Date(2020, 0, 20)}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-calendar--first-week-day",
 					"name": "firstWeekDay",
 					"snippet": "const firstWeekDay = () => (\n    <Example>\n        <Example.Item title=\"firstWeekDay: 3 (Wed)\">\n            <Calendar defaultMonth={new Date(2020, 0)} firstWeekDay={3} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "translation",
+					"id": "components-calendar--translation",
+					"name": "render functions",
 					"snippet": "const translation = () => (\n    <Example>\n        <Example.Item title=\"translated to NL\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                renderMonthLabel={({ date }) => date.toLocaleDateString(\"nl\", { month: \"short\" })}\n                renderSelectedMonthLabel={({ date }) =>\n                    date.toLocaleDateString(\"nl\", { month: \"long\", year: \"numeric\" })\n                }\n                renderWeekDay={({ date }) => date.toLocaleDateString(\"nl\", { weekday: \"short\" })}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "ariaLabels",
+					"id": "components-calendar--aria-labels",
+					"name": "aria labels",
 					"snippet": "const ariaLabels = () => (\n    <Example>\n        <Example.Item title=\"aria labels\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                nextYearAriaLabel=\"Test next year\"\n                nextMonthAriaLabel=\"Test next month\"\n                renderDateAriaLabel={() => \"Test date\"}\n                renderMonthAriaLabel={() => \"Test month\"}\n                previousYearAriaLabel=\"Test previous year\"\n                previousMonthAriaLabel=\"Test previous month\"\n                monthSelectionAriaLabel=\"Test month selection\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "monthSelection",
+					"id": "components-calendar--month-selection",
+					"name": "test: month selection",
 					"snippet": "const monthSelection = () => (\n    <Example>\n        <Example.Item title=\"month selection\">\n            <Calendar defaultMonth={new Date(2020, 1)} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "keyboardNavigation",
+					"id": "components-calendar--keyboard-navigation",
+					"name": "test: keyboard navigation",
 					"snippet": "const keyboardNavigation = () => (\n    <Example>\n        <Example.Item title=\"keyboard navigation\">\n            <Calendar defaultMonth={new Date(2020, 0)} />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Calendar, Example } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Calendar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Calendar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Calendar/Calendar.tsx",
-				"actualName": "Calendar",
+				"methods": [],
+				"props": {
+					"range": {
+						"defaultValue": null,
+						"description": "Disable range selection\nEnable range selection",
+						"name": "range",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Current selected date value, enables controlled mode\nCurrent selected range value, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date | RangeValue | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default selected date value, enables uncontrolled mode\nDefault selected range value, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date | RangeValue" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when date selection changes\nCallback when range selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { value: Date; }) => void) | ((args: { value: Date; }) => void) | ((args: { value: RangeValue; }) => void) | ((args: { value: RangeValue; }) => void)"
+						}
+					},
+					"defaultMonth": {
+						"defaultValue": { "value": "Date.now()" },
+						"description": "Default month to display",
+						"name": "defaultMonth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum date that can be selected",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum date that can be selected",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"firstWeekDay": {
+						"defaultValue": { "value": "1, Monday" },
+						"description": "First day of the week",
+						"name": "firstWeekDay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"selectedDates": {
+						"defaultValue": null,
+						"description": "Dates that are selected",
+						"name": "selectedDates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date[]" }
+					},
+					"renderWeekDay": {
+						"defaultValue": null,
+						"description": "Render a custom weekday label, can be used for localization",
+						"name": "renderWeekDay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { weekDay: number; date: Date; }) => string)" }
+					},
+					"renderSelectedMonthLabel": {
+						"defaultValue": null,
+						"description": "Render a custom month label, can be used for localization",
+						"name": "renderSelectedMonthLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { date: Date; }) => string)" }
+					},
+					"renderMonthLabel": {
+						"defaultValue": null,
+						"description": "Render a custom month label, can be used for localization",
+						"name": "renderMonthLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { month: number; date: Date; }) => string)" }
+					},
+					"previousMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the previous month button",
+						"name": "previousMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"nextMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "",
+						"name": "nextMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"previousYearAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the previous year button",
+						"name": "previousYearAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"nextYearAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the next year button",
+						"name": "nextYearAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"monthSelectionAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the month selection button",
+						"name": "monthSelectionAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"renderDateAriaLabel": {
+						"defaultValue": null,
+						"description": "Dynamic aria label applied to each date cell based on the arguments",
+						"name": "renderDateAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { date: Date; }) => string)" }
+					},
+					"renderMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "Dynamic aria label applied to each month element based on the arguments",
+						"name": "renderMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { month: number; }) => string)" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -439,50 +2589,356 @@
 			"path": "./src/components/Card/tests/Card.stories.tsx",
 			"stories": [
 				{
+					"id": "components-card--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: default\">\n            <Card>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title=\"padding: 2\">\n            <Card padding={2}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title=\"padding: 0\">\n            <Card padding={0}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive padding\", \"[s] 4\", \"[m+] 8\"]}>\n            <Card padding={{ s: 4, m: 8 }}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--selected",
 					"name": "selected",
 					"snippet": "const selected = () => (\n    <Example>\n        <Example.Item title=\"selected\">\n            <Card selected>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated\">\n            <Card elevated>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4\">\n            <Card bleed={4}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n        <Example.Item title={[\"responsive bleed\", \"[s] 4\", \"[m+] 0\"]}>\n            <Card bleed={{ s: 4, m: 0 }}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--height",
 					"name": "height",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"height: 200px\">\n            <Card height=\"200px\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Card onClick={fn()}>Trigger</Card>;"
 				},
 				{
+					"id": "components-card--href",
 					"name": "href",
 					"snippet": "const href = () => <Card href=\"https://reshaped.so\">Trigger</Card>;"
 				},
 				{
+					"id": "components-card--as",
 					"name": "as",
 					"snippet": "const as = () => <Card as=\"span\" attributes={{ \"data-testid\": \"root\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-card--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Card className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Card, Example, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Card/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Card",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Card/Card.tsx",
-				"actualName": "Card",
+				"methods": [],
+				"props": {
+					"padding": {
+						"defaultValue": null,
+						"description": "Component padding, base unit multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Remove side borders and apply negative margins, base unit multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"selected": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "selected",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when the component is clicked, turns component into a button",
+						"name": "onClick",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL to navigate to when the component is clicked, turns component into a link",
+						"name": "href",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"as": {
+						"defaultValue": { "value": "\"div\"" },
+						"description": "Custom component tag name",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(Attributes<keyof IntrinsicElements> & (Attributes))" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -492,56 +2948,181 @@
 			"path": "./src/components/Carousel/tests/Carousel.stories.tsx",
 			"stories": [
 				{
+					"id": "components-carousel--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Carousel attributes={{ \"data-testid\": \"test-id\" }} visibleItems={3}>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n    </Carousel>\n);"
 				},
 				{
+					"id": "components-carousel--visible-items",
 					"name": "visibleItems",
 					"snippet": "const visibleItems = () => (\n    <Example>\n        <Example.Item title=\"visibleItems: 3\">\n            <Carousel visibleItems={3}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive visibleItems\", \"s: 2, m+ 3\"]}>\n            <Carousel visibleItems={{ s: 2, m: 3 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title=\"visibleItems: auto\">\n            <Carousel>\n                <Placeholder h={100} />\n                <Placeholder h={100} w={200} />\n                <Placeholder h={100} w={300} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 2, visibleItems 3\">\n            <Carousel visibleItems={3} gap={2}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"gap: responsive, visibleItems: 3\", \"s: 2, l: 8\"]}>\n            <Carousel visibleItems={3} gap={{ s: 2, l: 8 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4, visibleItems: 3\">\n            <Carousel visibleItems={3} bleed={4}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive bleed, visibleItems: 3\", \"[s] 4, [l+] 0\"]}>\n            <Carousel visibleItems={3} bleed={{ s: 4, l: 0 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--navigation-display",
 					"name": "navigationDisplay",
 					"snippet": "const navigationDisplay = () => (\n    <Example>\n        <Example.Item title=\"navigationDisplay: hidden\">\n            <Carousel\n                visibleItems={3}\n                navigationDisplay=\"hidden\"\n                attributes={{ \"data-testid\": \"test-id\" }}\n            >\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "instanceRef",
+					"id": "components-carousel--instance-ref",
+					"name": "instanceRef, onChange",
 					"snippet": "const instanceRef = (args) => {\n    const carouselRef = React.useRef<CarouselInstanceRef>(null);\n    const [index, setIndex] = React.useState(0);\n\n    return (\n        <Example>\n            <Example.Item title=\"instanceRef, onChange\">\n                <View gap={3}>\n                    <View gap={3} direction=\"row\" align=\"center\">\n                        <Button onClick={() => carouselRef.current?.navigateBack()}>Back</Button>\n                        <Button onClick={() => carouselRef.current?.navigateForward()}>Forward</Button>\n                        <Button onClick={() => carouselRef.current?.navigateTo(3)}>To 3</Button>\n                        <View.Item>Index: {index}</View.Item>\n                    </View>\n                    <Carousel\n                        visibleItems={2}\n                        instanceRef={carouselRef}\n                        navigationDisplay=\"hidden\"\n                        onChange={(changeArgs) => {\n                            args.handleChange(changeArgs);\n                            setIndex(changeArgs.index);\n                        }}\n                    >\n                        <Placeholder h={100}>Item 0</Placeholder>\n                        <Placeholder h={100}>Item 1</Placeholder>\n                        <Placeholder h={100}>Item 2</Placeholder>\n                        <Placeholder h={100}>Item 3</Placeholder>\n                        <Placeholder h={100}>Item 4</Placeholder>\n                        <Placeholder h={100}>Item 5</Placeholder>\n                    </Carousel>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-carousel--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Carousel visibleItems={2} className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder h={100}>Item 0</Placeholder>\n            <Placeholder h={100}>Item 1</Placeholder>\n            <Placeholder h={100}>Item 2</Placeholder>\n            <Placeholder h={100}>Item 3</Placeholder>\n            <Placeholder h={100}>Item 4</Placeholder>\n            <Placeholder h={100}>Item 5</Placeholder>\n        </Carousel>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Carousel, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Carousel/index.ts",
 				"description": "",
-				"methods": [
-					{
-						"name": "navigateTo",
-						"docblock": null,
-						"modifiers": [],
-						"params": [
+				"displayName": "Carousel",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, each child is rendered as a carousel item",
+						"name": "children",
+						"declarations": [
 							{
-								"name": "index",
-								"optional": false,
-								"type": { "name": "number" }
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
 							}
 						],
-						"returns": null
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"visibleItems": {
+						"defaultValue": null,
+						"description": "Number of items visible at once in the container",
+						"name": "visibleItems",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between items in the container, base unit multiplier",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margins, base unit multiplier, can be used to make sure the items don't get clipped when scrolling",
+						"name": "bleed",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"navigationDisplay": {
+						"defaultValue": null,
+						"description": "Hide navigation controls",
+						"name": "navigationDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"hidden\"", "value": [{ "value": "\"hidden\"" }] }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the carousel methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the first visible carousel index changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { index: number; }) => void)" }
+					},
+					"onScroll": {
+						"defaultValue": null,
+						"description": "Callback when the carousel scrolls",
+						"name": "onScroll",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: UIEvent<HTMLUListElement, UIEvent>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
 					}
-				],
-				"displayName": "Carousel",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Carousel/Carousel.tsx",
-				"actualName": "Carousel",
+				},
 				"exportName": "default"
 			}
 		},
@@ -551,46 +3132,259 @@
 			"path": "./src/components/Checkbox/tests/Checkbox.stories.tsx",
 			"stories": [
 				{
-					"name": "render",
+					"id": "components-checkbox--render",
+					"name": "name, value",
 					"snippet": "const render = () => (\n    <Checkbox name=\"test-name\" value=\"test-value\">\n        Content\n    </Checkbox>\n);"
 				},
 				{
+					"id": "components-checkbox--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"small\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"small\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"medium\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"medium\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"large\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"large\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: responsive, s: small, m: large\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size={{ s: \"small\", m: \"large\" }} defaultChecked>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-checkbox--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Checkbox name=\"animal\" value=\"dog\" hasError>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-checkbox--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n        <Example.Item title=\"disabled, checked\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled checked>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n        <Example.Item title=\"disabled, indeterminate\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled indeterminate>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "checked",
+					"id": "components-checkbox--checked",
+					"name": "checked, controlled",
 					"snippet": "const checked = () => <Checkbox name=\"test-name\" value=\"test-value\" checked onChange={fn()}>Content\n            </Checkbox>;"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-checkbox--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Checkbox name=\"test-name\" value=\"test-value\" defaultChecked onChange={fn()}>Content\n            </Checkbox>;"
 				},
 				{
+					"id": "components-checkbox--indeterminate",
 					"name": "indeterminate",
 					"snippet": "const indeterminate = () => (\n    <Checkbox name=\"test-name\" value=\"test-value\" indeterminate>\n        Content\n    </Checkbox>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-checkbox--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Checkbox className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Checkbox>\n    </div>\n);"
 				}
 			],
 			"import": "import { Checkbox, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Checkbox/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Checkbox",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Checkbox/Checkbox.tsx",
-				"actualName": "Checkbox",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the label",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Component name attribute",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the component",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Component value used for form submission",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"indeterminate": {
+						"defaultValue": null,
+						"description": "Show a indeterminate state, used for \"select all\" checkboxes with some of the individual checkboxes selected",
+						"name": "indeterminate",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the component is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the component is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Component checked state, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default checked state, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -600,26 +3394,143 @@
 			"path": "./src/components/CheckboxGroup/tests/CheckboxGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "value",
+					"id": "components-checkboxgroup--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <View gap={2}>\n    <CheckboxGroup name=\"test-name\" value={[\"1\"]} onChange={fn()}>\n        {/* checked should be ignored */}\n        <Checkbox value=\"1\" checked={false}>Content\n                            </Checkbox>\n        <Checkbox value=\"2\">Content 2</Checkbox>\n    </CheckboxGroup>\n</View>;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-checkboxgroup--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <View gap={2}>\n    <CheckboxGroup name=\"test-name\" defaultValue={[\"1\"]} onChange={fn()}>\n        {/* checked should be ignored */}\n        <Checkbox value=\"1\" checked={false}>Content\n                            </Checkbox>\n        <Checkbox value=\"2\">Content 2</Checkbox>\n    </CheckboxGroup>\n</View>;"
 				},
 				{
+					"id": "components-checkboxgroup--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <CheckboxGroup name=\"test-name\" disabled>\n        <Checkbox value=\"test-value\">Item 1</Checkbox>\n        <Checkbox value=\"test-value-2\">Item 2</Checkbox>\n    </CheckboxGroup>\n);"
 				}
 			],
 			"import": "import { Checkbox, CheckboxGroup, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/CheckboxGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "CheckboxGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/CheckboxGroup/CheckboxGroup.tsx",
-				"actualName": "CheckboxGroup",
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Component id attribute",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting checkboxes or custom layout components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the component from form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Component name attribute",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string[], ChangeEvent<HTMLInputElement>>" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Component value, enables controlled mode\nComponent value, enables uncontrolled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -629,23 +3540,346 @@
 			"path": "./src/components/ContextMenu/tests/ContextMenu.stories.tsx",
 			"stories": [
 				{
+					"id": "components-contextmenu--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"base\">\n            <div style={{ height: 200, overflow: \"auto\" }}>\n                <ContextMenu>\n                    <View height=\"400px\" backgroundColor=\"neutral-faded\" borderRadius=\"medium\" />\n\n                    <ContextMenu.Content>\n                        <ContextMenu.Item>Item 1</ContextMenu.Item>\n                        <ContextMenu.Item>Item 2</ContextMenu.Item>\n                    </ContextMenu.Content>\n                </ContextMenu>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "components-contextmenu--handlers",
+					"name": "handleOpen, handleClose",
 					"snippet": "const handlers = () => <div style={{ height: 200, overflow: \"auto\" }} data-testid=\"scroll\">\n    <ContextMenu onOpen={fn()} onClose={fn()}>\n        <View\n            height=\"400px\"\n            backgroundColor=\"neutral-faded\"\n            borderRadius=\"medium\"\n            attributes={{ \"data-testid\": \"root\" }} />\n        <ContextMenu.Content>\n            <ContextMenu.Item>Item</ContextMenu.Item>\n        </ContextMenu.Content>\n    </ContextMenu>\n</div>;"
 				}
 			],
 			"import": "import { ContextMenu, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ContextMenu/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ContextMenu",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ContextMenu/ContextMenu.tsx",
-				"actualName": "ContextMenu",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/DropdownMenu/DropdownMenu.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | \"action-menu\" | \"selection-menu\"" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					}
+				},
+				"exportName": "ContextMenu"
 			}
 		},
 		"components-divider": {
@@ -654,30 +3888,118 @@
 			"path": "./src/components/Divider/tests/Divider.stories.tsx",
 			"stories": [
 				{
-					"name": "rendering",
+					"id": "components-divider--rendering",
+					"name": "base",
 					"snippet": "const rendering = () => (\n    <Example>\n        <Example.Item title=\"default rendering\">\n            <Divider />\n        </Example.Item>\n\n        <Example.Item title={[\"blank rendering\", \"box should overlap with divider\"]}>\n            <View width=\"40px\" height=\"10px\" backgroundColor=\"primary\" />\n            <Divider blank />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-divider--vertical",
 					"name": "vertical",
 					"snippet": "const vertical = () => (\n    <Example>\n        <Example.Item title=\"vertical\">\n            <View gap={3} direction=\"row\" align=\"stretch\">\n                <Placeholder />\n                <View.Item>\n                    <Divider vertical />\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive vertical\", \"[s] true\", \"[m+]: false\"]}>\n            <View gap={3} direction={{ s: \"row\", m: \"column\" }} align=\"stretch\">\n                <Placeholder />\n                <View.Item>\n                    <Divider vertical={{ s: true, m: false }} />\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "label",
+					"id": "components-divider--label",
+					"name": "children, contentPosition",
 					"snippet": "const label = () => {\n    return (\n        <Example>\n            <Example.Item title=\"alignment\">\n                <View gap={4}>\n                    <Divider>Centered label</Divider>\n                    <Divider contentPosition=\"start\">Start label</Divider>\n                    <Divider contentPosition=\"end\">End label</Divider>\n                </View>\n            </Example.Item>\n\n            <Example.Item title=\"responsive\">\n                <View gap={3} direction={{ s: \"column\", m: \"row\" }} align=\"stretch\">\n                    <Placeholder />\n                    <View.Item>\n                        <Divider vertical={{ s: false, m: true }}>or pick second option</Divider>\n                    </View.Item>\n                    <Placeholder />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-divider--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Divider className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Divider, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Divider/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Divider",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Divider/Divider.tsx",
-				"actualName": "Divider",
+				"methods": [],
+				"props": {
+					"blank": {
+						"defaultValue": null,
+						"description": "Change component to take no space, useful for using it as a border in components like Tabs",
+						"name": "blank",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"vertical": {
+						"defaultValue": null,
+						"description": "Change component to render vertically",
+						"name": "vertical",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"contentPosition": {
+						"defaultValue": null,
+						"description": "Position for rendering children",
+						"name": "contentPosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"center\" | \"start\" | \"end\"",
+							"value": [{ "value": "\"center\"" }, { "value": "\"start\"" }, { "value": "\"end\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting text labels or custom components as a part of divider",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"hr\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -687,51 +4009,415 @@
 			"path": "./src/components/DropdownMenu/tests/DropdownMenu.stories.tsx",
 			"stories": [
 				{
+					"id": "components-dropdownmenu--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: default\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <DropdownMenu position=\"end\">\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n\n        <Example.Item title={[\"position: top-start\", \"should change to top-start to fit viewport\"]}>\n            <DropdownMenu position=\"top-end\">\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n        <div style={{ height: 2000 }} />\n    </Example>\n);"
 				},
 				{
+					"id": "components-dropdownmenu--sections",
 					"name": "sections",
 					"snippet": "const sections = () => (\n    <Example>\n        <Example.Item title=\"2 sections\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Section>\n                        <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                    </DropdownMenu.Section>\n\n                    <DropdownMenu.Section>\n                        <DropdownMenu.Item>Item 3</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 4</DropdownMenu.Item>\n                    </DropdownMenu.Section>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-dropdownmenu--submenu",
 					"name": "submenu",
 					"snippet": "const submenu = () => (\n    <Example>\n        <Example.Item title=\"submenu\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item onClick={() => {}}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger>Item 2</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger>Item 3</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2-1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2-2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger disabled>Item 4, disabled</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 3-1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 3-2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-dropdownmenu--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <DropdownMenu onOpen={fn()} onClose={fn()} defaultActive>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "active",
+					"id": "components-dropdownmenu--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <DropdownMenu onOpen={fn()} onClose={fn()} active>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "components-dropdownmenu--active-false",
+					"name": "active false, controlled",
 					"snippet": "const activeFalse = () => <DropdownMenu onOpen={fn()} onClose={fn()} active={false}>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "className",
+					"id": "components-dropdownmenu--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <DropdownMenu active>\n            <DropdownMenu.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </DropdownMenu.Trigger>\n            <DropdownMenu.Content className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n                <DropdownMenu.Item>Item</DropdownMenu.Item>\n            </DropdownMenu.Content>\n        </DropdownMenu>\n    </div>\n);"
 				},
 				{
-					"name": "testScroll",
+					"id": "components-dropdownmenu--test-scroll",
+					"name": "test: scroll",
 					"snippet": "const testScroll = () => (\n    <Example>\n        <Example.Item title=\"Scrolls on page mount to the dropdown\">\n            <div style={{ height: 1000 }} />\n            <DropdownMenu position=\"end\" key=\"scroll\" defaultActive>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testTheme",
+					"id": "components-dropdownmenu--test-theme",
+					"name": "test: theme",
 					"snippet": "const testTheme = () => (\n    <Example>\n        <Example.Item title=\"switch color mode while dropdown is active and check that it still works\">\n            <ThemeSwitching />\n        </Example.Item>\n        <Example.Item title=\"dropdown inherits multiple themes\">\n            <ThemeMultiple />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, DropdownMenu, Example, Theme, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/DropdownMenu/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "DropdownMenu",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/DropdownMenu/DropdownMenu.tsx",
-				"actualName": "DropdownMenu",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/DropdownMenu/DropdownMenu.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | \"action-menu\" | \"selection-menu\"" }
+					}
+				},
+				"exportName": "DropdownMenu"
 			}
 		},
 		"components-fileupload": {
@@ -740,35 +4426,165 @@
 			"path": "./src/components/FileUpload/tests/FileUpload.stories.tsx",
 			"stories": [
 				{
+					"id": "components-fileupload--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"Base upload with previews\">\n            <Demo />\n        </Example.Item>\n        <Example.Item title=\"With trigger\">\n            <FileUpload name=\"file\">\n                <div>\n                    Drop files to attach, or{\" \"}\n                    <FileUpload.Trigger>\n                        <Link variant=\"plain\">browse</Link>\n                    </FileUpload.Trigger>\n                </div>\n            </FileUpload>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "inline",
+					"id": "components-fileupload--inline",
+					"name": "inline, variant, render props",
 					"snippet": "const inline = () => {\n    return (\n        <Example>\n            <Example.Item title=\"inline\">\n                <FileUpload name=\"file\" inline onChange={console.log}>\n                    <View padding={2} paddingInline={3}>\n                        Upload\n                    </View>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"variant headless\">\n                <FileUpload name=\"file2\" variant=\"headless\" onChange={console.log}>\n                    <Button variant=\"outline\" fullWidth>\n                        Upload\n                    </Button>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"variant headless, inline\">\n                <FileUpload name=\"file2\" variant=\"headless\" inline onChange={console.log}>\n                    <Button>Upload</Button>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"inline, render props\">\n                <FileUpload name=\"file3\" variant=\"headless\" inline onChange={console.log}>\n                    {(props) => <Button highlighted={props.highlighted}>Upload</Button>}\n                </FileUpload>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-fileupload--height",
 					"name": "height",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"Custom height\">\n            <FileUpload name=\"file\" height=\"300px\">\n                <View gap={3}>\n                    <Icon svg={IconMic} size={8} />\n                    Drop files to attach\n                </View>\n            </FileUpload>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onChange",
+					"id": "components-fileupload--on-change",
+					"name": "name, onChange",
 					"snippet": "const onChange = () => <div data-testid=\"root\">\n    <FileUpload name=\"test-name\" onChange={fn()}>Content\n                    </FileUpload>\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "components-fileupload--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <FileUpload\n            name=\"name\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ id: \"test-input-id\" }}\n        >\n            Content\n        </FileUpload>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, FileUpload, Icon, Image, Link, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/FileUpload/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "FileUpload",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/FileUpload/FileUpload.tsx",
-				"actualName": "FileUpload",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, can be a render function that receives component state",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode | ((props: { highlighted?: boolean; }) => ReactNode)" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component value is changed",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ChangeHandler<File[], ChangeEvent<HTMLInputElement> | DragEvent<HTMLDivElement>>"
+						}
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Component height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component variant, headless variant is useful for rendering custom triggers like a Button",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"headless\"",
+							"value": [{ "value": "\"outline\"" }, { "value": "\"headless\"" }]
+						}
+					},
+					"inline": {
+						"defaultValue": null,
+						"description": "Change component to render inline making it more compact",
+						"name": "inline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					}
+				},
+				"exportName": "FileUpload"
 			}
 		},
 		"components-hotkey": {
@@ -777,22 +4593,78 @@
 			"path": "./src/components/Hotkey/tests/Hotkey.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "components-hotkey--base",
+					"name": "Base",
 					"snippet": "const base = () => (\n\t<Example>\n\t\t<Example.Item title=\"Base\">\n\t\t\t<Demo />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"Active\">\n\t\t\t<Hotkey active>⌘K</Hotkey>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"Inside input slot\">\n\t\t\t<View width=\"300px\">\n\t\t\t\t<TextField\n\t\t\t\t\tname=\"hey\"\n\t\t\t\t\tendSlot={<Demo />}\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"hotkey test\" }}\n\t\t\t\t/>\n\t\t\t</View>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-hotkey--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Hotkey className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            ⌘K\n        </Hotkey>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Hotkey, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Hotkey/Hotkey.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Hotkey",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Hotkey/Hotkey.tsx",
-				"actualName": "Hotkey",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Highlight the component, can be used to show when hotkey is pressed",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -802,54 +4674,241 @@
 			"path": "./src/components/Link/tests/Link.stories.tsx",
 			"stories": [
 				{
+					"id": "components-link--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: underline\">\n            <Link href=\"http://reshaped.so\" attributes={{ target: \"_blank\" }}>\n                Reshaped\n            </Link>\n        </Example.Item>\n        <Example.Item title=\"variant: plain\">\n            <Link onClick={() => {}} variant=\"plain\">\n                Link\n            </Link>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary\">\n            <Link color=\"primary\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Link color=\"critical\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Link color=\"positive\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <Link color=\"warning\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <Link color=\"inherit\">Link</Link>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon, variant: underline\">\n            <Link icon={IconZap}>Link</Link>\n        </Example.Item>\n        <Example.Item title=\"icon, variant: plain\">\n            <Link icon={IconZap} variant=\"plain\">\n                Link\n            </Link>\n        </Example.Item>\n        <Example.Item\n            title={[\"icon, variant: underline\", \"should inherit display-1 size from the parent\"]}\n        >\n            <Text variant=\"title-3\">\n                <Link icon={IconZap} variant=\"underline\">\n                    Instant delivery\n                </Link>\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--href",
 					"name": "href",
 					"snippet": "const href = () => <Link href=\"https://reshaped.so\">Trigger</Link>;"
 				},
 				{
+					"id": "components-link--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Link onClick={fn()}>Trigger</Link>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-link--href-on-click",
+					"name": "href + onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <Link\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </Link>\n);"
 				},
 				{
+					"id": "components-link--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Link disabled onClick={() => {}}>\n        Trigger\n    </Link>\n);"
 				},
 				{
+					"id": "components-link--render",
 					"name": "render",
 					"snippet": "const render = () => <Link render={(props) => <section {...props} />}>Trigger</Link>;"
 				},
 				{
-					"name": "className",
+					"id": "components-link--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Link className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Link>\n    </div>\n);"
 				},
 				{
-					"name": "testMultilineInText",
+					"id": "components-link--test-multiline-in-text",
+					"name": "test: multiline",
 					"snippet": "const testMultilineInText = () => (\n    <Example>\n        <Example.Item title=\"should wrap inside the text\">\n            <div>\n                Someone asked me to write this text that is boring to ready for everyone and to add&nbsp;\n                <Link href=\"/\">this very very long link</Link> to it.\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Link, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Link/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Link",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Link/Link.tsx",
-				"actualName": "Link",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon at the start position",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"primary\"" },
+						"description": "Link color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"inherit\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"inherit\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"underline\"" },
+						"description": "Link render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"plain\" | \"underline\"",
+							"value": [{ "value": "\"plain\"" }, { "value": "\"underline\"" }]
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -859,30 +4918,110 @@
 			"path": "./src/components/Loader/tests/Loader.stories.tsx",
 			"stories": [
 				{
+					"id": "components-loader--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: medium\">\n                <Loader size=\"medium\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title=\"size: small\">\n                <Loader size=\"small\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title=\"size: large\">\n                <Loader size=\"large\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title={[\"responsive size\", \"[s] small\", \"[m+] medium\"]}>\n                <Loader size={{ s: \"small\", m: \"medium\" }} ariaLabel=\"Loading\" />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-loader--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary\">\n            <Loader ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Loader color=\"critical\" ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Loader color=\"positive\" ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <Loader color=\"inherit\" ariaLabel=\"Loading\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-loader--aria-label",
 					"name": "ariaLabel",
 					"snippet": "const ariaLabel = () => <Loader ariaLabel=\"Loading\" attributes={{ \"data-testid\": \"root\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-loader--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Loader className=\"test-classname\" attributes={{ id: \"test-id\" }} ariaLabel=\"Loading\" />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Loader } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Loader/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Loader",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Loader/Loader.tsx",
-				"actualName": "Loader",
+				"methods": [],
+				"props": {
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"inherit\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -892,67 +5031,504 @@
 			"path": "./src/components/MenuItem/tests/MenuItem.stories.tsx",
 			"stories": [
 				{
+					"id": "components-menuitem--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <MenuItem size=\"small\" icon={IconZap} onClick={() => {}} endSlot={<Hotkey>⌘K</Hotkey>}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <MenuItem icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <MenuItem size=\"large\" icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title={[\"responsive size\", \"[s] small\", \"[m] medium\", \"[l+] large\"]}>\n            <MenuItem size={{ s: \"small\", m: \"medium\", l: \"large\" }} icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <MenuItem color=\"neutral\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <MenuItem color=\"primary\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <MenuItem color=\"critical\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--selected",
 					"name": "selected",
 					"snippet": "const selected = () => (\n    <Example>\n        <Example.Item title=\"selected, color: neutral\">\n            <MenuItem color=\"neutral\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"selected, color: primary\">\n            <MenuItem color=\"primary\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"selected, color: critical\">\n            <MenuItem color=\"critical\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--rounded-corners",
 					"name": "roundedCorners",
 					"snippet": "const roundedCorners = () => (\n    <Example>\n        <Example.Item title=\"roundedCorners\">\n            <MenuItem roundedCorners selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive roundedCorners\", \"[s]: false\", \"[m+]: true\"]}>\n            <MenuItem roundedCorners={{ s: false, m: true }} selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "slots",
+					"id": "components-menuitem--slots",
+					"name": "startSlot, endSlot",
 					"snippet": "const slots = () => (\n    <Example>\n        <Example.Item title=\"startSlot, endSlot, selected\">\n            <MenuItem startSlot={<Placeholder h={20} />} endSlot={<Placeholder h={20} />} selected>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem size=\"small\" selected onClick={() => {}}>\n                        Menu item\n                    </MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem selected>Menu item</MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem size=\"large\" selected>\n                        Menu item\n                    </MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--href",
 					"name": "href",
 					"snippet": "const href = () => <MenuItem href=\"https://reshaped.so\">Trigger</MenuItem>;"
 				},
 				{
+					"id": "components-menuitem--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <MenuItem onClick={fn()}>Trigger</MenuItem>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-menuitem--href-on-click",
+					"name": "href + onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <MenuItem\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </MenuItem>\n);"
 				},
 				{
+					"id": "components-menuitem--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <MenuItem disabled onClick={() => {}}>\n        Trigger\n    </MenuItem>\n);"
 				},
 				{
-					"name": "as",
+					"id": "components-menuitem--as",
+					"name": "as, render",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"render, disabled\">\n            <MenuItem\n                disabled\n                onClick={() => {}}\n                render={(props) => <section {...props} />}\n                attributes={{ \"data-testid\": \"render-el\" }}\n            >\n                Trigger\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-menuitem--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <MenuItem className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </MenuItem>\n    </div>\n);"
 				},
 				{
-					"name": "alignerClassName",
+					"id": "components-menuitem--aligner-class-name",
+					"name": "aligner, className, attributes",
 					"snippet": "const alignerClassName = () => (\n    <div data-testid=\"root\">\n        <MenuItem.Aligner className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <MenuItem>Trigger</MenuItem>\n        </MenuItem.Aligner>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Hotkey, MenuItem, Placeholder, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/MenuItem/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "MenuItem",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/MenuItem/MenuItem.tsx",
-				"actualName": "MenuItem",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content\nNode for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"neutral\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"neutral\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content at the start side of the component",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content at the end side of the component",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component as hovered or focused. For example, when displaying currently focused item in Autocomplete",
+						"name": "highlighted",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"selected": {
+						"defaultValue": null,
+						"description": "Highlight the component as selected",
+						"name": "selected",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"roundedCorners": {
+						"defaultValue": null,
+						"description": "Round the corners of the component",
+						"name": "roundedCorners",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					}
+				},
+				"exportName": "MenuItem"
 			}
 		},
 		"components-modal": {
@@ -961,67 +5537,301 @@
 			"path": "./src/components/Modal/tests/Modal.stories.tsx",
 			"stories": [
 				{
+					"id": "components-modal--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title={[\"responsive position\", \"[s] full-screen\", \"[m] center\", \"[l] end\"]}>\n            <Demo position={{ s: \"full-screen\", m: \"center\", l: \"end\" }} />\n        </Example.Item>\n        <Example.Item title=\"position: center\">\n            <Demo position=\"center\" />\n        </Example.Item>\n        <Example.Item title=\"position: bottom\">\n            <Demo position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"position: start\">\n            <Demo position=\"start\" />\n        </Example.Item>\n        <Example.Item title=\"position: end\">\n            <Demo position=\"end\" />\n        </Example.Item>\n        <Example.Item title=\"position: full-screen\">\n            <Demo position=\"full-screen\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: default\">\n                <Demo />\n            </Example.Item>\n            <Example.Item title=\"size: 300px\">\n                <Demo size=\"300px\" />\n            </Example.Item>\n            <Example.Item\n                title={[\"size: 800px\", \"should have max width of 100% minus gaps on the sides\"]}\n            >\n                <Demo size=\"800px\" />\n            </Example.Item>\n            <Example.Item\n                title={[\n                    \"responsive size, responsive position\",\n                    \"[s] auto\",\n                    \"[m+] 600px\",\n                    \"bottom position changes height instead of width\",\n                ]}\n            >\n                <Demo\n                    position={{ s: \"bottom\", m: \"center\", l: \"end\" }}\n                    size={{ s: \"auto\", m: \"600px\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-modal--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 0\">\n            <Demo padding={0} />\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <Demo padding={6} />\n        </Example.Item>\n        <Example.Item title={[\"responsive padding\", \"[s] 2\", \"[m+]: 6\"]}>\n            <Demo padding={{ s: 2, m: 6 }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--overflow",
 					"name": "overflow",
 					"snippet": "const overflow = () => (\n    <Example>\n        <Example.Item title=\"default overflow\">\n            <Demo>\n                <div\n                    style={{\n                        position: \"absolute\",\n                        top: -32,\n                        left: -32,\n                        height: 100,\n                        width: 100,\n                        background: \"tomato\",\n                    }}\n                />\n            </Demo>\n        </Example.Item>\n\n        <Example.Item title=\"overflow: visible\">\n            <Demo overflow=\"visible\">\n                <div\n                    style={{\n                        position: \"absolute\",\n                        top: -32,\n                        left: -32,\n                        height: 100,\n                        width: 100,\n                        background: \"tomato\",\n                    }}\n                />\n            </Demo>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--composition",
 					"name": "composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"title, subtitle, dismissible\">\n            <Demo title=\"Modal title\" subtitle=\"Modal subtitle\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--overlay",
 					"name": "overlay",
 					"snippet": "const overlay = () => (\n    <Example>\n        <Example.Item title=\"transparentOverlay, doesn't lock scroll\">\n            <Demo transparentOverlay />\n        </Example.Item>\n        <Example.Item title=\"blurredOverlay\">\n            <Demo blurredOverlay />\n        </Example.Item>\n        <View height=\"1000px\" />\n    </Example>\n);"
 				},
 				{
-					"name": "flags",
+					"id": "components-modal--flags",
+					"name": "disableCloseOnOutsideClick",
 					"snippet": "const flags = () => {\n    return (\n        <Example>\n            <Example.Item title=\"disableCloseOnOutsideClick\">\n                <Demo disableCloseOnOutsideClick onClose={fn()} active />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-modal--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const containerRef2 = React.useRef<HTMLDivElement>(null);\n    const toggle = useToggle();\n    const toggle2 = useToggle();\n\n    return (\n        <Example>\n            <Example.Item title={[\"in scrollable container\", \"scroll and then open\"]}>\n                <View\n                    attributes={{ ref: containerRef2 }}\n                    borderRadius=\"medium\"\n                    height=\"400px\"\n                    overflow=\"auto\"\n                    backgroundColor=\"neutral-faded\"\n                    padding={4}\n                >\n                    <View gap={4} align=\"start\">\n                        <Button onClick={toggle2.activate}>Open modal</Button>\n                        <View height=\"500px\" backgroundColor=\"primary\" width=\"500px\" borderRadius=\"medium\" />\n                    </View>\n                    <Modal\n                        containerRef={containerRef2}\n                        active={toggle2.active}\n                        onClose={toggle2.deactivate}\n                        position=\"end\"\n                    >\n                        <Placeholder />\n                    </Modal>\n                </View>\n            </Example.Item>\n            <Example.Item title=\"in static container\">\n                <View\n                    attributes={{ ref: containerRef }}\n                    borderRadius=\"medium\"\n                    height=\"400px\"\n                    overflow=\"hidden\"\n                    backgroundColor=\"neutral-faded\"\n                    padding={4}\n                >\n                    <Button onClick={toggle.activate}>Open modal</Button>\n                    <Modal\n                        containerRef={containerRef}\n                        active={toggle.active}\n                        onClose={toggle.deactivate}\n                        position=\"end\"\n                    >\n                        <Placeholder />\n                    </Modal>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "renderProps",
+					"id": "components-modal--render-props",
+					"name": "children, render props",
 					"snippet": "const renderProps = () => (\n    <Modal active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        <Modal.Title>Title</Modal.Title>\n        Content\n    </Modal>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "components-modal--handlers",
+					"name": "onOpen, onClose, onAfterOpen, onAfterClose",
 					"snippet": "const handlers = () => {\n    const overlayToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => overlayToggle.toggle()}>Open overlay</Button>\n            <Modal\n                active={overlayToggle.active}\n                onClose={(closeArgs) => {\n                    overlayToggle.deactivate();\n                    args.handleClose(closeArgs);\n                }}\n                onOpen={fn()}\n                onAfterOpen={fn()}\n                onAfterClose={fn()}>\n                <Modal.Title>Title</Modal.Title>Content\n                                </Modal>\n        </>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-modal--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <Modal active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        <Modal.Title>Title</Modal.Title>\n        Content\n    </Modal>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-modal--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => {\n    const menuModalToggle = useToggle();\n    const menuModalToggleInner = useToggle();\n    const scrollModalToggle = useToggle();\n    const inputRef = React.useRef<HTMLInputElement>(null);\n\n    return (\n        <Example>\n            <Example.Item title=\"Scrolls with long content on touch devices\">\n                <Demo position=\"center\">\n                    <Button onClick={() => {}}>Action</Button>\n                    <View height=\"2000px\" backgroundColor=\"primary-faded\" />\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"keyboard focus stays on the modal first\">\n                <Demo title=\"Modal title\" autoFocus={false} />\n            </Example.Item>\n            <Example.Item title=\"trap focus works with custom children components\">\n                <Demo title=\"Modal title\">\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <Switch name=\"switch\" />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"focus moves to the input\">\n                <Demo\n                    title=\"Modal title\"\n                    onOpen={() => {\n                        inputRef.current?.focus();\n                    }}\n                >\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <TextField name=\"name\" inputAttributes={{ ref: inputRef }} />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"Focus moves to the input with autoFocus\">\n                <Demo title=\"Modal title\">\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <TextField\n                            name=\"name\"\n                            placeholder=\"autofocus\"\n                            inputAttributes={{ autoFocus: true }}\n                        />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"scrollable area in modal ignores swipe-to-close\">\n                <View gap={3} direction=\"row\">\n                    <Button onClick={scrollModalToggle.activate}>Open</Button>\n                    <Modal\n                        active={scrollModalToggle.active}\n                        onClose={scrollModalToggle.deactivate}\n                        size=\"300px\"\n                        position=\"bottom\"\n                    >\n                        <View\n                            height=\"1000px\"\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            padding={4}\n                        >\n                            Content\n                        </View>\n                    </Modal>\n                </View>\n            </Example.Item>\n            <Example.Item\n                title={[\n                    \"trap focus works correctly when it was already trapped\",\n                    \"focus return back to the dropdown trigger on modal close\",\n                    \"closing dropdown inside the modal doesn't close the modal\",\n                ]}\n            >\n                <DropdownMenu>\n                    <DropdownMenu.Trigger>\n                        {(attributes) => <Button attributes={attributes}>Open menu</Button>}\n                    </DropdownMenu.Trigger>\n                    <DropdownMenu.Content>\n                        <DropdownMenu.Item onClick={menuModalToggle.activate}>Open dialog</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                    </DropdownMenu.Content>\n                </DropdownMenu>\n                <Modal active={menuModalToggle.active} onClose={menuModalToggle.deactivate}>\n                    <View gap={3}>\n                        <DropdownMenu>\n                            <DropdownMenu.Trigger>\n                                {(attributes) => <Button attributes={attributes}>Open menu</Button>}\n                            </DropdownMenu.Trigger>\n                            <DropdownMenu.Content>\n                                <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                                <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                            </DropdownMenu.Content>\n                        </DropdownMenu>\n                        <Button onClick={menuModalToggleInner.activate}>Open dialog</Button>\n                        <Button onClick={menuModalToggle.deactivate}>Close</Button>\n                        <Modal active={menuModalToggleInner.active} onClose={menuModalToggleInner.deactivate}>\n                            <Button onClick={menuModalToggleInner.deactivate}>Close</Button>\n                        </Modal>\n                    </View>\n                </Modal>\n            </Example.Item>\n\n            <Example.Item title=\"disableSwipeGesture\">\n                <Demo disableSwipeGesture position=\"start\" />\n            </Example.Item>\n\n            <Example.Item title=\"scroll locks on open\">\n                <Demo />\n                <View height=\"1000px\" />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "trapFocusEdgeCases",
+					"id": "components-modal--trap-focus-edge-cases",
+					"name": "test: trap focus edge cases",
 					"snippet": "const trapFocusEdgeCases = () => {\n    const toggle = useToggle();\n\n    return (\n        <Example>\n            <Example.Item title=\"Radio should be navigatable with arrow keys\">\n                <Button onClick={toggle.activate}>Open modal</Button>\n                <Modal active={toggle.active} onClose={toggle.deactivate}>\n                    <View gap={2}>\n                        <Button onClick={() => {}}>Action 1</Button>\n                        <Radio name=\"radio\" value=\"1\">\n                            Option 1\n                        </Radio>\n                        <Radio name=\"radio\" value=\"2\">\n                            Option 2\n                        </Radio>\n                        <Button onClick={() => {}}>Action 2</Button>\n                    </View>\n                </Modal>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import {\n    Button,\n    Dismissible,\n    DropdownMenu,\n    Example,\n    Modal,\n    Placeholder,\n    Radio,\n    Switch,\n    TextField,\n    View,\n} from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Modal/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Modal",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Modal/Modal.tsx",
-				"actualName": "Modal",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Component position on the screen",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<\"bottom\" | \"center\" | \"start\" | \"end\" | \"full-screen\">"
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size, literal css value",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Component padding, unit token multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Remove overflow from the component content",
+						"name": "overflow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"visible\"", "value": [{ "value": "\"visible\"" }] }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is closed",
+						"name": "onClose",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((args: { reason: CloseReason | \"drag\"; }) => void)" }
+					},
+					"transparentOverlay": {
+						"defaultValue": null,
+						"description": "Make the overlay transparent",
+						"name": "transparentOverlay",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"blurredOverlay": {
+						"defaultValue": null,
+						"description": "Make the overlay blurred",
+						"name": "blurredOverlay",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableSwipeGesture": {
+						"defaultValue": null,
+						"description": "Disable swipe gesture to close the component on touch devices",
+						"name": "disableSwipeGesture",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable closing the component on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Focus the first focusable element in the component when it is opened, when false, focus will be set on the component content container",
+						"name": "autoFocus",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element, useful when there is no visible title",
+						"name": "ariaLabel",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"overlayClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the overlay element",
+						"name": "overlayClassName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "(Attributes<\"div\"> & { ref?: RefObject<HTMLDivElement | null>; })"
+						}
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the visibility of the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the component is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"containerRef": {
+						"defaultValue": null,
+						"description": "Element to render the component in",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"onAfterOpen": {
+						"defaultValue": null,
+						"description": "Callback after the component open transition is complete",
+						"name": "onAfterOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onAfterClose": {
+						"defaultValue": null,
+						"description": "Callback after the component close transition is complete",
+						"name": "onAfterClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					}
+				},
+				"exportName": "Modal"
 			}
 		},
 		"components-numberfield": {
@@ -1030,54 +5840,450 @@
 			"path": "./src/components/NumberField/tests/NumberField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-numberfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => {\n    return (\n        <Example>\n            <Example.Item title=\"variant: outline\">\n                <NumberField\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"variant: faded\">\n                <NumberField\n                    variant=\"faded\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"variant: headless\">\n                <NumberField\n                    variant=\"headless\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-numberfield--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: small\">\n                <NumberField\n                    size=\"small\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    suffix=\"m2\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: medium\">\n                <NumberField\n                    size=\"medium\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: large\">\n                <NumberField\n                    size=\"large\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: xlarge\">\n                <NumberField\n                    size=\"xlarge\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-numberfield--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <NumberField\n    name=\"test-name\"\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    disabled\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-numberfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <NumberField\n    name=\"test-name\"\n    defaultValue={2}\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-numberfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <NumberField\n    name=\"test-name\"\n    value={2}\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "minMax",
+					"id": "components-numberfield--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <NumberField\n        name=\"test-name\"\n        defaultValue={6}\n        min={5}\n        max={10}\n        increaseAriaLabel=\"Increase\"\n        decreaseAriaLabel=\"Decrease\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-numberfield--step",
 					"name": "step",
 					"snippet": "const step = () => (\n    <NumberField\n        name=\"test-name\"\n        defaultValue={6}\n        step={0.5}\n        increaseAriaLabel=\"Increase\"\n        decreaseAriaLabel=\"Decrease\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-numberfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <NumberField\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n            increaseAriaLabel=\"Increase\"\n            decreaseAriaLabel=\"Decrease\"\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-numberfield--form-control",
+					"name": "test: FormControl",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"FormControl\">\n            <FormControl>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"FormControl, disabled\">\n            <FormControl disabled>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"FormControl, error\">\n            <FormControl hasError>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "valueChanges",
+					"id": "components-numberfield--value-changes",
+					"name": "test: keyboard",
 					"snippet": "const valueChanges = () => (\n    <Example>\n        <Example.Item title=\"keyboard\">\n            <NumberField\n                name=\"name\"\n                increaseAriaLabel=\"Increase\"\n                decreaseAriaLabel=\"Decrease\"\n                inputAttributes={{ \"aria-label\": \"Label\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, FormControl, NumberField } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/NumberField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "NumberField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/NumberField/NumberField.tsx",
-				"actualName": "NumberField",
+				"methods": [],
+				"props": {
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component value is changed",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<number, ChangeEvent<HTMLInputElement>>" }
+					},
+					"increaseAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the increase button",
+						"name": "increaseAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"decreaseAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the decrease button",
+						"name": "decreaseAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum value supported in the form field",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum value supported in the form field",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"step": {
+						"defaultValue": null,
+						"description": "Step at which the value will increase or decrease when clicking the button controls",
+						"name": "step",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the form field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the form field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1087,34 +6293,166 @@
 			"path": "./src/components/Pagination/tests/Pagination.stories.tsx",
 			"stories": [
 				{
+					"id": "components-pagination--truncate",
 					"name": "truncate",
 					"snippet": "const truncate = () => {\n    return (\n        <Example>\n            <Example.Item title=\"start\">\n                <Pagination\n                    total={10}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"middle\">\n                <Pagination\n                    total={10}\n                    defaultPage={5}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"end\">\n                <Pagination\n                    total={10}\n                    defaultPage={10}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"no truncation\">\n                <Pagination\n                    total={4}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "render",
+					"id": "components-pagination--render",
+					"name": "rendering",
 					"snippet": "const render = () => (\n    <div data-testid=\"root\">\n        <Pagination\n            total={10}\n            previousAriaLabel=\"Previous\"\n            nextAriaLabel=\"Next\"\n            pageAriaLabel={(args) => `Page ${args.page}`}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "defaultPage",
+					"id": "components-pagination--default-page",
+					"name": "defaultPage, uncontrolled",
 					"snippet": "const defaultPage = () => <div data-testid=\"root\">\n    <Pagination\n        total={10}\n        defaultPage={2}\n        onChange={fn()}\n        previousAriaLabel=\"Previous\"\n        nextAriaLabel=\"Next\" />\n</div>;"
 				},
 				{
-					"name": "page",
+					"id": "components-pagination--page",
+					"name": "page, controlled",
 					"snippet": "const page = () => <div data-testid=\"root\">\n    <Pagination\n        total={10}\n        page={2}\n        onChange={fn()}\n        previousAriaLabel=\"Previous\"\n        nextAriaLabel=\"Next\" />\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "components-pagination--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Pagination\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            total={10}\n            previousAriaLabel=\"Previous\"\n            nextAriaLabel=\"Next\"\n        />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Pagination } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Pagination/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Pagination",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Pagination/Pagination.tsx",
-				"actualName": "Pagination",
+				"methods": [],
+				"props": {
+					"total": {
+						"defaultValue": null,
+						"description": "Total number of pages available",
+						"name": "total",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "number" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the current page changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { page: number; }) => void)" }
+					},
+					"pageAriaLabel": {
+						"defaultValue": null,
+						"description": "Function to dynamically get an aria-label for each page",
+						"name": "pageAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { page: number; }) => string)" }
+					},
+					"previousAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the previous page button",
+						"name": "previousAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"nextAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the next page button",
+						"name": "nextAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"page": {
+						"defaultValue": null,
+						"description": "Currently selected page number, starts with 1, enables controlled mode",
+						"name": "page",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultPage": {
+						"defaultValue": null,
+						"description": "Default selected page number, starts with 1, enables uncontrolled mode",
+						"name": "defaultPage",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1124,54 +6462,229 @@
 			"path": "./src/components/PinField/tests/PinField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-pinfield--base",
 					"name": "base",
 					"snippet": "const base = () => <PinField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-pinfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <PinField name=\"pin\" variant=\"faded\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-pinfield--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <PinField name=\"pin\" size=\"small\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <PinField name=\"pin\" size=\"medium\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <PinField name=\"pin\" size=\"large\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <PinField name=\"pin\" size=\"xlarge\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: responsive, s: medium, m+: xlarge\">\n            <PinField\n                name=\"pin\"\n                size={{ s: \"medium\", m: \"xlarge\" }}\n                inputAttributes={{ \"aria-label\": \"Pin\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-pinfield--value-length",
 					"name": "valueLength",
 					"snippet": "const valueLength = () => (\n    <PinField name=\"test-name\" valueLength={6} inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-pinfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <PinField\n    name=\"test-name\"\n    onChange={fn()}\n    defaultValue=\"12\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-pinfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <PinField\n    name=\"test-name\"\n    onChange={fn()}\n    value=\"12\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-pinfield--pattern",
 					"name": "pattern",
 					"snippet": "const pattern = () => <PinField\n    name=\"test-name\"\n    pattern=\"alphabetic\"\n    defaultValue=\"ab\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-pinfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <PinField\n            name=\"test-name\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ \"aria-label\": \"Label\", id: \"test-input-id\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-pinfield--form-control",
+					"name": "test: with FormControl",
 					"snippet": "const formControl = () => (\n    <FormControl>\n        <FormControl.Label>Label</FormControl.Label>\n        <PinField name=\"test-name\" />\n    </FormControl>\n);"
 				},
 				{
-					"name": "keyboard",
+					"id": "components-pinfield--keyboard",
+					"name": "test: keyboard navigation",
 					"snippet": "const keyboard = () => <PinField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				}
 			],
 			"import": "import { Example, FormControl, PinField } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/PinField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "PinField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/PinField/PinField.tsx",
-				"actualName": "PinField",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"valueLength": {
+						"defaultValue": null,
+						"description": "Amount of characters in the pin",
+						"name": "valueLength",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"pattern": {
+						"defaultValue": null,
+						"description": "Character pattern used in the input value",
+						"name": "pattern",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"numeric\" | \"alphabetic\" | \"alphanumeric\"",
+							"value": [
+								{ "value": "\"numeric\"" },
+								{ "value": "\"alphabetic\"" },
+								{ "value": "\"alphanumeric\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Input fields render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\"",
+							"value": [{ "value": "\"outline\"" }, { "value": "\"faded\"" }]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the input element, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1181,75 +6694,514 @@
 			"path": "./src/components/Popover/tests/Popover.stories.tsx",
 			"stories": [
 				{
+					"id": "components-popover--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: bottom\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"bottom-start\" />\n                <Demo position=\"bottom\" />\n                <Demo position=\"bottom-end\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: top\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"top-start\" />\n                <Demo position=\"top\" />\n                <Demo position=\"top-end\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: start\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"start-top\" />\n                <Demo position=\"start\" />\n                <Demo position=\"start-bottom\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: end\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"end-top\" />\n                <Demo position=\"end\" />\n                <Demo position=\"end-bottom\" defaultActive />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "widthNumber",
+					"id": "components-popover--width-number",
+					"name": "width: px",
 					"snippet": "const widthNumber = () => <Demo width=\"400px\" defaultActive />;"
 				},
 				{
-					"name": "widthFull",
+					"id": "components-popover--width-full",
+					"name": "width: 100%",
 					"snippet": "const widthFull = () => <Demo width=\"100%\" defaultActive />;"
 				},
 				{
+					"id": "components-popover--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 0\">\n            <Demo padding={0} />\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <Demo padding={6} defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-popover--elevation",
 					"name": "elevation",
 					"snippet": "const elevation = () => (\n    <Example>\n        <Example.Item title=\"elevation: raised\">\n            <Demo elevation=\"raised\" defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-popover--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <Popover onOpen={fn()} onClose={fn()} defaultActive>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "active",
+					"id": "components-popover--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <Popover onOpen={fn()} onClose={fn()} active>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "components-popover--active-false",
+					"name": "active false, controlled",
 					"snippet": "const activeFalse = () => <Popover onOpen={fn()} onClose={fn()} active={false}>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "dismissible",
+					"id": "components-popover--dismissible",
+					"name": "dismissible, onClose, className, attributes, closeAriaLabel",
 					"snippet": "const dismissible = () => <Popover onClose={fn()} defaultActive>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>\n        <Popover.Dismissible\n            closeAriaLabel=\"Close\"\n            attributes={{ \"data-testid\": \"test-id\" }}\n            className=\"test-classname\">Content\n                            </Popover.Dismissible>\n    </Popover.Content>\n</Popover>;"
 				},
 				{
+					"id": "components-popover--auto-focus",
 					"name": "autoFocus",
 					"snippet": "const autoFocus = () => (\n    <Example>\n        <Example.Item title=\"autoFocus=false\">\n            <Demo autoFocus={false} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-popover--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Popover active>\n            <Popover.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </Popover.Trigger>\n            <Popover.Content className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n                Content\n            </Popover.Content>\n        </Popover>\n    </div>\n);"
 				},
 				{
-					"name": "testNested",
+					"id": "components-popover--test-nested",
+					"name": "test: nested",
 					"snippet": "const testNested = () => (\n    <Popover position=\"bottom\">\n        <Popover.Trigger>\n            {(attributes) => <Button attributes={attributes}>Open</Button>}\n        </Popover.Trigger>\n        <Popover.Content>\n            <View gap={2} align=\"start\">\n                Popover content\n                <Popover>\n                    <Popover.Trigger>\n                        {(attributes) => <Button attributes={attributes}>Open</Button>}\n                    </Popover.Trigger>\n                    <Popover.Content>Hello</Popover.Content>\n                </Popover>\n            </View>\n        </Popover.Content>\n    </Popover>\n);"
 				},
 				{
-					"name": "testWithTooltip",
+					"id": "components-popover--test-with-tooltip",
+					"name": "test: with tooltip",
 					"snippet": "const testWithTooltip = () => (\n    <View paddingTop={10}>\n        <Tooltip position=\"top\" text=\"Hello\">\n            {(tooltipAttributes) => (\n                <Popover position=\"bottom\">\n                    <Popover.Trigger>\n                        {(attributes) => (\n                            <Button\n                                attributes={{\n                                    ...attributes,\n                                    ...tooltipAttributes,\n                                }}\n                            >\n                                Open\n                            </Button>\n                        )}\n                    </Popover.Trigger>\n                    <Popover.Content>\n                        <View gap={2} align=\"start\">\n                            Popover content\n                            <Button onClick={() => {}}>Button</Button>\n                        </View>\n                    </Popover.Content>\n                </Popover>\n            )}\n        </Tooltip>\n    </View>\n);"
 				},
 				{
-					"name": "testContentEditable",
+					"id": "components-popover--test-content-editable",
+					"name": "test: contenteditable",
 					"snippet": "const testContentEditable = () => {\n    const [active, setActive] = useState(false);\n\n    return (\n        <Popover>\n            <Popover.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </Popover.Trigger>\n            <Popover.Content>\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={() => {}}>Hello</Button>\n                    </View.Item>\n\n                    <ScrollArea height=\"100px\">\n                        <div\n                            style={{ height: \"200px\" }}\n                            contentEditable\n                            tabIndex={0}\n                            onInput={(e) => {\n                                setActive(e.currentTarget.innerText.startsWith(\"@\"));\n                            }}\n                            onKeyDown={(e) => {\n                                console.log(e.key);\n                                if (e.key === \"Enter\" && active) {\n                                    e.preventDefault();\n                                    e.currentTarget.innerText = \"@hello\";\n                                    setActive(false);\n                                }\n                            }}\n                        />\n                    </ScrollArea>\n\n                    <Popover\n                        active={active}\n                        onClose={() => setActive(false)}\n                        originCoordinates={{ x: 300, y: 300 }}\n                        trapFocusMode=\"selection-menu\"\n                    >\n                        <Popover.Content>\n                            <View gap={4}>\n                                <MenuItem onClick={() => {}}>Action</MenuItem>\n                                <MenuItem onClick={() => {}}>Close</MenuItem>\n                            </View>\n                        </Popover.Content>\n                    </Popover>\n                </View>\n            </Popover.Content>\n        </Popover>\n    );\n};"
 				},
 				{
-					"name": "variant",
+					"id": "components-popover--variant",
+					"name": "variant [deprecated]",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: headless\">\n            <Popover variant=\"headless\" defaultActive position=\"bottom-start\">\n                <Popover.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </Popover.Trigger>\n                <Popover.Content>\n                    <View\n                        height=\"100px\"\n                        width=\"100px\"\n                        borderColor=\"primary\"\n                        borderRadius=\"medium\"\n                        backgroundColor=\"primary-faded\"\n                    />\n                </Popover.Content>\n            </Popover>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, MenuItem, Popover, ScrollArea, Tooltip, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Popover/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Popover",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Popover/Popover.tsx",
-				"actualName": "Popover",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Automatically focus the first focusable element in the content, when false the content container will be focused instead",
+						"name": "autoFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | TrapMode" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Content element padding, unit token multiplier",
+						"name": "padding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "@deprecated use Flyout utility instead, will be removed in v4",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"elevated\" | \"headless\"",
+							"value": [{ "value": "\"elevated\"" }, { "value": "\"headless\"" }]
+						}
+					}
+				},
+				"exportName": "Popover"
 			}
 		},
 		"components-progress": {
@@ -1258,38 +7210,177 @@
 			"path": "./src/components/Progress/tests/Progress.stories.tsx",
 			"stories": [
 				{
+					"id": "components-progress--value",
 					"name": "value",
 					"snippet": "const value = () => (\n    <Example>\n        <Example.Item title=\"value: 50\">\n            <Progress value={50} ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"value: 20, min: 0, max: 40\">\n            <Progress value={20} min={0} max={40} ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"value: 50, min: 0, max: 40\">\n            <Progress value={50} min={0} max={40} ariaLabel=\"rating value\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small, value: 50\">\n            <Progress value={50} size=\"small\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"size: medium, value: 50\">\n            <Progress value={50} size=\"medium\" ariaLabel=\"rating value\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: critical, value: 50\">\n            <Progress value={50} color=\"critical\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: warning, value: 50\">\n            <Progress value={50} color=\"warning\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive, value: 50\">\n            <Progress value={50} color=\"positive\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: media, value: 50\">\n            <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                <Progress value={50} color=\"media\" ariaLabel=\"rating value\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--duration",
 					"name": "duration",
 					"snippet": "const duration = () => {\n    const [active, setActive] = React.useState(false);\n\n    const handleChange = () => {\n        setActive((state) => !state);\n    };\n\n    return (\n        <Example>\n            <Example.Item title=\"duration: 2000\">\n                <View gap={3}>\n                    <View.Item>\n                        <Button onClick={handleChange}>Change</Button>\n                    </View.Item>\n\n                    <Progress value={active ? 100 : 0} duration={2000} ariaLabel=\"rating value\" />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "render",
+					"id": "components-progress--render",
+					"name": "rendering",
 					"snippet": "const render = () => <Progress value={75} min={50} max={100} ariaLabel=\"progress\" />;"
 				},
 				{
-					"name": "className",
+					"id": "components-progress--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Progress className=\"test-classname\" attributes={{ id: \"test-id\" }} ariaLabel=\"progress\" />\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, Progress, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Progress/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Progress",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Progress/Progress.tsx",
-				"actualName": "Progress",
+				"methods": [],
+				"props": {
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the progress bar controlling the size of the fill",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Lower value boundary of the progress bar",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Upper value boundary of the progress bar",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"warning\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"duration": {
+						"defaultValue": null,
+						"description": "Duration of the progress bar animation in milliseconds",
+						"name": "duration",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1299,30 +7390,135 @@
 			"path": "./src/components/ProgressIndicator/tests/ProgressIndicator.stories.tsx",
 			"stories": [
 				{
+					"id": "components-progressindicator--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const [activeIndex, setActiveIndex] = React.useState(0);\n    const total = 10;\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <View gap={4}>\n                    <View direction=\"row\" gap={2} align=\"center\">\n                        <Button\n                            onClick={() => {\n                                setActiveIndex((prev) => Math.max(0, prev - 1));\n                            }}\n                        >\n                            Previous\n                        </Button>\n                        <Button\n                            onClick={() => {\n                                setActiveIndex((prev) => Math.min(total - 1, prev + 1));\n                            }}\n                        >\n                            Next\n                        </Button>\n                        <Text weight=\"medium\">Index: {activeIndex}</Text>\n                    </View>\n\n                    <View borderRadius=\"medium\" overflow=\"hidden\" width=\"300px\">\n                        <Scrim\n                            position=\"bottom\"\n                            backgroundSlot={<View aspectRatio={16 / 9} backgroundColor=\"neutral-faded\" />}\n                        >\n                            <View align=\"center\">\n                                <ProgressIndicator total={total} activeIndex={activeIndex} color=\"media\" />\n                            </View>\n                        </Scrim>\n                    </View>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-progressindicator--color",
 					"name": "color",
 					"snippet": "const color = () => {\n    return (\n        <Example>\n            <Example.Item title=\"color: primary\">\n                <ProgressIndicator total={10} activeIndex={5} color=\"primary\" />\n            </Example.Item>\n            <Example.Item title=\"color: media\">\n                <View borderRadius=\"medium\" overflow=\"hidden\" width=\"300px\">\n                    <Scrim\n                        position=\"bottom\"\n                        backgroundSlot={<View aspectRatio={16 / 9} backgroundColor=\"neutral-faded\" />}\n                    >\n                        <View align=\"center\">\n                            <ProgressIndicator total={10} activeIndex={5} color=\"media\" />\n                        </View>\n                    </Scrim>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-progressindicator--aria-label",
 					"name": "ariaLabel",
 					"snippet": "const ariaLabel = () => <ProgressIndicator total={10} className=\"test-classname\" ariaLabel=\"Progress\" />;"
 				},
 				{
-					"name": "className",
+					"id": "components-progressindicator--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ProgressIndicator total={10} className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, ProgressIndicator, Scrim, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ProgressIndicator/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ProgressIndicator",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ProgressIndicator/ProgressIndicator.tsx",
-				"actualName": "ProgressIndicator",
+				"methods": [],
+				"props": {
+					"total": {
+						"defaultValue": null,
+						"description": "Total amount of progress indicator dots",
+						"name": "total",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "number" }
+					},
+					"activeIndex": {
+						"defaultValue": null,
+						"description": "Index of the active progress indicator dot",
+						"name": "activeIndex",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\"",
+							"value": [{ "value": "\"media\"" }, { "value": "\"primary\"" }]
+						}
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1332,50 +7528,203 @@
 			"path": "./src/components/Radio/tests/Radio.stories.tsx",
 			"stories": [
 				{
+					"id": "components-radio--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"small\" defaultChecked>\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"medium\">\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"large\">\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: responsive, s: small, m: large\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size={{ s: \"small\", m: \"large\" }}>\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-radio--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Radio name=\"error\" value=\"dog\" hasError>\n                Radio\n            </Radio>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-radio--render",
+					"name": "name, value",
 					"snippet": "const render = () => (\n    <Radio name=\"test-name\" value=\"test-value\">\n        Content\n    </Radio>\n);"
 				},
 				{
-					"name": "checked",
+					"id": "components-radio--checked",
+					"name": "checked, controlled",
 					"snippet": "const checked = () => <Radio name=\"test-name\" value=\"test-value\" checked onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "checkedFalse",
+					"id": "components-radio--checked-false",
+					"name": "checked false, controlled",
 					"snippet": "const checkedFalse = () => <Radio name=\"test-name\" value=\"test-value\" checked={false} onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-radio--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Radio name=\"test-name\" value=\"test-value\" defaultChecked onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "defaultCheckedFalse",
+					"id": "components-radio--default-checked-false",
+					"name": "defaultChecked false, uncontrolled",
 					"snippet": "const defaultCheckedFalse = () => <Radio name=\"test-name\" value=\"test-value\" onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
+					"id": "components-radio--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Radio name=\"test-name\" value=\"test-value\" disabled>\n        Content\n    </Radio>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-radio--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Radio className=\"test-classname\" attributes={{ id: \"test-id\" }} value=\"value\">\n            Content\n        </Radio>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Radio, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Radio/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Radio",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Radio/Radio.tsx",
-				"actualName": "Radio",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the form field from the form submission",
+						"name": "disabled",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Indicate that the form field has an error",
+						"name": "hasError",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element",
+						"name": "value",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the input is focused",
+						"name": "onFocus",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the input is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "",
+						"name": "checked",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultChecked",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1385,26 +7734,169 @@
 			"path": "./src/components/RadioGroup/tests/RadioGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "value",
+					"id": "components-radiogroup--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <RadioGroup name=\"test-name\" value=\"1\" onChange={fn()}>\n    {/* checked should be ignored */}\n    <Radio value=\"1\" checked={false}>Content\n                    </Radio>\n    <Radio value=\"2\">Content 2</Radio>\n</RadioGroup>;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-radiogroup--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <RadioGroup name=\"test-name\" defaultValue=\"1\" onChange={fn()}>\n    {/* checked should be ignored */}\n    <Radio value=\"1\" checked={false}>Content\n                    </Radio>\n    <Radio value=\"2\">Content 2</Radio>\n</RadioGroup>;"
 				},
 				{
+					"id": "components-radiogroup--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <RadioGroup name=\"test-name\" disabled>\n        <Radio value=\"test-value\">Content</Radio>\n    </RadioGroup>\n);"
 				}
 			],
 			"import": "import { Radio, RadioGroup } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/RadioGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "RadioGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/RadioGroup/RadioGroup.tsx",
-				"actualName": "RadioGroup",
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the radio group",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the form field from the form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Indicate that the form field has an error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the input element, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1414,39 +7906,131 @@
 			"path": "./src/components/Resizable/tests/Resizable.stories.tsx",
 			"stories": [
 				{
+					"id": "components-resizable--direction",
 					"name": "direction",
 					"snippet": "const direction = () => {\n    return (\n        <Example>\n            <Example.Item title=\"row\">\n                <Resizable height=\"200px\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n            <Example.Item title=\"column\">\n                <Resizable height=\"400px\" direction=\"column\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n\n            {/* Test that page doesn't scroll on dragging */}\n            <div style={{ height: 2000 }} />\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-resizable--children",
 					"name": "children",
 					"snippet": "const children = () => {\n    return (\n        <Example>\n            <Example.Item title=\"render props, row\">\n                <Resizable height=\"200px\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n            <Example.Item title=\"render props, column\">\n                <Resizable height=\"400px\" direction=\"column\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-resizable--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"bordered, row\">\n            <Resizable height=\"200px\" variant=\"bordered\">\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n            </Resizable>\n        </Example.Item>\n        <Example.Item title=\"bordered, column\">\n            <Resizable height=\"400px\" direction=\"column\" variant=\"bordered\">\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n            </Resizable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "components-resizable--size",
+					"name": "minSize, maxSize, defaultSize",
 					"snippet": "const size = () => (\n    <Resizable className=\"test-classname\" attributes={{ id: \"test-id\" }} height=\"200px\">\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n        <Resizable.Handle />\n        <Resizable.Item minSize=\"200px\" maxSize=\"500px\" defaultSize=\"300px\">\n            <Panel />\n        </Resizable.Item>\n    </Resizable>\n);"
 				},
 				{
-					"name": "layout",
+					"id": "components-resizable--layout",
+					"name": "height, gap",
 					"snippet": "const layout = () => (\n    <Resizable height=\"100px\" gap={8}>\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n        <Resizable.Handle />\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n    </Resizable>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-resizable--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Resizable className=\"test-classname\" attributes={{ id: \"test-id\" }} height=\"200px\">\n            <Resizable.Item>\n                <Panel />\n            </Resizable.Item>\n            <Resizable.Handle />\n            <Resizable.Item>\n                <Panel />\n            </Resizable.Item>\n        </Resizable>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, Resizable, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Resizable/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Resizable",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Resizable/Resizable.tsx",
-				"actualName": "Resizable",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Resizable/Resizable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"bordered\" | \"borderless\"",
+							"value": [{ "value": "\"bordered\"" }, { "value": "\"borderless\"" }]
+						}
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Component content direction with the resize handle rendered in between the chidlren",
+						"name": "direction",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Resizable/Resizable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between children, base unit token number multiplier",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					}
+				},
+				"exportName": "Resizable"
 			}
 		},
 		"components-scrim": {
@@ -1455,26 +8039,101 @@
 			"path": "./src/components/Scrim/tests/Scrim.stories.tsx",
 			"stories": [
 				{
+					"id": "components-scrim--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: center\">\n            <Scrim backgroundSlot={<Placeholder h={200} />}>Scrim</Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <Scrim position=\"bottom\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: top\">\n            <Scrim position=\"top\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: start\">\n            <Scrim position=\"start\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <Scrim position=\"end\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-scrim--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Scrim className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Scrim>\n    </div>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "components-scrim--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"without backgroundSlot, size is based on the parent component\">\n            <div style={{ height: 300, position: \"relative\" }}>\n                <Scrim>Text</Scrim>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Placeholder, Scrim } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Scrim/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Scrim",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Scrim/Scrim.tsx",
-				"actualName": "Scrim",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"backgroundSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting background content behind the scrim",
+						"name": "backgroundSlot",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Component content position",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"bottom\" | \"start\" | \"end\" | \"full\"",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"full\"" }
+							]
+						}
+					},
+					"scrimClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the scrim element",
+						"name": "scrimClassName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1484,79 +8143,398 @@
 			"path": "./src/components/Select/tests/Select.stories.tsx",
 			"stories": [
 				{
-					"name": "nativeRender",
+					"id": "components-select--native-render",
+					"name": "native rendering, options, name, id",
 					"snippet": "const nativeRender = () => (\n    <Example>\n        <Example.Item title=\"native with options prop\">\n            <Select\n                name=\"animal\"\n                id=\"animal-1\"\n                placeholder=\"Select an animal\"\n                options={[\n                    { label: \"Dog\", value: \"dog\" },\n                    { label: \"Turtle\", value: \"turtle\" },\n                ]}\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            />\n        </Example.Item>\n        <Example.Item title=\"native with option tags\">\n            <Select\n                name=\"animal\"\n                id=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "customRender",
+					"id": "components-select--custom-render",
+					"name": "custom rendering, name, id, option groups",
 					"snippet": "const customRender = () => (\n    <Example>\n        <Example.Item title=\"custom with options\">\n            <Select.Custom\n                name=\"animal\"\n                id=\"animal-1\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"native with option tags\">\n            <Select.Custom\n                name=\"animal-2\"\n                id=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Group label=\"Birds\">\n                    <Select.Option value=\"pigeon\">Pigeon</Select.Option>\n                    <Select.Option value=\"parrot\">Parrot</Select.Option>\n                </Select.Group>\n                <Select.Group label=\"Sea Mammals\">\n                    <Select.Option value=\"whale\">Whale</Select.Option>\n                    <Select.Option value=\"dolphin\">Dolphin</Select.Option>\n                </Select.Group>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "nativeHandlers",
+					"id": "components-select--native-handlers",
+					"name": "native, controlled, uncontrolled, onFocus, onBlur, onChange",
 					"snippet": "const nativeHandlers = () => <Example>\n    <Example.Item title=\"native, uncontrolled, onChange\">\n        <Select\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n    <Example.Item title=\"native, controlled, onChange\">\n        <Select\n            name=\"animal-2\"\n            placeholder=\"Select an animal\"\n            value=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n    <Example.Item title=\"native, onFocus, onBlur, onClick\">\n        <Select\n            name=\"animal-3\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onFocus={fn()}\n            onBlur={fn()}\n            onClick={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "customHandlers",
+					"id": "components-select--custom-handlers",
+					"name": "custom, controlled, uncontrolled, onFocus, onBlur, onChange",
 					"snippet": "const customHandlers = () => <Example>\n    <Example.Item title=\"custom, uncontrolled, onChange\">\n        <Select.Custom\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n    <Example.Item title=\"custom, controlled, onChange\">\n        <Select.Custom\n            name=\"animal-2\"\n            placeholder=\"Select an animal\"\n            value=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n    <Example.Item title=\"native, onFocus, onBlur, onClick\">\n        <Select.Custom\n            name=\"animal-3\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onFocus={fn()}\n            onBlur={fn()}\n            onClick={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "triggerOnly",
+					"id": "components-select--trigger-only",
+					"name": "trigger only, onClick",
 					"snippet": "const triggerOnly = (args) => {\n    const toggle = useToggle();\n    const [value, setValue] = React.useState(\"Dog\");\n\n    const handleClick: SelectProps[\"onClick\"] = (e) => {\n        args.handleClick(e);\n        toggle.toggle();\n    };\n\n    return (\n        <Example>\n            <Example.Item title=\"trigger only, onClick\">\n                <Select\n                    name=\"animal\"\n                    placeholder=\"Select an animal\"\n                    onClick={handleClick}\n                    value=\"dog\"\n                    inputAttributes={{\n                        \"aria-label\": \"Select an animal\",\n                    }}\n                >\n                    {value}\n                </Select>\n                <Modal\n                    active={toggle.active}\n                    onClose={toggle.deactivate}\n                    position=\"bottom\"\n                    padding={2}\n                    attributes={{ \"aria-label\": \"Select an animal\" }}\n                >\n                    <div role=\"listbox\" aria-label=\"Select an animal\">\n                        <MenuItem\n                            roundedCorners\n                            onClick={() => {\n                                setValue(\"Dog\");\n                                toggle.deactivate();\n                            }}\n                            attributes={{\n                                role: \"option\",\n                            }}\n                        >\n                            Dog\n                        </MenuItem>\n                        <MenuItem\n                            roundedCorners\n                            attributes={{\n                                role: \"option\",\n                            }}\n                            onClick={() => {\n                                setValue(\"Turtle\");\n                                toggle.deactivate();\n                            }}\n                        >\n                            Turtle\n                        </MenuItem>\n                    </div>\n                </Modal>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-select--multiple",
 					"name": "multiple",
 					"snippet": "const multiple = () => <Example>\n    <Example.Item title=\"multiple\">\n        <Select.Custom\n            multiple\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue={[\"dog\"]}\n            onChange={fn()}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-select--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded, native\">\n            <Select\n                variant=\"faded\"\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n\n        <Example.Item title=\"variant: faded, custom\">\n            <Select.Custom\n                variant=\"faded\"\n                name=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless, native\">\n            <Select\n                variant=\"headless\"\n                name=\"animal-3\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless, custom\">\n            <Select.Custom\n                variant=\"headless\"\n                name=\"animal-4\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <Select.Custom size=\"small\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <Select.Custom size=\"medium\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <Select.Custom size=\"large\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: xlarge\">\n            <Select.Custom size=\"xlarge\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "startSlot",
+					"id": "components-select--start-slot",
+					"name": "icon,startSlot",
 					"snippet": "const startSlot = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Select.Custom name=\"animal\" placeholder=\"Select an animal\" icon={IconZap}>\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n\n        <Example.Item title=\"startSlot\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                startSlot={<Placeholder h={20} />}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--render-value",
 					"name": "renderValue",
 					"snippet": "const renderValue = () => {\n    const options = [\n        {\n            value: \"1\",\n            label: \"Title 1\",\n            subtitle: \"Subtitle 1\",\n        },\n        {\n            value: \"2\",\n            label: \"Title 2\",\n            subtitle: \"Subtitle 2\",\n        },\n    ];\n\n    return (\n        <Example>\n            <Example.Item title=\"default renderer, single\">\n                <Select.Custom name=\"animal\" defaultValue=\"1\" placeholder=\"Nothing selected\">\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"default renderer, multiple\">\n                <Select.Custom name=\"animal\" defaultValue={[\"1\"]} multiple placeholder=\"Nothing selected\">\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"renderValue, single\">\n                <Select.Custom\n                    name=\"animal\"\n                    defaultValue=\"1\"\n                    placeholder=\"Nothing selected\"\n                    renderValue={(args) => <Badge>Title {args.value}</Badge>}\n                >\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"renderValue, multiple\">\n                <Select.Custom\n                    name=\"animal\"\n                    defaultValue={[\"1\"]}\n                    multiple\n                    placeholder=\"Nothing selected\"\n                    renderValue={(args) => <Badge>Titles {args.value.join(\", \")}</Badge>}\n                >\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-select--error",
 					"name": "error",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Select.Custom name=\"animal\" placeholder=\"Select an animal\" hasError>\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, native\">\n            <Select\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                disabled\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n        <Example.Item title=\"disabled, custom\">\n            <Select.Custom\n                name=\"animal-2\"\n                placeholder=\"Select an animal\"\n                disabled\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-select--class-name",
+					"name": "className, attributes, inputAttributes",
 					"snippet": "const className = () => (\n    <Example>\n        <Example.Item title=\"native, className, attributes, inputAttributes\">\n            <Select\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                className=\"native-class\"\n                attributes={{ id: \"test-id\" }}\n                inputAttributes={{ \"aria-label\": \"test-label\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n        <Example.Item title=\"custom, className, attributes, inputAttributes\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                className=\"custom-class\"\n                attributes={{ id: \"test-id\" }}\n                inputAttributes={{ \"aria-label\": \"test-label\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "fallback",
+					"id": "components-select--fallback",
+					"name": "test: fallbackAdjustLayout",
 					"snippet": "const fallback = () => (\n    <Example>\n        <Example.Item title=\"fallback\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                {[...Array(100)].map((_, index) => (\n                    <Select.Option key={index} value={`item-${index}`}>\n                        Item {index + 1}\n                    </Select.Option>\n                ))}\n            </Select.Custom>\n            <div style={{ height: \"1000px\" }}></div>\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                {[...Array(100)].map((_, index) => (\n                    <Select.Option key={index} value={`item-${index}`}>\n                        Item {index + 1}\n                    </Select.Option>\n                ))}\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-select--form-control",
+					"name": "test: with FormControl",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"FormControl\">\n            <FormControl hasError>\n                <FormControl.Label>Animal</FormControl.Label>\n                <Select.Custom name=\"animal\" placeholder=\"Select an animal\">\n                    <Select.Option value=\"dog\">Dog</Select.Option>\n                    <Select.Option value=\"turtle\">Turtle</Select.Option>\n                </Select.Custom>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "components-select--test-composition",
+					"name": "test: composition",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item title=\"custom with options\">\n            <Select.Custom\n                name=\"animal\"\n                id=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Group>\n                    <Select.Option value=\"dog\">Dog</Select.Option>\n                    <Select.Option value=\"turtle\">Turtle</Select.Option>\n                </Select.Group>\n                <Select.Group>Hello</Select.Group>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Badge, Example, FormControl, MenuItem, Modal, Placeholder, Select, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Select/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Select",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Select/Select.tsx",
-				"actualName": "Select",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the select user interaction and form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value selected",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon to display in the select start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the select value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when the trigger is clicked",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"options": {
+						"defaultValue": null,
+						"description": "@deprecated Use <option /> children instead",
+						"name": "options",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NativeOption[]" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the input is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLSelectElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the input is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLSelectElement, Element>) => void)" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"select\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"renderValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "renderValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "undefined" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLSelectElement>>" }
+					}
+				},
+				"exportName": "Select"
 			}
 		},
 		"components-skeleton": {
@@ -1565,26 +8543,87 @@
 			"path": "./src/components/Skeleton/tests/Skeleton.stories.tsx",
 			"stories": [
 				{
+					"id": "components-skeleton--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"text\">\n            <Skeleton />\n        </Example.Item>\n\n        <Example.Item title=\"view, rectangle\">\n            <Skeleton width=\"100px\" height=\"100px\" />\n        </Example.Item>\n\n        <Example.Item title=\"view, circle\">\n            <Skeleton width=\"100px\" height=\"100px\" borderRadius=\"circular\" />\n        </Example.Item>\n\n        <Example.Item title=\"view, rectangle, responsive\">\n            <Skeleton width={{ s: \"100px\", m: \"200px\" }} height={{ s: \"100px\", m: \"200px\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-skeleton--radius",
 					"name": "radius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius=small\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"small\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=medium\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"medium\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=large\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"large\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=circular\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"circular\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-skeleton--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Skeleton className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Skeleton } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Skeleton/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Skeleton",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Skeleton/Skeleton.tsx",
-				"actualName": "Skeleton",
+				"methods": [],
+				"props": {
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width style, literal string value or a base unit token number multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Radius>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Skeleton/Skeleton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Skeleton/Skeleton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1594,66 +8633,421 @@
 			"path": "./src/components/Slider/tests/Slider.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "components-slider--base",
+					"name": "name, minName, maxName, range",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"single, name\">\n            <Slider name=\"slider-single\" defaultValue={30} />\n        </Example.Item>\n        <Example.Item title=\"range, name\">\n            <Slider range name=\"slider-range\" defaultMinValue={30} defaultMaxValue={85} />\n        </Example.Item>\n        <Example.Item title=\"range, minName, maxName\">\n            <Slider\n                range\n                minName=\"slider-min\"\n                maxName=\"slider-max\"\n                defaultMinValue={30}\n                defaultMaxValue={85}\n            />\n        </Example.Item>\n        <div style={{ height: 2000 }} />\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--orientation",
 					"name": "orientation",
 					"snippet": "const orientation = () => (\n    <Example>\n        <Example.Item title=\"orientation: vertical\">\n            <View height=\"200px\">\n                <Slider\n                    range\n                    name=\"slider\"\n                    defaultMinValue={30}\n                    defaultMaxValue={85}\n                    orientation=\"vertical\"\n                />\n            </View>\n        </Example.Item>\n        <View height=\"2000px\" />\n    </Example>\n);"
 				},
 				{
-					"name": "minMax",
+					"id": "components-slider--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <Example>\n        <Example.Item title=\"min, max\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={60} />\n        </Example.Item>\n        <Example.Item title=\"min, max, value < min\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={30} />\n        </Example.Item>\n        <Example.Item title=\"min, max, value > max\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={80} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--step",
 					"name": "step",
 					"snippet": "const step = () => (\n    <Example>\n        <Example.Item title=\"step: 5\">\n            <Slider name=\"slider\" defaultValue={30} step={5} />\n        </Example.Item>\n\n        <Example.Item title=\"step: 5, defaultValue: 31, rounded down to 30\">\n            <Slider name=\"slider\" defaultValue={31} step={5} />\n        </Example.Item>\n\n        <Example.Item title=\"step: 0.01, float\">\n            <Slider name=\"slider\" defaultValue={30} step={0.01} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <Slider name=\"slider\" defaultValue={30} disabled />\n        </Example.Item>\n\n        <Example.Item title=\"disabled, range\">\n            <Slider name=\"slider\" range defaultMinValue={30} defaultMaxValue={80} disabled />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--render-value",
 					"name": "renderValue",
 					"snippet": "const renderValue = () => (\n    <Example>\n        <Example.Item title=\"renderValue: $\">\n            <Slider name=\"name\" defaultValue={50} renderValue={(args) => `$${args.value}`} />\n        </Example.Item>\n        <Example.Item title=\"renderValue: false\">\n            <Slider name=\"name\" defaultValue={50} renderValue={false} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-slider--default-value",
+					"name": "defaultValue, onChange, onChangeCommit",
 					"snippet": "const defaultValue = () => <View paddingTop={10}>\n    <Slider name=\"test-name\" defaultValue={50} onChange={fn()} onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "value",
+					"id": "components-slider--value",
+					"name": "value, onChange, onChangeCommit",
 					"snippet": "const value = () => <View paddingTop={10}>\n    <Slider name=\"test-name\" value={50} onChange={fn()} onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "rangeDefaultValue",
+					"id": "components-slider--range-default-value",
+					"name": "range, defaultValue, onChange, onChangeCommit",
 					"snippet": "const rangeDefaultValue = () => <View paddingTop={10}>\n    <Slider\n        range\n        name=\"test-name\"\n        defaultMinValue={50}\n        defaultMaxValue={70}\n        onChange={fn()}\n        onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "rangeValue",
+					"id": "components-slider--range-value",
+					"name": "range, value, onChange, onChangeCommit, minName, maxName",
 					"snippet": "const rangeValue = () => <View paddingTop={10}>\n    <Slider\n        range\n        minName=\"test-name-min\"\n        maxName=\"test-name-max\"\n        minValue={50}\n        maxValue={70}\n        onChange={fn()}\n        onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "className",
+					"id": "components-slider--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Slider name=\"name\" className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				},
 				{
-					"name": "testForm",
+					"id": "components-slider--test-form",
+					"name": "test: form onChange",
 					"snippet": "const testForm = (args) => {\n    const formRef = React.useRef<HTMLFormElement>(null);\n    const [data, setData] = React.useState<[string, FormDataEntryValue][]>([]);\n\n    const handleChange = (e: React.FormEvent<HTMLFormElement>) => {\n        const formData = new FormData(e.currentTarget);\n        const nextState = [...formData.entries()];\n\n        args.handleFormChange({ formData: nextState });\n        setData(nextState);\n    };\n\n    return (\n        <View paddingTop={10} gap={4}>\n            <form onChange={handleChange} ref={formRef}>\n                <Slider\n                    range\n                    minName=\"slider-min\"\n                    maxName=\"slider-max\"\n                    defaultMinValue={30}\n                    defaultMaxValue={50}\n                />\n            </form>\n\n            {data.map((v) => v.join(\": \")).join(\", \")}\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testSwipe",
+					"id": "components-slider--test-swipe",
+					"name": "test: prevents parent swipe",
 					"snippet": "const testSwipe = () => {\n    const toggle = useToggle(true);\n\n    return (\n        <Modal active={toggle.active} onClose={toggle.deactivate} position=\"end\">\n            <View gap={4}>\n                <Modal.Title>Modal</Modal.Title>\n                <Slider name=\"slider\" defaultValue={30} />\n            </View>\n        </Modal>\n    );\n};"
 				}
 			],
 			"import": "import { Example, Modal, Slider, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Slider/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Slider",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Slider/Slider.tsx",
-				"actualName": "Slider",
+				"methods": [],
+				"props": {
+					"step": {
+						"defaultValue": null,
+						"description": "Step of the slider",
+						"name": "step",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the slider user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum value of the slider",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum value of the slider",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"orientation": {
+						"defaultValue": null,
+						"description": "Orientation of the slider",
+						"name": "orientation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"vertical\" | \"horizontal\"",
+							"value": [{ "value": "\"vertical\"" }, { "value": "\"horizontal\"" }]
+						}
+					},
+					"renderValue": {
+						"defaultValue": null,
+						"description": "Render a custom value in the thumb tooltip",
+						"name": "renderValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | ((args: { value: number; }) => string)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the slider, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the slider, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"range": {
+						"defaultValue": null,
+						"description": "Enables range slider with two thumbs",
+						"name": "range",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the slider input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"minName": {
+						"defaultValue": null,
+						"description": "Name of the slider min value input element, overrides the name",
+						"name": "minName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"maxName": {
+						"defaultValue": null,
+						"description": "Name of the slider max value input element, overrides the name",
+						"name": "maxName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the slider value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: SingleChangeArgs) => void) | ((args: RangeChangeArgs) => void) | ((args: RangeChangeArgs) => void)"
+						}
+					},
+					"onChangeCommit": {
+						"defaultValue": null,
+						"description": "Callback when the user commits the change by releasing the thumb\nCallback when the user commits the change by releasing the thumbs",
+						"name": "onChangeCommit",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: SingleChangeArgs) => void) | ((args: RangeChangeArgs) => void) | ((args: RangeChangeArgs) => void)"
+						}
+					},
+					"minValue": {
+						"defaultValue": null,
+						"description": "Minimum value of the slider",
+						"name": "minValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"maxValue": {
+						"defaultValue": null,
+						"description": "Maximum value of the slider",
+						"name": "maxValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultMinValue": {
+						"defaultValue": null,
+						"description": "Default minimum value of the slider, enables uncontrolled mode",
+						"name": "defaultMinValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultMaxValue": {
+						"defaultValue": null,
+						"description": "Default maximum value of the slider, enables uncontrolled mode",
+						"name": "defaultMaxValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1663,35 +9057,137 @@
 			"path": "./src/components/Stepper/tests/Stepper.stories.tsx",
 			"stories": [
 				{
+					"id": "components-stepper--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example>\n        <Example.Item title=\"direction: row\">\n            <Stepper activeId=\"1\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <Stepper activeId=\"1\" direction=\"column\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-stepper--label-display",
 					"name": "labelDisplay",
 					"snippet": "const labelDisplay = () => (\n    <Example>\n        <Example.Item title=\"direction: row, labels hidden\">\n            <Stepper activeId=\"1\" labelDisplay=\"hidden\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: column, labels hiden\">\n            <Stepper activeId=\"1\" direction=\"column\" labelDisplay=\"hidden\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: row, labels hidden on s\">\n            <Stepper activeId=\"1\" labelDisplay={{ s: \"hidden\", m: \"inline\" }}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-stepper--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 6, direction: row\">\n            <Stepper activeId=\"1\" gap={6}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"gap: 6, direction: column\">\n            <Stepper activeId=\"1\" direction=\"column\" gap={6}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap\", \"[s] 2\", \"[m+] 5\"]}>\n            <Stepper activeId=\"1\" gap={{ s: 2, m: 5 }}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-stepper--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Stepper className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Stepper.Item attributes={{ id: \"test-item-id\" }} className=\"test-item-classname\" />\n        </Stepper>\n    </div>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-stepper--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"multiline subtitle\",\n                \"should wrap the text correctly\",\n                \"should display the connector correctly\",\n            ]}\n        >\n            <Demo\n                activeId={0}\n                subtitle=\"It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, Placeholder, Stepper, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Stepper/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Stepper",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Stepper/Stepper.tsx",
-				"actualName": "Stepper",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"activeId": {
+						"defaultValue": null,
+						"description": "Id of the item to display as active",
+						"name": "activeId",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string | number" }
+					},
+					"labelDisplay": {
+						"defaultValue": null,
+						"description": "Display variant for the item label",
+						"name": "labelDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"hidden\" | \"inline\">" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Direction of the stepper",
+						"name": "direction",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between items (default: 3)",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
+				"exportName": "Stepper"
 			}
 		},
 		"components-switch": {
@@ -1700,38 +9196,236 @@
 			"path": "./src/components/Switch/tests/Switch.stories.tsx",
 			"stories": [
 				{
-					"name": "size",
+					"id": "components-switch--size",
+					"name": "Size",
 					"snippet": "const size = () => (\n\t<Example>\n\t\t<Example.Item title=\"size: medium\">\n\t\t\t<Switch name=\"active\" size=\"medium\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: small\">\n\t\t\t<Switch name=\"active\" size=\"small\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: large\">\n\t\t\t<Switch name=\"active\" size=\"large\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: responsive, s: small, m: large\">\n\t\t\t<Switch\n\t\t\t\tname=\"active\"\n\t\t\t\tsize={{ s: \"small\", m: \"large\" }}\n\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t/>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "label",
+					"id": "components-switch--label",
+					"name": "Label",
 					"snippet": "const label = () => (\n\t<Example>\n\t\t<Example.Item title=\"size: medium\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch reversed name=\"active\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: small\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" size=\"small\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch\n\t\t\t\t\treversed\n\t\t\t\t\tname=\"active\"\n\t\t\t\t\tsize=\"small\"\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t\t>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\n\t\t<Example.Item title=\"size: large\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" size=\"large\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch\n\t\t\t\t\treversed\n\t\t\t\t\tname=\"active\"\n\t\t\t\t\tsize=\"large\"\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t\t>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-switch--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Switch name=\"test-name\" defaultChecked onChange={fn()}>Label\n            </Switch>;"
 				},
 				{
-					"name": "checked",
+					"id": "components-switch--checked",
+					"name": "checked, uncontrolled",
 					"snippet": "const checked = () => <Switch name=\"test-name\" checked onChange={fn()}>Label\n            </Switch>;"
 				},
 				{
+					"id": "components-switch--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, unselected\">\n            <Switch name=\"active\" disabled inputAttributes={{ \"aria-label\": \"test switch\" }} />\n        </Example.Item>\n        <Example.Item title=\"disabled, selected\">\n            <Switch\n                name=\"active\"\n                disabled\n                defaultChecked\n                inputAttributes={{ \"aria-label\": \"test switch\" }}\n            />\n        </Example.Item>\n        <Example.Item title=\"disabled, with label\">\n            <Switch name=\"active\" disabled>\n                Switch\n            </Switch>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-switch--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Switch\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ \"aria-label\": \"test select\", id: \"test-input-id\" }}\n            name=\"name\"\n        >\n            Label\n        </Switch>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Switch, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Switch/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Switch",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Switch/Switch.tsx",
-				"actualName": "Switch",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the switch",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the switch input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the switch user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"reversed": {
+						"defaultValue": null,
+						"description": "Reverse the children position",
+						"name": "reversed",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the switch value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the switch is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the switch is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default value of the switch, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Value of the switch, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1741,51 +9435,112 @@
 			"path": "./src/components/Table/tests/Table.stories.tsx",
 			"stories": [
 				{
-					"name": "layout",
+					"id": "components-table--layout",
+					"name": "base",
 					"snippet": "const layout = () => (\n    <Example>\n        <Example.Item title=\"base\">\n            <Table>\n                <Table.Head>\n                    <Table.Row>\n                        <Table.Heading>Column 1</Table.Heading>\n                        <Table.Heading>Column 2</Table.Heading>\n                    </Table.Row>\n                </Table.Head>\n                <Table.Body>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell>Cell 2</Table.Cell>\n                    </Table.Row>\n                </Table.Body>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"colspan: 2 for col 2, rowspan: 2 for cell 3\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading colSpan={2}>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                    <Table.Cell rowSpan={2}>Cell 3</Table.Cell>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"align: center for heading 1, align: end for heading 2\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading align=\"center\">Column 1</Table.Heading>\n                    <Table.Heading align=\"end\">Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"valign: center for cell 2, valign: end for cell 3\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>\n                        <View height={15} backgroundColor=\"neutral-faded\" />\n                    </Table.Cell>\n                    <Table.Cell verticalAlign=\"center\">Cell 2</Table.Cell>\n                    <Table.Cell verticalAlign=\"end\">Cell 3</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"width: 40%, minWidth: 200px for col 1\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"40%\" minWidth=\"200px\">\n                        Column 1\n                    </Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-table--border",
 					"name": "border",
 					"snippet": "const border = () => (\n    <Example>\n        <Example.Item title=\"border: true\">\n            <Table border>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"columnBorder: true\">\n            <Table columnBorder>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"columnBorder: true, border: true\">\n            <Table columnBorder border>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-table--rows",
 					"name": "rows",
 					"snippet": "const rows = () => (\n    <Example>\n        <Example.Item title=\"highlighted for row 2\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row highlighted>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"clickable row 2, focus ring\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row onClick={() => {}}>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-table--render",
+					"name": "rendering",
 					"snippet": "const render = () => (\n    <Table>\n        <Table.Head>\n            <Table.Row>\n                <Table.Heading>Heading</Table.Heading>\n                <Table.Heading>Heading</Table.Heading>\n            </Table.Row>\n        </Table.Head>\n        <Table.Body>\n            <Table.Row>\n                <Table.Cell>Content</Table.Cell>\n                <Table.Cell>Content</Table.Cell>\n            </Table.Row>\n        </Table.Body>\n    </Table>\n);"
 				},
 				{
-					"name": "tbody",
+					"id": "components-table--tbody",
+					"name": "tbody rendering",
 					"snippet": "const tbody = () => (\n    <Table>\n        <Table.Row>\n            <Table.Heading>Heading</Table.Heading>\n            <Table.Heading>Heading</Table.Heading>\n        </Table.Row>\n    </Table>\n);"
 				},
 				{
-					"name": "tabIndex",
+					"id": "components-table--tab-index",
+					"name": "adds tabIndex for clickable rows",
 					"snippet": "const tabIndex = () => (\n    <Table>\n        <Table.Row>\n            <Table.Cell />\n        </Table.Row>\n        <Table.Row onClick={() => {}}>\n            <Table.Cell />\n        </Table.Row>\n        <Table.Row attributes={{ onClick: () => {} }}>\n            <Table.Cell />\n        </Table.Row>\n    </Table>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-table--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Table className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Table.Row attributes={{ id: \"test-row-id\" }}>\n                <Table.Cell attributes={{ id: \"test-cell-id\" }}></Table.Cell>\n            </Table.Row>\n        </Table>\n    </div>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-table--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"scroll fade\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"500px\">Column 1</Table.Heading>\n                    <Table.Heading width=\"500px\">Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"card with highlighted heading\">\n            <Card elevated padding={0}>\n                <Table>\n                    <Table.Row highlighted>\n                        <Table.Heading width=\"50%\" minWidth=\"200px\">\n                            Column 1\n                        </Table.Heading>\n                        <Table.Heading colSpan={2} align=\"end\">\n                            Column 2\n                        </Table.Heading>\n                    </Table.Row>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell align=\"center\">Cell 2</Table.Cell>\n                        <Table.Cell align=\"end\">Cell 3</Table.Cell>\n                    </Table.Row>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell align=\"center\">Cell 2</Table.Cell>\n                        <Table.Cell align=\"end\">Cell 3</Table.Cell>\n                    </Table.Row>\n                </Table>\n            </Card>\n        </Example.Item>\n        <Example.Item title=\"width: auto, nowrap\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"50%\">Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                    <Table.Heading>Column 3</Table.Heading>\n                    <Table.Heading width=\"auto\">Long heading title</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                    <Table.Cell>Cell 3</Table.Cell>\n                    <Table.Cell>Cell 4</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "examples",
+					"id": "components-table--examples",
+					"name": "test: selectable",
 					"snippet": "const examples = () => (\n    <Example>\n        <Example.Item title=\"selectable\">\n            <SelectionDemo />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Card, Checkbox, Example, Table, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Table/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Table",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Table/Table.tsx",
-				"actualName": "Table",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"border": {
+						"defaultValue": null,
+						"description": "Add border around the table",
+						"name": "border",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"columnBorder": {
+						"defaultValue": null,
+						"description": "Add border between the table columns",
+						"name": "columnBorder",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
+				"exportName": "Table"
 			}
 		},
 		"components-tabs": {
@@ -1794,71 +9549,196 @@
 			"path": "./src/components/Tabs/tests/Tabs.stories.tsx",
 			"stories": [
 				{
+					"id": "components-tabs--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Tabs>\n        <Tabs.List>\n            <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n            <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n        </Tabs.List>\n\n        <Tabs.Panel value=\"1\">\n            <View padding={4}>Content 1</View>\n        </Tabs.Panel>\n        <Tabs.Panel value=\"2\">\n            <View padding={4}>Content 2</View>\n        </Tabs.Panel>\n    </Tabs>\n);"
 				},
 				{
+					"id": "components-tabs--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Tabs defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills\">\n            <Tabs variant=\"pills\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills-elevated\">\n            <Tabs variant=\"pills-elevated\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: borderless\">\n            <Tabs variant=\"borderless\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"variant: default, size: large\">\n            <Tabs size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills, size: large\">\n            <Tabs variant=\"pills\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills-elevated, size: large\">\n            <Tabs variant=\"pills-elevated\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: borderless, size: large\">\n            <Tabs variant=\"borderless\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example>\n        <Example.Item title=\"direction: column, variant: underline\">\n            <Tabs direction=\"column\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: pills\">\n            <Tabs direction=\"column\" variant=\"pills\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: pills-elevated\">\n            <Tabs direction=\"column\" variant=\"pills-elevated\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: borderless\">\n            <Tabs direction=\"column\" variant=\"borderless\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Tabs>\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"1\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"icon only\">\n            <Tabs variant=\"pills-elevated\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap} attributes={{ \"aria-label\": \"Tab 1\" }} />\n                    <Tabs.Item value=\"1\" icon={IconZap} attributes={{ \"aria-label\": \"Tab 2\" }} />\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "equalWidth",
+					"id": "components-tabs--equal-width",
+					"name": "itemWidth",
 					"snippet": "const equalWidth = () => (\n    <Example>\n        <Example.Item title=\"equal width items\">\n            <Tabs onChange={console.log} itemWidth=\"equal\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"1\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                    <Tabs.Item value=\"2\" icon={IconZap}>\n                        Very long item 3\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--href",
 					"name": "href",
 					"snippet": "const href = () => (\n    <Example>\n        <Example.Item title=\"href, no onChange\">\n            <Tabs value=\"2\">\n                <Tabs.List>\n                    <Tabs.Item value=\"1\" href=\"#item-1\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"2\" href=\"#item-2\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                    <Tabs.Item value=\"3\" href=\"#item-3\" icon={IconZap}>\n                        Very long item 3\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "disabled",
+					"id": "components-tabs--disabled",
+					"name": "item, disabled",
 					"snippet": "const disabled = () => {\n    return (\n        <Example>\n            <Example.Item title=\"disabled\">\n                <Tabs defaultValue=\"1\">\n                    <Tabs.List>\n                        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"2\" disabled icon={IconZap}>\n                            Item 2\n                        </Tabs.Item>\n                        <Tabs.Item value=\"3\">Item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"1\">\n                        <View padding={4}>Content 1</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <View padding={4}>Content 2</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"3\">\n                        <View padding={4}>Content 3</View>\n                    </Tabs.Panel>\n                </Tabs>\n            </Example.Item>\n\n            <Example.Item title=\"disabled, href\">\n                <Tabs defaultValue=\"1\">\n                    <Tabs.List>\n                        <Tabs.Item href=\"#item1\" value=\"1\">\n                            Item 1\n                        </Tabs.Item>\n                        <Tabs.Item href=\"#item2\" value=\"2\" disabled icon={IconZap}>\n                            Item 2\n                        </Tabs.Item>\n                        <Tabs.Item href=\"#item3\" value=\"3\">\n                            Item 3\n                        </Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"1\">\n                        <View padding={4}>Content 1</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <View padding={4}>Content 2</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"3\">\n                        <View padding={4}>Content 3</View>\n                    </Tabs.Panel>\n                </Tabs>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-tabs--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <Tabs defaultValue=\"2\" onChange={fn()}>\n    <Tabs.List>\n        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n        <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n    </Tabs.List>\n    <Tabs.Panel value=\"1\">Content 1</Tabs.Panel>\n    <Tabs.Panel value=\"2\">Content 2</Tabs.Panel>\n</Tabs>;"
 				},
 				{
-					"name": "value",
+					"id": "components-tabs--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <Tabs value=\"2\" onChange={fn()}>\n    <Tabs.List>\n        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n        <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n    </Tabs.List>\n    <Tabs.Panel value=\"1\">Content 1</Tabs.Panel>\n    <Tabs.Panel value=\"2\">Content 2</Tabs.Panel>\n</Tabs>;"
 				},
 				{
-					"name": "className",
+					"id": "components-tabs--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Tabs>\n            <Tabs.List attributes={{ id: \"test-list-id\" }} className=\"test-list-classname\">\n                <Tabs.Item attributes={{ id: \"test-item-id\" }} value=\"1\">\n                    Item\n                </Tabs.Item>\n            </Tabs.List>\n\n            <Tabs.Panel\n                attributes={{ \"data-testid\": \"test-panel-id\" }}\n                className=\"test-panel-classname\"\n                value=\"1\"\n            />\n        </Tabs>\n    </div>\n);"
 				},
 				{
-					"name": "testFocusableContent",
+					"id": "components-tabs--test-focusable-content",
+					"name": "test: focusable content",
 					"snippet": "const testFocusableContent = () => (\n    <Example>\n        <Example.Item title=\"panels without focusable content\">\n            <Tabs>\n                <View gap={4}>\n                    <Tabs.List>\n                        <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                        <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"0\">Tab 1</Tabs.Panel>\n                    <Tabs.Panel value=\"1\">Tab 2</Tabs.Panel>\n                    <Tabs.Panel value=\"2\">Tab 3</Tabs.Panel>\n                </View>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"panels with focusable content\">\n            <Tabs>\n                <View gap={4}>\n                    <Tabs.List>\n                        <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                        <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"0\">\n                        <Button onClick={() => {}}>Tab 1 action</Button>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"1\">\n                        <Button onClick={() => {}}>Tab 2 action</Button>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <Button onClick={() => {}}>Tab 3 action</Button>\n                    </Tabs.Panel>\n                </View>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "components-tabs--test-composition",
+					"name": "test: composition",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item title=\"Viewport overflow\">\n            <Tabs>\n                <Tabs.List>\n                    {[...Array(8)].map((_, i) => (\n                        <Tabs.Item value={`${i}`} key={i} icon={IconZap}>\n                            Very long item {i}\n                        </Tabs.Item>\n                    ))}\n                </Tabs.List>\n\n                {[...Array(8)].map((_, i) => (\n                    <Tabs.Panel value={`${i}`} key={i}>\n                        Tab {i}\n                    </Tabs.Panel>\n                ))}\n            </Tabs>\n        </Example.Item>\n        <Example.Item>\n            <Tabs onChange={console.log} variant=\"pills-elevated\" name=\"hey\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">\n                        <View borderColor=\"neutral-faded\" padding={5}>\n                            Item 3\n                        </View>\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"Custom non-interactive list children\">\n            <Tabs direction=\"column\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <View height={6} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testEdgeCaseDom",
+					"id": "components-tabs--test-edge-case-dom",
+					"name": "test: scroll subscription",
 					"snippet": "const testEdgeCaseDom = () => {\n    const [activeItem, setActiveItem] = React.useState(\"1\");\n    const sectionsRef = React.useRef(null);\n\n    return (\n        <Example>\n            <Example.Item title=\"active item changes on scroll\">\n                <View justify=\"center\" align=\"center\" padding={10}>\n                    <View width={60} gap={2}>\n                        <Tabs value={activeItem} onChange={(args) => setActiveItem(args.value)}>\n                            <Tabs.List>\n                                <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                                <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n                                <Tabs.Item value=\"3\">Item 3</Tabs.Item>\n                                <Tabs.Item value=\"4\">Item 4</Tabs.Item>\n                            </Tabs.List>\n                        </Tabs>\n\n                        <ScrollArea\n                            attributes={{ ref: sectionsRef }}\n                            height={70}\n                            onScroll={(args) => {\n                                setActiveItem(Math.min(4, Math.floor(args.y * 10) + 1).toString());\n                            }}\n                        >\n                            <View gap={4}>\n                                <View gap={2}>\n                                    <Text>Section 1</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View grow height=\"100px\" backgroundColor=\"neutral-faded\" key={i} />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 2</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 3</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 4</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n                            </View>\n                        </ScrollArea>\n                    </View>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Example, ScrollArea, Tabs, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Tabs/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Tabs",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Tabs/Tabs.tsx",
-				"actualName": "Tabs",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Direction of the tab buttons",
+						"name": "direction",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"itemWidth": {
+						"defaultValue": null,
+						"description": "Equal width for the tab buttons",
+						"name": "itemWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"equal\"", "value": [{ "value": "\"equal\"" }] }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Render variant for component",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"bordered\" | \"borderless\" | \"pills\" | \"pills-elevated\"",
+							"value": [
+								{ "value": "\"bordered\"" },
+								{ "value": "\"borderless\"" },
+								{ "value": "\"pills\"" },
+								{ "value": "\"pills-elevated\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"large\" | \"medium\"",
+							"value": [{ "value": "\"large\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the tab buttons group when used as a form control",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the active tab value changes",
+						"name": "onChange",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((args: { value: string; name?: string; }) => void)" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the active tab, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the active tab, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "Tabs"
 			}
 		},
 		"components-textarea": {
@@ -1867,71 +9747,315 @@
 			"path": "./src/components/TextArea/tests/TextArea.stories.tsx",
 			"stories": [
 				{
-					"name": "variants",
+					"id": "components-textarea--variants",
+					"name": "variant",
 					"snippet": "const variants = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <TextArea variant=\"faded\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless\">\n            <TextArea variant=\"headless\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: medium\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"medium\" />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"large\" />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"xlarge\" />\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] large\", \"[m+] medium\"]}>\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size={{ s: \"xlarge\", m: \"medium\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--resize",
 					"name": "resize",
 					"snippet": "const resize = () => (\n    <Example>\n        <Example.Item title=\"resize: none\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" resize=\"none\" />\n        </Example.Item>\n        <Example.Item title=\"resize: auto\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" resize=\"auto\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-textarea--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" hasError />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner\">\n            <View gap={2}>\n                <Text variant=\"featured-2\">What problem are you trying to solve?</Text>\n                <TextArea.Aligner>\n                    <TextArea\n                        variant=\"headless\"\n                        placeholder=\"Try something like 'I have a job'\"\n                        name=\"description\"\n                    />\n                </TextArea.Aligner>\n                <View.Item>\n                    <Button>Next</Button>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-textarea--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"long value without breaks\">\n            <TextArea\n                name=\"hey\"\n                defaultValue={`<div style=\"position:relative;width:100%;padding-top:calc(150% + 72px)\">\n<iframe src=\"nskjdfdsdkjfsjkdfhbsjlhdfbsjlhfbs;jhbsdljfhsbljhfsbljhfbsjlfdhbsljhfbsdljhfbsljhfbslufbhsdlfds\" />\n</div>`}\n                resize=\"auto\"\n                placeholder=\"Placeholder\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-textarea--render",
+					"name": "base",
 					"snippet": "const render = () => <TextArea name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-textarea--placeholder",
 					"name": "placeholder",
 					"snippet": "const placeholder = () => (\n    <TextArea\n        name=\"test-name\"\n        placeholder=\"Placeholder\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-textarea--id",
 					"name": "id",
 					"snippet": "const id = () => (\n    <TextArea name=\"test-name\" id=\"test-id\" inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
+					"id": "components-textarea--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <TextArea name=\"test-name\" disabled inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-textarea--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <TextArea\n    name=\"test-name\"\n    defaultValue=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-textarea--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <TextArea\n    name=\"test-name\"\n    value=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-textarea--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <TextArea\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-textarea--form-control",
+					"name": "test: form control",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"with helper\">\n            <FormControl>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextArea name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n        <Example.Item title=\"with error\">\n            <FormControl hasError>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextArea name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, FormControl, Text, TextArea, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/TextArea/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "TextArea",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/TextArea/TextArea.tsx",
-				"actualName": "TextArea",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text area",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text area input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text area user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text area value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLTextAreaElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text area is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLTextAreaElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text area is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLTextAreaElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"textarea\">" }
+					},
+					"resize": {
+						"defaultValue": null,
+						"description": "Enable or disable the text area resizing, supports auto-sizing",
+						"name": "resize",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"none\" | \"auto\"",
+							"value": [{ "value": "\"none\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "TextArea"
 			}
 		},
 		"components-textfield": {
@@ -1940,71 +10064,445 @@
 			"path": "./src/components/TextField/tests/TextField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-textfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <TextField variant=\"faded\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless\">\n            <TextField variant=\"headless\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded\">\n            <TextField\n                rounded\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                icon={IconZap}\n                prefix=\"+31\"\n                endSlot={<Button rounded size=\"small\" icon={IconZap} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"rounded, variant: faded\">\n            <View direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <TextField\n                        rounded\n                        variant=\"faded\"\n                        name=\"Name\"\n                        placeholder=\"Enter your name\"\n                        startSlot={\n                            <Badge rounded size=\"small\">\n                                Hello\n                            </Badge>\n                        }\n                    />\n                </View.Item>\n                <Button rounded>Submit</Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-textfield--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" hasError />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "attachments",
+					"id": "components-textfield--attachments",
+					"name": "icon, endIcon, suffix, prefix, startSlot, endSlot, startSlotPadding, endSlotPadding",
 					"snippet": "const attachments = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" value=\"Reshaped\" icon={IconZap} />\n        </Example.Item>\n        <Example.Item title=\"endIcon\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" value=\"Reshaped\" endIcon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title={[\"startSlot\", \"vertical and horizontal padding aligned\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title={[\"endSlot\", \"vertical and horizontal padding aligned\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                endSlot={\n                    <Button\n                        icon={IconZap}\n                        size=\"small\"\n                        onClick={() => {}}\n                        attributes={{ \"aria-label\": \"Action\" }}\n                    />\n                }\n            />\n        </Example.Item>\n\n        <Example.Item title=\"paddingSlotStart=4, paddingSlotEnd=2\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlotPadding={4}\n                endSlotPadding={2}\n                startSlot={<Placeholder h={20} />}\n                endSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"with all affixes\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                endIcon={IconZap}\n                icon={IconZap}\n                prefix=\"Estimated value\"\n                suffix=\"m2\"\n                startSlot={<Placeholder h={20} />}\n                endSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"multiline wrap\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlot={[...Array(10).keys()].map((i) => (\n                    <Badge size=\"small\" key={i}>\n                        Item {i + 1}\n                    </Badge>\n                ))}\n                multiline\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"small\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"medium\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"large\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"xlarge\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] xlarge\", \"[m+] medium\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                size={{ s: \"xlarge\", m: \"medium\" }}\n                icon={IconZap}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner\">\n            <View gap={2}>\n                <Text variant=\"featured-2\">What problem are you trying to solve?</Text>\n                <TextField.Aligner>\n                    <TextField\n                        variant=\"headless\"\n                        placeholder=\"Try something like 'I have a job'\"\n                        name=\"description\"\n                    />\n                </TextField.Aligner>\n                <View.Item>\n                    <Button>Next</Button>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-textfield--render",
+					"name": "base",
 					"snippet": "const render = () => <TextField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-textfield--placeholder",
 					"name": "placeholder",
 					"snippet": "const placeholder = () => (\n    <TextField\n        name=\"test-name\"\n        placeholder=\"Placeholder\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-textfield--id",
 					"name": "id",
 					"snippet": "const id = () => (\n    <TextField name=\"test-name\" id=\"test-id\" inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
+					"id": "components-textfield--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <TextField name=\"test-name\" disabled inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-textfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <TextField\n    name=\"test-name\"\n    defaultValue=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-textfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <TextField\n    name=\"test-name\"\n    value=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-textfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <TextField\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-textfield--form-control",
+					"name": "test: form control",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"with helper\">\n            <FormControl>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextField name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n        <Example.Item title=\"with error\">\n            <FormControl hasError>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextField name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Badge, Button, Example, FormControl, Placeholder, Text, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/TextField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "TextField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/TextField/TextField.tsx",
-				"actualName": "TextField",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"multiline": {
+						"defaultValue": null,
+						"description": "Enable multiline text field wrapping",
+						"name": "multiline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to be fully rounded",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content after the text field value",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text field value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the text field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the text field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "TextField"
 			}
 		},
 		"components-timeline": {
@@ -2013,27 +10511,71 @@
 			"path": "./src/components/Timeline/tests/Timeline.stories.tsx",
 			"stories": [
 				{
+					"id": "components-timeline--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"children passed directly\">\n            <Timeline>\n                <Placeholder />\n                <Placeholder />\n                <Placeholder />\n            </Timeline>\n        </Example.Item>\n        <Example.Item title=\"children wrapped with Timeline.Item\">\n            <Timeline>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "marker",
+					"id": "components-timeline--marker",
+					"name": "markerSlot",
 					"snippet": "const marker = () => (\n    <Example>\n        <Example.Item title=\"slot\">\n            <Timeline>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n\n        <Example.Item title=\"null marker\">\n            <Timeline>\n                <Timeline.Item markerSlot={null}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={null}>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-timeline--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Timeline className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Timeline.Item className=\"test-item-classname\" attributes={{ id: \"test-item-id\" }}>\n                Content\n            </Timeline.Item>\n            <Timeline.Item>Content</Timeline.Item>\n        </Timeline>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Placeholder, Timeline } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Timeline/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Timeline",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Timeline/Timeline.tsx",
-				"actualName": "Timeline",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"ul\">" }
+					}
+				},
+				"exportName": "Timeline"
 			}
 		},
 		"components-toast": {
@@ -2041,32 +10583,54 @@
 			"name": "Toast",
 			"path": "./src/components/Toast/tests/Toast.stories.tsx",
 			"stories": [
-				{ "name": "size", "snippet": "const size = () => <Size />;" },
 				{
+					"id": "components-toast--size",
+					"name": "size",
+					"snippet": "const size = () => <Size />;"
+				},
+				{
+					"id": "components-toast--position",
 					"name": "position",
 					"snippet": "const position = () => <Position />;"
 				},
-				{ "name": "color", "snippet": "const color = () => <Color />;" },
-				{ "name": "timeout", "snippet": "const timeout = () => <Timeout />;" },
 				{
-					"name": "regionOptions",
+					"id": "components-toast--color",
+					"name": "color",
+					"snippet": "const color = () => <Color />;"
+				},
+				{
+					"id": "components-toast--timeout",
+					"name": "timeout",
+					"snippet": "const timeout = () => <Timeout />;"
+				},
+				{
+					"id": "components-toast--region-options",
+					"name": "expanded",
 					"snippet": "const regionOptions = () => <Expanded />;"
 				},
-				{ "name": "slots", "snippet": "const slots = () => <Slots />;" },
 				{
+					"id": "components-toast--slots",
+					"name": "slots",
+					"snippet": "const slots = () => <Slots />;"
+				},
+				{
+					"id": "components-toast--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const toast = useToast();\n\n    return (\n        <Button\n            onClick={() => {\n                const id = toast.show({\n                    title: \"Title\",\n                    text: \"Text\",\n                    children: \"Children\",\n                    startSlot: \"Slot\",\n                    actionsSlot: (\n                        <Button attributes={{ \"data-testid\": \"trigger-id\" }} onClick={() => toast.hide(id)}>\n                            Trigger\n                        </Button>\n                    ),\n                });\n            }}\n        >\n            Show toast\n        </Button>\n    );\n};"
 				},
 				{
-					"name": "nested",
+					"id": "components-toast--nested",
+					"name": "ToastProvider",
 					"snippet": "const nested = () => {\n    return (\n        <div data-testid=\"test-container-id\">\n            <ToastProvider>\n                <NestedDemo />\n            </ToastProvider>\n        </div>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-toast--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => {\n    const toast = useToast();\n\n    return (\n        <Button\n            onClick={() => {\n                const id = toast.show({\n                    text: \"Content\",\n                    attributes: { \"data-testid\": \"test-id\" },\n                    className: \"test-classname\",\n                });\n            }}\n        >\n            Show toast\n        </Button>\n    );\n};"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-toast--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"Multiline, should support dynamic height\">\n            <Multiline />\n        </Example.Item>\n        <Example.Item title=\"Nested ToastProvider\">\n            <ToastProvider>\n                <Nested />\n            </ToastProvider>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
@@ -2083,30 +10647,601 @@
 			"path": "./src/components/ToggleButton/tests/ToggleButton.stories.tsx",
 			"stories": [
 				{
+					"id": "components-togglebutton--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"outline\">\n            <ToggleButton>Button</ToggleButton>\n        </Example.Item>\n        <Example.Item title=\"ghost\">\n            <ToggleButton variant=\"ghost\">Button</ToggleButton>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-togglebutton--selected-color",
 					"name": "selectedColor",
 					"snippet": "const selectedColor = () => (\n    <Example>\n        <Example.Item title=\"selectedColor: primary\">\n            <ToggleButton selectedColor=\"primary\" defaultChecked>\n                Button\n            </ToggleButton>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onChange",
+					"id": "components-togglebutton--on-change",
+					"name": "checked, defaultChecked, onChange",
 					"snippet": "const onChange = () => <Example>\n    <Example.Item title=\"defaultChecked, onChange\">\n        <ToggleButton defaultChecked onChange={fn()} value=\"1\">Button\n                                </ToggleButton>\n    </Example.Item>\n    <Example.Item title=\"checked, onChange\">\n        <ToggleButton checked onChange={fn()} value=\"2\">Button\n                                </ToggleButton>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-togglebutton--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <ToggleButton onClick={fn()}>Button</ToggleButton>;"
 				}
 			],
 			"import": "import { Example, ToggleButton } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ToggleButton/ToggleButton.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "ToggleButton",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ToggleButton/ToggleButton.tsx",
-				"actualName": "ToggleButton",
+				"methods": [],
+				"props": {
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loading": {
+						"defaultValue": null,
+						"description": "Show loading state",
+						"name": "loading",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loadingAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the loading indicator",
+						"name": "loadingAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Make the component take the full width of the parent element",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"ghost\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"ghost\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"selectedColor": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme when selected",
+						"name": "selectedColor",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the toggle button, enables controlled mode for the ToggleButtonGroup",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the toggle button value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { checked: boolean; value: string; event: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>; }) => void)"
+						}
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default value of the toggle button, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Value of the toggle button, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2116,34 +11251,194 @@
 			"path": "./src/components/ToggleButtonGroup/tests/ToggleButtonGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "single",
+					"id": "components-togglebuttongroup--single",
+					"name": "checked, defaultChecked, onChange",
 					"snippet": "const single = () => <Example>\n    <Example.Item title=\"single, uncontrolled, onChange\">\n        <ToggleButtonGroup onChange={fn()}>\n            <ToggleButton value=\"1\" onChange={fn()}>Button\n                                    </ToggleButton>\n            <ToggleButton value=\"2\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n    <Example.Item title=\"single, controlled, onChange\">\n        <ToggleButtonGroup onChange={fn()} value={[]}>\n            <ToggleButton value=\"3\" onChange={fn()}>Button\n                                    </ToggleButton>\n            <ToggleButton value=\"4\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "multiple",
+					"id": "components-togglebuttongroup--multiple",
+					"name": "selectionMode, checked, defaultChecked, onChange",
 					"snippet": "const multiple = () => <Example>\n    <Example.Item title=\"multiple, uncontrolled, onChange\">\n        <ToggleButtonGroup onChange={fn()} selectionMode=\"multiple\">\n            <ToggleButton value=\"1\">Button</ToggleButton>\n            <ToggleButton value=\"2\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n    <Example.Item title=\"multiple, controlled, onChange\">\n        <ToggleButtonGroup onChange={fn()} value={[]} selectionMode=\"multiple\">\n            <ToggleButton value=\"3\">Button</ToggleButton>\n            <ToggleButton value=\"4\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "selectedColor",
+					"id": "components-togglebuttongroup--selected-color",
+					"name": "color,selectedColor",
 					"snippet": "const selectedColor = () => (\n    <Example>\n        <Example.Item title=\"selectedColor: primary\">\n            <ToggleButtonGroup selectedColor=\"primary\" defaultValue={[\"2\"]}>\n                <ToggleButton value=\"1\">Button</ToggleButton>\n                <ToggleButton value=\"2\">Button</ToggleButton>\n                <ToggleButton value=\"3\">Button</ToggleButton>\n            </ToggleButtonGroup>\n        </Example.Item>\n        <Example.Item title=\"color: primary, selectedColor: critical\">\n            <ToggleButtonGroup color=\"primary\" selectedColor=\"critical\" defaultValue={[\"2\"]}>\n                <ToggleButton value=\"1\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n                <ToggleButton value=\"2\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n                <ToggleButton value=\"3\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n            </ToggleButtonGroup>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-togglebuttongroup--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ToggleButtonGroup className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <ToggleButton>Button 1</ToggleButton>\n            <ToggleButton>Button 1</ToggleButton>\n        </ToggleButtonGroup>\n    </div>\n);"
 				},
 				{
-					"name": "testIcon",
+					"id": "components-togglebuttongroup--test-icon",
+					"name": "test: icon only",
 					"snippet": "const testIcon = () => (\n    <Example>\n        <Example.Item title=\"icon only\">\n            <ToggleButtonGroup selectedColor=\"primary\">\n                <ToggleButton value=\"1\" icon={IconPlus} />\n                <ToggleButton value=\"2\" icon={IconMinus} />\n                <ToggleButton value=\"3\" icon={IconCheckmark} />\n            </ToggleButtonGroup>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, ToggleButton, ToggleButtonGroup } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ToggleButtonGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ToggleButtonGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx",
-				"actualName": "ToggleButtonGroup",
+				"methods": [],
+				"props": {
+					"selectionMode": {
+						"defaultValue": { "value": "\"single\"" },
+						"description": "Selection mode for the toggle button group",
+						"name": "selectionMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"single\" | \"multiple\"",
+							"value": [{ "value": "\"single\"" }, { "value": "\"multiple\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme applied to each button",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"selectedColor": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme for the selected button",
+						"name": "selectedColor",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the toggle button group value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { value: string[]; event: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>; }) => void)"
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting child Button components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Selected values in the group, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default selected values in the group, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2153,30 +11448,269 @@
 			"path": "./src/components/Tooltip/tests/Tooltip.stories.tsx",
 			"stories": [
 				{
+					"id": "components-tooltip--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: bottom-start\">\n            <View direction=\"row\" gap={2}>\n                <Demo position=\"bottom-start\" text=\"Tooltip 1\" />\n                <Demo position=\"bottom-start\" text=\"Tooltip 2\" />\n                <Demo position=\"bottom-start\" text=\"Tooltip 3\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: bottom\">\n            <Demo position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"position: bottom-end\">\n            <Demo position=\"bottom-end\" />\n        </Example.Item>\n        <Example.Item title=\"position: top-start\">\n            <Demo position=\"top-start\" />\n        </Example.Item>\n        <Example.Item title=\"position: top\">\n            <Demo position=\"top\" />\n        </Example.Item>\n        <Example.Item title=\"position: top-end\">\n            <Demo position=\"top-end\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: start\">\n            <View align=\"end\">\n                <Demo position=\"start\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: start-top\">\n            <View align=\"end\">\n                <Demo position=\"start-top\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: start-bottom\">\n            <View align=\"end\">\n                <Demo position=\"start-bottom\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <Demo position=\"end\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: end-top\">\n            <Demo position=\"end-top\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: end-bottom\">\n            <Demo position=\"end-bottom\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tooltip--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: inverted\">\n            <Demo color=\"inverted\" position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"color: dark\">\n            <Demo color=\"dark\" position=\"bottom\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-tooltip--default-active",
+					"name": "uncontrolled",
 					"snippet": "const defaultActive = () => <Tooltip text=\"Content\" onOpen={fn()} onClose={fn()}>\n    {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n</Tooltip>;"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-tooltip--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"responsive visibility\">\n            <DemoResponsive text=\"Responsive\" />\n        </Example.Item>\n\n        <Example.Item title=\"without text\">\n            <Tooltip>{() => <Button>Button</Button>}</Tooltip>\n        </Example.Item>\n\n        <Example.Item title=\"tooltip with popover\">\n            <Tooltip text=\"Tooltip\" position=\"top\">\n                {(attributes) => (\n                    <Popover position=\"bottom\">\n                        <Popover.Trigger>\n                            {(popoverAttributes) => (\n                                <Button attributes={{ ...attributes, ...popoverAttributes }}>Action</Button>\n                            )}\n                        </Popover.Trigger>\n                        <Popover.Content>Popover</Popover.Content>\n                    </Popover>\n                )}\n            </Tooltip>\n        </Example.Item>\n\n        <Example.Item title=\"nested popovers inside a tooltip\">\n            <View direction=\"row\" gap={2}>\n                <Tooltip position=\"top\" text=\"Hello\">\n                    {(tooltipAttributes) => (\n                        <Popover position=\"bottom\" width=\"300px\">\n                            <Popover.Trigger>\n                                {(attributes) => (\n                                    <Button attributes={{ ...tooltipAttributes, ...attributes }}>\n                                        Tooltip with popover\n                                    </Button>\n                                )}\n                            </Popover.Trigger>\n                            <Popover.Content>\n                                <View gap={2} align=\"center\" direction=\"row\" justify=\"space-between\">\n                                    Popover content\n                                    <Popover position=\"bottom\" width=\"300px\">\n                                        <Popover.Trigger>\n                                            {(attributes) => <Button attributes={attributes}>Open</Button>}\n                                        </Popover.Trigger>\n                                        <Popover.Content>\n                                            <Popover.Dismissible align=\"center\" closeAriaLabel=\"Close\">\n                                                Another popover content\n                                            </Popover.Dismissible>\n                                        </Popover.Content>\n                                    </Popover>\n                                </View>\n                            </Popover.Content>\n                        </Popover>\n                    )}\n                </Tooltip>\n                <Tooltip position=\"top\" text=\"Hello\">\n                    {(tooltipAttributes) => <Button attributes={tooltipAttributes}>Just a tooltip</Button>}\n                </Tooltip>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, Popover, Tooltip, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Tooltip/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Tooltip",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Tooltip/Tooltip.tsx",
-				"actualName": "Tooltip",
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the flyout content interactivity",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"contentAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the content element",
+						"name": "contentAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"contentClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the content element",
+						"name": "contentClassName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "(attributes: TriggerAttributes) => ReactNode" }
+					},
+					"text": {
+						"defaultValue": null,
+						"description": "Text content for the tooltip",
+						"name": "text",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"inverted\"" },
+						"description": "Color of the tooltip",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"dark\" | \"inverted\"",
+							"value": [{ "value": "\"dark\"" }, { "value": "\"inverted\"" }]
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2186,51 +11720,191 @@
 			"path": "./src/components/Accordion/tests/Accordion.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-accordion--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Accordion defaultActive>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--icon-size",
 					"name": "iconSize",
 					"snippet": "const iconSize = () => (\n    <Accordion iconSize={6}>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--icon-position",
 					"name": "iconPosition",
 					"snippet": "const iconPosition = () => (\n    <Accordion iconPosition=\"start\">\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Accordion defaultActive gap={4}>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <Placeholder />\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--on-toggle",
 					"name": "onToggle",
 					"snippet": "const onToggle = () => <Accordion onToggle={fn()}>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
+					"id": "utility-components-accordion--active",
 					"name": "active",
 					"snippet": "const active = () => <Accordion onToggle={fn()} active>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
+					"id": "utility-components-accordion--default-active",
 					"name": "defaultActive",
 					"snippet": "const defaultActive = () => <Accordion onToggle={fn()} defaultActive>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
-					"name": "renderProps",
+					"id": "utility-components-accordion--render-props",
+					"name": "children: render props",
 					"snippet": "const renderProps = () => <Accordion onToggle={fn()}>\n    <Accordion.Trigger>\n        {(attributes, { active }) => (\n            <Button attributes={{ ...attributes, \"data-active\": active }}>Trigger</Button>\n        )}\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-accordion--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Accordion className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Accordion.Trigger>\n                <Placeholder>Trigger</Placeholder>\n            </Accordion.Trigger>\n            <Accordion.Content>\n                <View paddingTop={2}>\n                    <Placeholder />\n                </View>\n            </Accordion.Content>\n        </Accordion>\n    </div>\n);"
 				}
 			],
 			"import": "import { Accordion, Button, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Accordion/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Accordion",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Accordion/Accordion.tsx",
-				"actualName": "Accordion",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"iconSize": {
+						"defaultValue": null,
+						"description": "Expand / collapse icon size in units",
+						"name": "iconSize",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"iconPosition": {
+						"defaultValue": null,
+						"description": "Position of the expand / collapse icon",
+						"name": "iconPosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"start\" | \"end\"",
+							"value": [{ "value": "\"start\"" }, { "value": "\"end\"" }]
+						}
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between the trigger and the content",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the trigger and the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onToggle": {
+						"defaultValue": null,
+						"description": "Callback when the accordion is expanded or collapsed",
+						"name": "onToggle",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((active: boolean) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control whether the accordion is expanded or collapsed, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control whether the accordion is expanded or collapsed by default, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Accordion"
 			}
 		},
 		"utility-components-actionable": {
@@ -2239,54 +11913,456 @@
 			"path": "./src/components/Actionable/tests/Actionable.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "utility-components-actionable--base",
+					"name": "href, onClick",
 					"snippet": "const base = () => <Example>\n    <Example.Item title=\"span\">\n        <Actionable>Span</Actionable>\n    </Example.Item>\n    <Example.Item title=\"onClick\">\n        <Actionable onClick={fn()}>Button</Actionable>\n    </Example.Item>\n    <Example.Item title=\"href\">\n        <Actionable href=\"https://reshaped.so\" attributes={{ target: \"_blank\" }}>Link\n                            </Actionable>\n    </Example.Item>\n    <Example.Item title=\"attributes.href\">\n        <Actionable attributes={{ href: \"https://reshaped.so\" }}>Link with attributes</Actionable>\n    </Example.Item>\n    <Example.Item title=\"href, onClick\">\n        <Actionable\n            onClick={(e) => {\n                e.preventDefault();\n                args.handleSecondClick(e);\n            }}\n            href=\"https://reshaped.so\">Link with onClick\n                            </Actionable>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "utility-components-actionable--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, button\">\n            <Actionable disabled onClick={() => {}}>\n                Button\n            </Actionable>\n        </Example.Item>\n        <Example.Item title=\"disabled, link\">\n            <Actionable disabled href=\"https://reshaped.so\">\n                Link\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--full-width",
 					"name": "fullWidth",
 					"snippet": "const fullWidth = () => (\n    <Example>\n        <Example.Item title=\"fullWidth\">\n            <Actionable fullWidth href=\"https://reshaped.so\">\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--inset-focus",
 					"name": "insetFocus",
 					"snippet": "const insetFocus = () => (\n    <Example>\n        <Example.Item title=\"insetFocus\">\n            <Actionable insetFocus onClick={() => {}}>\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--disable-focus-ring",
 					"name": "disableFocusRing",
 					"snippet": "const disableFocusRing = () => (\n    <Example>\n        <Example.Item title=\"disableFocusRing\">\n            <Actionable disableFocusRing onClick={() => {}}>\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--border-radius",
 					"name": "borderRadius",
 					"snippet": "const borderRadius = () => (\n    <Example>\n        <Example.Item title=\"borderRadius: inherit\">\n            <Actionable borderRadius=\"inherit\" onClick={() => {}}>\n                <View borderRadius=\"large\">Actionable</View>\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--type",
 					"name": "type",
 					"snippet": "const type = (args) => (\n    <Example>\n        <Example.Item title=\"type: submit\">\n            <form\n                onSubmit={(e) => {\n                    e.preventDefault();\n                    args.handleSubmit();\n                }}\n            >\n                <Actionable onClick={() => {}} type=\"submit\">\n                    Submit\n                </Actionable>\n            </form>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "as",
+					"id": "utility-components-actionable--as",
+					"name": "as, render",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"as: span\">\n            <Actionable onClick={() => {}} as=\"span\">\n                Trigger\n            </Actionable>\n        </Example.Item>\n        <Example.Item title=\"render, disabled\">\n            <Actionable disabled onClick={() => {}} render={(props) => <section {...props} />}>\n                Trigger\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--stop-propagation",
 					"name": "stopPropagation",
 					"snippet": "const stopPropagation = () => <div onClick={fn()}>\n    <Actionable stopPropagation onClick={() => {}}>Trigger\n                    </Actionable>\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-actionable--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Actionable className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Actionable>\n    </div>\n);"
 				}
 			],
 			"import": "import { Actionable, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Actionable/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Actionable",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Actionable/Actionable.tsx",
-				"actualName": "Actionable",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"touchHitbox": {
+						"defaultValue": null,
+						"description": "Enable a minimum required touch hitbox",
+						"name": "touchHitbox",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Take up the full width of its parent",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"insetFocus": {
+						"defaultValue": null,
+						"description": "Enable a focus ring inside the element bounds",
+						"name": "insetFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableFocusRing": {
+						"defaultValue": null,
+						"description": "Don't show a focus ring on focus, can be used when it is within a container with a focus ring",
+						"name": "disableFocusRing",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Apply the focus ring to the child and rely on its border radius",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"inherit\"", "value": [{ "value": "\"inherit\"" }] }
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2296,30 +12372,149 @@
 			"path": "./src/components/Container/tests/Container.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-container--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: default\">\n            <Container>\n                <Placeholder />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"padding: 0\">\n            <Container padding={0}>\n                <Placeholder />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "utility-components-container--size",
+					"name": "width, height, maxHeight",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"width: 200px, height: 200px\">\n            <Container width=\"200px\" height=\"200px\">\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width: 200px, height: 200px, maxHeight: 100px\">\n            <Container width=\"200px\" height=\"200px\" maxHeight=\"100px\">\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width, height: [s] 100px, [m+] 200px\">\n            <Container width={{ s: \"100px\", m: \"200px\" }} height={{ s: \"100px\", m: \"200px\" }}>\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width, height: [s] 100px, [m+] 200px, maxHeight: [s] 50px, [m+]: 100px\">\n            <Container\n                width={{ s: \"100px\", m: \"200px\" }}\n                height={{ s: \"100px\", m: \"200px\" }}\n                maxHeight={{ s: \"50px\", m: \"100px\" }}\n            >\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "flex",
+					"id": "utility-components-container--flex",
+					"name": "align, justify",
 					"snippet": "const flex = () => (\n    <Example>\n        <Example.Item title=\"align: center, justify: center\">\n            <Container align=\"center\" justify=\"center\" height=\"200px\">\n                <Placeholder />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-container--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Container className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </Container>\n    </div>\n);"
 				}
 			],
 			"import": "import { Container, Example, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Container/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Container",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Container/Container.tsx",
-				"actualName": "Container",
+				"methods": [],
+				"props": {
+					"align": {
+						"defaultValue": null,
+						"description": "Flex align-items for the content",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Flex justify-content for the content",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier\nComponent height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" },
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height style, literal string value or a base unit token number multiplier\nComponent max height, literal css value or unit token multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" },
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Component inline padding",
+						"name": "padding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Component width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2329,34 +12524,157 @@
 			"path": "./src/components/Dismissible/tests/Dismissible.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-dismissible--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Dismissible closeAriaLabel=\"Close banner\" onClose={() => {}}>\n                <Placeholder />\n            </Dismissible>\n        </Example.Item>\n        <Example.Item title=\"variant: media\">\n            <View width=\"300px\">\n                <Dismissible variant=\"media\" closeAriaLabel=\"Close banner\" onClose={() => {}}>\n                    <View aspectRatio={16 / 9}>\n                        <Image\n                            height=\"100%\"\n                            src=\"https://images.unsplash.com/photo-1607030529528-ca6923e27f77?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1867&q=80)\"\n                        />\n                    </View>\n                </Dismissible>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-dismissible--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: center\">\n            <Dismissible align=\"center\" closeAriaLabel=\"Close\" onClose={() => {}}>\n                <Placeholder />\n            </Dismissible>\n        </Example.Item>\n\n        <Example.Item title=\"align: center, variant: media\">\n            <Dismissible align=\"center\" closeAriaLabel=\"Close\" variant=\"media\" onClose={() => {}}>\n                <View aspectRatio={16 / 9}>\n                    <Image\n                        height=\"100%\"\n                        src=\"https://images.unsplash.com/photo-1607030529528-ca6923e27f77?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1867&q=80)\"\n                    />\n                </View>\n            </Dismissible>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-dismissible--hide-close-button",
 					"name": "hideCloseButton",
 					"snippet": "const hideCloseButton = () => (\n    <Example>\n        <Example.Item title=\"hide close button\">\n            <div id=\"root\">\n                <Dismissible hideCloseButton>\n                    <Placeholder />\n                </Dismissible>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "closeAriaLabel",
+					"id": "utility-components-dismissible--close-aria-label",
+					"name": "onClose, closeAriaLabel",
 					"snippet": "const closeAriaLabel = () => <Dismissible closeAriaLabel=\"Close\" onClose={fn()}>\n    <Placeholder />\n</Dismissible>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-dismissible--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Dismissible\n            closeAriaLabel=\"Close\"\n            onClose={() => {}}\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n        >\n            <Placeholder />\n        </Dismissible>\n    </div>\n);"
 				}
 			],
 			"import": "import { Dismissible, Example, Image, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Dismissible/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Dismissible",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Dismissible/Dismissible.tsx",
-				"actualName": "Dismissible",
+				"methods": [],
+				"props": {
+					"hideCloseButton": {
+						"defaultValue": null,
+						"description": "Hide the close button\nShow the close button",
+						"name": "hideCloseButton",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"closeAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the close button",
+						"name": "closeAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"media\"", "value": [{ "value": "\"media\"" }] }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Close button alignment",
+						"name": "align",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"center\"",
+							"value": [{ "value": "\"top\"" }, { "value": "\"center\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is dismissed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2366,135 +12684,577 @@
 			"path": "./src/components/Flyout/tests/Flyout.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-flyout--position",
 					"name": "position",
 					"snippet": "const position = () => {\n    return (\n        <View gap={4} padding={50} align=\"center\" justify=\"center\" height=\"100vh\" width=\"120%\">\n            <View gap={4} direction=\"row\">\n                <Demo position=\"top-start\" defaultActive />\n                <Demo position=\"top\" />\n                <Demo position=\"top-end\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"end-top\" />\n                <Demo position=\"end\" />\n                <Demo position=\"end-bottom\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"start-top\" />\n                <Demo position=\"start\" />\n                <Demo position=\"start-bottom\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"bottom-start\" />\n                <Demo position=\"bottom\" />\n                <Demo position=\"bottom-end\" />\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "defaultActive",
+					"id": "utility-components-flyout--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <Flyout onOpen={fn()} onClose={fn()} defaultActive>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "active",
+					"id": "utility-components-flyout--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <Flyout onOpen={fn()} onClose={fn()} active>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "utility-components-flyout--active-false",
+					"name": "active: false, controlled",
 					"snippet": "const activeFalse = () => <Flyout onOpen={fn()} onClose={fn()} active={false}>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "modes",
+					"id": "utility-components-flyout--modes",
+					"name": "triggerType, trapFocusMode",
 					"snippet": "const modes = () => {\n    return (\n        <Example>\n            <Example.Item title=\"triggerType: click\">\n                <View direction=\"row\" gap={4}>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"dialog\" text=\"dialog\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"action-menu\" text=\"action-menu\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"action-bar\" text=\"action-bar\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"content-menu\" text=\"content-menu\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode={false} text=\"false\">\n                        {modeContent}\n                    </Demo>\n                </View>\n            </Example.Item>\n\n            <Example.Item title=\"triggerType: hover\">\n                <View direction=\"row\" gap={4}>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"dialog\" triggerType=\"hover\" text=\"dialog\">\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"action-menu\"\n                        triggerType=\"hover\"\n                        text=\"action-menu\"\n                    >\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"action-bar\"\n                        triggerType=\"hover\"\n                        text=\"action-bar\"\n                    >\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"content-menu\"\n                        triggerType=\"hover\"\n                        text=\"content-menu\"\n                    >\n                        {modeContent}\n                    </Demo>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "positionFallbacks",
+					"id": "utility-components-flyout--position-fallbacks",
+					"name": "fallbackPositions",
 					"snippet": "const positionFallbacks = () => {\n    return (\n        <Example>\n            <Example.Item title=\"position: top, default fallbacks\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" />\n                </View>\n            </Example.Item>\n            <Example.Item title=\"position: top, fallbackPositions: [start]\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" fallbackPositions={[\"start\"]} contentHeight={200} defaultActive />\n                </View>\n            </Example.Item>\n            <Example.Item title=\"position: top, fallbackPositions: false\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" fallbackPositions={false} contentHeight={400} />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--fallback-adjust-layout",
 					"name": "fallbackAdjustLayout",
 					"snippet": "const fallbackAdjustLayout = () => {\n    return (\n        <Demo\n            contentHeight={false}\n            position=\"bottom-start\"\n            width=\"200px\"\n            fallbackAdjustLayout\n            defaultActive\n        >\n            <div style={{ height: \"600px\" }}>Content</div>\n        </Demo>\n    );\n};"
 				},
 				{
-					"name": "fallbackAdjustLayoutShift",
+					"id": "utility-components-flyout--fallback-adjust-layout-shift",
+					"name": "fallbackAdjustLayout, shift",
 					"snippet": "const fallbackAdjustLayoutShift = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={10}>\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    attributes={{ ref: containerRef }}\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls containerRef={containerRef} />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <FallbackAdjustLayoutControls />\n            <div style={{ height: \"100vh\", width: \"250%\" }} />\n        </View>\n    );\n};"
 				},
 				{
-					"name": "fallbackAdjustLayoutSize",
+					"id": "utility-components-flyout--fallback-adjust-layout-size",
+					"name": "fallbackAdjustLayout, size",
 					"snippet": "const fallbackAdjustLayoutSize = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={10}>\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls large />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    attributes={{ ref: containerRef }}\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls containerRef={containerRef} large />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <FallbackAdjustLayoutControls large />\n            <div style={{ height: \"100vh\", width: \"250%\" }} />\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--origin-coordinates",
 					"name": "originCoordinates",
 					"snippet": "const originCoordinates = () => {\n    return (\n        <View gap={4} direction=\"row\">\n            <Demo position=\"bottom-start\" originCoordinates={{ x: 150, y: 150 }} defaultActive />\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--width",
 					"name": "width",
 					"snippet": "const width = () => (\n    <Example>\n        <Example.Item title=\"width: 300px\">\n            <Demo width=\"300px\" position=\"bottom\" />\n        </Example.Item>\n\n        <Example.Item title=\"width: trigger\">\n            <Demo width=\"trigger\" contentWidth={false} defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-flyout--content-gap",
 					"name": "contentGap",
 					"snippet": "const contentGap = () => <Demo contentGap={10} defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--content-shift",
 					"name": "contentShift",
 					"snippet": "const contentShift = () => <Demo contentShift={10} defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-content-hover",
 					"name": "disableContentHover",
 					"snippet": "const disableContentHover = () => <Demo triggerType=\"hover\" disableContentHover />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-close-on-outside-click",
 					"name": "disableCloseOnOutsideClick",
 					"snippet": "const disableCloseOnOutsideClick = () => <Demo disableCloseOnOutsideClick />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-hide-animation",
 					"name": "disableHideAnimation",
 					"snippet": "const disableHideAnimation = () => <Demo disableHideAnimation defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Flyout disabled>\n        <Flyout.Trigger>\n            {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n        </Flyout.Trigger>\n        <Flyout.Content>\n            <Content />\n        </Flyout.Content>\n    </Flyout>\n);"
 				},
 				{
+					"id": "utility-components-flyout--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const portalRef = React.useRef<HTMLDivElement>(null);\n    const portalRef2 = React.useRef<HTMLDivElement>(null);\n    const portalRef3 = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={4} direction=\"row\">\n            <View\n                grow\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef, \"data-testid\": \"container\" }}\n                justify=\"end\"\n                align=\"start\"\n                padding={4}\n            >\n                <Demo containerRef={portalRef} position=\"bottom-start\" defaultActive />\n            </View>\n            <View\n                grow\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef2 }}\n                justify=\"start\"\n                align=\"end\"\n                padding={4}\n            >\n                <Demo containerRef={portalRef2} position=\"top-end\" />\n            </View>\n            <View\n                width={50}\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef3 }}\n                padding={4}\n                overflow=\"auto\"\n            >\n                <View height={120} width=\"120%\" justify=\"center\" align=\"center\">\n                    <Demo containerRef={portalRef3} position=\"bottom-end\" />\n                </View>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--initial-focus-ref",
 					"name": "initialFocusRef",
 					"snippet": "const initialFocusRef = () => {\n    const initialFocusRef = React.useRef<HTMLInputElement>(null);\n\n    return (\n        <Demo initialFocusRef={initialFocusRef}>\n            <View gap={4}>\n                <Button onClick={() => {}}>Action 1</Button>\n                <TextField name=\"foo\" inputAttributes={{ ref: initialFocusRef }} />\n            </View>\n        </Demo>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--instance-ref",
 					"name": "instanceRef",
 					"snippet": "const instanceRef = () => {\n    const flyoutRef = React.useRef<FlyoutInstance>(null);\n\n    return (\n        <View direction=\"row\" gap={4}>\n            <Demo\n                instanceRef={flyoutRef}\n                disableCloseOnOutsideClick\n                onOpen={fn()}\n                onClose={fn()} />\n            <Button onClick={() => flyoutRef.current?.open()}>Open</Button>\n            <Button onClick={() => flyoutRef.current?.close()}>Close</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "contentAttributes",
+					"id": "utility-components-flyout--content-attributes",
+					"name": "content: className, attributes",
 					"snippet": "const contentAttributes = () => {\n    return (\n        <Flyout position=\"bottom\" defaultActive>\n            <Flyout.Trigger>\n                {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n            </Flyout.Trigger>\n            <Flyout.Content attributes={{ \"data-testid\": \"test-id\" }} className=\"test-classname\">\n                <Content />\n            </Flyout.Content>\n        </Flyout>\n    );\n};"
 				},
 				{
-					"name": "testShadowDom",
+					"id": "utility-components-flyout--test-shadow-dom",
+					"name": "test: shadow dom",
 					"snippet": "const testShadowDom = () => <custom-element-flyout />;"
 				},
 				{
-					"name": "testInsideFixed",
+					"id": "utility-components-flyout--test-inside-fixed",
+					"name": "test: inside position fixed",
 					"snippet": "const testInsideFixed = () => (\n    <React.Fragment>\n        <View\n            position=\"fixed\"\n            insetBottom={2}\n            insetStart={2}\n            insetEnd={2}\n            backgroundColor=\"elevation-overlay\"\n            borderColor=\"neutral-faded\"\n            borderRadius=\"small\"\n            padding={4}\n            zIndex={10}\n            attributes={{ \"data-testid\": \"container\" }}\n            height={20}\n        >\n            <Demo defaultActive position=\"top-start\" />\n        </View>\n        <View paddingTop={18} gap={4}>\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n        </View>\n    </React.Fragment>\n);"
 				},
 				{
-					"name": "testInsideSticky",
+					"id": "utility-components-flyout--test-inside-sticky",
+					"name": "test: inside position sticky",
 					"snippet": "const testInsideSticky = () => (\n    <React.Fragment>\n        <View\n            position=\"sticky\"\n            insetTop={4}\n            insetStart={0}\n            insetEnd={0}\n            backgroundColor=\"elevation-overlay\"\n            borderColor=\"neutral-faded\"\n            borderRadius=\"small\"\n            padding={4}\n            zIndex={10}\n            attributes={{ \"data-testid\": \"container\" }}\n        >\n            <Demo defaultActive />\n        </View>\n        <View gap={4} paddingTop={2}>\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n        </View>\n    </React.Fragment>\n);"
 				},
 				{
-					"name": "testInsideScrollable",
+					"id": "utility-components-flyout--test-inside-scrollable",
+					"name": "test: inside scrollable",
 					"snippet": "const testInsideScrollable = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View padding={20}>\n            <View height={30} overflow=\"auto\" backgroundColor=\"neutral-faded\" borderRadius=\"small\">\n                <View height={50} attributes={{ ref: containerRef }} padding={20} paddingBottom={30}>\n                    <Demo position=\"bottom\" />\n                </View>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testInsideModal",
+					"id": "utility-components-flyout--test-inside-modal",
+					"name": "test: inside modal",
 					"snippet": "const testInsideModal = () => {\n    return (\n        <Modal active position=\"end\">\n            <View gap={4} align=\"start\">\n                <Modal.Title>Title</Modal.Title>\n                <Demo position=\"bottom-start\" />\n                <View height={300} width={25} backgroundColor=\"neutral-faded\" />\n                <Demo position=\"start\" />\n                <View height={300} width={25} backgroundColor=\"neutral-faded\" />\n                <Demo position=\"bottom-start\" />\n            </View>\n        </Modal>\n    );\n};"
 				},
 				{
-					"name": "testDynamicBounds",
+					"id": "utility-components-flyout--test-dynamic-bounds",
+					"name": "test: auto position update",
 					"snippet": "const testDynamicBounds = () => {\n    const [left, setLeft] = React.useState(50);\n    const [top, setTop] = React.useState(50);\n    const [size, setSize] = React.useState<\"medium\" | \"large\">(\"medium\");\n    const flyoutRef = React.useRef<FlyoutInstance>(null);\n\n    React.useEffect(() => {\n        flyoutRef.current?.updatePosition();\n    }, [left, top]);\n\n    return (\n        <View gap={4}>\n            <View direction=\"row\" gap={2}>\n                <Button onClick={() => setLeft((prev) => prev - 10)}>Left</Button>\n                <Button onClick={() => setLeft((prev) => prev + 10)}>Right</Button>\n                <Button onClick={() => setTop((prev) => prev - 10)}>Up</Button>\n                <Button onClick={() => setTop((prev) => prev + 10)}>Down</Button>\n                <Button\n                    onClick={() => {\n                        setLeft(50);\n                        setTop(50);\n                    }}\n                >\n                    Center\n                </Button>\n                <Button onClick={() => setSize(\"large\")}>Large button</Button>\n                <Button onClick={() => setSize(\"medium\")}>Small button</Button>\n            </View>\n            <View height={100}>\n                <Flyout\n                    position=\"bottom\"\n                    instanceRef={flyoutRef}\n                    disableCloseOnOutsideClick\n                    defaultActive\n                >\n                    <Flyout.Trigger>\n                        {(attributes) => (\n                            <div style={{ position: \"absolute\", left: `${left}%`, top: `${top}%` }}>\n                                <Button color=\"primary\" attributes={attributes} size={size}>\n                                    Open\n                                </Button>\n                            </div>\n                        )}\n                    </Flyout.Trigger>\n                    <Flyout.Content>\n                        <Content />\n                    </Flyout.Content>\n                </Flyout>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testScopedTheming",
+					"id": "utility-components-flyout--test-scoped-theming",
+					"name": "test: content uses scope theme",
 					"snippet": "const testScopedTheming = () => (\n    <View gap={3} align=\"start\">\n        <Button color=\"primary\">Slate button</Button>\n        <Theme name=\"reshaped\">\n            <Flyout triggerType=\"click\" active position=\"bottom-start\">\n                <Flyout.Trigger>\n                    {(attributes) => (\n                        <Button color=\"primary\" attributes={attributes}>\n                            Reshaped button\n                        </Button>\n                    )}\n                </Flyout.Trigger>\n                <Flyout.Content>\n                    <Content>\n                        <View gap={1}>\n                            <View.Item>Portal content, rendered in body</View.Item>\n                            <Button color=\"primary\">Reshaped button</Button>\n                        </View>\n                    </Content>\n                </Flyout.Content>\n            </Flyout>\n        </Theme>\n    </View>\n);"
 				},
 				{
-					"name": "testWithoutFocusable",
+					"id": "utility-components-flyout--test-without-focusable",
+					"name": "test: without focusable content",
 					"snippet": "const testWithoutFocusable = () => <Demo position=\"bottom-start\" />;"
 				},
 				{
-					"name": "testChangeSize",
+					"id": "utility-components-flyout--test-change-size",
+					"name": "test: size updates",
 					"snippet": "const testChangeSize = () => {\n    const [position, setPosition] = React.useState<FlyoutProps[\"position\"]>(\"bottom-start\");\n    const [updatedHeight, setUpdatedHeight] = React.useState(false);\n\n    return (\n        <>\n            <View direction=\"row\" gap={4} align=\"center\">\n                <Select\n                    name=\"position\"\n                    options={[\n                        \"bottom-start\",\n                        \"bottom\",\n                        \"bottom-end\",\n                        \"top-start\",\n                        \"top\",\n                        \"top-end\",\n                        \"start-top\",\n                        \"start\",\n                        \"start-bottom\",\n                        \"end-top\",\n                        \"end\",\n                        \"end-bottom\",\n                    ].map((p) => ({ label: p, value: p }))}\n                    onChange={(args) => setPosition(args.value as FlyoutProps[\"position\"])}\n                    value={position}\n                />\n                <Switch name=\"height\" onChange={(args) => setUpdatedHeight(args.checked)}>\n                    Change height\n                </Switch>\n            </View>\n            <div\n                style={{\n                    position: \"fixed\",\n                    top: \"50%\",\n                    left: \"50%\",\n                    transform: \"translate(-50%, -50%)\",\n                }}\n            >\n                <Demo position={position} disableCloseOnOutsideClick active contentHeight={false}>\n                    <View\n                        backgroundColor=\"neutral-faded\"\n                        borderRadius=\"small\"\n                        height={updatedHeight ? 50 : 25}\n                        attributes={{ style: { transition: \"0.2s ease-in-out\" } }}\n                    />\n                </Demo>\n            </div>\n        </>\n    );\n};"
 				}
 			],
 			"import": "import {\n    Button,\n    Example,\n    Flyout,\n    Modal,\n    Reshaped,\n    Select,\n    Switch,\n    TextField,\n    Theme,\n    View,\n} from \"reshaped\";\nimport React from \"react\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Flyout/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Flyout",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Flyout/Flyout.tsx",
-				"actualName": "Flyout",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"groupTimeouts": {
+						"defaultValue": null,
+						"description": "Removes the content display delay if another flyout is already active",
+						"name": "groupTimeouts",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | TrapMode" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the flyout content interactivity",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Automatically focus the first focusable element in the content, when false the content container will be focused instead",
+						"name": "autoFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the content element",
+						"name": "contentClassName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"contentAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the content element",
+						"name": "contentAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Flyout"
 			}
 		},
 		"utility-components-formcontrol": {
@@ -2503,43 +13263,147 @@
 			"path": "./src/components/FormControl/tests/FormControl.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-formcontrol--status",
 					"name": "status",
 					"snippet": "const status = () => (\n    <Example>\n        <Example.Item title=\"status: default\">\n            <FormControl>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"status: error\">\n            <FormControl hasError>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: medium\">\n            <FormControl size=\"medium\">\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <FormControl size=\"large\">\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" size=\"large\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <FormControl disabled>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--required",
 					"name": "required",
 					"snippet": "const required = () => (\n    <Example>\n        <Example.Item title=\"required\">\n            <FormControl required>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "utility-components-formcontrol--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"horizontal\">\n            <FormControl>\n                <View direction=\"row\" gap={10} align=\"center\">\n                    <View width=\"100px\">\n                        <FormControl.Label>Label</FormControl.Label>\n                    </View>\n                    <View.Item grow>\n                        <TextField name=\"name\" placeholder=\"Enter value\" />\n                    </View.Item>\n                </View>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-formcontrol--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <FormControl id=\"test-id\" hasError>\n        <FormControl.Label>Label</FormControl.Label>\n        <TextField name=\"name\" />\n        <FormControl.Helper>Caption</FormControl.Helper>\n        <FormControl.Error>Error</FormControl.Error>\n    </FormControl>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--group",
 					"name": "group",
 					"snippet": "const group = () => (\n    <FormControl group>\n        <FormControl.Label>Label</FormControl.Label>\n        <RadioGroup name=\"name\">\n            <View gap={2}>\n                <Radio value=\"1\">One</Radio>\n                <Radio value=\"2\">Two</Radio>\n            </View>\n        </RadioGroup>\n    </FormControl>\n);"
 				}
 			],
 			"import": "import { Example, FormControl, Radio, RadioGroup, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/FormControl/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "FormControl",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/FormControl/FormControl.tsx",
-				"actualName": "FormControl",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size, to be used together with the other form component sizes",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"large\" | \"medium\"",
+							"value": [{ "value": "\"large\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"required": {
+						"defaultValue": null,
+						"description": "Change component to show a required indicator",
+						"name": "required",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Apply disabled styles",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"group": {
+						"defaultValue": null,
+						"description": "Apply semantic html markup when used for displaying multiple form fields together with a single label",
+						"name": "group",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Custom id for the form control",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "FormControl"
 			}
 		},
 		"utility-components-grid": {
@@ -2548,43 +13412,421 @@
 			"path": "./src/components/Grid/tests/Grid.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "utility-components-grid--base",
+					"name": "gap, columnGap, rowGap, align, justify, maxWidth, width, height",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"gap: 2\">\n            <Grid gap={2} columns={2}>\n                {[1, 2].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"columnGap: 2, rowGap: 4\">\n            <Grid columnGap={2} rowGap={4} columns={2}>\n                {[1, 2, 3, 4].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"align: center\">\n            <Grid gap={2} columns={2} align=\"center\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={8}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"justify: center\">\n            <Grid gap={2} columns=\"200px 200px\" justify=\"center\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"maxWidth: 400px\">\n            <Grid gap={2} columns=\"200px 200px\" maxWidth=\"400px\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"width: 400px, height: 200px\">\n            <Grid gap={2} columns={2} width=\"400px\" height=\"200px\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "layout",
+					"id": "utility-components-grid--layout",
+					"name": "rows, columns",
 					"snippet": "const layout = () => (\n    <Example>\n        <Example.Item title=\"simple: 2 rows, 3 columns\">\n            <Grid gap={4} columns={3} rows={2}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"columns template, 1fr 2fr 1fr\">\n            <Grid gap={4} columns=\"1fr 2fr 1fr\" rows={2}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"rows template, 1fr 2fr\">\n            <Grid gap={4} columns={3} rows=\"1fr 2fr\">\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"responsive\">\n            <Grid gap={4} columns={{ s: 3, m: \"1fr 2fr 1fr\" }} rows={{ s: 2, m: \"1fr 2fr\" }}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemLayout",
+					"id": "utility-components-grid--item-layout",
+					"name": "colStart, colEnd, rowStart, rowEnd",
 					"snippet": "const itemLayout = () => (\n    <Example>\n        <Example.Item title=\"column, start 1, end 3\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item colStart={1} colEnd={3}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"column, start 1, span 2\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item colStart={1} colSpan={2}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"row, start 1, end 3\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowEnd={3}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"row, start 1, span 2\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowSpan={2}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"responsive\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowSpan={{ s: 1, m: 2 }} colStart={1} colSpan={{ s: 1, m: 2 }}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-grid--areas",
 					"name": "areas",
 					"snippet": "const areas = () => (\n    <Example>\n        <Example.Item title=\"simple: 2 rows, 3 columns\">\n            <Grid gap={4} rows={2} areas={[\"a .\", \"a b\"]}>\n                {[\"a\", \"b\"].map((area) => (\n                    <Grid.Item area={area} key={area}>\n                        <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                            {area}\n                        </View>\n                    </Grid.Item>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "auto",
+					"id": "utility-components-grid--auto",
+					"name": "autoFlow, autoColumns, autoRows",
 					"snippet": "const auto = () => (\n    <Example>\n        <Example.Item title=\"auto flow: column\">\n            <Grid gap={4} autoFlow=\"column\" rows={2} columns={2}>\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"auto rows\">\n            <Grid gap={4} autoRows=\"100px\" columns={2}>\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"auto columns\">\n            <Grid gap={4} autoColumns=\"100px\" autoFlow=\"column\">\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-grid--as",
 					"name": "as",
 					"snippet": "const as = () => (\n    <Grid as=\"ul\">\n        <Grid.Item as=\"li\">Content</Grid.Item>\n    </Grid>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-grid--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Grid className=\"test-class\" attributes={{ id: \"test-id\" }}>\n            <Grid.Item className=\"test-item-class\" attributes={{ id: \"test-item-id\" }}>\n                Content\n            </Grid.Item>\n        </Grid>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Grid, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Grid/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Grid",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Grid/Grid.tsx",
-				"actualName": "Grid",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between grid items",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"columnGap": {
+						"defaultValue": null,
+						"description": "Horizontal gap between grid items",
+						"name": "columnGap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"rowGap": {
+						"defaultValue": null,
+						"description": "Vertical gap between grid items",
+						"name": "rowGap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Align grid items vertically",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Justify grid items horizontally",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"rows": {
+						"defaultValue": null,
+						"description": "Grid template rows",
+						"name": "rows",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<number | \"inherit\" | \"none\" | \"auto\" | (string & {}) | \"-moz-initial\" | \"initial\" | \"revert\" | \"revert-layer\" | \"unset\" | \"max-content\" | \"min-content\" | \"subgrid\">"
+						}
+					},
+					"columns": {
+						"defaultValue": null,
+						"description": "Grid template columns",
+						"name": "columns",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<number | \"inherit\" | \"none\" | \"auto\" | (string & {}) | \"-moz-initial\" | \"initial\" | \"revert\" | \"revert-layer\" | \"unset\" | \"max-content\" | \"min-content\" | \"subgrid\">"
+						}
+					},
+					"areas": {
+						"defaultValue": null,
+						"description": "Grid areas for template syntax",
+						"name": "areas",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string[]>" }
+					},
+					"autoFlow": {
+						"defaultValue": null,
+						"description": "Grid auto flow",
+						"name": "autoFlow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoFlow>" }
+					},
+					"autoColumns": {
+						"defaultValue": null,
+						"description": "Grid auto columns",
+						"name": "autoColumns",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoColumns<0 | (string & {})>>" }
+					},
+					"autoRows": {
+						"defaultValue": null,
+						"description": "Grid auto rows",
+						"name": "autoRows",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoRows<0 | (string & {})>>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Maximum width of the grid container, literal css value or unit token multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width of the grid container, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height of the grid container, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Custom root element html tag",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					}
+				},
+				"exportName": "Grid"
 			}
 		},
 		"utility-components-hidden": {
@@ -2593,22 +13835,261 @@
 			"path": "./src/components/Hidden/tests/Hidden.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-hidden--visibility",
 					"name": "visibility",
 					"snippet": "const visibility = () => (\n    <Example>\n        <Example.Item title=\"hide: always\">\n            <Hidden hide={true}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on s\">\n            <Hidden hide={{ s: false, m: true }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on l/xl\">\n            <Hidden hide={{ s: true, l: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on m/l/xl\">\n            <Hidden hide={{ s: true, m: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on m\">\n            <Hidden hide={{ s: true, m: false, l: true }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on s/xl\">\n            <Hidden hide={{ s: false, m: true, xl: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"hide: always, visibility\">\n            <Hidden hide visibility>\n                Content\n            </Hidden>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-hidden--as",
 					"name": "as",
 					"snippet": "const as = () => <Hidden as=\"span\">Content</Hidden>;"
 				}
 			],
 			"import": "import { Example, Hidden } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Hidden/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Hidden",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Hidden/Hidden.tsx",
-				"actualName": "Hidden",
+				"methods": [],
+				"props": {
+					"hide": {
+						"defaultValue": null,
+						"description": "Pick at which viewport sizes to hide the children",
+						"name": "hide",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"visibility": {
+						"defaultValue": null,
+						"description": "Use visibility hidden instead of display none",
+						"name": "visibility",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Custom root element html tag",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2618,22 +14099,39 @@
 			"path": "./src/components/HiddenVisually/tests/HiddenVisually.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-hiddenvisually--visibility",
 					"name": "visibility",
 					"snippet": "const visibility = () => (\n    <Example>\n        <Example.Item title=\"pronounced by screen readers\">\n            <HiddenVisually>Screen-reader only</HiddenVisually>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-hiddenvisually--children",
 					"name": "children",
 					"snippet": "const children = () => <HiddenVisually>Content</HiddenVisually>;"
 				}
 			],
 			"import": "import { Example, HiddenVisually } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/HiddenVisually/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "HiddenVisually",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/HiddenVisually/HiddenVisually.tsx",
-				"actualName": "HiddenVisually",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/HiddenVisually/HiddenVisually.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2643,34 +14141,115 @@
 			"path": "./src/components/Icon/tests/Icon.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-icon--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: 4\">\n            <Icon svg={IconZap} size={4} />\n        </Example.Item>\n        <Example.Item title=\"size: 8\">\n            <Icon svg={IconZap} size={8} />\n        </Example.Item>\n        <Example.Item title=\"size: 100%\">\n            <View width={25} height={25}>\n                <Icon svg={IconZap} size=\"100%\" />\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive size\", \"[s] 5\", \"[m]: 10\"]}>\n            <Icon svg={IconZap} size={{ s: 5, m: 10 }} />\n        </Example.Item>\n        <Example.Item title=\"size: inherit from font\">\n            <Text variant=\"title-6\">\n                <View direction=\"row\" align=\"center\" gap={2}>\n                    <Icon svg={IconZap} />\n                    <View.Item>Reshaped</View.Item>\n                </View>\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-icon--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <Icon svg={IconZap} color=\"neutral\" />\n        </Example.Item>\n        <Example.Item title=\"color: neutral-faded\">\n            <Icon svg={IconZap} color=\"neutral-faded\" />\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <Icon svg={IconZap} color=\"primary\" />\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Icon svg={IconZap} color=\"critical\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Icon svg={IconZap} color=\"positive\" />\n        </Example.Item>\n        <Example.Item title=\"color: disabled\">\n            <Icon svg={IconZap} color=\"disabled\" />\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <div style={{ color: \"tomato\" }}>\n                <Icon svg={IconZap} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "autoWidth",
+					"id": "utility-components-icon--auto-width",
+					"name": "autoWidth, blank",
 					"snippet": "const autoWidth = () => (\n    <Example>\n        <Example.Item title=\"square boundaries\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={IconMic} size={10} />\n            </div>\n        </Example.Item>\n        <Example.Item title=\"auto width boundaries\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={IconMic} size={10} autoWidth />\n            </div>\n        </Example.Item>\n        <Example.Item title=\"blank\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={null} size={10} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-icon--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Icon svg={IconZap} className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				},
 				{
-					"name": "render",
+					"id": "utility-components-icon--render",
+					"name": "test: hidden from sr",
 					"snippet": "const render = () => (\n    <div data-testid=\"root\">\n        <Icon svg={IconZap} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Icon, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Icon/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Icon",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Icon/Icon.tsx",
-				"actualName": "Icon",
+				"methods": [],
+				"props": {
+					"svg": {
+						"defaultValue": null,
+						"description": "Icon svg component or node",
+						"name": "svg",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Icon size, literal css value or unit token multiplier",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Icon color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"warning\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"autoWidth": {
+						"defaultValue": null,
+						"description": "Use the width of the svg asset instead of providing a square bounding box",
+						"name": "autoWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2680,54 +14259,230 @@
 			"path": "./src/components/Image/tests/Image.stories.tsx",
 			"stories": [
 				{
-					"name": "src",
+					"id": "utility-components-image--src",
+					"name": "src, alt",
 					"snippet": "const src = () => (\n    <Example>\n        <Example.Item title=\"src, alt\">\n            <Image src={imgUrl} alt=\"Image alt\" />\n        </Example.Item>\n\n        <Example.Item title=\"src\">\n            <Image src={imgUrl} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "utility-components-image--size",
+					"name": "width, height, maxWidth, aspectRatio",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"width: 200px\">\n            <Image src={imgUrl} width=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"height: 200px\">\n            <Image src={imgUrl} height=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"maxWidth: 200px\">\n            <Image src={imgUrl} maxWidth=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"aspectRatio: 1/1\">\n            <Image src={imgUrl} aspectRatio={1 / 1} width=\"300px\" />\n        </Example.Item>\n        <Example.Item title={[\"responsive width\", \"[s] 200px\", \"[m+] 300px\"]}>\n            <Image src={imgUrl} width={{ s: \"200px\", m: \"300px\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "radius",
+					"id": "utility-components-image--radius",
+					"name": "borderRadius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius: small\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"small\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"radius: medium\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"medium\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"radius: large\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--display-mode",
 					"name": "displayMode",
 					"snippet": "const displayMode = () => (\n    <Example>\n        <Example.Item title=\"mode: cover\">\n            <Image src={imgUrl} height=\"200px\" width=\"100%\" displayMode=\"cover\" />\n        </Example.Item>\n        <Example.Item title=\"mode: contain\">\n            <Image src={imgUrl} height=\"200px\" width=\"100%\" displayMode=\"contain\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--on-load",
 					"name": "onLoad",
 					"snippet": "const onLoad = () => <Image src={imgUrl} alt=\"photo\" onLoad={fn()} />;"
 				},
 				{
+					"id": "utility-components-image--on-error",
 					"name": "onError",
 					"snippet": "const onError = () => <Image src=\"/invalid.png\" alt=\"photo\" onError={fn()} />;"
 				},
 				{
+					"id": "utility-components-image--fallback",
 					"name": "fallback",
 					"snippet": "const fallback = () => (\n    <Example>\n        <Example.Item title=\"fallback, background, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"fallback, image, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback={imgUrl} />\n                </View>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"fallback, icon, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback={<Icon svg={IconZap} size={10} />} />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"fallback, icon, no url\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image fallback={<Icon svg={IconZap} size={10} />} />\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--render-image",
 					"name": "renderImage",
 					"snippet": "const renderImage = () => (\n    <Example>\n        <Example.Item title=\"renderImage\">\n            <Image\n                src={imgUrl}\n                alt=\"Amsterdam canal\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image\" />}\n            />\n        </Example.Item>\n        <Example.Item title=\"renderImage, fallback\">\n            <Image\n                src=\"error\"\n                fallback={imgUrl}\n                alt=\"Amsterdam canal 2\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image-fallback\" />}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "imageAttributes",
+					"id": "utility-components-image--image-attributes",
+					"name": "className, attributes,imageAttributes",
 					"snippet": "const imageAttributes = () => (\n    <div data-testid=\"root\">\n        <Image\n            src={imgUrl}\n            alt=\"photo\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            imageAttributes={{ \"data-testid\": \"test-img-id\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "ratio",
+					"id": "utility-components-image--ratio",
+					"name": "test: aspectRatio",
 					"snippet": "const ratio = () => (\n    <Example>\n        <Example.Item title=\"ratio: 16/9\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"ratio: 16/9, displayMode: contain\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} displayMode=\"contain\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Icon, Image, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Image/Image.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Image",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Image/Image.tsx",
-				"actualName": "Image",
+				"methods": [],
+				"props": {
+					"src": {
+						"defaultValue": null,
+						"description": "Image URL",
+						"name": "src",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"alt": {
+						"defaultValue": null,
+						"description": "Image alt text",
+						"name": "alt",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Image width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Image height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Image max width, literal css value or unit token multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"aspectRatio": {
+						"defaultValue": null,
+						"description": "Image aspect ratio, width / height",
+						"name": "aspectRatio",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Image border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"large\" | \"medium\"",
+							"value": [
+								{ "value": "\"small\"" },
+								{ "value": "\"large\"" },
+								{ "value": "\"medium\"" }
+							]
+						}
+					},
+					"displayMode": {
+						"defaultValue": null,
+						"description": "Image display mode for controlling how it fits into the provided boundaries",
+						"name": "displayMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"cover\" | \"contain\"",
+							"value": [{ "value": "\"cover\"" }, { "value": "\"contain\"" }]
+						}
+					},
+					"onLoad": {
+						"defaultValue": null,
+						"description": "Image on load event",
+						"name": "onLoad",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: SyntheticEvent<Element, Event>) => void)" }
+					},
+					"onError": {
+						"defaultValue": null,
+						"description": "Image on error event",
+						"name": "onError",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: SyntheticEvent<Element, Event>) => void)" }
+					},
+					"fallback": {
+						"defaultValue": null,
+						"description": "Image fallback content if the image fails to load or was not provided",
+						"name": "fallback",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"renderImage": {
+						"defaultValue": null,
+						"description": "Image render function, can be used for integrating with Image component in 3rd party frameworks",
+						"name": "renderImage",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Omit<Attributes<\"img\">, \"src\" | \"alt\"> & { src: string; alt: string; }) => ReactNode)"
+						}
+					},
+					"imageAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the image element",
+						"name": "imageAttributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"img\">" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(Attributes<\"div\"> & Attributes<\"img\">)" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2737,46 +14492,229 @@
 			"path": "./src/components/Overlay/tests/Overlay.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-overlay--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate}>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--transparent",
 					"name": "transparent",
 					"snippet": "const transparent = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate} transparent>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--blurred",
 					"name": "blurred",
 					"snippet": "const blurred = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate} blurred>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "renderProps",
+					"id": "utility-components-overlay--render-props",
+					"name": "children, render props",
 					"snippet": "const renderProps = () => (\n    <Overlay active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        {(args) => (args.active ? \"Opened\" : \"Closed\")}\n    </Overlay>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "utility-components-overlay--handlers",
+					"name": "onOpen, onClose, onAfterOpen, onAfterClose",
 					"snippet": "const handlers = () => {\n    const overlayToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => overlayToggle.toggle()}>Open overlay</Button>\n            <Overlay\n                active={overlayToggle.active}\n                onClose={(closeArgs) => {\n                    overlayToggle.deactivate();\n                    args.handleClose(closeArgs);\n                }}\n                onOpen={fn()}\n                onAfterOpen={fn()}\n                onAfterClose={fn()}>Content\n                                </Overlay>\n        </>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--disable-close-on-click",
 					"name": "disableCloseOnClick",
 					"snippet": "const disableCloseOnClick = (args) => (\n    <Overlay\n        active\n        disableCloseOnClick\n        onClose={(closeArgs) => {\n            args.handleClose(closeArgs);\n        }}\n    >\n        Content\n    </Overlay>\n);"
 				},
 				{
+					"id": "utility-components-overlay--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <>\n            <div ref={containerRef} data-testid=\"test-id\" style={{ height: 200 }} />\n            <Overlay active containerRef={containerRef}>\n                Content\n            </Overlay>\n        </>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-overlay--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <Overlay active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        Content\n    </Overlay>\n);"
 				}
 			],
 			"import": "import { Button, Example, Overlay } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Overlay/index.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Overlay",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Overlay/Overlay.tsx",
-				"actualName": "Overlay",
+				"methods": [],
+				"props": {
+					"transparent": {
+						"defaultValue": null,
+						"description": "Make the overlay transparent",
+						"name": "transparent",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number | boolean" }
+					},
+					"blurred": {
+						"defaultValue": null,
+						"description": "Make the overlay blurred",
+						"name": "blurred",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Control the overflow of the component content",
+						"name": "overflow",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"auto\"",
+							"value": [{ "value": "\"hidden\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, render function receives the state of the component as an argument",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode | ((props: { active: boolean; }) => ReactNode)" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the visibility of the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason: CloseReason; }) => void)" }
+					},
+					"onAfterClose": {
+						"defaultValue": null,
+						"description": "Callback after the component close transition is complete",
+						"name": "onAfterClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the component is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onAfterOpen": {
+						"defaultValue": null,
+						"description": "Callback after the component open transition is complete",
+						"name": "onAfterOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"disableCloseOnClick": {
+						"defaultValue": null,
+						"description": "Disable closing the component on outside click",
+						"name": "disableCloseOnClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": null,
+						"description": "Element to render the component in",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2786,42 +14724,213 @@
 			"path": "./src/components/Reshaped/tests/Reshaped.stories.tsx",
 			"stories": [
 				{
-					"name": "rtl",
+					"id": "utility-components-reshaped--rtl",
+					"name": "defaultRTL",
 					"snippet": "const rtl = () => (\n    <Reshaped defaultRTL theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				},
 				{
-					"name": "controlledMode",
+					"id": "utility-components-reshaped--controlled-mode",
+					"name": "colorMode, controlled",
 					"snippet": "const controlledMode = () => {\n    const [mode, setMode] = useState<G.ColorMode>(\"dark\");\n\n    return (\n        <Reshaped theme=\"reshaped\" colorMode={mode}>\n            <Button\n                onClick={() => {\n                    setMode(mode === \"dark\" ? \"light\" : \"dark\");\n                }}\n            >\n                Toggle color mode\n            </Button>\n        </Reshaped>\n    );\n};"
 				},
 				{
-					"name": "lightMode",
+					"id": "utility-components-reshaped--light-mode",
+					"name": "defaultColorMode=light",
 					"snippet": "const lightMode = () => <Reshaped theme=\"reshaped\">Hello</Reshaped>;"
 				},
 				{
-					"name": "darkMode",
+					"id": "utility-components-reshaped--dark-mode",
+					"name": "defaultColorMode=dark",
 					"snippet": "const darkMode = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				},
 				{
+					"id": "utility-components-reshaped--scoped",
 					"name": "scoped",
 					"snippet": "const scoped = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\" scoped>\n        Hello\n    </Reshaped>\n);"
 				},
 				{
-					"name": "testScoped",
+					"id": "utility-components-reshaped--test-scoped",
+					"name": "test: scoped switch",
 					"snippet": "const testScoped = () => (\n    <Reshaped theme=\"reshaped\">\n        <Reshaped theme=\"slate\" scoped>\n            <ScopedComponent />\n        </Reshaped>\n    </Reshaped>\n);"
 				},
 				{
-					"name": "keyboardMode",
+					"id": "utility-components-reshaped--keyboard-mode",
+					"name": "test: keyboard mode",
 					"snippet": "const keyboardMode = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				}
 			],
 			"import": "import { Button, Reshaped } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Reshaped/Reshaped.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Reshaped",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Reshaped/Reshaped.tsx",
-				"actualName": "Reshaped",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"theme": {
+						"defaultValue": null,
+						"description": "Theme of the application, enables controlled mode",
+						"name": "theme",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NonNullable<Theme>" }
+					},
+					"defaultTheme": {
+						"defaultValue": null,
+						"description": "Default theme of the application, enables uncontrolled mode",
+						"name": "defaultTheme",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NonNullable<Theme>" }
+					},
+					"defaultRTL": {
+						"defaultValue": null,
+						"description": "Default content direction of the application",
+						"name": "defaultRTL",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode of the application, enables controlled mode",
+						"name": "colorMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode",
+							"value": [{ "value": "\"light\"" }, { "value": "\"dark\"" }]
+						}
+					},
+					"defaultColorMode": {
+						"defaultValue": null,
+						"description": "Default color mode of the application, enables uncontrolled mode",
+						"name": "defaultColorMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode",
+							"value": [{ "value": "\"light\"" }, { "value": "\"dark\"" }]
+						}
+					},
+					"defaultViewport": {
+						"defaultValue": null,
+						"description": "Default viewport size of the application",
+						"name": "defaultViewport",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Viewport",
+							"value": [
+								{ "value": "\"s\"" },
+								{ "value": "\"m\"" },
+								{ "value": "\"l\"" },
+								{ "value": "\"xl\"" }
+							]
+						}
+					},
+					"toastOptions": {
+						"defaultValue": null,
+						"description": "Global options for the ToastProvider",
+						"name": "toastOptions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "Partial<Record<Position, { width?: string; expanded?: boolean; }>> | undefined"
+						}
+					},
+					"scoped": {
+						"defaultValue": null,
+						"description": "Enable scoped mode for applications not using Reshaped provider at the application root",
+						"name": "scoped",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2831,42 +14940,150 @@
 			"path": "./src/components/ScrollArea/tests/ScrollArea.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-scrollarea--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"vertical scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"horizontal scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\" height=\"100px\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"horizontal and vertical scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-scrollarea--scrollbar-display",
 					"name": "scrollbarDisplay",
 					"snippet": "const scrollbarDisplay = () => (\n    <Example>\n        <Example.Item title=\"scrollbarDisplay: hover\">\n            <ScrollArea height=\"100px\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"scrollbarDisplay: hidden\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"hidden\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"scrollbarDisplay: visible\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "height",
+					"id": "utility-components-scrollarea--height",
+					"name": "height, maxHeight",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"height: 80px\">\n            <ScrollArea height=\"80px\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"responsive height: s 80px, m: 120px\">\n            <ScrollArea height={{ s: \"80px\", m: \"120px\" }}>\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"maxHeight: 80px\">\n            <ScrollArea maxHeight=\"80px\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"responsive max height: s 80px, m: 200px\">\n            <ScrollArea maxHeight={{ s: \"80px\", m: \"200px\" }}>\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onScroll",
+					"id": "utility-components-scrollarea--on-scroll",
+					"name": "ref, onScroll",
 					"snippet": "const onScroll = () => {\n    const ref = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={4}>\n            <View.Item>\n                <Button onClick={() => ref.current?.scrollBy({ top: 50, left: 50 })}>Scroll</Button>\n            </View.Item>\n            <ScrollArea height=\"100px\" ref={ref} scrollbarDisplay=\"visible\" onScroll={fn()}>\n                <View backgroundColor=\"neutral-faded\" padding={4} width=\"1000px\" height=\"200px\">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                                            has been the industry's standard dummy text ever since the 1500s, when an unknown\n                                            printer took a galley of type and scrambled it to make a type specimen book. It has\n                                            survived not only five centuries, but also the leap into electronic typesetting,\n                                            remaining essentially unchanged. It was popularised in the 1960s with the release of\n                                            Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                                            publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                                        </View>\n            </ScrollArea>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-scrollarea--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ScrollArea className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </ScrollArea>\n    </div>\n);"
 				},
 				{
-					"name": "testNested",
+					"id": "utility-components-scrollarea--test-nested",
+					"name": "test: nested",
 					"snippet": "const testNested = () => (\n    <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n        <View padding={4} paddingInline={16}>\n            <ScrollArea height=\"200px\" scrollbarDisplay=\"visible\">\n                {Array(20)\n                    .fill(\"\")\n                    .map((_, index) => {\n                        return <div key={index}>Item {index + 1}</div>;\n                    })}\n            </ScrollArea>\n        </View>\n    </ScrollArea>\n);"
 				},
 				{
-					"name": "testDynamicHeight",
+					"id": "utility-components-scrollarea--test-dynamic-height",
+					"name": "test: dynamic height change",
 					"snippet": "const testDynamicHeight = () => {\n    const [count, setCount] = React.useState(10);\n\n    return (\n        <View gap={4}>\n            <View.Item>\n                <Button onClick={() => setCount((prev) => prev + 10)}>Add more items</Button>\n            </View.Item>\n\n            <ScrollArea height=\"200px\" scrollbarDisplay=\"visible\">\n                <View gap={2}>\n                    {new Array(count).fill(\"\").map((_, i) => (\n                        <View.Item key={i}>Item {i + 1}</View.Item>\n                    ))}\n                </View>\n            </ScrollArea>\n        </View>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Example, ScrollArea, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ScrollArea/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ScrollArea",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ScrollArea/ScrollArea.tsx",
-				"actualName": "ScrollArea",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"scrollbarDisplay": {
+						"defaultValue": null,
+						"description": "Scrollbar visibility behavior based on the user interaction",
+						"name": "scrollbarDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"hover\" | \"visible\"",
+							"value": [
+								{ "value": "\"hidden\"" },
+								{ "value": "\"hover\"" },
+								{ "value": "\"visible\"" }
+							]
+						}
+					},
+					"onScroll": {
+						"defaultValue": null,
+						"description": "Callback when the scroll area is scrolled",
+						"name": "onScroll",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: Coordinates) => void)" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height of the scroll area, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height of the scroll area, literal css value or unit token multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2876,54 +15093,387 @@
 			"path": "./src/components/Text/tests/Text.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-text--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: title-1\">\n            <Text variant=\"title-1\">Title 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-2\">\n            <Text variant=\"title-2\">Title 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-3\">\n            <Text variant=\"title-3\">Title 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-4\">\n            <Text variant=\"title-4\">Title 4</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-5\">\n            <Text variant=\"title-5\">Title 5</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-6\">\n            <Text variant=\"title-6\">Title 6</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-1\">\n            <Text variant=\"featured-1\">Featured 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-2\">\n            <Text variant=\"featured-2\">Featured 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-3\">\n            <Text variant=\"featured-3\">Featured 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-1\">\n            <Text variant=\"body-1\">Body 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-2\">\n            <Text variant=\"body-2\">Body 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-3\">\n            <Text variant=\"body-3\">Body 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: caption-1\">\n            <Text variant=\"caption-1\">Caption 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: caption-2\">\n            <Text variant=\"caption-2\">Caption 2</Text>\n        </Example.Item>\n        <Example.Item title={[\"responsive variant\", \"[s] body-3\", \"[m+] title-4\"]}>\n            <Text variant={{ s: \"body-3\", m: \"title-4\" }}>Responsive</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--weight",
 					"name": "weight",
 					"snippet": "const weight = () => (\n    <Example>\n        <Example.Item title=\"weight: regular\">\n            <Text weight=\"regular\">Regular</Text>\n        </Example.Item>\n        <Example.Item title=\"weight: medium\">\n            <Text weight=\"medium\">Medium</Text>\n        </Example.Item>\n        <Example.Item title=\"weight: bold\">\n            <Text weight=\"bold\">Bold</Text>\n        </Example.Item>\n        <Example.Item title={[\"responsive\", \"[s] weight: regular\", \"[m+] bold\"]}>\n            <Text weight={{ s: \"regular\", m: \"bold\" }}>Responsive</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: inherit\">\n            <Text>Neutral</Text>\n        </Example.Item>\n        <Example.Item title=\"color: neutral-faded\">\n            <Text color=\"neutral-faded\">Faded</Text>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Text color=\"positive\">Positive</Text>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <Text color=\"warning\">Warning</Text>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Text color=\"critical\">Critical</Text>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <Text color=\"primary\">Primary</Text>\n        </Example.Item>\n        <Example.Item title=\"color: disabled\">\n            <Text color=\"disabled\" attributes={{ \"aria-disabled\": true }}>\n                Disabled\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--decoration",
 					"name": "decoration",
 					"snippet": "const decoration = () => (\n    <Example>\n        <Example.Item title=\"decoration: line-through\">\n            <Text decoration=\"line-through\">Line through</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--wrap",
 					"name": "wrap",
 					"snippet": "const wrap = () => (\n    <Example>\n        <Example.Item title=\"wrap: balance\">\n            <Text wrap=\"balance\" variant=\"title-3\">\n                The design system you want to build\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "mono",
+					"id": "utility-components-text--mono",
+					"name": "monospace",
 					"snippet": "const mono = () => (\n    <Example>\n        <Example.Item title=\"monospace\">\n            <Text monospace>Content</Text>\n        </Example.Item>\n        <Example.Item title=\"monospace, variant, weight\">\n            <Text monospace variant=\"title-1\" weight=\"regular\">\n                Content\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--max-lines",
 					"name": "maxLines",
 					"snippet": "const maxLines = () => (\n    <Example>\n        <Example.Item title=\"maxLines: 2\">\n            <Text maxLines={2}>\n                There are many variations of passages of Lorem Ipsum available, but the majority have\n                suffered alteration in some form, by injected humour, or randomised words which don't look\n                even slightly believable. If you are going to use a passage of Lorem Ipsum, you need to be\n                sure there isn't anything embarrassing hidden in the middle of text. All the Lorem Ipsum\n                generators on the Internet tend to repeat predefined chunks as necessary, making this the\n                first true generator on the Internet. It uses a dictionary of over 200 Latin words,\n                combined with a handful of model sentence structures, to generate Lorem Ipsum which looks\n                reasonable. The generated Lorem Ipsum is therefore always free from repetition, injected\n                humour, or non-characteristic words etc.\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: start\">\n            <Text align=\"start\">Text content</Text>\n        </Example.Item>\n        <Example.Item title=\"align: center\">\n            <Text align=\"center\">Text content</Text>\n        </Example.Item>\n        <Example.Item title=\"align: end\">\n            <Text align=\"end\">Text content</Text>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive alignment\", \"[s]: center\", \"[m+] start\"]}>\n            <Text align={{ s: \"center\", m: \"start\" }}>Text content</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "asProp",
+					"id": "utility-components-text--as-prop",
+					"name": "as",
 					"snippet": "const asProp = () => (\n    <>\n        <Text as=\"h1\">Content</Text>\n        <Text variant=\"title-3\">Content</Text>\n        <Text variant={{ s: \"title-3\", m: \"title-4\" }}>Content</Text>\n    </>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-text--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Text className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Text>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Text/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Text",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Text/Text.tsx",
-				"actualName": "Text",
+				"methods": [],
+				"props": {
+					"variant": {
+						"defaultValue": null,
+						"description": "Text render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Variant>" }
+					},
+					"weight": {
+						"defaultValue": null,
+						"description": "Text font weight",
+						"name": "weight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"medium\" | \"bold\" | \"regular\">" }
+					},
+					"monospace": {
+						"defaultValue": null,
+						"description": "Render monospace font",
+						"name": "monospace",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Text color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"warning\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Text alignment",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"center\" | \"start\" | \"end\">" }
+					},
+					"wrap": {
+						"defaultValue": null,
+						"description": "CSS wrapping style",
+						"name": "wrap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"balance\"", "value": [{ "value": "\"balance\"" }] }
+					},
+					"decoration": {
+						"defaultValue": null,
+						"description": "CSS text decoration style",
+						"name": "decoration",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"line-through\"",
+							"value": [{ "value": "\"line-through\"" }]
+						}
+					},
+					"maxLines": {
+						"defaultValue": null,
+						"description": "Maximum number of lines to render, used for text truncation",
+						"name": "maxLines",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different html tag",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2933,46 +15483,114 @@
 			"path": "./src/components/Theme/tests/Theme.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-theme--scoped",
 					"name": "scoped",
 					"snippet": "const scoped = () => (\n    <Example>\n        <Example.Item title=\"scoped, single\">\n            <Theme name=\"reshaped\">\n                <Card attributes={{ \"data-testid\": \"test-id\" }}>\n                    <Button color=\"primary\">Action</Button>\n                </Card>\n            </Theme>\n        </Example.Item>\n\n        <Example.Item title=\"scoped, multiple\">\n            <Theme name={[\"reshaped\", \"figma\"]}>\n                <Card attributes={{ \"data-testid\": \"test-id-multi\" }}>\n                    <View direction=\"row\" gap={4}>\n                        <Button color=\"primary\">Action</Button>\n\n                        <Popover>\n                            <Popover.Trigger>\n                                {(attributes) => <Button attributes={attributes}>Popover</Button>}\n                            </Popover.Trigger>\n                            <Popover.Content>Content</Popover.Content>\n                        </Popover>\n                    </View>\n                </Card>\n            </Theme>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-theme--light",
 					"name": "light",
 					"snippet": "const light = () => (\n    <Theme name=\"reshaped\" colorMode=\"light\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--dark",
 					"name": "dark",
 					"snippet": "const dark = () => (\n    <Theme name=\"reshaped\" colorMode=\"dark\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--inherited",
 					"name": "inherited",
 					"snippet": "const inherited = () => (\n    <Theme name=\"reshaped\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--inverted",
 					"name": "inverted",
 					"snippet": "const inverted = () => (\n    <Theme name=\"reshaped\" colorMode=\"inverted\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--controlled",
 					"name": "controlled",
 					"snippet": "const controlled = () => {\n    const Internal = () => {\n        const { setTheme, theme } = useTheme();\n\n        return (\n            <Button color=\"primary\" onClick={() => setTheme(\"slate\")}>\n                Switch to slate\n            </Button>\n        );\n    };\n\n    return (\n        <div data-testid=\"root\">\n            <Theme name=\"reshaped\">\n                <Internal />\n            </Theme>\n        </div>\n    );\n};"
 				},
 				{
+					"id": "utility-components-theme--uncontrolled",
 					"name": "uncontrolled",
 					"snippet": "const uncontrolled = () => {\n    const Internal = () => {\n        const { setTheme } = useTheme();\n\n        return (\n            <Button color=\"primary\" onClick={() => setTheme(\"slate\")}>\n                Switch to slate\n            </Button>\n        );\n    };\n\n    return (\n        <div data-testid=\"root\">\n            <Theme defaultName=\"reshaped\">\n                <Internal />\n            </Theme>\n        </div>\n    );\n};"
 				},
 				{
-					"name": "disabledTransition",
+					"id": "utility-components-theme--disabled-transition",
+					"name": "disabled transitions",
 					"snippet": "const disabledTransition = () => {\n    const { invertColorMode } = useTheme();\n\n    return (\n        <Example>\n            <Example.Item title=\"should have no transitions while switching color mode\">\n                <View gap={3}>\n                    <Button onClick={invertColorMode}>Invert mode</Button>\n\n                    <MenuItem selected>Test transition</MenuItem>\n\n                    <Card>Default card</Card>\n\n                    <Theme colorMode=\"inverted\">\n                        <Card>Inverted card</Card>\n                    </Theme>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Card, Example, MenuItem, Popover, Theme, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Theme/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Theme",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Theme/Theme.tsx",
-				"actualName": "Theme",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the theme to use, enables controlled mode",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"defaultName": {
+						"defaultValue": null,
+						"description": "Default name of the theme to use, enables uncontrolled mode",
+						"name": "defaultName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode to use",
+						"name": "colorMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode | \"inverted\"",
+							"value": [
+								{ "value": "\"light\"" },
+								{ "value": "\"dark\"" },
+								{ "value": "\"inverted\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2982,147 +15600,880 @@
 			"path": "./src/components/View/tests/View.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-view--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example title=\"Border is used to highlight the padding value\">\n        <Example.Item title=\"padding: 4\">\n            <View padding={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <View padding={6} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: 0\">\n            <View padding={0} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: vertical 2, horizontal 4\">\n            <View paddingInline={4} paddingBlock={2} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingTop: 4\">\n            <View paddingTop={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingBottom: 4\">\n            <View paddingBottom={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingStart: 4\">\n            <View paddingStart={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingEnd: 4\">\n            <View paddingEnd={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive padding:\",\n                \"[s] vertical 2, horizontal 4\",\n                \"[m+] vertical 4, horizontal 8\",\n            ]}\n        >\n            <View paddingInline={{ s: 4, m: 8 }} paddingBlock={{ s: 2, m: 4 }} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"responsive padding:\", \"[s] top 2, bottom 4\", \"[m+] top 4, bottom 0, start: 8\"]}\n        >\n            <View\n                paddingTop={{ s: 2, m: 4 }}\n                paddingBottom={{ s: 4, m: 0 }}\n                paddingStart={{ s: 0, m: 8 }}\n                borderColor=\"neutral\"\n            >\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"nested padding, child view should have no horizontal padding\">\n            <View paddingStart={4} borderColor=\"neutral\">\n                <View borderColor=\"primary\" paddingBlock={4}>\n                    <Placeholder />\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example title=\"Item 1 is another component, Item 2 is View.Item, Item 3 is text\">\n        <Example.Item title=\"direction: column as default\">\n            <View gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <View gap={3} direction=\"column\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column-reverse\">\n            <View gap={3} direction=\"column-reverse\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row\">\n            <View gap={3} direction=\"row\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row-reverse\">\n            <View gap={3} direction=\"row-reverse\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"responsive direction\", \"[s] column-reverse\", \"[m] row-reverse\", \"[l+] row\"]}\n        >\n            <View direction={{ s: \"column-reverse\", m: \"row-reverse\", l: \"row\" }} gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 4, direction: row\">\n            <View direction=\"row\" gap={4} divided>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n                <Placeholder>Item 3</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 0, direction: row\">\n            <View direction=\"row\" gap={0}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap, direction: row\", \"[s] 4\", \"[m+] 8\"]}>\n            <View direction=\"row\" gap={{ s: 4, m: 8 }}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 4, direction: column\">\n            <View gap={4}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 0, direction: column\">\n            <View gap={0}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap, direction: column\", \"[s] 4\", \"[m+] 8\"]}>\n            <View gap={{ s: 4, m: 8 }}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--divided",
 					"name": "divided",
 					"snippet": "const divided = () => (\n    <Example>\n        <Example.Item title=\"direction: row\">\n            <View divided direction=\"row\" gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <View divided gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive divided\", \"[s] direction: row\", \"[m+] direction: column\"]}>\n            <View divided direction={{ s: \"row\", m: \"column\" }} gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row, columns\">\n            <View divided gap={3} direction=\"row\">\n                <View.Item columns={2}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={8}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={2}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"with React.Fragment\">\n            <View direction=\"row\" gap={4} divided>\n                <Placeholder>Item 1</Placeholder>\n                <>\n                    <Placeholder>Item 2</Placeholder>\n                    <Placeholder>Item 3</Placeholder>\n                </>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example title=\"Removes side borders and border radius when applied\">\n        <Example.Item title=\"bleed: 4\">\n            <View bleed={4} padding={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive bleed\", \"[s] 4\", \"[m+] 0\"]}>\n            <View bleed={{ s: 4, m: 0 }} padding={4} borderRadius=\"small\" borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--wrap",
 					"name": "wrap",
 					"snippet": "const wrap = () => (\n    <Example>\n        <Example.Item title=\"wrap: false\">\n            <View direction=\"row\" wrap={false} gap={3}>\n                <Placeholder w={600} h={100} />\n                <Placeholder w={600} h={100} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: start, direction: row\">\n            <View align=\"start\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: center, direction: row\">\n            <View align=\"center\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: end, direction: row\">\n            <View align=\"end\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"align: stretch, direction: row\",\n                \"2nd item is stretched based on the 1st item height\",\n            ]}\n        >\n            <View align=\"stretch\" direction=\"row\" gap={3}>\n                <Placeholder h={100} />\n                <Placeholder h=\"auto\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: baseline, direction: row\">\n            <View align=\"baseline\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Text variant=\"title-6\">Content</Text>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"align: start, direction: column\">\n            <View align=\"start\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: center, direction: column\">\n            <View align=\"center\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: end, direction: row\">\n            <View align=\"end\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"align: stretch, direction: column\",\n                \"1st item uses its own width, 2nd item is stretched to full width\",\n            ]}\n        >\n            <View align=\"stretch\" direction=\"column\" gap={3}>\n                <Placeholder w={100} />\n                <Placeholder w=\"auto\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--justify",
 					"name": "justify",
 					"snippet": "const justify = () => (\n    <Example>\n        <Example.Item title=\"justify: start, direction: row\">\n            <View justify=\"start\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: center, direction: row\">\n            <View justify=\"center\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: end, direction: row\">\n            <View justify=\"end\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: space-between, direction: row\">\n            <View justify=\"space-between\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"justify: start, direction: column, height: 200px\">\n            <View height=\"200px\" justify=\"start\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: center, direction: column, height: 200px\">\n            <View height=\"200px\" justify=\"center\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: end, direction: column, height: 200px\">\n            <View justify=\"end\" height=\"200px\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: space-between, direction: column, height: 200px\">\n            <View justify=\"space-between\" height=\"200px\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--text-align",
 					"name": "textAlign",
 					"snippet": "const textAlign = () => (\n    <Example>\n        <Example.Item title=\"textAlign: start\">\n            <View textAlign=\"start\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: center\">\n            <View textAlign=\"center\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: end\">\n            <View textAlign=\"end\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: [s] start, [m+] end\">\n            <View textAlign={{ s: \"start\", m: \"end\" }}>Content</View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"height: 100px, width: 100px\">\n            <View backgroundColor=\"neutral-faded\" height=\"100px\" width=\"100px\" />\n        </Example.Item>\n        <Example.Item title=\"height: 25, width: 25\">\n            <View backgroundColor=\"neutral-faded\" height={25} width={25} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive height and width\",\n                \"[s] height: 25, width: 25\",\n                \"[m+] height: 200px, width: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                height={{ s: 25, m: \"200px\" }}\n                width={{ s: 25, m: \"200px\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "ratio",
+					"id": "utility-components-view--ratio",
+					"name": "aspectRatio",
 					"snippet": "const ratio = () => (\n    <Example>\n        <Example.Item title=\"ratio: 16 / 9\">\n            <View backgroundColor=\"neutral-faded\" aspectRatio={16 / 9} width=\"200px\" />\n        </Example.Item>\n        <Example.Item title={[\"responsive ratio\", \"[s] 1/1\", \"[m+] 16/9\"]}>\n            <View backgroundColor=\"neutral-faded\" aspectRatio={{ s: 1, m: 16 / 9 }} width=\"200px\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "maxSize",
+					"id": "utility-components-view--max-size",
+					"name": "width, height, maxWidth, maxHeight",
 					"snippet": "const maxSize = () => (\n    <Example>\n        <Example.Item title=\"maxHeight: 150px, maxWidth: 150px, height: 300px\">\n            <View backgroundColor=\"neutral-faded\" maxHeight=\"150px\" maxWidth=\"150px\" height=\"300px\" />\n        </Example.Item>\n        <Example.Item title=\"maxHeight: 25, maxWidth: 25, height: 50\">\n            <View backgroundColor=\"neutral-faded\" maxHeight={25} maxWidth={25} height={50} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive maxHeight and maxWidth, height: 300\",\n                \"[s] maxHeight: 25, maxWidth: 25\",\n                \"[m+] maxHeight: 200px, maxWidth: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                maxHeight={{ s: 25, m: \"200px\" }}\n                maxWidth={{ s: 25, m: \"200px\" }}\n                height=\"300px\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "minSize",
+					"id": "utility-components-view--min-size",
+					"name": "width, height, minWidth, minHeight",
 					"snippet": "const minSize = () => (\n    <Example>\n        <Example.Item title=\"minHeight: 150px, minWidth: 150px, height: 50px, width: 50px\">\n            <View\n                backgroundColor=\"neutral-faded\"\n                minHeight=\"150px\"\n                minWidth=\"150px\"\n                height=\"50px\"\n                width=\"50px\"\n            />\n        </Example.Item>\n        <Example.Item title=\"minHeight: 25, minWidth: 25, height: 5, width: 5\">\n            <View backgroundColor=\"neutral-faded\" minHeight={25} minWidth={25} height={5} width={5} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive minHeight and minWidth, height: 50px, width: 50px\",\n                \"[s] minHeight: 25, minWidth: 25\",\n                \"[m+] minHeight: 200px, minWidth: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                minHeight={{ s: 25, m: \"200px\" }}\n                minWidth={{ s: 25, m: \"200px\" }}\n                height=\"50px\"\n                width=\"50px\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "background",
+					"id": "utility-components-view--background",
+					"name": "backgroundColor",
 					"snippet": "const background = () => (\n    <Example title=\"border is used to highlight the backround value when it's similar to the page background, text color changes based on the background\">\n        <Example.Item title=\"bg: page\">\n            <View backgroundColor=\"page\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: page-faded\">\n            <View backgroundColor=\"page-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: disabled\">\n            <View backgroundColor=\"disabled\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: disabled-faded\">\n            <View backgroundColor=\"disabled-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-base\">\n            <View backgroundColor=\"elevation-base\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-raised\">\n            <View backgroundColor=\"elevation-raised\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-overlay\">\n            <View backgroundColor=\"elevation-overlay\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: neutral\">\n            <View backgroundColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: neutral-faded\">\n            <View backgroundColor=\"neutral-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: primary\">\n            <View backgroundColor=\"primary\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: primary-faded\">\n            <View backgroundColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: critical\">\n            <View backgroundColor=\"critical\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: critical-faded\">\n            <View backgroundColor=\"critical-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: warning\">\n            <View backgroundColor=\"warning\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: warning-faded\">\n            <View backgroundColor=\"warning-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: positive\">\n            <View backgroundColor=\"positive\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: positive-faded\">\n            <View backgroundColor=\"positive-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--border-color",
 					"name": "borderColor",
 					"snippet": "const borderColor = () => (\n    <Example>\n        <Example.Item title=\"border: neutral\">\n            <View borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: neutral-faded\">\n            <View borderColor=\"neutral-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: primary\">\n            <View borderColor=\"primary\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: primary-faded\">\n            <View borderColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: critical\">\n            <View borderColor=\"critical\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: critical-faded\">\n            <View borderColor=\"critical-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: warning\">\n            <View borderColor=\"warning\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: warning-faded\">\n            <View borderColor=\"warning-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: positive\">\n            <View borderColor=\"positive\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: positive-faded\">\n            <View borderColor=\"positive-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: transparent, background: primary-faded\">\n            <View borderColor=\"transparent\" backgroundColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive\", \"[s] primary\", \"[m+] neutral\"]}>\n            <View borderColor={{ s: \"primary\", m: \"neutral\" }} padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--border",
 					"name": "border",
 					"snippet": "const border = () => (\n    <Example>\n        <Example.Item title=\"border: true\">\n            <View border borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderTop: true\">\n            <View borderTop borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderBottom: true\">\n            <View borderBottom borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderStart: true\">\n            <View borderStart borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderEnd: true\">\n            <View borderEnd borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderInline: true\">\n            <View borderInline borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderBlock: true\">\n            <View borderBlock borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderTop: true, borderStart: true, \">\n            <View borderColor=\"neutral\" borderTop borderStart padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"responsive\",\n                \"[s] borderTop: true, borderStart: true\",\n                \"[m+] borderBottom: true, borderEnd: true\",\n            ]}\n        >\n            <View\n                borderColor=\"neutral\"\n                borderTop={{ s: true, m: false }}\n                borderStart={{ s: true, m: false }}\n                borderBottom={{ s: false, m: true }}\n                borderEnd={{ s: false, m: true }}\n                padding={4}\n            >\n                Content\n            </View>\n        </Example.Item>\n\n        <div style={{ height: 100 }} />\n    </Example>\n);"
 				},
 				{
-					"name": "radius",
+					"id": "utility-components-view--radius",
+					"name": "borderRadius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius: small\">\n            <View borderRadius=\"small\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: medium\">\n            <View borderRadius=\"medium\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: large\">\n            <View borderRadius=\"large\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: circular\">\n            <View borderRadius=\"circular\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--shadow",
 					"name": "shadow",
 					"snippet": "const shadow = () => (\n    <Example>\n        <Example.Item title=\"shadow: raised, radius: medium\">\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                shadow=\"raised\"\n                borderRadius=\"medium\"\n                backgroundColor=\"elevation-raised\"\n            />\n        </Example.Item>\n        <Example.Item title=\"shadow: overlay, radius: medium\">\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                shadow=\"overlay\"\n                borderRadius=\"medium\"\n                backgroundColor=\"elevation-overlay\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--overflow",
 					"name": "overflow",
 					"snippet": "const overflow = () => (\n    <Example>\n        <Example.Item\n            title={[\"overflow: hidden, radius: medium\", \"child background should have radius\"]}\n        >\n            <View height=\"100px\" width=\"100px\" shadow=\"raised\" borderRadius=\"medium\" overflow=\"hidden\">\n                <View backgroundColor=\"primary\" height=\"100%\" width=\"100%\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positioning",
+					"id": "utility-components-view--positioning",
+					"name": "position",
 					"snippet": "const positioning = () => (\n    <Example>\n        <Example.Item title=\"position: relative + absolute\">\n            <View borderColor=\"neutral\" position=\"relative\">\n                <Placeholder />\n                <View\n                    position=\"absolute\"\n                    insetTop={0}\n                    insetEnd={0}\n                    backgroundColor=\"critical\"\n                    zIndex={5}\n                    height={10}\n                    width={10}\n                />\n                <View\n                    position=\"absolute\"\n                    insetTop={0}\n                    insetEnd={0}\n                    backgroundColor=\"primary\"\n                    height={15}\n                    width={15}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: sticky\">\n            <div style={{ overflow: \"auto\", height: 100 }} tabIndex={0}>\n                <View position=\"sticky\" borderColor=\"primary\" insetTop={0}>\n                    Content\n                </View>\n                <Placeholder h={1000} />\n            </div>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive\", \"[s] position: absolute\", \"[m+]: position: relative\"]}>\n            <div style={{ overflow: \"auto\", height: 100, position: \"relative\" }} tabIndex={0}>\n                <View position={{ s: \"absolute\", m: \"relative\" }} borderColor=\"primary\" insetTop={0}>\n                    Content\n                </View>\n                <Placeholder h={1000} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--inset",
 					"name": "inset",
 					"snippet": "const inset = () => (\n    <Example>\n        <Example.Item title=\"inset: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" inset={4} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetTop: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" insetTop={4} height={10} width={10} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetStart: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetStart={4}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetEnd: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" insetEnd={4} height={10} width={10} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetBottom: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetBottom={4}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"responsive, [s] insetBottom: 4 [m+] insetEnd: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetBottom={{ s: 4, m: \"auto\" }}\n                    insetEnd={{ s: \"auto\", m: 4 }}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--animated",
 					"name": "animated",
 					"snippet": "const animated = () => {\n    const [background, setBackground] = React.useState<ViewProps[\"backgroundColor\"]>(\"neutral\");\n\n    return (\n        <View gap={3} align=\"start\">\n            <Button\n                onClick={() => setBackground((prev) => (prev === \"neutral\" ? \"primary\" : \"neutral\"))}\n            >\n                Change background\n            </Button>\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                backgroundColor={background}\n                align=\"center\"\n                justify=\"center\"\n                animated\n            >\n                Content\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "itemGapBefore",
+					"id": "utility-components-view--item-gap-before",
+					"name": "item, gapBefore",
 					"snippet": "const itemGapBefore = () => (\n    <Example>\n        <Example.Item title={[\"gap: 4, 3rd item gapBefore: 10, direction: row\", \"increased gap\"]}>\n            <View direction=\"row\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={10}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 4, direction: row\", \"reduced gap\"]}>\n            <View direction=\"row\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={4}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 0, direction: row\", \"removed gap\"]}>\n            <View direction=\"row\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={0}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"gap: 4, direction: row, 2nd item gap: auto\">\n            <View direction=\"row\" gap={4}>\n                <Placeholder w={200} />\n                <View.Item gapBefore=\"auto\">\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"gap: 4, 3rd item gapBefore: 10, direction: column\", \"increased gap\"]}>\n            <View direction=\"column\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={10}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 4, direction: column\", \"reduced gap\"]}>\n            <View direction=\"column\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={4}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 0, direction: column\", \"removed gap\"]}>\n            <View direction=\"column\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={0}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"gap: 4, direction: column, height: 200px, 2nd item gap: auto\">\n            <View height=\"200px\" gap={4}>\n                <Placeholder />\n                <View.Item gapBefore=\"auto\">\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"responsive item gap\",\n                \"gap: 4, direction: row\",\n                \"[s] 3rd item gapBefore: 10\",\n                \"[m+] 3rd item gapBefore: 0\",\n            ]}\n        >\n            <View direction=\"row\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={{ s: 10, m: 0 }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemGrow",
+					"id": "utility-components-view--item-grow",
+					"name": "item, grow",
 					"snippet": "const itemGrow = () => (\n    <Example>\n        <Example.Item title=\"direction: row, 2nd item grow\">\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column, height: 200px, 2nd item grow\">\n            <View direction=\"column\" gap={3} height=\"200px\">\n                <Placeholder />\n                <View.Item grow>\n                    <Placeholder h=\"100%\" />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row, 2nd item grow, applied to View\">\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View grow>\n                    <Placeholder />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive item grow, direction: row\",\n                \"[s] 2nd item grow\",\n                \"[m+] 2nd item doesn't grow\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View.Item grow={{ s: true, m: false }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive item grow, direction: column, height: 200px\",\n                \"[s] 2nd item grow\",\n                \"[m+] 2nd item doesn't grow\",\n            ]}\n        >\n            <View direction=\"column\" gap={3} height=\"200px\">\n                <Placeholder />\n                <View.Item grow={{ s: true, m: false }}>\n                    <Placeholder h=\"100%\" />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemColumns",
+					"id": "utility-components-view--item-columns",
+					"name": "item, columns",
 					"snippet": "const itemColumns = () => (\n    <Example>\n        <Example.Item title=\"columns 6, 6, gap: 0\">\n            <View direction=\"row\">\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 3, 9, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={3}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, 9, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive columns\", \"[s] columns 6, 6, 12, gap: 4\", \"[m+]: 4, 4, 4\"]}>\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={{ s: 6, m: 4 }}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 6, m: 4 }}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 12, m: 4 }}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, 9, gap: 4, 2nd item gapBefore: 20\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6} gapBefore={20}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemOrder",
+					"id": "utility-components-view--item-order",
+					"name": "item, order",
 					"snippet": "const itemOrder = () => (\n    <Example>\n        <Example.Item title=\"order: 1 3 2\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={4}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={4} order={1}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={4}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive order\", \"[s] 1 2 3\", \"[m+] 1 3 2\"]}>\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={4}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={4} order={{ s: 0, m: 1 }}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={4}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive order\",\n                \"[s]: 1 3 2, 2 is full width on second row\",\n                \"[m+]: 1 2 3, 2 has grow in the center of the first row\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <View.Item columns={{ s: 6, m: \"auto\" }}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item\n                    grow={{ s: false, m: true }}\n                    order={{ s: 1, m: 0 }}\n                    columns={{ s: 12, m: \"auto\" }}\n                >\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 6, m: \"auto\" }}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "hiddenItem",
+					"id": "utility-components-view--hidden-item",
+					"name": "composition, Hidden item",
 					"snippet": "const hiddenItem = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"[s] 2nd item: visible, grow, 3rd item: !grow\",\n                \"[m+] 2nd item: hidden, 2nd item divider: hidden, 3rd item: grow\",\n            ]}\n        >\n            <View direction=\"row\" divided gap={3}>\n                <Placeholder />\n                <Hidden hide={{ s: false, m: true }}>\n                    <View.Item grow key=\"3\">\n                        <Placeholder />\n                    </View.Item>\n                </Hidden>\n                <View.Item grow={{ s: false, m: true }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"[s] 2nd item: visible, grow, 3rd item: !grow\",\n                \"[m+] 2nd item: hidden, 2nd item: grow doesn't push 3rd item, 3rd item: grow\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Placeholder />\n                <Hidden hide={{ s: false, m: true }}>\n                    <View.Item grow>\n                        <Placeholder />\n                    </View.Item>\n                </Hidden>\n                <View.Item grow={{ s: false, m: true }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "keys",
+					"id": "utility-components-view--keys",
+					"name": "item, key",
 					"snippet": "const keys = () => {\n    const toggle = useToggle();\n\n    return (\n        <View gap={2}>\n            <Button onClick={() => toggle.toggle()}>Toggle</Button>\n            <View.Item>Item 1</View.Item>\n            {toggle.active && <KeyItem>Item 2</KeyItem>}\n            <KeyItem>Item 3</KeyItem>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "nestedGaps",
+					"id": "utility-components-view--nested-gaps",
+					"name": "composition, nested gap",
 					"snippet": "const nestedGaps = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"direction: column, gap: 10\",\n                \"Child 1: direction: column, gap: 2\",\n                \"Child 2: direction column, gap: 6\",\n                \"Child 3: gapBefore: 0\",\n                \"Child 3 view: direction: row, gap: 2\",\n            ]}\n        >\n            <View gap={10}>\n                <View gap={2}>\n                    <Placeholder>Child 1</Placeholder>\n                    <Placeholder>Child 1</Placeholder>\n                </View>\n\n                <View gap={6}>\n                    <Placeholder>Child 2</Placeholder>\n                    <Placeholder>Child 2</Placeholder>\n                </View>\n\n                <View.Item gapBefore={0}>\n                    <View direction=\"row\" gap={2}>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "utility-components-view--test-composition",
+					"name": "composition, edge cases",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item>\n            <View direction=\"row\" align=\"center\" gap={4} padding={4}>\n                <View width=\"80px\" height=\"60px\" backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n\n                <View direction=\"row\" align=\"center\" gap={1} grow>\n                    <View.Item shrink>\n                        <Text>Text (like Jeff's Puzzles)</Text>\n                    </View.Item>\n\n                    <View minWidth=\"auto\" grow>\n                        <Button size=\"small\" color=\"neutral\" icon={IconPlus} />\n                    </View>\n                </View>\n\n                <Button color=\"primary\" rounded>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"View.Item, MenuItem, Aspect ratio\",\n                \"ratio should increase height on viewport change\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <View.Item>\n                    <Placeholder />\n                </View.Item>\n                <MenuItem selected roundedCorners>\n                    Menu\n                </MenuItem>\n                <View.Item grow>\n                    <View aspectRatio={16 / 9}>\n                        <Placeholder h=\"100%\" />\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"Scrollable tabs inside View.Item with grow\">\n            <View direction=\"row\" align=\"center\" gap={3}>\n                <Placeholder />\n                <View.Item grow>\n                    <View padding={0} align=\"center\">\n                        <Tabs variant=\"pills\">\n                            <Tabs.List>\n                                <Tabs.Item value=\"1\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"2\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"3\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"4\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"5\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"6\">Very long item</Tabs.Item>\n                            </Tabs.List>\n                            {[1, 2, 3, 5, 6].map((i) => (\n                                <Tabs.Panel key={i} value={i.toString()} />\n                            ))}\n                        </Tabs>\n                    </View>\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"2nd item has grow, Avatar stays circle\">\n            <View direction=\"row\" gap={3}>\n                <Avatar initials=\"DB\" />\n                <View.Item grow>\n                    Veggies sunt bona vobis, proinde vos postulo esse magis grape pea sprouts horseradish\n                    courgette maize spinach prairie turnip jícama coriander quandong gourd broccoli seakale\n                    gumbo. Parsley corn lentil zucchini radicchio maize burdock avocado sea lettuce.\n                    Garbanzo tigernut earthnut pea fennel.\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"item gapBefore from parent doesn't affect the child view\",\n                \"columns should take full width\",\n            ]}\n        >\n            <View>\n                <View.Item gapBefore={20}>\n                    <View direction=\"row\" gap={4}>\n                        <View.Item columns={6}>\n                            <Placeholder />\n                        </View.Item>\n                        <View.Item columns={6}>\n                            <Placeholder />\n                        </View.Item>\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"View becomes flexbox if there is a child with grow\">\n            <View height=\"300px\" borderColor=\"neutral-faded\">\n                <View height=\"50px\" />\n                <View grow backgroundColor=\"neutral-faded\" padding={4}>\n                    Grow\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "asProp",
+					"id": "utility-components-view--as-prop",
+					"name": "as",
 					"snippet": "const asProp = () => (\n    <View as=\"ul\">\n        <View.Item as=\"li\">Content</View.Item>\n    </View>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-view--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <View className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </View>\n    </div>\n);"
 				},
 				{
-					"name": "itemClassName",
+					"id": "utility-components-view--item-class-name",
+					"name": "item className, attributes",
 					"snippet": "const itemClassName = () => (\n    <div data-testid=\"root\">\n        <View.Item className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </View.Item>\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Button, Example, Hidden, MenuItem, Placeholder, Tabs, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/View/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "View",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/View/View.tsx",
-				"actualName": "View",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"divided": {
+						"defaultValue": null,
+						"description": "Render a divider between each child",
+						"name": "divided",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Flex direction for the content",
+						"name": "direction",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Direction>" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between children, base unit token number multiplier",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"wrap": {
+						"defaultValue": null,
+						"description": "Flex wrap for the content",
+						"name": "wrap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Flex align-items for the content",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Flex justify-content for the content",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width style, literal string value or a base unit token number multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"aspectRatio": {
+						"defaultValue": null,
+						"description": "Aspect ratio style, represented as width / height",
+						"name": "aspectRatio",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height style, literal string value or a base unit token number multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Maximum width style, literal string value or a base unit token number multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"minHeight": {
+						"defaultValue": null,
+						"description": "Minimum height style, literal string value or a base unit token number multiplier",
+						"name": "minHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"minWidth": {
+						"defaultValue": null,
+						"description": "Minimum width style, literal string value or a base unit token number multiplier",
+						"name": "minWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Padding style for all sides, base unit token number multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingTop": {
+						"defaultValue": null,
+						"description": "Padding top, base unit token number multiplier",
+						"name": "paddingTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingBottom": {
+						"defaultValue": null,
+						"description": "Padding bottom, base unit token number multiplier",
+						"name": "paddingBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingStart": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "paddingStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingEnd": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "paddingEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingInline": {
+						"defaultValue": null,
+						"description": "Padding inline, base unit token number multiplier",
+						"name": "paddingInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingBlock": {
+						"defaultValue": null,
+						"description": "Padding block, base unit token number multiplier",
+						"name": "paddingBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margin and remove side borders, base unit token number multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"textAlign": {
+						"defaultValue": null,
+						"description": "Text align for the content",
+						"name": "textAlign",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<TextAlign>" }
+					},
+					"backgroundColor": {
+						"defaultValue": null,
+						"description": "Background color, based on the color tokens",
+						"name": "backgroundColor",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"critical-faded\" | \"warning\" | \"warning-faded\" | \"positive-faded\" | \"primary-faded\" | \"elevation-base\" | \"elevation-raised\" | \"elevation-overlay\" | \"page\" | \"page-faded\" | \"disabled-faded\" | \"brand\" | \"white\" | \"black\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"critical-faded\"" },
+								{ "value": "\"warning\"" },
+								{ "value": "\"warning-faded\"" },
+								{ "value": "\"positive-faded\"" },
+								{ "value": "\"primary-faded\"" },
+								{ "value": "\"elevation-base\"" },
+								{ "value": "\"elevation-raised\"" },
+								{ "value": "\"elevation-overlay\"" },
+								{ "value": "\"page\"" },
+								{ "value": "\"page-faded\"" },
+								{ "value": "\"disabled-faded\"" },
+								{ "value": "\"brand\"" },
+								{ "value": "\"white\"" },
+								{ "value": "\"black\"" }
+							]
+						}
+					},
+					"borderColor": {
+						"defaultValue": null,
+						"description": "Border color, based on the color tokens",
+						"name": "borderColor",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<BorderColor>" }
+					},
+					"border": {
+						"defaultValue": null,
+						"description": "Add border to all sides",
+						"name": "border",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderTop": {
+						"defaultValue": null,
+						"description": "Add border to the top side",
+						"name": "borderTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderBottom": {
+						"defaultValue": null,
+						"description": "Add border to the bottom side",
+						"name": "borderBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderStart": {
+						"defaultValue": null,
+						"description": "Add border to the inline start side",
+						"name": "borderStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderEnd": {
+						"defaultValue": null,
+						"description": "Add border to the inline end side",
+						"name": "borderEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderInline": {
+						"defaultValue": null,
+						"description": "Add border to the inline direction",
+						"name": "borderInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderBlock": {
+						"defaultValue": null,
+						"description": "Add border to the block direction",
+						"name": "borderBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Radius>" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Position style",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Position>" }
+					},
+					"inset": {
+						"defaultValue": null,
+						"description": "Inset style, base unit token number multiplier when used as a number",
+						"name": "inset",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetStart": {
+						"defaultValue": null,
+						"description": "Inset start, base unit token number multiplier when used as a number",
+						"name": "insetStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetEnd": {
+						"defaultValue": null,
+						"description": "Inset end, base unit token number multiplier when used as a number",
+						"name": "insetEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetTop": {
+						"defaultValue": null,
+						"description": "Inset top, base unit token number multiplier when used as a number",
+						"name": "insetTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetBottom": {
+						"defaultValue": null,
+						"description": "Inset bottom, base unit token number multiplier when used as a number",
+						"name": "insetBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"zIndex": {
+						"defaultValue": null,
+						"description": "z-index style",
+						"name": "zIndex",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"shadow": {
+						"defaultValue": null,
+						"description": "Shadow style, based on the shadow tokens",
+						"name": "shadow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Overflow style",
+						"name": "overflow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"auto\"",
+							"value": [{ "value": "\"hidden\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"animated": {
+						"defaultValue": null,
+						"description": "Add transition for the properties",
+						"name": "animated",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					},
+					"grow": {
+						"defaultValue": null,
+						"description": "Apply flex-grow, using it on View.Item applies additional styles on the parent View",
+						"name": "grow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"shrink": {
+						"defaultValue": null,
+						"description": "Apply flex-shrink",
+						"name": "shrink",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "View"
 			}
 		},
 		"hooks-useelementid": {
@@ -3131,7 +16482,8 @@
 			"path": "./src/hooks/tests/useElementId.stories.tsx",
 			"stories": [
 				{
-					"name": "id",
+					"id": "hooks-useelementid--id",
+					"name": "passed id",
 					"snippet": "const id = () => {\n    return <Component id=\"hey\" />;\n};"
 				}
 			],
@@ -3148,6 +16500,7 @@
 			"path": "./src/hooks/tests/useHandlerRef.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usehandlerref--base",
 					"name": "base",
 					"snippet": "const base = (args) => {\n    const [count, setCount] = React.useState(0);\n\n    // Creating a new handler on each render\n    const handleEffect = () => {\n        args.handleEffect(0);\n    };\n\n    return (\n        <View gap={4}>\n            <Button onClick={() => setCount((prev) => prev + 1)}>Increase count</Button>\n            <Component onEffect={handleEffect} count={count} />\n        </View>\n    );\n};"
 				}
@@ -3165,43 +16518,53 @@
 			"path": "./src/hooks/tests/useHotkeys.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usehotkeys--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const { checkHotkeyState } = useHotkeys({\n        \"shift + b + n\": () => console.log(\"pressed\"),\n        \"c + v\": () => console.log(\"c + v\"),\n        \"Meta + k\": () => console.log(\"meta + k\"),\n        \"Meta + f\": () => console.log(\"meta + f\"),\n        \"Meta + v\": () => console.log(\"meta + v\"),\n        \"Meta + b\": () => console.log(\"meta + b\"),\n        \"control + enter\": () => console.log(\"control + enter\"),\n        \"meta + enter\": () => console.log(\"meta + enter\"),\n        \"mod + enter\": () => console.log(\"mod + enter\"),\n        \"mod + ArrowRight\": () => console.log(\"right\"),\n        \"mod + ArrowUp\": () => console.log(\"top\"),\n        \"shift + ArrowRight\": () => console.log(\"right\"),\n        \"shift + ArrowUp\": () => console.log(\"top\"),\n        \"alt+shift+n\": () => console.log(\"alt+shift+n\"),\n        \"shift+alt+n\": () => console.log(\"shift+alt+n\"),\n        \"alt+shiftLeft+n\": () => console.log(\"alt+shiftLeft+n\"),\n    });\n    const active = checkHotkeyState(\"shift + b + n\");\n    const shiftActive = checkHotkeyState(\"shift\");\n    const bActive = checkHotkeyState(\"b\");\n    const nActive = checkHotkeyState(\"n\");\n\n    return (\n        <View\n            animated\n            gap={2}\n            direction=\"row\"\n            backgroundColor={active ? \"positive-faded\" : undefined}\n            padding={2}\n            borderRadius=\"small\"\n        >\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={shiftActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={shiftActive ? undefined : \"raised\"}\n            >\n                Shift\n            </View>\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={bActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={bActive ? undefined : \"raised\"}\n            >\n                b\n            </View>\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={nActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={nActive ? undefined : \"raised\"}\n            >\n                n\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "singleKey",
+					"id": "hooks-usehotkeys--single-key",
+					"name": "single key",
 					"snippet": "const singleKey = (args) => <Component hotkeys={{ a: args.handleHotkey }} />;"
 				},
 				{
-					"name": "modKey",
+					"id": "hooks-usehotkeys--mod-key",
+					"name": "mod key",
 					"snippet": "const modKey = (args) => <Component hotkeys={{ mod: args.handleHotkey }} />;"
 				},
 				{
-					"name": "modKeyHold",
+					"id": "hooks-usehotkeys--mod-key-hold",
+					"name": "mod key on hold",
 					"snippet": "const modKeyHold = (args) => <Component hotkeys={{ \"Meta + b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyList",
+					"id": "hooks-usehotkeys--key-list",
+					"name": "key list",
 					"snippet": "const keyList = (args) => <Component hotkeys={{ \"a,b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombination",
+					"id": "hooks-usehotkeys--key-combination",
+					"name": "key combination",
 					"snippet": "const keyCombination = (args) => <Component hotkeys={{ \"a+b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationFormat",
+					"id": "hooks-usehotkeys--key-combination-format",
+					"name": "key combination without formatting",
 					"snippet": "const keyCombinationFormat = (args) => <Component hotkeys={{ \"A  + b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationOrder",
+					"id": "hooks-usehotkeys--key-combination-order",
+					"name": "key combination without order",
 					"snippet": "const keyCombinationOrder = (args) => <Component hotkeys={{ \"b+a\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationMoreThanRequired",
+					"id": "hooks-usehotkeys--key-combination-more-than-required",
+					"name": "key combination, more keys pressed",
 					"snippet": "const keyCombinationMoreThanRequired = (args) => <Component hotkeys={{ \"z + x\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "optionModified",
+					"id": "hooks-usehotkeys--option-modified",
+					"name": "modified with alt/option",
 					"snippet": "const optionModified = (args) => (\n    <Component hotkeys={{ \"alt+n\": args.handleHotkeyModified, \"alt+shift\": args.handleHotkey }} />\n);"
 				}
 			],
@@ -3218,22 +16581,27 @@
 			"path": "./src/hooks/tests/useKeyboardArrowNavigation.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usekeyboardarrownavigation--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "horizontal",
+					"id": "hooks-usekeyboardarrownavigation--horizontal",
+					"name": "orientation: horizontal",
 					"snippet": "const horizontal = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, orientation: \"horizontal\" });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "vertical",
+					"id": "hooks-usekeyboardarrownavigation--vertical",
+					"name": "orientation: vertical",
 					"snippet": "const vertical = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, orientation: \"vertical\" });\n\n    return (\n        <View gap={2} direction=\"column\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-usekeyboardarrownavigation--circular",
 					"name": "circular",
 					"snippet": "const circular = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, circular: true });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-usekeyboardarrownavigation--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, disabled: true });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				}
@@ -3249,7 +16617,13 @@
 			"id": "hooks-usekeyboardmode",
 			"name": "useKeyboardMode",
 			"path": "./src/hooks/tests/useKeyboardMode.stories.tsx",
-			"stories": [{ "name": "base", "snippet": "const base = () => <Component />;" }],
+			"stories": [
+				{
+					"id": "hooks-usekeyboardmode--base",
+					"name": "base",
+					"snippet": "const base = () => <Component />;"
+				}
+			],
 			"import": "import { Button, View } from \"reshaped\";",
 			"jsDocTags": {},
 			"error": {
@@ -3263,19 +16637,23 @@
 			"path": "./src/hooks/tests/useOnClickOutside.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-useonclickoutside--base",
 					"name": "base",
 					"snippet": "const base = (args) => {\n    const ref = React.useRef(null);\n    const [target, setTarget] = React.useState<\"inside\" | \"outside\" | null>(null);\n\n    useOnClickOutside([ref], () => {\n        args.handleOutsideClick();\n        setTarget(\"outside\");\n    });\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }} onClick={() => setTarget(\"inside\")}>\n                Trigger\n            </Button>\n            {target && `Clicked ${target}`}\n        </View>\n    );\n};"
 				},
 				{
-					"name": "refs",
+					"id": "hooks-useonclickoutside--refs",
+					"name": "multiple refs",
 					"snippet": "const refs = (args) => {\n    const ref = React.useRef(null);\n    const ref2 = React.useRef(null);\n\n    useOnClickOutside([ref, ref2], () => {\n        args.handleOutsideClick();\n    });\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }}>Trigger</Button>\n            <Button attributes={{ ref: ref2 }}>Trigger 2</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-useonclickoutside--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = (args) => {\n    const ref = React.useRef(null);\n\n    useOnClickOutside(\n        [ref],\n        () => {\n            args.handleOutsideClick();\n        },\n        {\n            disabled: true,\n        }\n    );\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }}>Trigger</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "deps",
+					"id": "hooks-useonclickoutside--deps",
+					"name": "test: handler uses latest state",
 					"snippet": "const deps = (args) => {\n    const ref = React.useRef(null);\n    const [count, setCount] = React.useState(0);\n\n    useOnClickOutside([ref], () => {\n        args.handleOutsideClick({ count });\n    });\n\n    return (\n        <Button attributes={{ ref }} onClick={() => setCount((prev) => prev + 1)}>\n            Trigger\n        </Button>\n    );\n};"
 				}
 			],
@@ -3290,7 +16668,13 @@
 			"id": "hooks-usertl",
 			"name": "useRTL",
 			"path": "./src/hooks/tests/useRTL.stories.tsx",
-			"stories": [{ "name": "setRTL", "snippet": "const setRTL = () => <Component />;" }],
+			"stories": [
+				{
+					"id": "hooks-usertl--set-rtl",
+					"name": "setRTL",
+					"snippet": "const setRTL = () => <Component />;"
+				}
+			],
 			"import": "",
 			"jsDocTags": {},
 			"error": {
@@ -3304,10 +16688,12 @@
 			"path": "./src/hooks/tests/useResponsiveClientValue.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-useresponsiveclientvalue--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const value = useResponsiveClientValue<ViewProps[\"backgroundColor\"]>({\n        s: \"neutral\",\n        m: \"critical\",\n        l: \"positive\",\n    });\n\n    return <View width={25} height={25} backgroundColor={value} />;\n};"
 				},
 				{
+					"id": "hooks-useresponsiveclientvalue--boolean",
 					"name": "boolean",
 					"snippet": "const boolean = () => {\n    const value = useResponsiveClientValue<boolean>({\n        s: true,\n        l: false,\n    });\n\n    return <div>{value?.toString()}</div>;\n};"
 				}
@@ -3325,19 +16711,23 @@
 			"path": "./src/hooks/tests/useScrollLock.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usescrolllock--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock();\n\n    return (\n        <React.Fragment>\n            <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n            <div style={{ height: \"150vh\" }} />\n        </React.Fragment>\n    );\n};"
 				},
 				{
-					"name": "origin",
+					"id": "hooks-usescrolllock--origin",
+					"name": "originRef",
 					"snippet": "const origin = () => {\n    const originRef = React.useRef<HTMLDivElement>(null);\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock({ originRef });\n\n    return (\n        <View overflow=\"auto\" height={25} attributes={{ ref: originRef, \"data-testid\": \"root\" }}>\n            <View height={50} padding={4} backgroundColor=\"neutral-faded\" borderRadius=\"medium\">\n                <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "container",
+					"id": "hooks-usescrolllock--container",
+					"name": "containerRef",
 					"snippet": "const container = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock({ containerRef });\n\n    return (\n        <View height={25} attributes={{ ref: containerRef, \"data-testid\": \"root\" }}>\n            <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testContainerAsync",
+					"id": "hooks-usescrolllock--test-container-async",
+					"name": "test: containerRef locked count",
 					"snippet": "const testContainerAsync = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const globalLock = useScrollLock();\n    const scopedLock = useScrollLock({ containerRef });\n\n    return (\n        <Example>\n            <Example.Item title=\"calling regular lock and lock with a container only requires a single unlock to remove overflow\">\n                <View attributes={{ ref: containerRef }} gap={4} direction=\"row\">\n                    <Button\n                        onClick={globalLock.scrollLocked ? globalLock.unlockScroll : globalLock.lockScroll}\n                    >\n                        Toggle\n                    </Button>\n                    <Button\n                        onClick={scopedLock.scrollLocked ? scopedLock.unlockScroll : scopedLock.lockScroll}\n                    >\n                        Toggle\n                    </Button>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
@@ -3354,14 +16744,17 @@
 			"path": "./src/hooks/tests/useToggle.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usetoggle--toggle",
 					"name": "toggle",
 					"snippet": "const toggle = () => {\n    const { toggle, active } = useToggle();\n\n    return (\n        <Button onClick={() => toggle()} attributes={{ \"data-active\": active }}>\n            {active ? \"Deactivate\" : \"Activate\"}\n        </Button>\n    );\n};"
 				},
 				{
+					"id": "hooks-usetoggle--activate",
 					"name": "activate",
 					"snippet": "const activate = () => {\n    const { activate, active } = useToggle();\n\n    return (\n        <React.Fragment>\n            <Button onClick={activate} attributes={{ \"data-active\": active }}>\n                Activate\n            </Button>\n        </React.Fragment>\n    );\n};"
 				},
 				{
+					"id": "hooks-usetoggle--deactivate",
 					"name": "deactivate",
 					"snippet": "const deactivate = () => {\n    const { deactivate, active } = useToggle(true);\n\n    return (\n        <Button onClick={deactivate} attributes={{ \"data-active\": active }}>\n            Deactivate\n        </Button>\n    );\n};"
 				}
@@ -3379,39 +16772,48 @@
 			"path": "./src/utilities/a11y/tests/TrapFocus.stories.tsx",
 			"stories": [
 				{
-					"name": "modeDialog",
+					"id": "utilities-trapfocus--mode-dialog",
+					"name": "mode: dialog",
 					"snippet": "const modeDialog = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, { mode: \"dialog\" });\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\"mode: dialog\", \"tab navigation, always stays inside until released\"]}\n            >\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View.Item>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeActionMenu",
+					"id": "utilities-trapfocus--mode-action-menu",
+					"name": "mode: action-menu",
 					"snippet": "const modeActionMenu = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"action-menu\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: action-menu\",\n                    \"up/down arrow navigation, tab and shift+tab release the focus and follows natural tab order\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeActionBar",
+					"id": "utilities-trapfocus--mode-action-bar",
+					"name": "mode: action-bar",
 					"snippet": "const modeActionBar = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"action-bar\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: action-bar\",\n                    \"left/right arrow navigation, tab and shift+tab release the focus and follows natural tab order\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeContentMenu",
+					"id": "utilities-trapfocus--mode-content-menu",
+					"name": "mode: content-menu",
 					"snippet": "const modeContentMenu = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"content-menu\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: content-menu\",\n                    \"tab navigation, tabbing outside the content will trigger the release\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utilities-trapfocus--include-trigger",
 					"name": "includeTrigger",
 					"snippet": "const includeTrigger = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n            includeTrigger: true,\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utilities-trapfocus--initial-focus-el",
 					"name": "initialFocusEl",
 					"snippet": "const initialFocusEl = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const initialFocusRef = React.useRef<HTMLButtonElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n            initialFocusEl: initialFocusRef.current,\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View\n                            gap={4}\n                            direction=\"row\"\n                            padding={4}\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            attributes={{ ref: rootRef }}\n                        >\n                            <Button onClick={() => {}}>Action 1</Button>\n                            <Button onClick={() => {}} attributes={{ ref: initialFocusRef }}>\n                                Action 2\n                            </Button>\n                            <Button onClick={() => {}}>Action 3</Button>\n                            <Button onClick={trapToggle.deactivate}>Release</Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "focusableElements",
+					"id": "utilities-trapfocus--focusable-elements",
+					"name": "test: focusable elements",
 					"snippet": "const focusableElements = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current);\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title=\"test with all types of focusable elements\">\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={trapToggle.activate}>Activate</Button>\n                    </View.Item>\n\n                    {trapToggle.active && (\n                        <View\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            padding={4}\n                            gap={4}\n                            attributes={{ ref: rootRef }}\n                            align=\"start\"\n                        >\n                            <Link href=\"#\" attributes={{ \"data-testid\": \"test-link\" }}>\n                                Link\n                            </Link>\n\n                            <TextField\n                                name=\"input\"\n                                placeholder=\"Input\"\n                                inputAttributes={{ \"data-testid\": \"test-text-field\" }}\n                            />\n\n                            <TextArea name=\"textarea\" inputAttributes={{ \"data-testid\": \"test-text-area\" }} />\n\n                            <Select\n                                name=\"select\"\n                                options={[\n                                    { label: \"Option 1\", value: \"1\" },\n                                    { label: \"Option 2\", value: \"2\" },\n                                ]}\n                                inputAttributes={{ \"data-testid\": \"test-select\" }}\n                            />\n\n                            <RadioGroup name=\"radio\">\n                                <Radio value=\"1\" inputAttributes={{ \"data-testid\": \"test-radio-1\" }}>\n                                    Option 1\n                                </Radio>\n                                <Radio value=\"2\" inputAttributes={{ \"data-testid\": \"test-radio-2\" }}>\n                                    Option 2\n                                </Radio>\n                            </RadioGroup>\n\n                            <Editor />\n\n                            <div tabIndex={0} role=\"button\" data-testid=\"test-tabindex\">\n                                div with tabIndex\n                            </div>\n\n                            <div style={{ display: \"none\" }}>\n                                <Button onClick={() => {}} attributes={{ \"data-testid\": \"test-hidden-button\" }}>\n                                    Hidden\n                                </Button>\n                            </div>\n\n                            <Button\n                                onClick={() => {}}\n                                attributes={{ tabIndex: -1, \"data-testid\": \"test-button-negative-tabindex\" }}\n                            >\n                                Excluded\n                            </Button>\n\n                            <input type=\"hidden\" data-testid=\"test-input-hidden\" />\n\n                            <Button\n                                onClick={trapToggle.deactivate}\n                                attributes={{ \"data-testid\": \"test-button\" }}\n                            >\n                                Release button\n                            </Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "nested",
+					"id": "utilities-trapfocus--nested",
+					"name": "test: nested",
 					"snippet": "const nested = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const innerRootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n    const innerTrapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    React.useEffect(() => {\n        if (!innerTrapToggle.active) return;\n        if (!innerRootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(innerRootRef.current, {\n            mode: \"dialog\",\n        });\n\n        return () => trapFocus.release();\n    }, [innerTrapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"nested, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View gap={4}>\n                            <View\n                                gap={4}\n                                direction=\"row\"\n                                padding={4}\n                                backgroundColor=\"neutral-faded\"\n                                borderRadius=\"medium\"\n                                attributes={{ ref: rootRef }}\n                            >\n                                <Button onClick={() => {}}>Action</Button>\n                                <Button onClick={innerTrapToggle.activate}>Inner trap focus</Button>\n                                <Button onClick={trapToggle.deactivate}>Release</Button>\n                            </View>\n\n                            {innerTrapToggle.active && (\n                                <View\n                                    gap={4}\n                                    direction=\"row\"\n                                    padding={4}\n                                    backgroundColor=\"neutral-faded\"\n                                    borderRadius=\"medium\"\n                                    attributes={{ ref: innerRootRef }}\n                                >\n                                    <Button onClick={() => {}}>Action</Button>\n                                    <Button onClick={innerTrapToggle.deactivate}>Release</Button>\n                                </View>\n                            )}\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "mutationObserver",
+					"id": "utilities-trapfocus--mutation-observer",
+					"name": "test: mutation observer",
 					"snippet": "const mutationObserver = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n    const [mutated, setMutated] = React.useState(false);\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n        });\n\n        setTimeout(() => {\n            setMutated(true);\n        }, 50);\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View\n                            gap={4}\n                            direction=\"row\"\n                            padding={4}\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            attributes={{ ref: rootRef }}\n                        >\n                            {!mutated && (\n                                <>\n                                    <Button onClick={() => {}}>Action 1</Button>\n                                    <Button onClick={() => {}}>Action 2</Button>\n                                </>\n                            )}\n                            <Button onClick={() => {}}>Action 3</Button>\n                            <Button onClick={trapToggle.deactivate}>Release</Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
@@ -3428,15 +16830,35 @@
 			"path": "./src/components/_private/Portal/tests/Portal.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "internal-portal--base",
+					"name": "Base",
 					"snippet": "const base = () => {\n\tconst ref = React.useRef<HTMLDivElement>(null);\n\tconst [mounted, setMounted] = React.useState(false);\n\n\tReact.useEffect(() => {\n\t\tsetMounted(true);\n\t}, []);\n\n\treturn (\n\t\t<>\n\t\t\t<div style={{ border: \"2px solid #333\", padding: 16 }}>\n\t\t\t\tApp\n\t\t\t\t{mounted && <Portal targetRef={ref}>Ported to green</Portal>}\n\t\t\t</div>\n\t\t\t<div ref={ref} style={{ border: \"2px solid green\", padding: 16 }} />\n\t\t</>\n\t);\n};"
 				}
 			],
 			"import": "import { Portal } from \"reshaped\";",
 			"jsDocTags": {},
-			"error": {
-				"name": "No component definition found",
-				"message": "File: /Users/shilman/projects/design-systems/reshaped/src/components/_private/Portal/index.ts\nError:\nNo suitable component definition found.\nYou can debug your component file in this playground: https://react-docgen.dev/playground\nCode:\nimport Portal, { PortalScope } from \"./Portal\";\n\nconst PortalRoot = Portal as typeof Portal & {\n\tScope: typeof PortalScope;\n};\n\nPortalRoot.Scope = PortalScope;\n\nexport default PortalRoot;\nexport type { Props as PortalProps } from \"./Portal.types\";\n\n\nFile: /Users/shilman/projects/design-systems/reshaped/src/components/_private/Portal/Portal.types.ts\nError:\nNo suitable component definition found.\nYou can debug your component file in this playground: https://react-docgen.dev/playground\nCode:\nimport React from \"react\";\n\nexport type Props = {\n\tchildren?: React.ReactNode;\n\ttargetRef?: React.RefObject<HTMLElement | ShadowRoot | null>;\n};\n\nexport type ScopeProps<T extends HTMLElement> = {\n\tchildren: (ref: React.RefObject<T | null>) => React.ReactNode;\n};\n\nexport type Context = {\n\tscopeRef: React.RefObject<HTMLElement | null>;\n};\n"
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/_private/Portal/index.ts",
+				"description": "",
+				"displayName": "Portal",
+				"methods": [],
+				"props": {
+					"targetRef": {
+						"defaultValue": null,
+						"description": "",
+						"name": "targetRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/_private/Portal/Portal.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | ShadowRoot | null>" }
+					}
+				},
+				"exportName": "Portal"
 			}
 		},
 		"internal-usedrag": {
@@ -3444,24 +16866,33 @@
 			"name": "useDrag",
 			"path": "./src/hooks/tests/useDrag.stories.tsx",
 			"stories": [
-				{ "name": "base", "snippet": "const base = () => <Example />;" },
 				{
-					"name": "mouseEvents",
+					"id": "internal-usedrag--base",
+					"name": "base",
+					"snippet": "const base = () => <Example />;"
+				},
+				{
+					"id": "internal-usedrag--mouse-events",
+					"name": "onDrag, mouse events",
 					"snippet": "const mouseEvents = () => {\n    return <Demo onDrag={fn()} />;\n};"
 				},
 				{
-					"name": "touchEvents",
+					"id": "internal-usedrag--touch-events",
+					"name": "onDrag, touch events",
 					"snippet": "const touchEvents = () => {\n    return <Demo onDrag={fn()} />;\n};"
 				},
 				{
-					"name": "orientationHorizontal",
+					"id": "internal-usedrag--orientation-horizontal",
+					"name": "orientation horizontal",
 					"snippet": "const orientationHorizontal = () => {\n    return <Demo onDrag={fn()} orientation=\"horizontal\" />;\n};"
 				},
 				{
-					"name": "orientationVertical",
+					"id": "internal-usedrag--orientation-vertical",
+					"name": "orientation vertical",
 					"snippet": "const orientationVertical = () => {\n    return <Demo onDrag={fn()} orientation=\"vertical\" />;\n};"
 				},
 				{
+					"id": "internal-usedrag--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => {\n    return <Demo onDrag={fn()} disabled />;\n};"
 				}
@@ -3479,7 +16910,8 @@
 			"path": "./src/tests/ShadowDOM.stories.tsx",
 			"stories": [
 				{
-					"name": "behavior",
+					"id": "internal-shadowdom--behavior",
+					"name": "Behavior",
 					"snippet": "const behavior = () => (\n\t<Example>\n\t\t<Example.Item title=\"base\">\n\t\t\t<Component />\n\t\t</Example.Item>\n\t</Example>\n);"
 				}
 			],
@@ -3496,30 +16928,94 @@
 			"path": "./src/tests/themes.stories.tsx",
 			"stories": [
 				{
-					"name": "test",
+					"id": "internal-themes--test",
+					"name": "Test",
 					"snippet": "const test = () => {\n\tconst { colorMode } = useTheme();\n\tconst [activeColor, setColor] = useState(colors[0]);\n\tconst [theme, setTheme] = useState(\"\");\n\tconst [algo, setAlgo] = useState<\"wcag\" | \"apca\">(\"wcag\");\n\n\tuseLayoutEffect(() => {\n\t\tsetTheme(\n\t\t\tgetThemeCSS(\n\t\t\t\t\"test\",\n\t\t\t\t{\n\t\t\t\t\tcolor: generateThemeColors({\n\t\t\t\t\t\tprimary: activeColor === colors[0] ? undefined : activeColor,\n\t\t\t\t\t}),\n\t\t\t\t},\n\t\t\t\t{\n\t\t\t\t\tcolorContrastAlgorithm: algo,\n\t\t\t\t}\n\t\t\t)\n\t\t);\n\t}, [activeColor, algo]);\n\n\treturn (\n\t\t<>\n\t\t\t<style>{theme}</style>\n\t\t\t<Theme name=\"test\">\n\t\t\t\t<View gap={4}>\n\t\t\t\t\t<View direction=\"row\" align=\"center\" gap={4}>\n\t\t\t\t\t\t{colors.map((color) => {\n\t\t\t\t\t\t\tconst hex = colorMode === \"dark\" && color === \"#000000\" ? \"#ffffff\" : color;\n\n\t\t\t\t\t\t\treturn (\n\t\t\t\t\t\t\t\t<Actionable key={color} onClick={() => setColor(color)} borderRadius=\"inherit\">\n\t\t\t\t\t\t\t\t\t<View\n\t\t\t\t\t\t\t\t\t\twidth={5}\n\t\t\t\t\t\t\t\t\t\theight={5}\n\t\t\t\t\t\t\t\t\t\tborderRadius=\"circular\"\n\t\t\t\t\t\t\t\t\t\tattributes={{\n\t\t\t\t\t\t\t\t\t\t\tstyle: {\n\t\t\t\t\t\t\t\t\t\t\t\ttransition: `box-shadow var(--rs-duration-fast) var(--rs-easing-standard)`,\n\t\t\t\t\t\t\t\t\t\t\t\tbackground: hex,\n\t\t\t\t\t\t\t\t\t\t\t\tboxShadow:\n\t\t\t\t\t\t\t\t\t\t\t\t\tcolor === activeColor\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t? `0 0 0 3px var(--rs-color-background-elevation-base), 0 0 0 5px ${hex}`\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t: undefined,\n\t\t\t\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t\t\t\t}}\n\t\t\t\t\t\t\t\t\t/>\n\t\t\t\t\t\t\t\t</Actionable>\n\t\t\t\t\t\t\t);\n\t\t\t\t\t\t})}\n\t\t\t\t\t\t<View.Item gapBefore=\"auto\">\n\t\t\t\t\t\t\t<Switch name=\"algo\" onChange={(args) => setAlgo(args.checked ? \"apca\" : \"wcag\")}>\n\t\t\t\t\t\t\t\tUse APCA\n\t\t\t\t\t\t\t</Switch>\n\t\t\t\t\t\t</View.Item>\n\t\t\t\t\t</View>\n\n\t\t\t\t\t<ThemePlayground />\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</>\n\t);\n};"
 				},
 				{
-					"name": "base",
+					"id": "internal-themes--base",
+					"name": "Base",
 					"snippet": "const base = () => (\n\t<Example>\n\t\t<Example.Item title=\"custom runtime theme\">\n\t\t\t<style>{css}</style>\n\t\t\t<Theme name=\"green\">\n\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"on colors generation\">\n\t\t\t<style>{css2}</style>\n\t\t\t<Theme name=\"peach\">\n\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "generation",
+					"id": "internal-themes--generation",
+					"name": "Generation",
 					"snippet": "const generation = () => (\n\t<div>\n\t\t<style>{cssGenerated}</style>\n\t\t<Theme name=\"generated\">{componentExamples}</Theme>\n\t</div>\n);"
 				},
 				{
-					"name": "onColors",
+					"id": "internal-themes--on-colors",
+					"name": "On Colors",
 					"snippet": "const onColors = () => (\n\t<Example>\n\t\t<Example.Item title=\"custom on color values\">\n\t\t\t<style>{onColorsCss}</style>\n\t\t\t<Theme name=\"on-color\">\n\t\t\t\t<View gap={2} direction=\"row\">\n\t\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t\t\t<Button color=\"critical\">Critical button</Button>\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"custom on color values, apca\">\n\t\t\t<style>{onColorsCssApca}</style>\n\t\t\t<Theme name=\"on-color-apca\">\n\t\t\t\t<View gap={2} direction=\"row\">\n\t\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t\t\t<Button color=\"critical\">Critical button</Button>\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t</Example>\n);"
 				}
 			],
 			"import": "import {\n    Actionable,\n    Alert,\n    Avatar,\n    Badge,\n    Button,\n    Card,\n    DropdownMenu,\n    Example,\n    Link,\n    Switch,\n    Text,\n    TextField,\n    Theme,\n    ThemePlayground,\n    View,\n} from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Theme/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Theme",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Theme/Theme.tsx",
-				"actualName": "Theme",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the theme to use, enables controlled mode",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"defaultName": {
+						"defaultValue": null,
+						"description": "Default name of the theme to use, enables uncontrolled mode",
+						"name": "defaultName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode to use",
+						"name": "colorMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode | \"inverted\"",
+							"value": [
+								{ "value": "\"light\"" },
+								{ "value": "\"dark\"" },
+								{ "value": "\"inverted\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -3529,7 +17025,8 @@
 			"path": "./src/Sandbox.stories.tsx",
 			"stories": [
 				{
-					"name": "preview",
+					"id": "sandbox--preview",
+					"name": "Preview",
 					"snippet": "const preview = () => {\n\treturn (\n\t\t<Preview>\n\t\t\t<Component />\n\t\t</Preview>\n\t);\n};"
 				}
 			],
@@ -3540,5 +17037,6 @@
 				"message": "We could not detect the component from your story file. Specify meta.component.\n   7 | import MenuItem from \"components/MenuItem\";\n   8 |\n>  9 | export default {\n     | ^\n  10 | \ttitle: \"Sandbox\",\n  11 | \tchromatic: { disableSnapshot: true },\n  12 | };\n\n./src/Sandbox.stories.tsx:\nimport View from \"components/View\";\nimport Image from \"components/Image\";\nimport React from \"react\";\nimport Select from \"components/Select\";\nimport useToggle from \"hooks/useToggle\";\nimport Modal from \"components/Modal\";\nimport MenuItem from \"components/MenuItem\";\n\nexport default {\n\ttitle: \"Sandbox\",\n\tchromatic: { disableSnapshot: true },\n};\n\nconst Preview: React.FC<{ children: React.ReactNode }> = (props) => {\n\treturn (\n\t\t<View padding={20} gap={6}>\n\t\t\t<View position=\"absolute\" insetTop={0} insetStart={0}>\n\t\t\t\t<Image src=\"./logo.svg\" />\n\t\t\t</View>\n\n\t\t\t{props.children}\n\t\t</View>\n\t);\n};\n\nexport const preview = () => {\n\treturn (\n\t\t<Preview>\n\t\t\t<Component />\n\t\t</Preview>\n\t);\n};\n\nconst Component = () => {\n\tconst toggle = useToggle();\n\tconst [value, setValue] = React.useState(\"Dog\");\n\n\tconst handleClick = () => {\n\t\ttoggle.toggle();\n\t};\n\n\treturn (\n\t\t<>\n\t\t\t<Select name=\"animal\" placeholder=\"Select an animal\" onClick={handleClick}>\n\t\t\t\t{value}\n\t\t\t</Select>\n\t\t\t<Modal active={toggle.active} onClose={toggle.deactivate} position=\"bottom\" padding={2}>\n\t\t\t\t<MenuItem\n\t\t\t\t\troundedCorners\n\t\t\t\t\tonClick={() => {\n\t\t\t\t\t\tsetValue(\"Dog\");\n\t\t\t\t\t\ttoggle.deactivate();\n\t\t\t\t\t}}\n\t\t\t\t\tattributes={{\n\t\t\t\t\t\trole: \"option\",\n\t\t\t\t\t}}\n\t\t\t\t>\n\t\t\t\t\tDog\n\t\t\t\t</MenuItem>\n\t\t\t\t<MenuItem\n\t\t\t\t\troundedCorners\n\t\t\t\t\tattributes={{\n\t\t\t\t\t\trole: \"option\",\n\t\t\t\t\t}}\n\t\t\t\t\tonClick={() => {\n\t\t\t\t\t\tsetValue(\"Turtle\");\n\t\t\t\t\t\ttoggle.deactivate();\n\t\t\t\t\t}}\n\t\t\t\t>\n\t\t\t\t\tTurtle\n\t\t\t\t</MenuItem>\n\t\t\t</Modal>\n\t\t</>\n\t);\n};\n"
 			}
 		}
-	}
+	},
+	"meta": { "docgen": "react-docgen-typescript", "durationMs": 2919 }
 }

--- a/eval/tasks/906-existing-component-edit-story-reshaped/manifests/components.json
+++ b/eval/tasks/906-existing-component-edit-story-reshaped/manifests/components.json
@@ -7,46 +7,201 @@
 			"path": "./src/components/ActionBar/tests/ActionBar.stories.tsx",
 			"stories": [
 				{
-					"name": "positionRelative",
+					"id": "components-actionbar--position-relative",
+					"name": "position, positionType: relative",
 					"snippet": "const positionRelative = () => (\n    <Example>\n        <Example.Item title=\"position: top\">\n            <ActionBar position=\"top\">\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <ActionBar position=\"bottom\">\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positionAbsolute",
+					"id": "components-actionbar--position-absolute",
+					"name": "position, positionType: absolute",
 					"snippet": "const positionAbsolute = () => (\n    <Example>\n        <Example.Item title=\"position: top-start\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top-start\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: top\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: top-end\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top-end\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom-start\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom-start\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom-end\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positionFixed",
+					"id": "components-actionbar--position-fixed",
+					"name": "position, positionType: fixed",
 					"snippet": "const positionFixed = () => (\n    <>\n        <ActionBar padding={2} position=\"top-start\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"top\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"top-end\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom-start\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom-end\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <div style={{ height: 2000 }} />\n    </>\n);"
 				},
 				{
+					"id": "components-actionbar--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated, position: top\">\n            <ActionBar position=\"top\" elevated>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"elevated, position: bottom\">\n            <ActionBar elevated>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"auto elevated, position: bottom\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-actionbar--offset",
 					"name": "offset",
 					"snippet": "const offset = () => (\n    <Example>\n        <Example.Item title=\"offset 2, position: top\">\n            <Fixtures.Container>\n                <ActionBar position=\"top\" positionType=\"absolute\" offset={2}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"offset 2, position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\" offset={2}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"offset s: 2, m: 4, position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\" offset={{ s: 2, m: 4 }}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-actionbar--active",
 					"name": "active",
 					"snippet": "const active = () => {\n    const barToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => barToggle.toggle()}>Toggle</Button>\n            <ActionBar active={barToggle.active} positionType=\"fixed\" position=\"top-end\">\n                <Fixtures.Actions />\n            </ActionBar>\n        </>\n    );\n};"
 				},
 				{
-					"name": "padding",
+					"id": "components-actionbar--padding",
+					"name": "padding, paddingBlock, paddingInline",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 6\">\n            <ActionBar padding={6}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"paddingBlock: 2, paddingInline: 4\">\n            <ActionBar paddingBlock={2} paddingInline={4}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"padding: [s] 4, [m+] 6\">\n            <ActionBar padding={{ s: 4, m: 6 }}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-actionbar--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ActionBar className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </ActionBar>\n    </div>\n);"
 				}
 			],
 			"import": "import { ActionBar, Button, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ActionBar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ActionBar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ActionBar/ActionBar.tsx",
-				"actualName": "ActionBar",
+				"methods": [],
+				"props": {
+					"paddingBlock": {
+						"defaultValue": null,
+						"description": "Padding block, base unit token number multiplier",
+						"name": "paddingBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingInline": {
+						"defaultValue": null,
+						"description": "Padding inline, base unit token number multiplier",
+						"name": "paddingInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Padding style for all sides, base unit token number multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Show or hide the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"offset": {
+						"defaultValue": null,
+						"description": "Offset from the container bounds",
+						"name": "offset",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"position": {
+						"defaultValue": { "value": "\"bottom\"" },
+						"description": "Position based on the container bounds",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"top-end\" | \"top-start\" | \"bottom\" | \"bottom-start\" | \"bottom-end\"",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" }
+							]
+						}
+					},
+					"positionType": {
+						"defaultValue": null,
+						"description": "CSS position style",
+						"name": "positionType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"relative\" | \"absolute\" | \"fixed\">" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Display above the content with elevated shadow and background",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -56,30 +211,138 @@
 			"path": "./src/components/Alert/tests/Alert.stories.tsx",
 			"stories": [
 				{
+					"id": "components-alert--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        {([\"neutral\", \"primary\", \"critical\", \"positive\", \"warning\"] as const).map((color) => (\n            <Example.Item title={`color: ${color}`} key={color}>\n                <Alert\n                    color={color}\n                    title=\"Alert title goes here\"\n                    icon={IconZap}\n                    actionsSlot={\n                        <>\n                            <Link\n                                variant=\"plain\"\n                                color={color === \"neutral\" ? \"primary\" : color}\n                                onClick={() => {}}\n                            >\n                                View now\n                            </Link>\n                            <Link\n                                variant=\"plain\"\n                                color={color === \"neutral\" ? \"primary\" : color}\n                                onClick={() => {}}\n                            >\n                                Dismiss\n                            </Link>\n                        </>\n                    }\n                >\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard\n                </Alert>\n            </Example.Item>\n        ))}\n    </Example>\n);"
 				},
 				{
+					"id": "components-alert--inline",
 					"name": "inline",
 					"snippet": "const inline = () => (\n    <Example>\n        <Example.Item title=\"inline: true\">\n            <Alert\n                inline\n                title=\"Alert title goes here\"\n                icon={IconZap}\n                actionsSlot={\n                    <>\n                        <Link variant=\"plain\" onClick={() => {}}>\n                            View now\n                        </Link>\n                        <Link variant=\"plain\" onClick={() => {}}>\n                            Dismiss\n                        </Link>\n                    </>\n                }\n            >\n                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has\n                been the industry's standard\n            </Alert>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-alert--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4\">\n            <Alert bleed={4} icon={IconZap}>\n                Content\n            </Alert>\n        </Example.Item>\n        <Example.Item title=\"bleed: [s] 4, [m+] 0\">\n            <Alert bleed={{ s: 4, m: 0 }} icon={IconZap}>\n                Content\n            </Alert>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-alert--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Alert className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </Alert>\n    </div>\n);"
 				}
 			],
 			"import": "import { Alert, Example, Link, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Alert/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Alert",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Alert/Alert.tsx",
-				"actualName": "Alert",
+				"methods": [],
+				"props": {
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"title": {
+						"defaultValue": null,
+						"description": "Title slot",
+						"name": "title",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Slot for rendering the main content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"actionsSlot": {
+						"defaultValue": null,
+						"description": "Actions slot, usually used for Buttons and Links, automatically adds a gap between the actions",
+						"name": "actionsSlot",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Color scheme of the alert elements",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"inline": {
+						"defaultValue": null,
+						"description": "Display action to the right of the content",
+						"name": "inline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margin and remove side borders, base unit token number multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -89,35 +352,573 @@
 			"path": "./src/components/Autocomplete/tests/Autocomplete.stories.tsx",
 			"stories": [
 				{
-					"name": "active",
+					"id": "components-autocomplete--active",
+					"name": "active, onOpen, onClose",
 					"snippet": "const active = (args) => {\n    const toggle = useToggle(true);\n\n    return (\n        <Example>\n            <Example.Item title=\"active, onOpen, onClose\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete\n                        name=\"fruit\"\n                        placeholder=\"Pick your food\"\n                        active={toggle.active}\n                        onOpen={() => {\n                            args.handleOpen();\n                            toggle.activate();\n                        }}\n                        onClose={() => {\n                            args.handleClose();\n                            toggle.deactivate();\n                        }}\n                        onChange={(args) => console.log(args)}\n                    >\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "base",
+					"id": "components-autocomplete--base",
+					"name": "onInput, onItemSelect, onBackspace",
 					"snippet": "const base = () => {\n    const [value, setValue] = React.useState(\"\");\n\n    return (\n        <Example>\n            <Example.Item title=\"Base\">\n                <FormControl>\n                    <FormControl.Label>Food</FormControl.Label>\n                    <Autocomplete\n                        name=\"fruit\"\n                        placeholder=\"Pick your food\"\n                        value={value}\n                        onChange={(args) => setValue(args.value)}\n                        onBackspace={fn()}\n                        onItemSelect={fn()}>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "itemData",
+					"id": "components-autocomplete--item-data",
+					"name": "item data",
 					"snippet": "const itemData = () => {\n    return (\n        <Example>\n            <Example.Item title=\"item data\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete name=\"fruit\" placeholder=\"Pick your food\" onItemSelect={fn()} active>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v} data={i === 1 ? { foo: true } : undefined}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "itemDisabled",
+					"id": "components-autocomplete--item-disabled",
+					"name": "item disabled",
 					"snippet": "const itemDisabled = () => {\n    return (\n        <Example>\n            <Example.Item title=\"item disabled\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete name=\"fruit\" placeholder=\"Pick your food\" active>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v} disabled={i === 1}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "multiselect",
+					"id": "components-autocomplete--multiselect",
+					"name": "test: multiselect",
 					"snippet": "const multiselect = () => {\n    const options = [\n        \"Pizza\",\n        \"Pie\",\n        \"Ice-cream\",\n        \"Fries\",\n        \"Salad\",\n        \"Option 4\",\n        \"Option 5\",\n        \"Option 6\",\n    ];\n\n    const inputRef = React.useRef<HTMLInputElement>(null);\n    const [values, setValues] = React.useState<string[]>([\n        \"Option 4\",\n        \"Option 5\",\n        \"Option 6\",\n        \"Pizza\",\n        \"Ice-cream\",\n    ]);\n    const [query, setQuery] = React.useState(\"\");\n\n    const handleDismiss = (dismissedValue: string) => {\n        const nextValues = values.filter((value) => value !== dismissedValue);\n        setValues(nextValues);\n        inputRef.current?.focus();\n    };\n\n    const valuesNode = values.map((value) => (\n        <Badge dismissAriaLabel=\"Dismiss value\" onDismiss={() => handleDismiss(value)} key={value}>\n            {value}\n        </Badge>\n    ));\n\n    return (\n        <FormControl>\n            <FormControl.Label>Food</FormControl.Label>\n            <Autocomplete\n                name=\"fruit\"\n                value={query}\n                placeholder=\"Pick your food\"\n                startSlot={valuesNode}\n                multiline\n                inputAttributes={{ ref: inputRef }}\n                onChange={(args) => setQuery(args.value)}\n                onBackspace={() => {\n                    if (query.length === 0) {\n                        setValues((prev) => prev.slice(0, -1));\n                    }\n                }}\n                onItemSelect={(args) => {\n                    setQuery(\"\");\n                    setValues((prev) => [...prev, args.value]);\n                }}\n            >\n                {options.map((v) => {\n                    if (!v.toLowerCase().includes(query.toLowerCase())) return;\n                    if (values.includes(v)) return;\n\n                    return (\n                        <Autocomplete.Item key={v} value={v}>\n                            {v}\n                        </Autocomplete.Item>\n                    );\n                })}\n            </Autocomplete>\n        </FormControl>\n    );\n};"
 				}
 			],
 			"import": "import { Autocomplete, Badge, Example, FormControl } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Autocomplete/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Autocomplete",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Autocomplete/Autocomplete.tsx",
-				"actualName": "Autocomplete",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"multiline": {
+						"defaultValue": null,
+						"description": "Enable multiline text field wrapping",
+						"name": "multiline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to be fully rounded",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content after the text field value",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text field value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the text field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the text field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"onInput": {
+						"defaultValue": null,
+						"description": "Callback for when value changes from user input",
+						"name": "onInput",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onItemSelect": {
+						"defaultValue": null,
+						"description": "Callback for when an item is selected in the dropdown",
+						"name": "onItemSelect",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: SelectArgs) => void)" }
+					},
+					"onBackspace": {
+						"defaultValue": null,
+						"description": "Callback for when the backspace key is pressed while the input is focused",
+						"name": "onBackspace",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onEnter": {
+						"defaultValue": null,
+						"description": "Callback for when the enter key is pressed while the input is focused",
+						"name": "onEnter",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Slot for rendering the Autocomplete.Item components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					}
+				},
+				"exportName": "Autocomplete"
 			}
 		},
 		"components-avatar": {
@@ -126,46 +927,230 @@
 			"path": "./src/components/Avatar/tests/Avatar.stories.tsx",
 			"stories": [
 				{
-					"name": "src",
+					"id": "components-avatar--src",
+					"name": "src, alt",
 					"snippet": "const src = () => (\n    <Example>\n        <Example.Item title=\"src, alt\">\n            <Avatar\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n                alt=\"Amsterdam canal\"\n                size={12}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"src\">\n            <Avatar src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "initials",
+					"id": "components-avatar--initials",
+					"name": "initials, icon",
 					"snippet": "const initials = () => (\n    <Example>\n        <Example.Item title=\"initials\">\n            <Avatar initials=\"RS\" />\n        </Example.Item>\n\n        <Example.Item title=\"icon\">\n            <Avatar icon={IconZap} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-avatar--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: 6\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={6} icon={IconZap} />\n                <Avatar size={6} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: 15\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={15} icon={IconZap} />\n                <Avatar size={15} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: 40\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={40} icon={IconZap} />\n                <Avatar size={40} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] 10\", \"[m+] 20\"]}>\n            <View direction=\"row\" gap={3}>\n                <Avatar size={{ s: 10, m: 20 }} icon={IconZap} />\n                <Avatar size={{ s: 10, m: 20 }} icon={IconZap} squared />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-avatar--squared",
 					"name": "squared",
 					"snippet": "const squared = () => (\n    <Example>\n        <Example.Item title=\"squared, with image\">\n            <Avatar\n                squared\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n            />\n        </Example.Item>\n        <Example.Item title=\"squared, with initials\">\n            <Avatar squared initials=\"RS\" />\n        </Example.Item>\n        <Example.Item title=\"squared, with initials\">\n            <Avatar squared icon={IconZap} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "colors",
+					"id": "components-avatar--colors",
+					"name": "color, variant",
 					"snippet": "const colors = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"neutral\" icon={IconZap} />\n                <Avatar color=\"neutral\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"primary\" icon={IconZap} />\n                <Avatar color=\"primary\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"positive\" icon={IconZap} />\n                <Avatar color=\"positive\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"warning\" icon={IconZap} />\n                <Avatar color=\"warning\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"critical\" icon={IconZap} />\n                <Avatar color=\"critical\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "fallback",
+					"id": "components-avatar--fallback",
+					"name": "test: fallback",
 					"snippet": "const fallback = (args) => {\n    const [error, setError] = useState(false);\n\n    return (\n        <Avatar\n            src={error ? undefined : \"/foo\"}\n            icon={IconZap}\n            imageAttributes={{\n                onError: () => {\n                    setError(true);\n                    args.handleError();\n                },\n            }}\n        />\n    );\n};"
 				},
 				{
+					"id": "components-avatar--render-image",
 					"name": "renderImage",
 					"snippet": "const renderImage = () => (\n    <Example>\n        <Example.Item title=\"renderImage\">\n            <Avatar\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n                alt=\"Amsterdam canal\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image\" />}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-avatar--class-name",
+					"name": "className, attributes, imageAttributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Avatar\n            src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            imageAttributes={{ id: \"test-image-id\", alt: \"test image\" }}\n        />\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Avatar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Avatar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Avatar/Avatar.tsx",
-				"actualName": "Avatar",
+				"methods": [],
+				"props": {
+					"src": {
+						"defaultValue": null,
+						"description": "Image URL",
+						"name": "src",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"alt": {
+						"defaultValue": null,
+						"description": "Image alt text",
+						"name": "alt",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"imageAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the image element",
+						"name": "imageAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"img\">" }
+					},
+					"renderImage": {
+						"defaultValue": null,
+						"description": "Render prop for the image element, useful for integrating with the Image component from third party frameworks",
+						"name": "renderImage",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Omit<Attributes<\"img\">, \"src\" | \"alt\"> & { src: string; alt: string; }) => ReactNode)"
+						}
+					},
+					"initials": {
+						"defaultValue": null,
+						"description": "Initials to display if no image is provided",
+						"name": "initials",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon, used when no image is provided",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"squared": {
+						"defaultValue": null,
+						"description": "Change the shape to rounded square",
+						"name": "squared",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"faded\"",
+							"value": [{ "value": "\"solid\"" }, { "value": "\"faded\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "12" },
+						"description": "Size of the component, base unit token number multiplier",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -175,63 +1160,273 @@
 			"path": "./src/components/Badge/tests/Badge.stories.tsx",
 			"stories": [
 				{
+					"id": "components-badge--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Badge>Badge</Badge>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <Badge variant=\"faded\">Badge</Badge>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <Badge variant=\"outline\">Badge</Badge>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"primary\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"primary\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"primary\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: positive, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"positive\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"positive\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"positive\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: critical, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"critical\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"critical\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"critical\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: warning, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"warning\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"warning\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"warning\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"small\">Badge</Badge>\n                <Badge rounded size=\"small\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge>Badge</Badge>\n                <Badge rounded>Badge</Badge>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"large\">Badge</Badge>\n                <Badge rounded size=\"large\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={3} direction=\"row\">\n                <Badge icon={IconCheckmark} endIcon={IconChevronRight} size=\"small\">\n                    Badge\n                </Badge>\n                <Badge icon={IconCheckmark} size=\"small\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={3} direction=\"row\">\n                <Badge icon={IconCheckmark} endIcon={IconChevronRight}>\n                    Badge\n                </Badge>\n                <Badge icon={IconCheckmark} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"large\" icon={IconCheckmark} endIcon={IconChevronRight}>\n                    Badge\n                </Badge>\n\n                <Badge icon={IconCheckmark} size=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onDismiss",
+					"id": "components-badge--on-dismiss",
+					"name": "onDismiss, dismissAriaLabel",
 					"snippet": "const onDismiss = () => <Example>\n    <Example.Item title=\"onDismiss\">\n        <Badge onDismiss={fn()} dismissAriaLabel=\"Dismiss\">Badge\n                            </Badge>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-badge--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded>Badge</Badge>\n                <Badge rounded variant=\"faded\">\n                    Badge\n                </Badge>\n                <Badge rounded variant=\"outline\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"rounded, all sizes, color: critical\", \"one character, renders as circle\"]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Badge rounded color=\"critical\" size=\"small\">\n                    2\n                </Badge>\n                <Badge rounded color=\"critical\">\n                    2\n                </Badge>\n                <Badge rounded color=\"critical\" size=\"large\">\n                    2\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--empty",
 					"name": "empty",
 					"snippet": "const empty = () => (\n    <Example>\n        <Example.Item title=\"empty, not rounded, all sizes, color: critical\">\n            <View direction=\"row\" gap={3}>\n                <Badge size=\"small\" color=\"critical\" />\n                <Badge color=\"critical\" />\n                <Badge size=\"large\" color=\"critical\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"empty, rounded, all sizes, color: critical\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded size=\"small\" color=\"critical\" />\n                <Badge rounded color=\"critical\" />\n                <Badge rounded size=\"large\" color=\"critical\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"empty, rounded, all sizes, color: neutral\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded size=\"small\" color=\"neutral\" />\n                <Badge rounded />\n                <Badge rounded size=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--highlighted",
 					"name": "highlighted",
 					"snippet": "const highlighted = () => (\n    <Example>\n        <Example.Item title=\"highlighted, color: neutral\">\n            <View gap={3} direction=\"row\">\n                <Badge highlighted>Badge</Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--container",
 					"name": "container",
 					"snippet": "const container = () => {\n    const [hidden, setHidden] = React.useState(false);\n\n    return (\n        <Example title={<Button onClick={() => setHidden(!hidden)}>Toggle badges</Button>}>\n            <Example.Item title=\"position: top-end\">\n                <Badge.Container>\n                    <Badge color=\"primary\" hidden={hidden}>\n                        5\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: bottom-end\">\n                <Badge.Container position=\"bottom-end\">\n                    <Badge color=\"primary\" hidden={hidden}>\n                        5\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: top-end, rounded, multiple digits\">\n                <Badge.Container>\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        123\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: top-end, rounded, empty\">\n                <Badge.Container>\n                    <Badge color=\"primary\" rounded hidden={hidden} />\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: top-end, overlap\", \"should cover the circular avatar\"]}>\n                <Badge.Container overlap>\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        2\n                    </Badge>\n                    <Avatar initials=\"A\" />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: bottom-end, overlap\", \"should cover the circular avatar\"]}>\n                <Badge.Container overlap position=\"bottom-end\">\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        2\n                    </Badge>\n                    <Avatar initials=\"A\" />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: top-end, overlap\", \"should cover the icon\"]}>\n                <Badge.Container overlap position=\"top-end\">\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden} />\n                    <Icon svg={IconCheckmark} size={5} />\n                </Badge.Container>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-badge--href",
 					"name": "href",
 					"snippet": "const href = () => (\n    <Badge href=\"https://reshaped.so\" dismissAriaLabel=\"Dismiss\">\n        Badge\n    </Badge>\n);"
 				},
 				{
+					"id": "components-badge--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Badge onClick={fn()}>Badge</Badge>;"
 				},
 				{
-					"name": "className",
+					"id": "components-badge--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Badge color=\"primary\" className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Badge, Button, Example, Icon, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Badge/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Badge",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Badge/Badge.tsx",
-				"actualName": "Badge",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"large\" | \"medium\"",
+							"value": [
+								{ "value": "\"small\"" },
+								{ "value": "\"large\"" },
+								{ "value": "\"medium\"" }
+							]
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "highlighted",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hidden": {
+						"defaultValue": null,
+						"description": "Transition the component to hidden state",
+						"name": "hidden",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting text or other content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"onDismiss": {
+						"defaultValue": null,
+						"description": "Callback triggered when the dismiss button is pressed",
+						"name": "onDismiss",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"dismissAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the dismiss button",
+						"name": "dismissAriaLabel",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "Badge"
 			}
 		},
 		"components-breadcrumbs": {
@@ -240,51 +1435,185 @@
 			"path": "./src/components/Breadcrumbs/tests/Breadcrumbs.stories.tsx",
 			"stories": [
 				{
+					"id": "components-breadcrumbs--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <Breadcrumbs ariaLabel=\"breadcrumb neutral\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"color: primary\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb primary\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "item",
+					"id": "components-breadcrumbs--item",
+					"name": "item, disabled",
 					"snippet": "const item = () => (\n    <Example>\n        <Example.Item title=\"disabled item\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb disabled\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}} disabled>\n                    Disabled item 2\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "icon",
+					"id": "components-breadcrumbs--icon",
+					"name": "item, icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"item with icon\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb with icon\">\n                <Breadcrumbs.Item icon={IconZap} onClick={() => {}}>\n                    Item 1\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "slots",
+					"id": "components-breadcrumbs--slots",
+					"name": "separator, children",
 					"snippet": "const slots = () => (\n    <Example>\n        <Example.Item title=\"slot: separator\">\n            <Breadcrumbs color=\"primary\" separator=\"/\" ariaLabel=\"breadcrumb with separator\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"custom child content\">\n            <Breadcrumbs ariaLabel=\"breadcrumb with custom children\">\n                <Breadcrumbs.Item onClick={() => {}}>\n                    <Badge>Item 1</Badge>\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>\n                    <Badge>Item 2</Badge>\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-breadcrumbs--collapsed",
 					"name": "collapsed",
 					"snippet": "const collapsed = () => (\n    <Example>\n        <Example.Item title=\"collapsed, 3 items shown by default\">\n            <Breadcrumbs\n                defaultVisibleItems={3}\n                ariaLabel=\"breadcrumbs one\"\n                expandAriaLabel=\"Expand items\"\n            >\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"collapsed, 4 items shown by default\">\n            <Breadcrumbs\n                defaultVisibleItems={4}\n                ariaLabel=\"breadcrumb two\"\n                expandAriaLabel=\"Expand items\"\n            >\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"collapsed, 3 items shown by default, not expandable\">\n            <Breadcrumbs defaultVisibleItems={3} ariaLabel=\"breadcrumb three\" disableExpand>\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "multiline",
+					"id": "components-breadcrumbs--multiline",
+					"name": "composition, multiline",
 					"snippet": "const multiline = () => (\n    <Example>\n        <Example.Item title=\"wraps content when multiline\">\n            <Breadcrumbs ariaLabel=\"breadcrumb multiline\">\n                {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((i) => (\n                    <Breadcrumbs.Item onClick={() => {}} key={i}>\n                        Item {i}\n                    </Breadcrumbs.Item>\n                ))}\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onClick",
+					"id": "components-breadcrumbs--on-click",
+					"name": "item, onClick, disabled",
 					"snippet": "const onClick = () => <Breadcrumbs>\n    <Breadcrumbs.Item onClick={fn()}>Trigger</Breadcrumbs.Item>\n    <Breadcrumbs.Item onClick={fn()} disabled>Trigger\n                    </Breadcrumbs.Item>\n</Breadcrumbs>;"
 				},
 				{
-					"name": "href",
+					"id": "components-breadcrumbs--href",
+					"name": "item, href",
 					"snippet": "const href = () => (\n    <Breadcrumbs>\n        <Breadcrumbs.Item href=\"https://reshaped.so\">Trigger</Breadcrumbs.Item>\n    </Breadcrumbs>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-breadcrumbs--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Breadcrumbs className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Breadcrumbs.Item>Trigger</Breadcrumbs.Item>\n        </Breadcrumbs>\n    </div>\n);"
 				}
 			],
 			"import": "import { Badge, Breadcrumbs, Example } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Breadcrumbs/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Breadcrumbs",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Breadcrumbs/Breadcrumbs.tsx",
-				"actualName": "Breadcrumbs",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children to position items",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ReactElement<unknown, string | JSXElementConstructor<any>>[]"
+						}
+					},
+					"separator": {
+						"defaultValue": null,
+						"description": "Node for defining custom separator between items",
+						"name": "separator",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"neutral\"",
+							"value": [{ "value": "\"primary\"" }, { "value": "\"neutral\"" }]
+						}
+					},
+					"defaultVisibleItems": {
+						"defaultValue": null,
+						"description": "Number of items to show by default, others will be hidden and can be expanded",
+						"name": "defaultVisibleItems",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"expandAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the expand button",
+						"name": "expandAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disableExpand": {
+						"defaultValue": null,
+						"description": "Turn expand button into static text and disable the expand functionality",
+						"name": "disableExpand",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the component",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"nav\">" }
+					}
+				},
+				"exportName": "Breadcrumbs"
 			}
 		},
 		"components-button": {
@@ -293,87 +1622,599 @@
 			"path": "./src/components/Button/tests/Button.stories.tsx",
 			"stories": [
 				{
-					"name": "variantAndColor",
+					"id": "components-button--variant-and-color",
+					"name": "variant, color",
 					"snippet": "const variantAndColor = () => (\n    <Example>\n        <Example.Item title=\"variant: solid\">\n            <View gap={4} direction=\"row\">\n                <Button onClick={() => {}}>Button</Button>\n                <Button onClick={() => {}} color=\"primary\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"faded\">\n                    Button\n                </Button>\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"outline\">\n                    Button\n                </Button>\n\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: ghost\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"ghost\">\n                    Button\n                </Button>\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: media\">\n            <View backgroundColor=\"primary\" borderRadius=\"medium\" padding={4} direction=\"row\" gap={4}>\n                <Button onClick={() => {}} color=\"media\">\n                    Button\n                </Button>\n\n                <Button onClick={() => {}} color=\"media\" variant=\"faded\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Button onClick={() => {}} icon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"endIcon\">\n            <Button onClick={() => {}} endIcon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"icon, endIcon\">\n            <Button onClick={() => {}} icon={IconZap} endIcon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"icon only\">\n            <Button onClick={() => {}} icon={IconZap} attributes={{ \"aria-label\": \"Action\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"small\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"small\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Button icon={IconZap}>Button</Button>\n                <Button variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"large\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"large\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"xlarge\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"xlarge\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"xlarge\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large, [m+] medium\">\n            <Button size={{ s: \"large\", m: \"medium\" }} icon={IconZap}>\n                Responsive\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated, color: neutral\">\n            <View direction=\"row\" gap={4}>\n                <Button elevated onClick={() => {}}>\n                    Button\n                </Button>\n                <Button elevated variant=\"outline\" onClick={() => {}}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"elevated, color\">\n            <View direction=\"row\" gap={4}>\n                <Button elevated color=\"primary\">\n                    Button\n                </Button>\n                <Button elevated variant=\"outline\" color=\"primary\">\n                    Button\n                </Button>\n                <View backgroundColor=\"primary\" padding={4} borderRadius=\"medium\">\n                    <Button color=\"media\" elevated>\n                        Button\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded, size: small, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, size: medium, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, size: large, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, icon only, all sizes\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"small\" icon={IconZap} />\n                <Button rounded icon={IconZap} />\n                <Button rounded size=\"large\" icon={IconZap} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--full-width",
 					"name": "fullWidth",
 					"snippet": "const fullWidth = () => (\n    <Example>\n        <Example.Item title=\"fullWidth, all variants\">\n            <View gap={3}>\n                <Button fullWidth>Neutral</Button>\n                <Button fullWidth variant=\"faded\">\n                    Faded\n                </Button>\n                <Button fullWidth variant=\"outline\">\n                    Outline\n                </Button>\n                <Button fullWidth variant=\"ghost\">\n                    Ghost\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive fullWidth\", \"[s] true\", \"[m+] false\"]}>\n            <Button fullWidth={{ s: true, m: false }}>Button</Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--loading",
 					"name": "loading",
 					"snippet": "const loading = () => (\n    <Example>\n        <Example.Item title=\"loading, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"loading, color critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"loading, color positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"loading, color: media\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n\n                <div style={{ position: \"absolute\", top: 16, left: 16 }}>\n                    <View gap={3} direction=\"row\">\n                        <Button color=\"media\" loading loadingAriaLabel=\"Loading\">\n                            Button\n                        </Button>\n                        <Button color=\"media\" variant=\"faded\" loading loadingAriaLabel=\"Loading\">\n                            Button\n                        </Button>\n                    </View>\n                </div>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"loading, long button text\", \"button size should stay the same\"]}>\n            <Button loading loadingAriaLabel=\"Loading\" color=\"primary\">\n                Long button text\n            </Button>\n        </Example.Item>\n\n        <Example.Item title={[\"loading, icon only\", \"button keep square 1/1 ratio\"]}>\n            <Button icon={IconZap} rounded loading loadingAriaLabel=\"Loading\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--highlighted",
 					"name": "highlighted",
 					"snippet": "const highlighted = () => (\n    <Example>\n        <Example.Item title=\"highlighted, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"highlighted, color: critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted color=\"critical\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"highlighted, color: positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted color=\"positive\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled icon={IconZap} onClick={() => {}}>\n                    Button\n                </Button>\n                <Button disabled variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"disabled, color: critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled color=\"critical\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"disabled, color: positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled color=\"positive\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"disabled, color: media\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n\n                <div style={{ position: \"absolute\", top: 16, left: 16 }}>\n                    <View gap={3} direction=\"row\">\n                        <Button color=\"media\" disabled>\n                            Button\n                        </Button>\n                        <Button color=\"media\" variant=\"faded\" disabled>\n                            Button\n                        </Button>\n                    </View>\n                </div>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner: all\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>Content</View.Item>\n                <Button.Aligner>\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: top\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"top\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: top and end\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side={[\"top\", \"end\"]}>\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: bottom\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2} align=\"end\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"bottom\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: start\">\n            <View padding={4} borderColor=\"neutral-faded\" gap={2} align=\"start\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"start\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: end\">\n            <View padding={4} borderColor=\"neutral-faded\" gap={2} align=\"end\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"end\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "components-button--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"slot gap\">\n            <Button variant=\"outline\">\n                <Avatar size={6} initials=\"RS\" />\n                Label\n                <Hotkey>B</Hotkey>\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--href",
 					"name": "href",
 					"snippet": "const href = () => <Button href=\"https://reshaped.so\">Trigger</Button>;"
 				},
 				{
+					"id": "components-button--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Button onClick={fn()}>Trigger</Button>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-button--href-on-click",
+					"name": "href, onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <Button\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </Button>\n);"
 				},
 				{
+					"id": "components-button--as",
 					"name": "as",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"as: span\">\n            <Button onClick={() => {}} as=\"span\">\n                Trigger\n            </Button>\n        </Example.Item>\n        <Example.Item title=\"render, disabled\">\n            <Button\n                disabled\n                onClick={() => {}}\n                render={(props) => <section {...props} />}\n                attributes={{ \"data-testid\": \"render-el\" }}\n            >\n                Trigger\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-button--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Button className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Button>\n    </div>\n);"
 				},
 				{
+					"id": "components-button--group",
 					"name": "group",
 					"snippet": "const group = () => (\n    <Example>\n        <Example.Item title=\"with icon\">\n            <Button.Group>\n                <Button rounded>Submit</Button>\n                <Button rounded icon={IconZap} />\n            </Button.Group>\n        </Example.Item>\n        <Example.Item title=\"variant: solid\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\", \"media\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color}>One</Button>\n                        <Button color={color}>Two</Button>\n                        <Button color={color}>Three</Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"outline\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"outline\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"outline\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\", \"media\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"faded\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"faded\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"faded\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"variant: ghost\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"ghost\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"ghost\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"ghost\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "groupClassName",
+					"id": "components-button--group-class-name",
+					"name": "group className, attributes",
 					"snippet": "const groupClassName = () => (\n    <div data-testid=\"root\">\n        <Button.Group className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Button>Trigger</Button>\n        </Button.Group>\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Button, Example, Hotkey, Image, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Button/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Button",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Button/Button.tsx",
-				"actualName": "Button",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"ghost\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"ghost\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loading": {
+						"defaultValue": null,
+						"description": "Show loading state",
+						"name": "loading",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loadingAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the loading indicator",
+						"name": "loadingAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Make the component take the full width of the parent element",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "highlighted",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Button"
 			}
 		},
 		"components-calendar": {
@@ -382,54 +2223,363 @@
 			"path": "./src/components/Calendar/tests/Calendar.stories.tsx",
 			"stories": [
 				{
+					"id": "components-calendar--default-month",
 					"name": "defaultMonth",
 					"snippet": "const defaultMonth = () => (\n    <Example>\n        <Example.Item title=\"defaultMonth: 2020 January\">\n            <Calendar defaultMonth={new Date(2020, 0)} range />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "uncontrolled",
+					"id": "components-calendar--uncontrolled",
+					"name": "defaultValue, range",
 					"snippet": "const uncontrolled = () => <Example>\n    <Example.Item title=\"defaultValue\">\n        <Calendar\n            defaultMonth={new Date(2020, 0)}\n            defaultValue={new Date(2020, 0, 10)}\n            onChange={fn()} />\n    </Example.Item>\n    <Example.Item title=\"defaultValue, range\">\n        <Calendar\n            range\n            defaultMonth={new Date(2020, 0)}\n            defaultValue={{ start: new Date(2020, 0, 10), end: new Date(2020, 0, 15) }}\n            onChange={fn()} />\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "controlled",
+					"id": "components-calendar--controlled",
+					"name": "value, range",
 					"snippet": "const controlled = () => <Example>\n    <Example.Item title=\"value\">\n        <Calendar\n            defaultMonth={new Date(2020, 0)}\n            value={new Date(2020, 0, 10)}\n            onChange={fn()} />\n    </Example.Item>\n    <Example.Item title=\"defaultValue, range\">\n        <Calendar\n            range\n            defaultMonth={new Date(2020, 0)}\n            value={{ start: new Date(2020, 0, 10), end: new Date(2020, 0, 15) }}\n            onChange={fn()} />\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-calendar--selected-dates",
 					"name": "selectedDates",
 					"snippet": "const selectedDates = () => (\n    <Example>\n        <Example.Item title=\"selectedDates: [4,8]\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                value={null}\n                selectedDates={[new Date(2020, 0, 4), new Date(2020, 0, 8)]}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "minMax",
+					"id": "components-calendar--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <Example>\n        <Example.Item title=\"min: 4, max: 20\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                min={new Date(2020, 0, 4)}\n                max={new Date(2020, 0, 20)}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-calendar--first-week-day",
 					"name": "firstWeekDay",
 					"snippet": "const firstWeekDay = () => (\n    <Example>\n        <Example.Item title=\"firstWeekDay: 3 (Wed)\">\n            <Calendar defaultMonth={new Date(2020, 0)} firstWeekDay={3} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "translation",
+					"id": "components-calendar--translation",
+					"name": "render functions",
 					"snippet": "const translation = () => (\n    <Example>\n        <Example.Item title=\"translated to NL\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                renderMonthLabel={({ date }) => date.toLocaleDateString(\"nl\", { month: \"short\" })}\n                renderSelectedMonthLabel={({ date }) =>\n                    date.toLocaleDateString(\"nl\", { month: \"long\", year: \"numeric\" })\n                }\n                renderWeekDay={({ date }) => date.toLocaleDateString(\"nl\", { weekday: \"short\" })}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "ariaLabels",
+					"id": "components-calendar--aria-labels",
+					"name": "aria labels",
 					"snippet": "const ariaLabels = () => (\n    <Example>\n        <Example.Item title=\"aria labels\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                nextYearAriaLabel=\"Test next year\"\n                nextMonthAriaLabel=\"Test next month\"\n                renderDateAriaLabel={() => \"Test date\"}\n                renderMonthAriaLabel={() => \"Test month\"}\n                previousYearAriaLabel=\"Test previous year\"\n                previousMonthAriaLabel=\"Test previous month\"\n                monthSelectionAriaLabel=\"Test month selection\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "monthSelection",
+					"id": "components-calendar--month-selection",
+					"name": "test: month selection",
 					"snippet": "const monthSelection = () => (\n    <Example>\n        <Example.Item title=\"month selection\">\n            <Calendar defaultMonth={new Date(2020, 1)} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "keyboardNavigation",
+					"id": "components-calendar--keyboard-navigation",
+					"name": "test: keyboard navigation",
 					"snippet": "const keyboardNavigation = () => (\n    <Example>\n        <Example.Item title=\"keyboard navigation\">\n            <Calendar defaultMonth={new Date(2020, 0)} />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Calendar, Example } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Calendar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Calendar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Calendar/Calendar.tsx",
-				"actualName": "Calendar",
+				"methods": [],
+				"props": {
+					"range": {
+						"defaultValue": null,
+						"description": "Disable range selection\nEnable range selection",
+						"name": "range",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Current selected date value, enables controlled mode\nCurrent selected range value, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date | RangeValue | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default selected date value, enables uncontrolled mode\nDefault selected range value, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date | RangeValue" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when date selection changes\nCallback when range selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { value: Date; }) => void) | ((args: { value: Date; }) => void) | ((args: { value: RangeValue; }) => void) | ((args: { value: RangeValue; }) => void)"
+						}
+					},
+					"defaultMonth": {
+						"defaultValue": { "value": "Date.now()" },
+						"description": "Default month to display",
+						"name": "defaultMonth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum date that can be selected",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum date that can be selected",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"firstWeekDay": {
+						"defaultValue": { "value": "1, Monday" },
+						"description": "First day of the week",
+						"name": "firstWeekDay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"selectedDates": {
+						"defaultValue": null,
+						"description": "Dates that are selected",
+						"name": "selectedDates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date[]" }
+					},
+					"renderWeekDay": {
+						"defaultValue": null,
+						"description": "Render a custom weekday label, can be used for localization",
+						"name": "renderWeekDay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { weekDay: number; date: Date; }) => string)" }
+					},
+					"renderSelectedMonthLabel": {
+						"defaultValue": null,
+						"description": "Render a custom month label, can be used for localization",
+						"name": "renderSelectedMonthLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { date: Date; }) => string)" }
+					},
+					"renderMonthLabel": {
+						"defaultValue": null,
+						"description": "Render a custom month label, can be used for localization",
+						"name": "renderMonthLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { month: number; date: Date; }) => string)" }
+					},
+					"previousMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the previous month button",
+						"name": "previousMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"nextMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "",
+						"name": "nextMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"previousYearAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the previous year button",
+						"name": "previousYearAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"nextYearAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the next year button",
+						"name": "nextYearAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"monthSelectionAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the month selection button",
+						"name": "monthSelectionAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"renderDateAriaLabel": {
+						"defaultValue": null,
+						"description": "Dynamic aria label applied to each date cell based on the arguments",
+						"name": "renderDateAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { date: Date; }) => string)" }
+					},
+					"renderMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "Dynamic aria label applied to each month element based on the arguments",
+						"name": "renderMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { month: number; }) => string)" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -439,50 +2589,356 @@
 			"path": "./src/components/Card/tests/Card.stories.tsx",
 			"stories": [
 				{
+					"id": "components-card--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: default\">\n            <Card>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title=\"padding: 2\">\n            <Card padding={2}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title=\"padding: 0\">\n            <Card padding={0}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive padding\", \"[s] 4\", \"[m+] 8\"]}>\n            <Card padding={{ s: 4, m: 8 }}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--selected",
 					"name": "selected",
 					"snippet": "const selected = () => (\n    <Example>\n        <Example.Item title=\"selected\">\n            <Card selected>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated\">\n            <Card elevated>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4\">\n            <Card bleed={4}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n        <Example.Item title={[\"responsive bleed\", \"[s] 4\", \"[m+] 0\"]}>\n            <Card bleed={{ s: 4, m: 0 }}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--height",
 					"name": "height",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"height: 200px\">\n            <Card height=\"200px\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Card onClick={fn()}>Trigger</Card>;"
 				},
 				{
+					"id": "components-card--href",
 					"name": "href",
 					"snippet": "const href = () => <Card href=\"https://reshaped.so\">Trigger</Card>;"
 				},
 				{
+					"id": "components-card--as",
 					"name": "as",
 					"snippet": "const as = () => <Card as=\"span\" attributes={{ \"data-testid\": \"root\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-card--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Card className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Card, Example, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Card/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Card",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Card/Card.tsx",
-				"actualName": "Card",
+				"methods": [],
+				"props": {
+					"padding": {
+						"defaultValue": null,
+						"description": "Component padding, base unit multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Remove side borders and apply negative margins, base unit multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"selected": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "selected",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when the component is clicked, turns component into a button",
+						"name": "onClick",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL to navigate to when the component is clicked, turns component into a link",
+						"name": "href",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"as": {
+						"defaultValue": { "value": "\"div\"" },
+						"description": "Custom component tag name",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(Attributes<keyof IntrinsicElements> & (Attributes))" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -492,56 +2948,181 @@
 			"path": "./src/components/Carousel/tests/Carousel.stories.tsx",
 			"stories": [
 				{
+					"id": "components-carousel--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Carousel attributes={{ \"data-testid\": \"test-id\" }} visibleItems={3}>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n    </Carousel>\n);"
 				},
 				{
+					"id": "components-carousel--visible-items",
 					"name": "visibleItems",
 					"snippet": "const visibleItems = () => (\n    <Example>\n        <Example.Item title=\"visibleItems: 3\">\n            <Carousel visibleItems={3}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive visibleItems\", \"s: 2, m+ 3\"]}>\n            <Carousel visibleItems={{ s: 2, m: 3 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title=\"visibleItems: auto\">\n            <Carousel>\n                <Placeholder h={100} />\n                <Placeholder h={100} w={200} />\n                <Placeholder h={100} w={300} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 2, visibleItems 3\">\n            <Carousel visibleItems={3} gap={2}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"gap: responsive, visibleItems: 3\", \"s: 2, l: 8\"]}>\n            <Carousel visibleItems={3} gap={{ s: 2, l: 8 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4, visibleItems: 3\">\n            <Carousel visibleItems={3} bleed={4}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive bleed, visibleItems: 3\", \"[s] 4, [l+] 0\"]}>\n            <Carousel visibleItems={3} bleed={{ s: 4, l: 0 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--navigation-display",
 					"name": "navigationDisplay",
 					"snippet": "const navigationDisplay = () => (\n    <Example>\n        <Example.Item title=\"navigationDisplay: hidden\">\n            <Carousel\n                visibleItems={3}\n                navigationDisplay=\"hidden\"\n                attributes={{ \"data-testid\": \"test-id\" }}\n            >\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "instanceRef",
+					"id": "components-carousel--instance-ref",
+					"name": "instanceRef, onChange",
 					"snippet": "const instanceRef = (args) => {\n    const carouselRef = React.useRef<CarouselInstanceRef>(null);\n    const [index, setIndex] = React.useState(0);\n\n    return (\n        <Example>\n            <Example.Item title=\"instanceRef, onChange\">\n                <View gap={3}>\n                    <View gap={3} direction=\"row\" align=\"center\">\n                        <Button onClick={() => carouselRef.current?.navigateBack()}>Back</Button>\n                        <Button onClick={() => carouselRef.current?.navigateForward()}>Forward</Button>\n                        <Button onClick={() => carouselRef.current?.navigateTo(3)}>To 3</Button>\n                        <View.Item>Index: {index}</View.Item>\n                    </View>\n                    <Carousel\n                        visibleItems={2}\n                        instanceRef={carouselRef}\n                        navigationDisplay=\"hidden\"\n                        onChange={(changeArgs) => {\n                            args.handleChange(changeArgs);\n                            setIndex(changeArgs.index);\n                        }}\n                    >\n                        <Placeholder h={100}>Item 0</Placeholder>\n                        <Placeholder h={100}>Item 1</Placeholder>\n                        <Placeholder h={100}>Item 2</Placeholder>\n                        <Placeholder h={100}>Item 3</Placeholder>\n                        <Placeholder h={100}>Item 4</Placeholder>\n                        <Placeholder h={100}>Item 5</Placeholder>\n                    </Carousel>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-carousel--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Carousel visibleItems={2} className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder h={100}>Item 0</Placeholder>\n            <Placeholder h={100}>Item 1</Placeholder>\n            <Placeholder h={100}>Item 2</Placeholder>\n            <Placeholder h={100}>Item 3</Placeholder>\n            <Placeholder h={100}>Item 4</Placeholder>\n            <Placeholder h={100}>Item 5</Placeholder>\n        </Carousel>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Carousel, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Carousel/index.ts",
 				"description": "",
-				"methods": [
-					{
-						"name": "navigateTo",
-						"docblock": null,
-						"modifiers": [],
-						"params": [
+				"displayName": "Carousel",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, each child is rendered as a carousel item",
+						"name": "children",
+						"declarations": [
 							{
-								"name": "index",
-								"optional": false,
-								"type": { "name": "number" }
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
 							}
 						],
-						"returns": null
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"visibleItems": {
+						"defaultValue": null,
+						"description": "Number of items visible at once in the container",
+						"name": "visibleItems",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between items in the container, base unit multiplier",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margins, base unit multiplier, can be used to make sure the items don't get clipped when scrolling",
+						"name": "bleed",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"navigationDisplay": {
+						"defaultValue": null,
+						"description": "Hide navigation controls",
+						"name": "navigationDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"hidden\"", "value": [{ "value": "\"hidden\"" }] }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the carousel methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the first visible carousel index changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { index: number; }) => void)" }
+					},
+					"onScroll": {
+						"defaultValue": null,
+						"description": "Callback when the carousel scrolls",
+						"name": "onScroll",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: UIEvent<HTMLUListElement, UIEvent>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
 					}
-				],
-				"displayName": "Carousel",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Carousel/Carousel.tsx",
-				"actualName": "Carousel",
+				},
 				"exportName": "default"
 			}
 		},
@@ -551,46 +3132,259 @@
 			"path": "./src/components/Checkbox/tests/Checkbox.stories.tsx",
 			"stories": [
 				{
-					"name": "render",
+					"id": "components-checkbox--render",
+					"name": "name, value",
 					"snippet": "const render = () => (\n    <Checkbox name=\"test-name\" value=\"test-value\">\n        Content\n    </Checkbox>\n);"
 				},
 				{
+					"id": "components-checkbox--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"small\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"small\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"medium\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"medium\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"large\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"large\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: responsive, s: small, m: large\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size={{ s: \"small\", m: \"large\" }} defaultChecked>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-checkbox--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Checkbox name=\"animal\" value=\"dog\" hasError>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-checkbox--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n        <Example.Item title=\"disabled, checked\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled checked>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n        <Example.Item title=\"disabled, indeterminate\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled indeterminate>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "checked",
+					"id": "components-checkbox--checked",
+					"name": "checked, controlled",
 					"snippet": "const checked = () => <Checkbox name=\"test-name\" value=\"test-value\" checked onChange={fn()}>Content\n            </Checkbox>;"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-checkbox--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Checkbox name=\"test-name\" value=\"test-value\" defaultChecked onChange={fn()}>Content\n            </Checkbox>;"
 				},
 				{
+					"id": "components-checkbox--indeterminate",
 					"name": "indeterminate",
 					"snippet": "const indeterminate = () => (\n    <Checkbox name=\"test-name\" value=\"test-value\" indeterminate>\n        Content\n    </Checkbox>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-checkbox--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Checkbox className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Checkbox>\n    </div>\n);"
 				}
 			],
 			"import": "import { Checkbox, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Checkbox/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Checkbox",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Checkbox/Checkbox.tsx",
-				"actualName": "Checkbox",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the label",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Component name attribute",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the component",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Component value used for form submission",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"indeterminate": {
+						"defaultValue": null,
+						"description": "Show a indeterminate state, used for \"select all\" checkboxes with some of the individual checkboxes selected",
+						"name": "indeterminate",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the component is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the component is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Component checked state, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default checked state, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -600,26 +3394,143 @@
 			"path": "./src/components/CheckboxGroup/tests/CheckboxGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "value",
+					"id": "components-checkboxgroup--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <View gap={2}>\n    <CheckboxGroup name=\"test-name\" value={[\"1\"]} onChange={fn()}>\n        {/* checked should be ignored */}\n        <Checkbox value=\"1\" checked={false}>Content\n                            </Checkbox>\n        <Checkbox value=\"2\">Content 2</Checkbox>\n    </CheckboxGroup>\n</View>;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-checkboxgroup--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <View gap={2}>\n    <CheckboxGroup name=\"test-name\" defaultValue={[\"1\"]} onChange={fn()}>\n        {/* checked should be ignored */}\n        <Checkbox value=\"1\" checked={false}>Content\n                            </Checkbox>\n        <Checkbox value=\"2\">Content 2</Checkbox>\n    </CheckboxGroup>\n</View>;"
 				},
 				{
+					"id": "components-checkboxgroup--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <CheckboxGroup name=\"test-name\" disabled>\n        <Checkbox value=\"test-value\">Item 1</Checkbox>\n        <Checkbox value=\"test-value-2\">Item 2</Checkbox>\n    </CheckboxGroup>\n);"
 				}
 			],
 			"import": "import { Checkbox, CheckboxGroup, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/CheckboxGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "CheckboxGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/CheckboxGroup/CheckboxGroup.tsx",
-				"actualName": "CheckboxGroup",
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Component id attribute",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting checkboxes or custom layout components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the component from form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Component name attribute",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string[], ChangeEvent<HTMLInputElement>>" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Component value, enables controlled mode\nComponent value, enables uncontrolled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -629,23 +3540,346 @@
 			"path": "./src/components/ContextMenu/tests/ContextMenu.stories.tsx",
 			"stories": [
 				{
+					"id": "components-contextmenu--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"base\">\n            <div style={{ height: 200, overflow: \"auto\" }}>\n                <ContextMenu>\n                    <View height=\"400px\" backgroundColor=\"neutral-faded\" borderRadius=\"medium\" />\n\n                    <ContextMenu.Content>\n                        <ContextMenu.Item>Item 1</ContextMenu.Item>\n                        <ContextMenu.Item>Item 2</ContextMenu.Item>\n                    </ContextMenu.Content>\n                </ContextMenu>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "components-contextmenu--handlers",
+					"name": "handleOpen, handleClose",
 					"snippet": "const handlers = () => <div style={{ height: 200, overflow: \"auto\" }} data-testid=\"scroll\">\n    <ContextMenu onOpen={fn()} onClose={fn()}>\n        <View\n            height=\"400px\"\n            backgroundColor=\"neutral-faded\"\n            borderRadius=\"medium\"\n            attributes={{ \"data-testid\": \"root\" }} />\n        <ContextMenu.Content>\n            <ContextMenu.Item>Item</ContextMenu.Item>\n        </ContextMenu.Content>\n    </ContextMenu>\n</div>;"
 				}
 			],
 			"import": "import { ContextMenu, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ContextMenu/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ContextMenu",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ContextMenu/ContextMenu.tsx",
-				"actualName": "ContextMenu",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/DropdownMenu/DropdownMenu.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | \"action-menu\" | \"selection-menu\"" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					}
+				},
+				"exportName": "ContextMenu"
 			}
 		},
 		"components-divider": {
@@ -654,30 +3888,118 @@
 			"path": "./src/components/Divider/tests/Divider.stories.tsx",
 			"stories": [
 				{
-					"name": "rendering",
+					"id": "components-divider--rendering",
+					"name": "base",
 					"snippet": "const rendering = () => (\n    <Example>\n        <Example.Item title=\"default rendering\">\n            <Divider />\n        </Example.Item>\n\n        <Example.Item title={[\"blank rendering\", \"box should overlap with divider\"]}>\n            <View width=\"40px\" height=\"10px\" backgroundColor=\"primary\" />\n            <Divider blank />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-divider--vertical",
 					"name": "vertical",
 					"snippet": "const vertical = () => (\n    <Example>\n        <Example.Item title=\"vertical\">\n            <View gap={3} direction=\"row\" align=\"stretch\">\n                <Placeholder />\n                <View.Item>\n                    <Divider vertical />\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive vertical\", \"[s] true\", \"[m+]: false\"]}>\n            <View gap={3} direction={{ s: \"row\", m: \"column\" }} align=\"stretch\">\n                <Placeholder />\n                <View.Item>\n                    <Divider vertical={{ s: true, m: false }} />\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "label",
+					"id": "components-divider--label",
+					"name": "children, contentPosition",
 					"snippet": "const label = () => {\n    return (\n        <Example>\n            <Example.Item title=\"alignment\">\n                <View gap={4}>\n                    <Divider>Centered label</Divider>\n                    <Divider contentPosition=\"start\">Start label</Divider>\n                    <Divider contentPosition=\"end\">End label</Divider>\n                </View>\n            </Example.Item>\n\n            <Example.Item title=\"responsive\">\n                <View gap={3} direction={{ s: \"column\", m: \"row\" }} align=\"stretch\">\n                    <Placeholder />\n                    <View.Item>\n                        <Divider vertical={{ s: false, m: true }}>or pick second option</Divider>\n                    </View.Item>\n                    <Placeholder />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-divider--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Divider className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Divider, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Divider/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Divider",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Divider/Divider.tsx",
-				"actualName": "Divider",
+				"methods": [],
+				"props": {
+					"blank": {
+						"defaultValue": null,
+						"description": "Change component to take no space, useful for using it as a border in components like Tabs",
+						"name": "blank",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"vertical": {
+						"defaultValue": null,
+						"description": "Change component to render vertically",
+						"name": "vertical",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"contentPosition": {
+						"defaultValue": null,
+						"description": "Position for rendering children",
+						"name": "contentPosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"center\" | \"start\" | \"end\"",
+							"value": [{ "value": "\"center\"" }, { "value": "\"start\"" }, { "value": "\"end\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting text labels or custom components as a part of divider",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"hr\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -687,51 +4009,415 @@
 			"path": "./src/components/DropdownMenu/tests/DropdownMenu.stories.tsx",
 			"stories": [
 				{
+					"id": "components-dropdownmenu--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: default\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <DropdownMenu position=\"end\">\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n\n        <Example.Item title={[\"position: top-start\", \"should change to top-start to fit viewport\"]}>\n            <DropdownMenu position=\"top-end\">\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n        <div style={{ height: 2000 }} />\n    </Example>\n);"
 				},
 				{
+					"id": "components-dropdownmenu--sections",
 					"name": "sections",
 					"snippet": "const sections = () => (\n    <Example>\n        <Example.Item title=\"2 sections\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Section>\n                        <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                    </DropdownMenu.Section>\n\n                    <DropdownMenu.Section>\n                        <DropdownMenu.Item>Item 3</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 4</DropdownMenu.Item>\n                    </DropdownMenu.Section>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-dropdownmenu--submenu",
 					"name": "submenu",
 					"snippet": "const submenu = () => (\n    <Example>\n        <Example.Item title=\"submenu\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item onClick={() => {}}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger>Item 2</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger>Item 3</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2-1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2-2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger disabled>Item 4, disabled</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 3-1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 3-2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-dropdownmenu--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <DropdownMenu onOpen={fn()} onClose={fn()} defaultActive>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "active",
+					"id": "components-dropdownmenu--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <DropdownMenu onOpen={fn()} onClose={fn()} active>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "components-dropdownmenu--active-false",
+					"name": "active false, controlled",
 					"snippet": "const activeFalse = () => <DropdownMenu onOpen={fn()} onClose={fn()} active={false}>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "className",
+					"id": "components-dropdownmenu--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <DropdownMenu active>\n            <DropdownMenu.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </DropdownMenu.Trigger>\n            <DropdownMenu.Content className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n                <DropdownMenu.Item>Item</DropdownMenu.Item>\n            </DropdownMenu.Content>\n        </DropdownMenu>\n    </div>\n);"
 				},
 				{
-					"name": "testScroll",
+					"id": "components-dropdownmenu--test-scroll",
+					"name": "test: scroll",
 					"snippet": "const testScroll = () => (\n    <Example>\n        <Example.Item title=\"Scrolls on page mount to the dropdown\">\n            <div style={{ height: 1000 }} />\n            <DropdownMenu position=\"end\" key=\"scroll\" defaultActive>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testTheme",
+					"id": "components-dropdownmenu--test-theme",
+					"name": "test: theme",
 					"snippet": "const testTheme = () => (\n    <Example>\n        <Example.Item title=\"switch color mode while dropdown is active and check that it still works\">\n            <ThemeSwitching />\n        </Example.Item>\n        <Example.Item title=\"dropdown inherits multiple themes\">\n            <ThemeMultiple />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, DropdownMenu, Example, Theme, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/DropdownMenu/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "DropdownMenu",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/DropdownMenu/DropdownMenu.tsx",
-				"actualName": "DropdownMenu",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/DropdownMenu/DropdownMenu.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | \"action-menu\" | \"selection-menu\"" }
+					}
+				},
+				"exportName": "DropdownMenu"
 			}
 		},
 		"components-fileupload": {
@@ -740,35 +4426,165 @@
 			"path": "./src/components/FileUpload/tests/FileUpload.stories.tsx",
 			"stories": [
 				{
+					"id": "components-fileupload--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"Base upload with previews\">\n            <Demo />\n        </Example.Item>\n        <Example.Item title=\"With trigger\">\n            <FileUpload name=\"file\">\n                <div>\n                    Drop files to attach, or{\" \"}\n                    <FileUpload.Trigger>\n                        <Link variant=\"plain\">browse</Link>\n                    </FileUpload.Trigger>\n                </div>\n            </FileUpload>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "inline",
+					"id": "components-fileupload--inline",
+					"name": "inline, variant, render props",
 					"snippet": "const inline = () => {\n    return (\n        <Example>\n            <Example.Item title=\"inline\">\n                <FileUpload name=\"file\" inline onChange={console.log}>\n                    <View padding={2} paddingInline={3}>\n                        Upload\n                    </View>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"variant headless\">\n                <FileUpload name=\"file2\" variant=\"headless\" onChange={console.log}>\n                    <Button variant=\"outline\" fullWidth>\n                        Upload\n                    </Button>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"variant headless, inline\">\n                <FileUpload name=\"file2\" variant=\"headless\" inline onChange={console.log}>\n                    <Button>Upload</Button>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"inline, render props\">\n                <FileUpload name=\"file3\" variant=\"headless\" inline onChange={console.log}>\n                    {(props) => <Button highlighted={props.highlighted}>Upload</Button>}\n                </FileUpload>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-fileupload--height",
 					"name": "height",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"Custom height\">\n            <FileUpload name=\"file\" height=\"300px\">\n                <View gap={3}>\n                    <Icon svg={IconMic} size={8} />\n                    Drop files to attach\n                </View>\n            </FileUpload>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onChange",
+					"id": "components-fileupload--on-change",
+					"name": "name, onChange",
 					"snippet": "const onChange = () => <div data-testid=\"root\">\n    <FileUpload name=\"test-name\" onChange={fn()}>Content\n                    </FileUpload>\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "components-fileupload--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <FileUpload\n            name=\"name\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ id: \"test-input-id\" }}\n        >\n            Content\n        </FileUpload>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, FileUpload, Icon, Image, Link, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/FileUpload/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "FileUpload",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/FileUpload/FileUpload.tsx",
-				"actualName": "FileUpload",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, can be a render function that receives component state",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode | ((props: { highlighted?: boolean; }) => ReactNode)" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component value is changed",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ChangeHandler<File[], ChangeEvent<HTMLInputElement> | DragEvent<HTMLDivElement>>"
+						}
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Component height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component variant, headless variant is useful for rendering custom triggers like a Button",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"headless\"",
+							"value": [{ "value": "\"outline\"" }, { "value": "\"headless\"" }]
+						}
+					},
+					"inline": {
+						"defaultValue": null,
+						"description": "Change component to render inline making it more compact",
+						"name": "inline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					}
+				},
+				"exportName": "FileUpload"
 			}
 		},
 		"components-hotkey": {
@@ -777,22 +4593,78 @@
 			"path": "./src/components/Hotkey/tests/Hotkey.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "components-hotkey--base",
+					"name": "Base",
 					"snippet": "const base = () => (\n\t<Example>\n\t\t<Example.Item title=\"Base\">\n\t\t\t<Demo />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"Active\">\n\t\t\t<Hotkey active>⌘K</Hotkey>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"Inside input slot\">\n\t\t\t<View width=\"300px\">\n\t\t\t\t<TextField\n\t\t\t\t\tname=\"hey\"\n\t\t\t\t\tendSlot={<Demo />}\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"hotkey test\" }}\n\t\t\t\t/>\n\t\t\t</View>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-hotkey--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Hotkey className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            ⌘K\n        </Hotkey>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Hotkey, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Hotkey/Hotkey.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Hotkey",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Hotkey/Hotkey.tsx",
-				"actualName": "Hotkey",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Highlight the component, can be used to show when hotkey is pressed",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -802,54 +4674,241 @@
 			"path": "./src/components/Link/tests/Link.stories.tsx",
 			"stories": [
 				{
+					"id": "components-link--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: underline\">\n            <Link href=\"http://reshaped.so\" attributes={{ target: \"_blank\" }}>\n                Reshaped\n            </Link>\n        </Example.Item>\n        <Example.Item title=\"variant: plain\">\n            <Link onClick={() => {}} variant=\"plain\">\n                Link\n            </Link>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary\">\n            <Link color=\"primary\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Link color=\"critical\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Link color=\"positive\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <Link color=\"warning\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <Link color=\"inherit\">Link</Link>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon, variant: underline\">\n            <Link icon={IconZap}>Link</Link>\n        </Example.Item>\n        <Example.Item title=\"icon, variant: plain\">\n            <Link icon={IconZap} variant=\"plain\">\n                Link\n            </Link>\n        </Example.Item>\n        <Example.Item\n            title={[\"icon, variant: underline\", \"should inherit display-1 size from the parent\"]}\n        >\n            <Text variant=\"title-3\">\n                <Link icon={IconZap} variant=\"underline\">\n                    Instant delivery\n                </Link>\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--href",
 					"name": "href",
 					"snippet": "const href = () => <Link href=\"https://reshaped.so\">Trigger</Link>;"
 				},
 				{
+					"id": "components-link--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Link onClick={fn()}>Trigger</Link>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-link--href-on-click",
+					"name": "href + onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <Link\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </Link>\n);"
 				},
 				{
+					"id": "components-link--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Link disabled onClick={() => {}}>\n        Trigger\n    </Link>\n);"
 				},
 				{
+					"id": "components-link--render",
 					"name": "render",
 					"snippet": "const render = () => <Link render={(props) => <section {...props} />}>Trigger</Link>;"
 				},
 				{
-					"name": "className",
+					"id": "components-link--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Link className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Link>\n    </div>\n);"
 				},
 				{
-					"name": "testMultilineInText",
+					"id": "components-link--test-multiline-in-text",
+					"name": "test: multiline",
 					"snippet": "const testMultilineInText = () => (\n    <Example>\n        <Example.Item title=\"should wrap inside the text\">\n            <div>\n                Someone asked me to write this text that is boring to ready for everyone and to add&nbsp;\n                <Link href=\"/\">this very very long link</Link> to it.\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Link, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Link/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Link",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Link/Link.tsx",
-				"actualName": "Link",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon at the start position",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"primary\"" },
+						"description": "Link color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"inherit\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"inherit\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"underline\"" },
+						"description": "Link render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"plain\" | \"underline\"",
+							"value": [{ "value": "\"plain\"" }, { "value": "\"underline\"" }]
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -859,30 +4918,110 @@
 			"path": "./src/components/Loader/tests/Loader.stories.tsx",
 			"stories": [
 				{
+					"id": "components-loader--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: medium\">\n                <Loader size=\"medium\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title=\"size: small\">\n                <Loader size=\"small\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title=\"size: large\">\n                <Loader size=\"large\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title={[\"responsive size\", \"[s] small\", \"[m+] medium\"]}>\n                <Loader size={{ s: \"small\", m: \"medium\" }} ariaLabel=\"Loading\" />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-loader--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary\">\n            <Loader ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Loader color=\"critical\" ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Loader color=\"positive\" ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <Loader color=\"inherit\" ariaLabel=\"Loading\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-loader--aria-label",
 					"name": "ariaLabel",
 					"snippet": "const ariaLabel = () => <Loader ariaLabel=\"Loading\" attributes={{ \"data-testid\": \"root\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-loader--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Loader className=\"test-classname\" attributes={{ id: \"test-id\" }} ariaLabel=\"Loading\" />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Loader } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Loader/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Loader",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Loader/Loader.tsx",
-				"actualName": "Loader",
+				"methods": [],
+				"props": {
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"inherit\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -892,67 +5031,504 @@
 			"path": "./src/components/MenuItem/tests/MenuItem.stories.tsx",
 			"stories": [
 				{
+					"id": "components-menuitem--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <MenuItem size=\"small\" icon={IconZap} onClick={() => {}} endSlot={<Hotkey>⌘K</Hotkey>}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <MenuItem icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <MenuItem size=\"large\" icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title={[\"responsive size\", \"[s] small\", \"[m] medium\", \"[l+] large\"]}>\n            <MenuItem size={{ s: \"small\", m: \"medium\", l: \"large\" }} icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <MenuItem color=\"neutral\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <MenuItem color=\"primary\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <MenuItem color=\"critical\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--selected",
 					"name": "selected",
 					"snippet": "const selected = () => (\n    <Example>\n        <Example.Item title=\"selected, color: neutral\">\n            <MenuItem color=\"neutral\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"selected, color: primary\">\n            <MenuItem color=\"primary\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"selected, color: critical\">\n            <MenuItem color=\"critical\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--rounded-corners",
 					"name": "roundedCorners",
 					"snippet": "const roundedCorners = () => (\n    <Example>\n        <Example.Item title=\"roundedCorners\">\n            <MenuItem roundedCorners selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive roundedCorners\", \"[s]: false\", \"[m+]: true\"]}>\n            <MenuItem roundedCorners={{ s: false, m: true }} selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "slots",
+					"id": "components-menuitem--slots",
+					"name": "startSlot, endSlot",
 					"snippet": "const slots = () => (\n    <Example>\n        <Example.Item title=\"startSlot, endSlot, selected\">\n            <MenuItem startSlot={<Placeholder h={20} />} endSlot={<Placeholder h={20} />} selected>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem size=\"small\" selected onClick={() => {}}>\n                        Menu item\n                    </MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem selected>Menu item</MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem size=\"large\" selected>\n                        Menu item\n                    </MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--href",
 					"name": "href",
 					"snippet": "const href = () => <MenuItem href=\"https://reshaped.so\">Trigger</MenuItem>;"
 				},
 				{
+					"id": "components-menuitem--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <MenuItem onClick={fn()}>Trigger</MenuItem>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-menuitem--href-on-click",
+					"name": "href + onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <MenuItem\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </MenuItem>\n);"
 				},
 				{
+					"id": "components-menuitem--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <MenuItem disabled onClick={() => {}}>\n        Trigger\n    </MenuItem>\n);"
 				},
 				{
-					"name": "as",
+					"id": "components-menuitem--as",
+					"name": "as, render",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"render, disabled\">\n            <MenuItem\n                disabled\n                onClick={() => {}}\n                render={(props) => <section {...props} />}\n                attributes={{ \"data-testid\": \"render-el\" }}\n            >\n                Trigger\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-menuitem--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <MenuItem className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </MenuItem>\n    </div>\n);"
 				},
 				{
-					"name": "alignerClassName",
+					"id": "components-menuitem--aligner-class-name",
+					"name": "aligner, className, attributes",
 					"snippet": "const alignerClassName = () => (\n    <div data-testid=\"root\">\n        <MenuItem.Aligner className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <MenuItem>Trigger</MenuItem>\n        </MenuItem.Aligner>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Hotkey, MenuItem, Placeholder, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/MenuItem/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "MenuItem",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/MenuItem/MenuItem.tsx",
-				"actualName": "MenuItem",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content\nNode for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"neutral\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"neutral\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content at the start side of the component",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content at the end side of the component",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component as hovered or focused. For example, when displaying currently focused item in Autocomplete",
+						"name": "highlighted",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"selected": {
+						"defaultValue": null,
+						"description": "Highlight the component as selected",
+						"name": "selected",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"roundedCorners": {
+						"defaultValue": null,
+						"description": "Round the corners of the component",
+						"name": "roundedCorners",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					}
+				},
+				"exportName": "MenuItem"
 			}
 		},
 		"components-modal": {
@@ -961,67 +5537,301 @@
 			"path": "./src/components/Modal/tests/Modal.stories.tsx",
 			"stories": [
 				{
+					"id": "components-modal--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title={[\"responsive position\", \"[s] full-screen\", \"[m] center\", \"[l] end\"]}>\n            <Demo position={{ s: \"full-screen\", m: \"center\", l: \"end\" }} />\n        </Example.Item>\n        <Example.Item title=\"position: center\">\n            <Demo position=\"center\" />\n        </Example.Item>\n        <Example.Item title=\"position: bottom\">\n            <Demo position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"position: start\">\n            <Demo position=\"start\" />\n        </Example.Item>\n        <Example.Item title=\"position: end\">\n            <Demo position=\"end\" />\n        </Example.Item>\n        <Example.Item title=\"position: full-screen\">\n            <Demo position=\"full-screen\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: default\">\n                <Demo />\n            </Example.Item>\n            <Example.Item title=\"size: 300px\">\n                <Demo size=\"300px\" />\n            </Example.Item>\n            <Example.Item\n                title={[\"size: 800px\", \"should have max width of 100% minus gaps on the sides\"]}\n            >\n                <Demo size=\"800px\" />\n            </Example.Item>\n            <Example.Item\n                title={[\n                    \"responsive size, responsive position\",\n                    \"[s] auto\",\n                    \"[m+] 600px\",\n                    \"bottom position changes height instead of width\",\n                ]}\n            >\n                <Demo\n                    position={{ s: \"bottom\", m: \"center\", l: \"end\" }}\n                    size={{ s: \"auto\", m: \"600px\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-modal--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 0\">\n            <Demo padding={0} />\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <Demo padding={6} />\n        </Example.Item>\n        <Example.Item title={[\"responsive padding\", \"[s] 2\", \"[m+]: 6\"]}>\n            <Demo padding={{ s: 2, m: 6 }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--overflow",
 					"name": "overflow",
 					"snippet": "const overflow = () => (\n    <Example>\n        <Example.Item title=\"default overflow\">\n            <Demo>\n                <div\n                    style={{\n                        position: \"absolute\",\n                        top: -32,\n                        left: -32,\n                        height: 100,\n                        width: 100,\n                        background: \"tomato\",\n                    }}\n                />\n            </Demo>\n        </Example.Item>\n\n        <Example.Item title=\"overflow: visible\">\n            <Demo overflow=\"visible\">\n                <div\n                    style={{\n                        position: \"absolute\",\n                        top: -32,\n                        left: -32,\n                        height: 100,\n                        width: 100,\n                        background: \"tomato\",\n                    }}\n                />\n            </Demo>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--composition",
 					"name": "composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"title, subtitle, dismissible\">\n            <Demo title=\"Modal title\" subtitle=\"Modal subtitle\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--overlay",
 					"name": "overlay",
 					"snippet": "const overlay = () => (\n    <Example>\n        <Example.Item title=\"transparentOverlay, doesn't lock scroll\">\n            <Demo transparentOverlay />\n        </Example.Item>\n        <Example.Item title=\"blurredOverlay\">\n            <Demo blurredOverlay />\n        </Example.Item>\n        <View height=\"1000px\" />\n    </Example>\n);"
 				},
 				{
-					"name": "flags",
+					"id": "components-modal--flags",
+					"name": "disableCloseOnOutsideClick",
 					"snippet": "const flags = () => {\n    return (\n        <Example>\n            <Example.Item title=\"disableCloseOnOutsideClick\">\n                <Demo disableCloseOnOutsideClick onClose={fn()} active />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-modal--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const containerRef2 = React.useRef<HTMLDivElement>(null);\n    const toggle = useToggle();\n    const toggle2 = useToggle();\n\n    return (\n        <Example>\n            <Example.Item title={[\"in scrollable container\", \"scroll and then open\"]}>\n                <View\n                    attributes={{ ref: containerRef2 }}\n                    borderRadius=\"medium\"\n                    height=\"400px\"\n                    overflow=\"auto\"\n                    backgroundColor=\"neutral-faded\"\n                    padding={4}\n                >\n                    <View gap={4} align=\"start\">\n                        <Button onClick={toggle2.activate}>Open modal</Button>\n                        <View height=\"500px\" backgroundColor=\"primary\" width=\"500px\" borderRadius=\"medium\" />\n                    </View>\n                    <Modal\n                        containerRef={containerRef2}\n                        active={toggle2.active}\n                        onClose={toggle2.deactivate}\n                        position=\"end\"\n                    >\n                        <Placeholder />\n                    </Modal>\n                </View>\n            </Example.Item>\n            <Example.Item title=\"in static container\">\n                <View\n                    attributes={{ ref: containerRef }}\n                    borderRadius=\"medium\"\n                    height=\"400px\"\n                    overflow=\"hidden\"\n                    backgroundColor=\"neutral-faded\"\n                    padding={4}\n                >\n                    <Button onClick={toggle.activate}>Open modal</Button>\n                    <Modal\n                        containerRef={containerRef}\n                        active={toggle.active}\n                        onClose={toggle.deactivate}\n                        position=\"end\"\n                    >\n                        <Placeholder />\n                    </Modal>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "renderProps",
+					"id": "components-modal--render-props",
+					"name": "children, render props",
 					"snippet": "const renderProps = () => (\n    <Modal active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        <Modal.Title>Title</Modal.Title>\n        Content\n    </Modal>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "components-modal--handlers",
+					"name": "onOpen, onClose, onAfterOpen, onAfterClose",
 					"snippet": "const handlers = () => {\n    const overlayToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => overlayToggle.toggle()}>Open overlay</Button>\n            <Modal\n                active={overlayToggle.active}\n                onClose={(closeArgs) => {\n                    overlayToggle.deactivate();\n                    args.handleClose(closeArgs);\n                }}\n                onOpen={fn()}\n                onAfterOpen={fn()}\n                onAfterClose={fn()}>\n                <Modal.Title>Title</Modal.Title>Content\n                                </Modal>\n        </>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-modal--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <Modal active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        <Modal.Title>Title</Modal.Title>\n        Content\n    </Modal>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-modal--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => {\n    const menuModalToggle = useToggle();\n    const menuModalToggleInner = useToggle();\n    const scrollModalToggle = useToggle();\n    const inputRef = React.useRef<HTMLInputElement>(null);\n\n    return (\n        <Example>\n            <Example.Item title=\"Scrolls with long content on touch devices\">\n                <Demo position=\"center\">\n                    <Button onClick={() => {}}>Action</Button>\n                    <View height=\"2000px\" backgroundColor=\"primary-faded\" />\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"keyboard focus stays on the modal first\">\n                <Demo title=\"Modal title\" autoFocus={false} />\n            </Example.Item>\n            <Example.Item title=\"trap focus works with custom children components\">\n                <Demo title=\"Modal title\">\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <Switch name=\"switch\" />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"focus moves to the input\">\n                <Demo\n                    title=\"Modal title\"\n                    onOpen={() => {\n                        inputRef.current?.focus();\n                    }}\n                >\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <TextField name=\"name\" inputAttributes={{ ref: inputRef }} />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"Focus moves to the input with autoFocus\">\n                <Demo title=\"Modal title\">\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <TextField\n                            name=\"name\"\n                            placeholder=\"autofocus\"\n                            inputAttributes={{ autoFocus: true }}\n                        />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"scrollable area in modal ignores swipe-to-close\">\n                <View gap={3} direction=\"row\">\n                    <Button onClick={scrollModalToggle.activate}>Open</Button>\n                    <Modal\n                        active={scrollModalToggle.active}\n                        onClose={scrollModalToggle.deactivate}\n                        size=\"300px\"\n                        position=\"bottom\"\n                    >\n                        <View\n                            height=\"1000px\"\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            padding={4}\n                        >\n                            Content\n                        </View>\n                    </Modal>\n                </View>\n            </Example.Item>\n            <Example.Item\n                title={[\n                    \"trap focus works correctly when it was already trapped\",\n                    \"focus return back to the dropdown trigger on modal close\",\n                    \"closing dropdown inside the modal doesn't close the modal\",\n                ]}\n            >\n                <DropdownMenu>\n                    <DropdownMenu.Trigger>\n                        {(attributes) => <Button attributes={attributes}>Open menu</Button>}\n                    </DropdownMenu.Trigger>\n                    <DropdownMenu.Content>\n                        <DropdownMenu.Item onClick={menuModalToggle.activate}>Open dialog</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                    </DropdownMenu.Content>\n                </DropdownMenu>\n                <Modal active={menuModalToggle.active} onClose={menuModalToggle.deactivate}>\n                    <View gap={3}>\n                        <DropdownMenu>\n                            <DropdownMenu.Trigger>\n                                {(attributes) => <Button attributes={attributes}>Open menu</Button>}\n                            </DropdownMenu.Trigger>\n                            <DropdownMenu.Content>\n                                <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                                <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                            </DropdownMenu.Content>\n                        </DropdownMenu>\n                        <Button onClick={menuModalToggleInner.activate}>Open dialog</Button>\n                        <Button onClick={menuModalToggle.deactivate}>Close</Button>\n                        <Modal active={menuModalToggleInner.active} onClose={menuModalToggleInner.deactivate}>\n                            <Button onClick={menuModalToggleInner.deactivate}>Close</Button>\n                        </Modal>\n                    </View>\n                </Modal>\n            </Example.Item>\n\n            <Example.Item title=\"disableSwipeGesture\">\n                <Demo disableSwipeGesture position=\"start\" />\n            </Example.Item>\n\n            <Example.Item title=\"scroll locks on open\">\n                <Demo />\n                <View height=\"1000px\" />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "trapFocusEdgeCases",
+					"id": "components-modal--trap-focus-edge-cases",
+					"name": "test: trap focus edge cases",
 					"snippet": "const trapFocusEdgeCases = () => {\n    const toggle = useToggle();\n\n    return (\n        <Example>\n            <Example.Item title=\"Radio should be navigatable with arrow keys\">\n                <Button onClick={toggle.activate}>Open modal</Button>\n                <Modal active={toggle.active} onClose={toggle.deactivate}>\n                    <View gap={2}>\n                        <Button onClick={() => {}}>Action 1</Button>\n                        <Radio name=\"radio\" value=\"1\">\n                            Option 1\n                        </Radio>\n                        <Radio name=\"radio\" value=\"2\">\n                            Option 2\n                        </Radio>\n                        <Button onClick={() => {}}>Action 2</Button>\n                    </View>\n                </Modal>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import {\n    Button,\n    Dismissible,\n    DropdownMenu,\n    Example,\n    Modal,\n    Placeholder,\n    Radio,\n    Switch,\n    TextField,\n    View,\n} from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Modal/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Modal",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Modal/Modal.tsx",
-				"actualName": "Modal",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Component position on the screen",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<\"bottom\" | \"center\" | \"start\" | \"end\" | \"full-screen\">"
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size, literal css value",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Component padding, unit token multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Remove overflow from the component content",
+						"name": "overflow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"visible\"", "value": [{ "value": "\"visible\"" }] }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is closed",
+						"name": "onClose",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((args: { reason: CloseReason | \"drag\"; }) => void)" }
+					},
+					"transparentOverlay": {
+						"defaultValue": null,
+						"description": "Make the overlay transparent",
+						"name": "transparentOverlay",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"blurredOverlay": {
+						"defaultValue": null,
+						"description": "Make the overlay blurred",
+						"name": "blurredOverlay",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableSwipeGesture": {
+						"defaultValue": null,
+						"description": "Disable swipe gesture to close the component on touch devices",
+						"name": "disableSwipeGesture",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable closing the component on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Focus the first focusable element in the component when it is opened, when false, focus will be set on the component content container",
+						"name": "autoFocus",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element, useful when there is no visible title",
+						"name": "ariaLabel",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"overlayClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the overlay element",
+						"name": "overlayClassName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "(Attributes<\"div\"> & { ref?: RefObject<HTMLDivElement | null>; })"
+						}
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the visibility of the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the component is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"containerRef": {
+						"defaultValue": null,
+						"description": "Element to render the component in",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"onAfterOpen": {
+						"defaultValue": null,
+						"description": "Callback after the component open transition is complete",
+						"name": "onAfterOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onAfterClose": {
+						"defaultValue": null,
+						"description": "Callback after the component close transition is complete",
+						"name": "onAfterClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					}
+				},
+				"exportName": "Modal"
 			}
 		},
 		"components-numberfield": {
@@ -1030,54 +5840,450 @@
 			"path": "./src/components/NumberField/tests/NumberField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-numberfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => {\n    return (\n        <Example>\n            <Example.Item title=\"variant: outline\">\n                <NumberField\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"variant: faded\">\n                <NumberField\n                    variant=\"faded\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"variant: headless\">\n                <NumberField\n                    variant=\"headless\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-numberfield--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: small\">\n                <NumberField\n                    size=\"small\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    suffix=\"m2\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: medium\">\n                <NumberField\n                    size=\"medium\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: large\">\n                <NumberField\n                    size=\"large\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: xlarge\">\n                <NumberField\n                    size=\"xlarge\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-numberfield--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <NumberField\n    name=\"test-name\"\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    disabled\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-numberfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <NumberField\n    name=\"test-name\"\n    defaultValue={2}\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-numberfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <NumberField\n    name=\"test-name\"\n    value={2}\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "minMax",
+					"id": "components-numberfield--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <NumberField\n        name=\"test-name\"\n        defaultValue={6}\n        min={5}\n        max={10}\n        increaseAriaLabel=\"Increase\"\n        decreaseAriaLabel=\"Decrease\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-numberfield--step",
 					"name": "step",
 					"snippet": "const step = () => (\n    <NumberField\n        name=\"test-name\"\n        defaultValue={6}\n        step={0.5}\n        increaseAriaLabel=\"Increase\"\n        decreaseAriaLabel=\"Decrease\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-numberfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <NumberField\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n            increaseAriaLabel=\"Increase\"\n            decreaseAriaLabel=\"Decrease\"\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-numberfield--form-control",
+					"name": "test: FormControl",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"FormControl\">\n            <FormControl>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"FormControl, disabled\">\n            <FormControl disabled>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"FormControl, error\">\n            <FormControl hasError>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "valueChanges",
+					"id": "components-numberfield--value-changes",
+					"name": "test: keyboard",
 					"snippet": "const valueChanges = () => (\n    <Example>\n        <Example.Item title=\"keyboard\">\n            <NumberField\n                name=\"name\"\n                increaseAriaLabel=\"Increase\"\n                decreaseAriaLabel=\"Decrease\"\n                inputAttributes={{ \"aria-label\": \"Label\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, FormControl, NumberField } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/NumberField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "NumberField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/NumberField/NumberField.tsx",
-				"actualName": "NumberField",
+				"methods": [],
+				"props": {
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component value is changed",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<number, ChangeEvent<HTMLInputElement>>" }
+					},
+					"increaseAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the increase button",
+						"name": "increaseAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"decreaseAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the decrease button",
+						"name": "decreaseAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum value supported in the form field",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum value supported in the form field",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"step": {
+						"defaultValue": null,
+						"description": "Step at which the value will increase or decrease when clicking the button controls",
+						"name": "step",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the form field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the form field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1087,34 +6293,166 @@
 			"path": "./src/components/Pagination/tests/Pagination.stories.tsx",
 			"stories": [
 				{
+					"id": "components-pagination--truncate",
 					"name": "truncate",
 					"snippet": "const truncate = () => {\n    return (\n        <Example>\n            <Example.Item title=\"start\">\n                <Pagination\n                    total={10}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"middle\">\n                <Pagination\n                    total={10}\n                    defaultPage={5}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"end\">\n                <Pagination\n                    total={10}\n                    defaultPage={10}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"no truncation\">\n                <Pagination\n                    total={4}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "render",
+					"id": "components-pagination--render",
+					"name": "rendering",
 					"snippet": "const render = () => (\n    <div data-testid=\"root\">\n        <Pagination\n            total={10}\n            previousAriaLabel=\"Previous\"\n            nextAriaLabel=\"Next\"\n            pageAriaLabel={(args) => `Page ${args.page}`}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "defaultPage",
+					"id": "components-pagination--default-page",
+					"name": "defaultPage, uncontrolled",
 					"snippet": "const defaultPage = () => <div data-testid=\"root\">\n    <Pagination\n        total={10}\n        defaultPage={2}\n        onChange={fn()}\n        previousAriaLabel=\"Previous\"\n        nextAriaLabel=\"Next\" />\n</div>;"
 				},
 				{
-					"name": "page",
+					"id": "components-pagination--page",
+					"name": "page, controlled",
 					"snippet": "const page = () => <div data-testid=\"root\">\n    <Pagination\n        total={10}\n        page={2}\n        onChange={fn()}\n        previousAriaLabel=\"Previous\"\n        nextAriaLabel=\"Next\" />\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "components-pagination--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Pagination\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            total={10}\n            previousAriaLabel=\"Previous\"\n            nextAriaLabel=\"Next\"\n        />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Pagination } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Pagination/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Pagination",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Pagination/Pagination.tsx",
-				"actualName": "Pagination",
+				"methods": [],
+				"props": {
+					"total": {
+						"defaultValue": null,
+						"description": "Total number of pages available",
+						"name": "total",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "number" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the current page changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { page: number; }) => void)" }
+					},
+					"pageAriaLabel": {
+						"defaultValue": null,
+						"description": "Function to dynamically get an aria-label for each page",
+						"name": "pageAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { page: number; }) => string)" }
+					},
+					"previousAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the previous page button",
+						"name": "previousAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"nextAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the next page button",
+						"name": "nextAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"page": {
+						"defaultValue": null,
+						"description": "Currently selected page number, starts with 1, enables controlled mode",
+						"name": "page",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultPage": {
+						"defaultValue": null,
+						"description": "Default selected page number, starts with 1, enables uncontrolled mode",
+						"name": "defaultPage",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1124,54 +6462,229 @@
 			"path": "./src/components/PinField/tests/PinField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-pinfield--base",
 					"name": "base",
 					"snippet": "const base = () => <PinField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-pinfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <PinField name=\"pin\" variant=\"faded\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-pinfield--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <PinField name=\"pin\" size=\"small\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <PinField name=\"pin\" size=\"medium\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <PinField name=\"pin\" size=\"large\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <PinField name=\"pin\" size=\"xlarge\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: responsive, s: medium, m+: xlarge\">\n            <PinField\n                name=\"pin\"\n                size={{ s: \"medium\", m: \"xlarge\" }}\n                inputAttributes={{ \"aria-label\": \"Pin\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-pinfield--value-length",
 					"name": "valueLength",
 					"snippet": "const valueLength = () => (\n    <PinField name=\"test-name\" valueLength={6} inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-pinfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <PinField\n    name=\"test-name\"\n    onChange={fn()}\n    defaultValue=\"12\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-pinfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <PinField\n    name=\"test-name\"\n    onChange={fn()}\n    value=\"12\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-pinfield--pattern",
 					"name": "pattern",
 					"snippet": "const pattern = () => <PinField\n    name=\"test-name\"\n    pattern=\"alphabetic\"\n    defaultValue=\"ab\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-pinfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <PinField\n            name=\"test-name\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ \"aria-label\": \"Label\", id: \"test-input-id\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-pinfield--form-control",
+					"name": "test: with FormControl",
 					"snippet": "const formControl = () => (\n    <FormControl>\n        <FormControl.Label>Label</FormControl.Label>\n        <PinField name=\"test-name\" />\n    </FormControl>\n);"
 				},
 				{
-					"name": "keyboard",
+					"id": "components-pinfield--keyboard",
+					"name": "test: keyboard navigation",
 					"snippet": "const keyboard = () => <PinField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				}
 			],
 			"import": "import { Example, FormControl, PinField } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/PinField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "PinField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/PinField/PinField.tsx",
-				"actualName": "PinField",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"valueLength": {
+						"defaultValue": null,
+						"description": "Amount of characters in the pin",
+						"name": "valueLength",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"pattern": {
+						"defaultValue": null,
+						"description": "Character pattern used in the input value",
+						"name": "pattern",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"numeric\" | \"alphabetic\" | \"alphanumeric\"",
+							"value": [
+								{ "value": "\"numeric\"" },
+								{ "value": "\"alphabetic\"" },
+								{ "value": "\"alphanumeric\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Input fields render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\"",
+							"value": [{ "value": "\"outline\"" }, { "value": "\"faded\"" }]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the input element, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1181,75 +6694,514 @@
 			"path": "./src/components/Popover/tests/Popover.stories.tsx",
 			"stories": [
 				{
+					"id": "components-popover--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: bottom\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"bottom-start\" />\n                <Demo position=\"bottom\" />\n                <Demo position=\"bottom-end\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: top\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"top-start\" />\n                <Demo position=\"top\" />\n                <Demo position=\"top-end\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: start\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"start-top\" />\n                <Demo position=\"start\" />\n                <Demo position=\"start-bottom\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: end\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"end-top\" />\n                <Demo position=\"end\" />\n                <Demo position=\"end-bottom\" defaultActive />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "widthNumber",
+					"id": "components-popover--width-number",
+					"name": "width: px",
 					"snippet": "const widthNumber = () => <Demo width=\"400px\" defaultActive />;"
 				},
 				{
-					"name": "widthFull",
+					"id": "components-popover--width-full",
+					"name": "width: 100%",
 					"snippet": "const widthFull = () => <Demo width=\"100%\" defaultActive />;"
 				},
 				{
+					"id": "components-popover--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 0\">\n            <Demo padding={0} />\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <Demo padding={6} defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-popover--elevation",
 					"name": "elevation",
 					"snippet": "const elevation = () => (\n    <Example>\n        <Example.Item title=\"elevation: raised\">\n            <Demo elevation=\"raised\" defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-popover--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <Popover onOpen={fn()} onClose={fn()} defaultActive>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "active",
+					"id": "components-popover--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <Popover onOpen={fn()} onClose={fn()} active>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "components-popover--active-false",
+					"name": "active false, controlled",
 					"snippet": "const activeFalse = () => <Popover onOpen={fn()} onClose={fn()} active={false}>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "dismissible",
+					"id": "components-popover--dismissible",
+					"name": "dismissible, onClose, className, attributes, closeAriaLabel",
 					"snippet": "const dismissible = () => <Popover onClose={fn()} defaultActive>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>\n        <Popover.Dismissible\n            closeAriaLabel=\"Close\"\n            attributes={{ \"data-testid\": \"test-id\" }}\n            className=\"test-classname\">Content\n                            </Popover.Dismissible>\n    </Popover.Content>\n</Popover>;"
 				},
 				{
+					"id": "components-popover--auto-focus",
 					"name": "autoFocus",
 					"snippet": "const autoFocus = () => (\n    <Example>\n        <Example.Item title=\"autoFocus=false\">\n            <Demo autoFocus={false} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-popover--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Popover active>\n            <Popover.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </Popover.Trigger>\n            <Popover.Content className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n                Content\n            </Popover.Content>\n        </Popover>\n    </div>\n);"
 				},
 				{
-					"name": "testNested",
+					"id": "components-popover--test-nested",
+					"name": "test: nested",
 					"snippet": "const testNested = () => (\n    <Popover position=\"bottom\">\n        <Popover.Trigger>\n            {(attributes) => <Button attributes={attributes}>Open</Button>}\n        </Popover.Trigger>\n        <Popover.Content>\n            <View gap={2} align=\"start\">\n                Popover content\n                <Popover>\n                    <Popover.Trigger>\n                        {(attributes) => <Button attributes={attributes}>Open</Button>}\n                    </Popover.Trigger>\n                    <Popover.Content>Hello</Popover.Content>\n                </Popover>\n            </View>\n        </Popover.Content>\n    </Popover>\n);"
 				},
 				{
-					"name": "testWithTooltip",
+					"id": "components-popover--test-with-tooltip",
+					"name": "test: with tooltip",
 					"snippet": "const testWithTooltip = () => (\n    <View paddingTop={10}>\n        <Tooltip position=\"top\" text=\"Hello\">\n            {(tooltipAttributes) => (\n                <Popover position=\"bottom\">\n                    <Popover.Trigger>\n                        {(attributes) => (\n                            <Button\n                                attributes={{\n                                    ...attributes,\n                                    ...tooltipAttributes,\n                                }}\n                            >\n                                Open\n                            </Button>\n                        )}\n                    </Popover.Trigger>\n                    <Popover.Content>\n                        <View gap={2} align=\"start\">\n                            Popover content\n                            <Button onClick={() => {}}>Button</Button>\n                        </View>\n                    </Popover.Content>\n                </Popover>\n            )}\n        </Tooltip>\n    </View>\n);"
 				},
 				{
-					"name": "testContentEditable",
+					"id": "components-popover--test-content-editable",
+					"name": "test: contenteditable",
 					"snippet": "const testContentEditable = () => {\n    const [active, setActive] = useState(false);\n\n    return (\n        <Popover>\n            <Popover.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </Popover.Trigger>\n            <Popover.Content>\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={() => {}}>Hello</Button>\n                    </View.Item>\n\n                    <ScrollArea height=\"100px\">\n                        <div\n                            style={{ height: \"200px\" }}\n                            contentEditable\n                            tabIndex={0}\n                            onInput={(e) => {\n                                setActive(e.currentTarget.innerText.startsWith(\"@\"));\n                            }}\n                            onKeyDown={(e) => {\n                                console.log(e.key);\n                                if (e.key === \"Enter\" && active) {\n                                    e.preventDefault();\n                                    e.currentTarget.innerText = \"@hello\";\n                                    setActive(false);\n                                }\n                            }}\n                        />\n                    </ScrollArea>\n\n                    <Popover\n                        active={active}\n                        onClose={() => setActive(false)}\n                        originCoordinates={{ x: 300, y: 300 }}\n                        trapFocusMode=\"selection-menu\"\n                    >\n                        <Popover.Content>\n                            <View gap={4}>\n                                <MenuItem onClick={() => {}}>Action</MenuItem>\n                                <MenuItem onClick={() => {}}>Close</MenuItem>\n                            </View>\n                        </Popover.Content>\n                    </Popover>\n                </View>\n            </Popover.Content>\n        </Popover>\n    );\n};"
 				},
 				{
-					"name": "variant",
+					"id": "components-popover--variant",
+					"name": "variant [deprecated]",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: headless\">\n            <Popover variant=\"headless\" defaultActive position=\"bottom-start\">\n                <Popover.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </Popover.Trigger>\n                <Popover.Content>\n                    <View\n                        height=\"100px\"\n                        width=\"100px\"\n                        borderColor=\"primary\"\n                        borderRadius=\"medium\"\n                        backgroundColor=\"primary-faded\"\n                    />\n                </Popover.Content>\n            </Popover>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, MenuItem, Popover, ScrollArea, Tooltip, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Popover/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Popover",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Popover/Popover.tsx",
-				"actualName": "Popover",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Automatically focus the first focusable element in the content, when false the content container will be focused instead",
+						"name": "autoFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | TrapMode" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Content element padding, unit token multiplier",
+						"name": "padding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "@deprecated use Flyout utility instead, will be removed in v4",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"elevated\" | \"headless\"",
+							"value": [{ "value": "\"elevated\"" }, { "value": "\"headless\"" }]
+						}
+					}
+				},
+				"exportName": "Popover"
 			}
 		},
 		"components-progress": {
@@ -1258,38 +7210,177 @@
 			"path": "./src/components/Progress/tests/Progress.stories.tsx",
 			"stories": [
 				{
+					"id": "components-progress--value",
 					"name": "value",
 					"snippet": "const value = () => (\n    <Example>\n        <Example.Item title=\"value: 50\">\n            <Progress value={50} ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"value: 20, min: 0, max: 40\">\n            <Progress value={20} min={0} max={40} ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"value: 50, min: 0, max: 40\">\n            <Progress value={50} min={0} max={40} ariaLabel=\"rating value\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small, value: 50\">\n            <Progress value={50} size=\"small\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"size: medium, value: 50\">\n            <Progress value={50} size=\"medium\" ariaLabel=\"rating value\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: critical, value: 50\">\n            <Progress value={50} color=\"critical\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: warning, value: 50\">\n            <Progress value={50} color=\"warning\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive, value: 50\">\n            <Progress value={50} color=\"positive\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: media, value: 50\">\n            <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                <Progress value={50} color=\"media\" ariaLabel=\"rating value\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--duration",
 					"name": "duration",
 					"snippet": "const duration = () => {\n    const [active, setActive] = React.useState(false);\n\n    const handleChange = () => {\n        setActive((state) => !state);\n    };\n\n    return (\n        <Example>\n            <Example.Item title=\"duration: 2000\">\n                <View gap={3}>\n                    <View.Item>\n                        <Button onClick={handleChange}>Change</Button>\n                    </View.Item>\n\n                    <Progress value={active ? 100 : 0} duration={2000} ariaLabel=\"rating value\" />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "render",
+					"id": "components-progress--render",
+					"name": "rendering",
 					"snippet": "const render = () => <Progress value={75} min={50} max={100} ariaLabel=\"progress\" />;"
 				},
 				{
-					"name": "className",
+					"id": "components-progress--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Progress className=\"test-classname\" attributes={{ id: \"test-id\" }} ariaLabel=\"progress\" />\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, Progress, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Progress/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Progress",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Progress/Progress.tsx",
-				"actualName": "Progress",
+				"methods": [],
+				"props": {
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the progress bar controlling the size of the fill",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Lower value boundary of the progress bar",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Upper value boundary of the progress bar",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"warning\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"duration": {
+						"defaultValue": null,
+						"description": "Duration of the progress bar animation in milliseconds",
+						"name": "duration",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1299,30 +7390,135 @@
 			"path": "./src/components/ProgressIndicator/tests/ProgressIndicator.stories.tsx",
 			"stories": [
 				{
+					"id": "components-progressindicator--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const [activeIndex, setActiveIndex] = React.useState(0);\n    const total = 10;\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <View gap={4}>\n                    <View direction=\"row\" gap={2} align=\"center\">\n                        <Button\n                            onClick={() => {\n                                setActiveIndex((prev) => Math.max(0, prev - 1));\n                            }}\n                        >\n                            Previous\n                        </Button>\n                        <Button\n                            onClick={() => {\n                                setActiveIndex((prev) => Math.min(total - 1, prev + 1));\n                            }}\n                        >\n                            Next\n                        </Button>\n                        <Text weight=\"medium\">Index: {activeIndex}</Text>\n                    </View>\n\n                    <View borderRadius=\"medium\" overflow=\"hidden\" width=\"300px\">\n                        <Scrim\n                            position=\"bottom\"\n                            backgroundSlot={<View aspectRatio={16 / 9} backgroundColor=\"neutral-faded\" />}\n                        >\n                            <View align=\"center\">\n                                <ProgressIndicator total={total} activeIndex={activeIndex} color=\"media\" />\n                            </View>\n                        </Scrim>\n                    </View>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-progressindicator--color",
 					"name": "color",
 					"snippet": "const color = () => {\n    return (\n        <Example>\n            <Example.Item title=\"color: primary\">\n                <ProgressIndicator total={10} activeIndex={5} color=\"primary\" />\n            </Example.Item>\n            <Example.Item title=\"color: media\">\n                <View borderRadius=\"medium\" overflow=\"hidden\" width=\"300px\">\n                    <Scrim\n                        position=\"bottom\"\n                        backgroundSlot={<View aspectRatio={16 / 9} backgroundColor=\"neutral-faded\" />}\n                    >\n                        <View align=\"center\">\n                            <ProgressIndicator total={10} activeIndex={5} color=\"media\" />\n                        </View>\n                    </Scrim>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-progressindicator--aria-label",
 					"name": "ariaLabel",
 					"snippet": "const ariaLabel = () => <ProgressIndicator total={10} className=\"test-classname\" ariaLabel=\"Progress\" />;"
 				},
 				{
-					"name": "className",
+					"id": "components-progressindicator--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ProgressIndicator total={10} className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, ProgressIndicator, Scrim, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ProgressIndicator/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ProgressIndicator",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ProgressIndicator/ProgressIndicator.tsx",
-				"actualName": "ProgressIndicator",
+				"methods": [],
+				"props": {
+					"total": {
+						"defaultValue": null,
+						"description": "Total amount of progress indicator dots",
+						"name": "total",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "number" }
+					},
+					"activeIndex": {
+						"defaultValue": null,
+						"description": "Index of the active progress indicator dot",
+						"name": "activeIndex",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\"",
+							"value": [{ "value": "\"media\"" }, { "value": "\"primary\"" }]
+						}
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1332,50 +7528,203 @@
 			"path": "./src/components/Radio/tests/Radio.stories.tsx",
 			"stories": [
 				{
+					"id": "components-radio--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"small\" defaultChecked>\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"medium\">\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"large\">\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: responsive, s: small, m: large\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size={{ s: \"small\", m: \"large\" }}>\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-radio--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Radio name=\"error\" value=\"dog\" hasError>\n                Radio\n            </Radio>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-radio--render",
+					"name": "name, value",
 					"snippet": "const render = () => (\n    <Radio name=\"test-name\" value=\"test-value\">\n        Content\n    </Radio>\n);"
 				},
 				{
-					"name": "checked",
+					"id": "components-radio--checked",
+					"name": "checked, controlled",
 					"snippet": "const checked = () => <Radio name=\"test-name\" value=\"test-value\" checked onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "checkedFalse",
+					"id": "components-radio--checked-false",
+					"name": "checked false, controlled",
 					"snippet": "const checkedFalse = () => <Radio name=\"test-name\" value=\"test-value\" checked={false} onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-radio--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Radio name=\"test-name\" value=\"test-value\" defaultChecked onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "defaultCheckedFalse",
+					"id": "components-radio--default-checked-false",
+					"name": "defaultChecked false, uncontrolled",
 					"snippet": "const defaultCheckedFalse = () => <Radio name=\"test-name\" value=\"test-value\" onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
+					"id": "components-radio--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Radio name=\"test-name\" value=\"test-value\" disabled>\n        Content\n    </Radio>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-radio--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Radio className=\"test-classname\" attributes={{ id: \"test-id\" }} value=\"value\">\n            Content\n        </Radio>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Radio, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Radio/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Radio",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Radio/Radio.tsx",
-				"actualName": "Radio",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the form field from the form submission",
+						"name": "disabled",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Indicate that the form field has an error",
+						"name": "hasError",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element",
+						"name": "value",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the input is focused",
+						"name": "onFocus",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the input is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "",
+						"name": "checked",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultChecked",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1385,26 +7734,169 @@
 			"path": "./src/components/RadioGroup/tests/RadioGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "value",
+					"id": "components-radiogroup--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <RadioGroup name=\"test-name\" value=\"1\" onChange={fn()}>\n    {/* checked should be ignored */}\n    <Radio value=\"1\" checked={false}>Content\n                    </Radio>\n    <Radio value=\"2\">Content 2</Radio>\n</RadioGroup>;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-radiogroup--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <RadioGroup name=\"test-name\" defaultValue=\"1\" onChange={fn()}>\n    {/* checked should be ignored */}\n    <Radio value=\"1\" checked={false}>Content\n                    </Radio>\n    <Radio value=\"2\">Content 2</Radio>\n</RadioGroup>;"
 				},
 				{
+					"id": "components-radiogroup--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <RadioGroup name=\"test-name\" disabled>\n        <Radio value=\"test-value\">Content</Radio>\n    </RadioGroup>\n);"
 				}
 			],
 			"import": "import { Radio, RadioGroup } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/RadioGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "RadioGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/RadioGroup/RadioGroup.tsx",
-				"actualName": "RadioGroup",
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the radio group",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the form field from the form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Indicate that the form field has an error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the input element, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1414,39 +7906,131 @@
 			"path": "./src/components/Resizable/tests/Resizable.stories.tsx",
 			"stories": [
 				{
+					"id": "components-resizable--direction",
 					"name": "direction",
 					"snippet": "const direction = () => {\n    return (\n        <Example>\n            <Example.Item title=\"row\">\n                <Resizable height=\"200px\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n            <Example.Item title=\"column\">\n                <Resizable height=\"400px\" direction=\"column\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n\n            {/* Test that page doesn't scroll on dragging */}\n            <div style={{ height: 2000 }} />\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-resizable--children",
 					"name": "children",
 					"snippet": "const children = () => {\n    return (\n        <Example>\n            <Example.Item title=\"render props, row\">\n                <Resizable height=\"200px\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n            <Example.Item title=\"render props, column\">\n                <Resizable height=\"400px\" direction=\"column\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-resizable--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"bordered, row\">\n            <Resizable height=\"200px\" variant=\"bordered\">\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n            </Resizable>\n        </Example.Item>\n        <Example.Item title=\"bordered, column\">\n            <Resizable height=\"400px\" direction=\"column\" variant=\"bordered\">\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n            </Resizable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "components-resizable--size",
+					"name": "minSize, maxSize, defaultSize",
 					"snippet": "const size = () => (\n    <Resizable className=\"test-classname\" attributes={{ id: \"test-id\" }} height=\"200px\">\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n        <Resizable.Handle />\n        <Resizable.Item minSize=\"200px\" maxSize=\"500px\" defaultSize=\"300px\">\n            <Panel />\n        </Resizable.Item>\n    </Resizable>\n);"
 				},
 				{
-					"name": "layout",
+					"id": "components-resizable--layout",
+					"name": "height, gap",
 					"snippet": "const layout = () => (\n    <Resizable height=\"100px\" gap={8}>\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n        <Resizable.Handle />\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n    </Resizable>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-resizable--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Resizable className=\"test-classname\" attributes={{ id: \"test-id\" }} height=\"200px\">\n            <Resizable.Item>\n                <Panel />\n            </Resizable.Item>\n            <Resizable.Handle />\n            <Resizable.Item>\n                <Panel />\n            </Resizable.Item>\n        </Resizable>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, Resizable, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Resizable/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Resizable",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Resizable/Resizable.tsx",
-				"actualName": "Resizable",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Resizable/Resizable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"bordered\" | \"borderless\"",
+							"value": [{ "value": "\"bordered\"" }, { "value": "\"borderless\"" }]
+						}
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Component content direction with the resize handle rendered in between the chidlren",
+						"name": "direction",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Resizable/Resizable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between children, base unit token number multiplier",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					}
+				},
+				"exportName": "Resizable"
 			}
 		},
 		"components-scrim": {
@@ -1455,26 +8039,101 @@
 			"path": "./src/components/Scrim/tests/Scrim.stories.tsx",
 			"stories": [
 				{
+					"id": "components-scrim--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: center\">\n            <Scrim backgroundSlot={<Placeholder h={200} />}>Scrim</Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <Scrim position=\"bottom\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: top\">\n            <Scrim position=\"top\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: start\">\n            <Scrim position=\"start\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <Scrim position=\"end\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-scrim--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Scrim className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Scrim>\n    </div>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "components-scrim--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"without backgroundSlot, size is based on the parent component\">\n            <div style={{ height: 300, position: \"relative\" }}>\n                <Scrim>Text</Scrim>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Placeholder, Scrim } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Scrim/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Scrim",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Scrim/Scrim.tsx",
-				"actualName": "Scrim",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"backgroundSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting background content behind the scrim",
+						"name": "backgroundSlot",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Component content position",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"bottom\" | \"start\" | \"end\" | \"full\"",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"full\"" }
+							]
+						}
+					},
+					"scrimClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the scrim element",
+						"name": "scrimClassName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1484,79 +8143,398 @@
 			"path": "./src/components/Select/tests/Select.stories.tsx",
 			"stories": [
 				{
-					"name": "nativeRender",
+					"id": "components-select--native-render",
+					"name": "native rendering, options, name, id",
 					"snippet": "const nativeRender = () => (\n    <Example>\n        <Example.Item title=\"native with options prop\">\n            <Select\n                name=\"animal\"\n                id=\"animal-1\"\n                placeholder=\"Select an animal\"\n                options={[\n                    { label: \"Dog\", value: \"dog\" },\n                    { label: \"Turtle\", value: \"turtle\" },\n                ]}\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            />\n        </Example.Item>\n        <Example.Item title=\"native with option tags\">\n            <Select\n                name=\"animal\"\n                id=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "customRender",
+					"id": "components-select--custom-render",
+					"name": "custom rendering, name, id, option groups",
 					"snippet": "const customRender = () => (\n    <Example>\n        <Example.Item title=\"custom with options\">\n            <Select.Custom\n                name=\"animal\"\n                id=\"animal-1\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"native with option tags\">\n            <Select.Custom\n                name=\"animal-2\"\n                id=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Group label=\"Birds\">\n                    <Select.Option value=\"pigeon\">Pigeon</Select.Option>\n                    <Select.Option value=\"parrot\">Parrot</Select.Option>\n                </Select.Group>\n                <Select.Group label=\"Sea Mammals\">\n                    <Select.Option value=\"whale\">Whale</Select.Option>\n                    <Select.Option value=\"dolphin\">Dolphin</Select.Option>\n                </Select.Group>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "nativeHandlers",
+					"id": "components-select--native-handlers",
+					"name": "native, controlled, uncontrolled, onFocus, onBlur, onChange",
 					"snippet": "const nativeHandlers = () => <Example>\n    <Example.Item title=\"native, uncontrolled, onChange\">\n        <Select\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n    <Example.Item title=\"native, controlled, onChange\">\n        <Select\n            name=\"animal-2\"\n            placeholder=\"Select an animal\"\n            value=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n    <Example.Item title=\"native, onFocus, onBlur, onClick\">\n        <Select\n            name=\"animal-3\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onFocus={fn()}\n            onBlur={fn()}\n            onClick={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "customHandlers",
+					"id": "components-select--custom-handlers",
+					"name": "custom, controlled, uncontrolled, onFocus, onBlur, onChange",
 					"snippet": "const customHandlers = () => <Example>\n    <Example.Item title=\"custom, uncontrolled, onChange\">\n        <Select.Custom\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n    <Example.Item title=\"custom, controlled, onChange\">\n        <Select.Custom\n            name=\"animal-2\"\n            placeholder=\"Select an animal\"\n            value=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n    <Example.Item title=\"native, onFocus, onBlur, onClick\">\n        <Select.Custom\n            name=\"animal-3\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onFocus={fn()}\n            onBlur={fn()}\n            onClick={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "triggerOnly",
+					"id": "components-select--trigger-only",
+					"name": "trigger only, onClick",
 					"snippet": "const triggerOnly = (args) => {\n    const toggle = useToggle();\n    const [value, setValue] = React.useState(\"Dog\");\n\n    const handleClick: SelectProps[\"onClick\"] = (e) => {\n        args.handleClick(e);\n        toggle.toggle();\n    };\n\n    return (\n        <Example>\n            <Example.Item title=\"trigger only, onClick\">\n                <Select\n                    name=\"animal\"\n                    placeholder=\"Select an animal\"\n                    onClick={handleClick}\n                    value=\"dog\"\n                    inputAttributes={{\n                        \"aria-label\": \"Select an animal\",\n                    }}\n                >\n                    {value}\n                </Select>\n                <Modal\n                    active={toggle.active}\n                    onClose={toggle.deactivate}\n                    position=\"bottom\"\n                    padding={2}\n                    attributes={{ \"aria-label\": \"Select an animal\" }}\n                >\n                    <div role=\"listbox\" aria-label=\"Select an animal\">\n                        <MenuItem\n                            roundedCorners\n                            onClick={() => {\n                                setValue(\"Dog\");\n                                toggle.deactivate();\n                            }}\n                            attributes={{\n                                role: \"option\",\n                            }}\n                        >\n                            Dog\n                        </MenuItem>\n                        <MenuItem\n                            roundedCorners\n                            attributes={{\n                                role: \"option\",\n                            }}\n                            onClick={() => {\n                                setValue(\"Turtle\");\n                                toggle.deactivate();\n                            }}\n                        >\n                            Turtle\n                        </MenuItem>\n                    </div>\n                </Modal>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-select--multiple",
 					"name": "multiple",
 					"snippet": "const multiple = () => <Example>\n    <Example.Item title=\"multiple\">\n        <Select.Custom\n            multiple\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue={[\"dog\"]}\n            onChange={fn()}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-select--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded, native\">\n            <Select\n                variant=\"faded\"\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n\n        <Example.Item title=\"variant: faded, custom\">\n            <Select.Custom\n                variant=\"faded\"\n                name=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless, native\">\n            <Select\n                variant=\"headless\"\n                name=\"animal-3\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless, custom\">\n            <Select.Custom\n                variant=\"headless\"\n                name=\"animal-4\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <Select.Custom size=\"small\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <Select.Custom size=\"medium\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <Select.Custom size=\"large\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: xlarge\">\n            <Select.Custom size=\"xlarge\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "startSlot",
+					"id": "components-select--start-slot",
+					"name": "icon,startSlot",
 					"snippet": "const startSlot = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Select.Custom name=\"animal\" placeholder=\"Select an animal\" icon={IconZap}>\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n\n        <Example.Item title=\"startSlot\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                startSlot={<Placeholder h={20} />}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--render-value",
 					"name": "renderValue",
 					"snippet": "const renderValue = () => {\n    const options = [\n        {\n            value: \"1\",\n            label: \"Title 1\",\n            subtitle: \"Subtitle 1\",\n        },\n        {\n            value: \"2\",\n            label: \"Title 2\",\n            subtitle: \"Subtitle 2\",\n        },\n    ];\n\n    return (\n        <Example>\n            <Example.Item title=\"default renderer, single\">\n                <Select.Custom name=\"animal\" defaultValue=\"1\" placeholder=\"Nothing selected\">\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"default renderer, multiple\">\n                <Select.Custom name=\"animal\" defaultValue={[\"1\"]} multiple placeholder=\"Nothing selected\">\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"renderValue, single\">\n                <Select.Custom\n                    name=\"animal\"\n                    defaultValue=\"1\"\n                    placeholder=\"Nothing selected\"\n                    renderValue={(args) => <Badge>Title {args.value}</Badge>}\n                >\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"renderValue, multiple\">\n                <Select.Custom\n                    name=\"animal\"\n                    defaultValue={[\"1\"]}\n                    multiple\n                    placeholder=\"Nothing selected\"\n                    renderValue={(args) => <Badge>Titles {args.value.join(\", \")}</Badge>}\n                >\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-select--error",
 					"name": "error",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Select.Custom name=\"animal\" placeholder=\"Select an animal\" hasError>\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, native\">\n            <Select\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                disabled\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n        <Example.Item title=\"disabled, custom\">\n            <Select.Custom\n                name=\"animal-2\"\n                placeholder=\"Select an animal\"\n                disabled\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-select--class-name",
+					"name": "className, attributes, inputAttributes",
 					"snippet": "const className = () => (\n    <Example>\n        <Example.Item title=\"native, className, attributes, inputAttributes\">\n            <Select\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                className=\"native-class\"\n                attributes={{ id: \"test-id\" }}\n                inputAttributes={{ \"aria-label\": \"test-label\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n        <Example.Item title=\"custom, className, attributes, inputAttributes\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                className=\"custom-class\"\n                attributes={{ id: \"test-id\" }}\n                inputAttributes={{ \"aria-label\": \"test-label\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "fallback",
+					"id": "components-select--fallback",
+					"name": "test: fallbackAdjustLayout",
 					"snippet": "const fallback = () => (\n    <Example>\n        <Example.Item title=\"fallback\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                {[...Array(100)].map((_, index) => (\n                    <Select.Option key={index} value={`item-${index}`}>\n                        Item {index + 1}\n                    </Select.Option>\n                ))}\n            </Select.Custom>\n            <div style={{ height: \"1000px\" }}></div>\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                {[...Array(100)].map((_, index) => (\n                    <Select.Option key={index} value={`item-${index}`}>\n                        Item {index + 1}\n                    </Select.Option>\n                ))}\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-select--form-control",
+					"name": "test: with FormControl",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"FormControl\">\n            <FormControl hasError>\n                <FormControl.Label>Animal</FormControl.Label>\n                <Select.Custom name=\"animal\" placeholder=\"Select an animal\">\n                    <Select.Option value=\"dog\">Dog</Select.Option>\n                    <Select.Option value=\"turtle\">Turtle</Select.Option>\n                </Select.Custom>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "components-select--test-composition",
+					"name": "test: composition",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item title=\"custom with options\">\n            <Select.Custom\n                name=\"animal\"\n                id=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Group>\n                    <Select.Option value=\"dog\">Dog</Select.Option>\n                    <Select.Option value=\"turtle\">Turtle</Select.Option>\n                </Select.Group>\n                <Select.Group>Hello</Select.Group>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Badge, Example, FormControl, MenuItem, Modal, Placeholder, Select, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Select/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Select",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Select/Select.tsx",
-				"actualName": "Select",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the select user interaction and form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value selected",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon to display in the select start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the select value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when the trigger is clicked",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"options": {
+						"defaultValue": null,
+						"description": "@deprecated Use <option /> children instead",
+						"name": "options",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NativeOption[]" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the input is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLSelectElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the input is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLSelectElement, Element>) => void)" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"select\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"renderValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "renderValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "undefined" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLSelectElement>>" }
+					}
+				},
+				"exportName": "Select"
 			}
 		},
 		"components-skeleton": {
@@ -1565,26 +8543,87 @@
 			"path": "./src/components/Skeleton/tests/Skeleton.stories.tsx",
 			"stories": [
 				{
+					"id": "components-skeleton--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"text\">\n            <Skeleton />\n        </Example.Item>\n\n        <Example.Item title=\"view, rectangle\">\n            <Skeleton width=\"100px\" height=\"100px\" />\n        </Example.Item>\n\n        <Example.Item title=\"view, circle\">\n            <Skeleton width=\"100px\" height=\"100px\" borderRadius=\"circular\" />\n        </Example.Item>\n\n        <Example.Item title=\"view, rectangle, responsive\">\n            <Skeleton width={{ s: \"100px\", m: \"200px\" }} height={{ s: \"100px\", m: \"200px\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-skeleton--radius",
 					"name": "radius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius=small\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"small\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=medium\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"medium\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=large\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"large\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=circular\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"circular\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-skeleton--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Skeleton className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Skeleton } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Skeleton/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Skeleton",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Skeleton/Skeleton.tsx",
-				"actualName": "Skeleton",
+				"methods": [],
+				"props": {
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width style, literal string value or a base unit token number multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Radius>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Skeleton/Skeleton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Skeleton/Skeleton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1594,66 +8633,421 @@
 			"path": "./src/components/Slider/tests/Slider.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "components-slider--base",
+					"name": "name, minName, maxName, range",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"single, name\">\n            <Slider name=\"slider-single\" defaultValue={30} />\n        </Example.Item>\n        <Example.Item title=\"range, name\">\n            <Slider range name=\"slider-range\" defaultMinValue={30} defaultMaxValue={85} />\n        </Example.Item>\n        <Example.Item title=\"range, minName, maxName\">\n            <Slider\n                range\n                minName=\"slider-min\"\n                maxName=\"slider-max\"\n                defaultMinValue={30}\n                defaultMaxValue={85}\n            />\n        </Example.Item>\n        <div style={{ height: 2000 }} />\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--orientation",
 					"name": "orientation",
 					"snippet": "const orientation = () => (\n    <Example>\n        <Example.Item title=\"orientation: vertical\">\n            <View height=\"200px\">\n                <Slider\n                    range\n                    name=\"slider\"\n                    defaultMinValue={30}\n                    defaultMaxValue={85}\n                    orientation=\"vertical\"\n                />\n            </View>\n        </Example.Item>\n        <View height=\"2000px\" />\n    </Example>\n);"
 				},
 				{
-					"name": "minMax",
+					"id": "components-slider--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <Example>\n        <Example.Item title=\"min, max\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={60} />\n        </Example.Item>\n        <Example.Item title=\"min, max, value < min\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={30} />\n        </Example.Item>\n        <Example.Item title=\"min, max, value > max\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={80} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--step",
 					"name": "step",
 					"snippet": "const step = () => (\n    <Example>\n        <Example.Item title=\"step: 5\">\n            <Slider name=\"slider\" defaultValue={30} step={5} />\n        </Example.Item>\n\n        <Example.Item title=\"step: 5, defaultValue: 31, rounded down to 30\">\n            <Slider name=\"slider\" defaultValue={31} step={5} />\n        </Example.Item>\n\n        <Example.Item title=\"step: 0.01, float\">\n            <Slider name=\"slider\" defaultValue={30} step={0.01} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <Slider name=\"slider\" defaultValue={30} disabled />\n        </Example.Item>\n\n        <Example.Item title=\"disabled, range\">\n            <Slider name=\"slider\" range defaultMinValue={30} defaultMaxValue={80} disabled />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--render-value",
 					"name": "renderValue",
 					"snippet": "const renderValue = () => (\n    <Example>\n        <Example.Item title=\"renderValue: $\">\n            <Slider name=\"name\" defaultValue={50} renderValue={(args) => `$${args.value}`} />\n        </Example.Item>\n        <Example.Item title=\"renderValue: false\">\n            <Slider name=\"name\" defaultValue={50} renderValue={false} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-slider--default-value",
+					"name": "defaultValue, onChange, onChangeCommit",
 					"snippet": "const defaultValue = () => <View paddingTop={10}>\n    <Slider name=\"test-name\" defaultValue={50} onChange={fn()} onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "value",
+					"id": "components-slider--value",
+					"name": "value, onChange, onChangeCommit",
 					"snippet": "const value = () => <View paddingTop={10}>\n    <Slider name=\"test-name\" value={50} onChange={fn()} onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "rangeDefaultValue",
+					"id": "components-slider--range-default-value",
+					"name": "range, defaultValue, onChange, onChangeCommit",
 					"snippet": "const rangeDefaultValue = () => <View paddingTop={10}>\n    <Slider\n        range\n        name=\"test-name\"\n        defaultMinValue={50}\n        defaultMaxValue={70}\n        onChange={fn()}\n        onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "rangeValue",
+					"id": "components-slider--range-value",
+					"name": "range, value, onChange, onChangeCommit, minName, maxName",
 					"snippet": "const rangeValue = () => <View paddingTop={10}>\n    <Slider\n        range\n        minName=\"test-name-min\"\n        maxName=\"test-name-max\"\n        minValue={50}\n        maxValue={70}\n        onChange={fn()}\n        onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "className",
+					"id": "components-slider--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Slider name=\"name\" className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				},
 				{
-					"name": "testForm",
+					"id": "components-slider--test-form",
+					"name": "test: form onChange",
 					"snippet": "const testForm = (args) => {\n    const formRef = React.useRef<HTMLFormElement>(null);\n    const [data, setData] = React.useState<[string, FormDataEntryValue][]>([]);\n\n    const handleChange = (e: React.FormEvent<HTMLFormElement>) => {\n        const formData = new FormData(e.currentTarget);\n        const nextState = [...formData.entries()];\n\n        args.handleFormChange({ formData: nextState });\n        setData(nextState);\n    };\n\n    return (\n        <View paddingTop={10} gap={4}>\n            <form onChange={handleChange} ref={formRef}>\n                <Slider\n                    range\n                    minName=\"slider-min\"\n                    maxName=\"slider-max\"\n                    defaultMinValue={30}\n                    defaultMaxValue={50}\n                />\n            </form>\n\n            {data.map((v) => v.join(\": \")).join(\", \")}\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testSwipe",
+					"id": "components-slider--test-swipe",
+					"name": "test: prevents parent swipe",
 					"snippet": "const testSwipe = () => {\n    const toggle = useToggle(true);\n\n    return (\n        <Modal active={toggle.active} onClose={toggle.deactivate} position=\"end\">\n            <View gap={4}>\n                <Modal.Title>Modal</Modal.Title>\n                <Slider name=\"slider\" defaultValue={30} />\n            </View>\n        </Modal>\n    );\n};"
 				}
 			],
 			"import": "import { Example, Modal, Slider, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Slider/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Slider",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Slider/Slider.tsx",
-				"actualName": "Slider",
+				"methods": [],
+				"props": {
+					"step": {
+						"defaultValue": null,
+						"description": "Step of the slider",
+						"name": "step",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the slider user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum value of the slider",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum value of the slider",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"orientation": {
+						"defaultValue": null,
+						"description": "Orientation of the slider",
+						"name": "orientation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"vertical\" | \"horizontal\"",
+							"value": [{ "value": "\"vertical\"" }, { "value": "\"horizontal\"" }]
+						}
+					},
+					"renderValue": {
+						"defaultValue": null,
+						"description": "Render a custom value in the thumb tooltip",
+						"name": "renderValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | ((args: { value: number; }) => string)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the slider, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the slider, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"range": {
+						"defaultValue": null,
+						"description": "Enables range slider with two thumbs",
+						"name": "range",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the slider input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"minName": {
+						"defaultValue": null,
+						"description": "Name of the slider min value input element, overrides the name",
+						"name": "minName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"maxName": {
+						"defaultValue": null,
+						"description": "Name of the slider max value input element, overrides the name",
+						"name": "maxName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the slider value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: SingleChangeArgs) => void) | ((args: RangeChangeArgs) => void) | ((args: RangeChangeArgs) => void)"
+						}
+					},
+					"onChangeCommit": {
+						"defaultValue": null,
+						"description": "Callback when the user commits the change by releasing the thumb\nCallback when the user commits the change by releasing the thumbs",
+						"name": "onChangeCommit",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: SingleChangeArgs) => void) | ((args: RangeChangeArgs) => void) | ((args: RangeChangeArgs) => void)"
+						}
+					},
+					"minValue": {
+						"defaultValue": null,
+						"description": "Minimum value of the slider",
+						"name": "minValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"maxValue": {
+						"defaultValue": null,
+						"description": "Maximum value of the slider",
+						"name": "maxValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultMinValue": {
+						"defaultValue": null,
+						"description": "Default minimum value of the slider, enables uncontrolled mode",
+						"name": "defaultMinValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultMaxValue": {
+						"defaultValue": null,
+						"description": "Default maximum value of the slider, enables uncontrolled mode",
+						"name": "defaultMaxValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1663,35 +9057,137 @@
 			"path": "./src/components/Stepper/tests/Stepper.stories.tsx",
 			"stories": [
 				{
+					"id": "components-stepper--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example>\n        <Example.Item title=\"direction: row\">\n            <Stepper activeId=\"1\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <Stepper activeId=\"1\" direction=\"column\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-stepper--label-display",
 					"name": "labelDisplay",
 					"snippet": "const labelDisplay = () => (\n    <Example>\n        <Example.Item title=\"direction: row, labels hidden\">\n            <Stepper activeId=\"1\" labelDisplay=\"hidden\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: column, labels hiden\">\n            <Stepper activeId=\"1\" direction=\"column\" labelDisplay=\"hidden\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: row, labels hidden on s\">\n            <Stepper activeId=\"1\" labelDisplay={{ s: \"hidden\", m: \"inline\" }}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-stepper--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 6, direction: row\">\n            <Stepper activeId=\"1\" gap={6}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"gap: 6, direction: column\">\n            <Stepper activeId=\"1\" direction=\"column\" gap={6}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap\", \"[s] 2\", \"[m+] 5\"]}>\n            <Stepper activeId=\"1\" gap={{ s: 2, m: 5 }}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-stepper--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Stepper className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Stepper.Item attributes={{ id: \"test-item-id\" }} className=\"test-item-classname\" />\n        </Stepper>\n    </div>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-stepper--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"multiline subtitle\",\n                \"should wrap the text correctly\",\n                \"should display the connector correctly\",\n            ]}\n        >\n            <Demo\n                activeId={0}\n                subtitle=\"It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, Placeholder, Stepper, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Stepper/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Stepper",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Stepper/Stepper.tsx",
-				"actualName": "Stepper",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"activeId": {
+						"defaultValue": null,
+						"description": "Id of the item to display as active",
+						"name": "activeId",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string | number" }
+					},
+					"labelDisplay": {
+						"defaultValue": null,
+						"description": "Display variant for the item label",
+						"name": "labelDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"hidden\" | \"inline\">" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Direction of the stepper",
+						"name": "direction",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between items (default: 3)",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
+				"exportName": "Stepper"
 			}
 		},
 		"components-switch": {
@@ -1700,38 +9196,236 @@
 			"path": "./src/components/Switch/tests/Switch.stories.tsx",
 			"stories": [
 				{
-					"name": "size",
+					"id": "components-switch--size",
+					"name": "Size",
 					"snippet": "const size = () => (\n\t<Example>\n\t\t<Example.Item title=\"size: medium\">\n\t\t\t<Switch name=\"active\" size=\"medium\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: small\">\n\t\t\t<Switch name=\"active\" size=\"small\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: large\">\n\t\t\t<Switch name=\"active\" size=\"large\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: responsive, s: small, m: large\">\n\t\t\t<Switch\n\t\t\t\tname=\"active\"\n\t\t\t\tsize={{ s: \"small\", m: \"large\" }}\n\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t/>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "label",
+					"id": "components-switch--label",
+					"name": "Label",
 					"snippet": "const label = () => (\n\t<Example>\n\t\t<Example.Item title=\"size: medium\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch reversed name=\"active\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: small\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" size=\"small\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch\n\t\t\t\t\treversed\n\t\t\t\t\tname=\"active\"\n\t\t\t\t\tsize=\"small\"\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t\t>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\n\t\t<Example.Item title=\"size: large\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" size=\"large\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch\n\t\t\t\t\treversed\n\t\t\t\t\tname=\"active\"\n\t\t\t\t\tsize=\"large\"\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t\t>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-switch--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Switch name=\"test-name\" defaultChecked onChange={fn()}>Label\n            </Switch>;"
 				},
 				{
-					"name": "checked",
+					"id": "components-switch--checked",
+					"name": "checked, uncontrolled",
 					"snippet": "const checked = () => <Switch name=\"test-name\" checked onChange={fn()}>Label\n            </Switch>;"
 				},
 				{
+					"id": "components-switch--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, unselected\">\n            <Switch name=\"active\" disabled inputAttributes={{ \"aria-label\": \"test switch\" }} />\n        </Example.Item>\n        <Example.Item title=\"disabled, selected\">\n            <Switch\n                name=\"active\"\n                disabled\n                defaultChecked\n                inputAttributes={{ \"aria-label\": \"test switch\" }}\n            />\n        </Example.Item>\n        <Example.Item title=\"disabled, with label\">\n            <Switch name=\"active\" disabled>\n                Switch\n            </Switch>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-switch--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Switch\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ \"aria-label\": \"test select\", id: \"test-input-id\" }}\n            name=\"name\"\n        >\n            Label\n        </Switch>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Switch, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Switch/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Switch",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Switch/Switch.tsx",
-				"actualName": "Switch",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the switch",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the switch input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the switch user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"reversed": {
+						"defaultValue": null,
+						"description": "Reverse the children position",
+						"name": "reversed",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the switch value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the switch is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the switch is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default value of the switch, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Value of the switch, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1741,51 +9435,112 @@
 			"path": "./src/components/Table/tests/Table.stories.tsx",
 			"stories": [
 				{
-					"name": "layout",
+					"id": "components-table--layout",
+					"name": "base",
 					"snippet": "const layout = () => (\n    <Example>\n        <Example.Item title=\"base\">\n            <Table>\n                <Table.Head>\n                    <Table.Row>\n                        <Table.Heading>Column 1</Table.Heading>\n                        <Table.Heading>Column 2</Table.Heading>\n                    </Table.Row>\n                </Table.Head>\n                <Table.Body>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell>Cell 2</Table.Cell>\n                    </Table.Row>\n                </Table.Body>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"colspan: 2 for col 2, rowspan: 2 for cell 3\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading colSpan={2}>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                    <Table.Cell rowSpan={2}>Cell 3</Table.Cell>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"align: center for heading 1, align: end for heading 2\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading align=\"center\">Column 1</Table.Heading>\n                    <Table.Heading align=\"end\">Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"valign: center for cell 2, valign: end for cell 3\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>\n                        <View height={15} backgroundColor=\"neutral-faded\" />\n                    </Table.Cell>\n                    <Table.Cell verticalAlign=\"center\">Cell 2</Table.Cell>\n                    <Table.Cell verticalAlign=\"end\">Cell 3</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"width: 40%, minWidth: 200px for col 1\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"40%\" minWidth=\"200px\">\n                        Column 1\n                    </Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-table--border",
 					"name": "border",
 					"snippet": "const border = () => (\n    <Example>\n        <Example.Item title=\"border: true\">\n            <Table border>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"columnBorder: true\">\n            <Table columnBorder>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"columnBorder: true, border: true\">\n            <Table columnBorder border>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-table--rows",
 					"name": "rows",
 					"snippet": "const rows = () => (\n    <Example>\n        <Example.Item title=\"highlighted for row 2\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row highlighted>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"clickable row 2, focus ring\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row onClick={() => {}}>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-table--render",
+					"name": "rendering",
 					"snippet": "const render = () => (\n    <Table>\n        <Table.Head>\n            <Table.Row>\n                <Table.Heading>Heading</Table.Heading>\n                <Table.Heading>Heading</Table.Heading>\n            </Table.Row>\n        </Table.Head>\n        <Table.Body>\n            <Table.Row>\n                <Table.Cell>Content</Table.Cell>\n                <Table.Cell>Content</Table.Cell>\n            </Table.Row>\n        </Table.Body>\n    </Table>\n);"
 				},
 				{
-					"name": "tbody",
+					"id": "components-table--tbody",
+					"name": "tbody rendering",
 					"snippet": "const tbody = () => (\n    <Table>\n        <Table.Row>\n            <Table.Heading>Heading</Table.Heading>\n            <Table.Heading>Heading</Table.Heading>\n        </Table.Row>\n    </Table>\n);"
 				},
 				{
-					"name": "tabIndex",
+					"id": "components-table--tab-index",
+					"name": "adds tabIndex for clickable rows",
 					"snippet": "const tabIndex = () => (\n    <Table>\n        <Table.Row>\n            <Table.Cell />\n        </Table.Row>\n        <Table.Row onClick={() => {}}>\n            <Table.Cell />\n        </Table.Row>\n        <Table.Row attributes={{ onClick: () => {} }}>\n            <Table.Cell />\n        </Table.Row>\n    </Table>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-table--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Table className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Table.Row attributes={{ id: \"test-row-id\" }}>\n                <Table.Cell attributes={{ id: \"test-cell-id\" }}></Table.Cell>\n            </Table.Row>\n        </Table>\n    </div>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-table--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"scroll fade\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"500px\">Column 1</Table.Heading>\n                    <Table.Heading width=\"500px\">Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"card with highlighted heading\">\n            <Card elevated padding={0}>\n                <Table>\n                    <Table.Row highlighted>\n                        <Table.Heading width=\"50%\" minWidth=\"200px\">\n                            Column 1\n                        </Table.Heading>\n                        <Table.Heading colSpan={2} align=\"end\">\n                            Column 2\n                        </Table.Heading>\n                    </Table.Row>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell align=\"center\">Cell 2</Table.Cell>\n                        <Table.Cell align=\"end\">Cell 3</Table.Cell>\n                    </Table.Row>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell align=\"center\">Cell 2</Table.Cell>\n                        <Table.Cell align=\"end\">Cell 3</Table.Cell>\n                    </Table.Row>\n                </Table>\n            </Card>\n        </Example.Item>\n        <Example.Item title=\"width: auto, nowrap\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"50%\">Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                    <Table.Heading>Column 3</Table.Heading>\n                    <Table.Heading width=\"auto\">Long heading title</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                    <Table.Cell>Cell 3</Table.Cell>\n                    <Table.Cell>Cell 4</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "examples",
+					"id": "components-table--examples",
+					"name": "test: selectable",
 					"snippet": "const examples = () => (\n    <Example>\n        <Example.Item title=\"selectable\">\n            <SelectionDemo />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Card, Checkbox, Example, Table, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Table/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Table",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Table/Table.tsx",
-				"actualName": "Table",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"border": {
+						"defaultValue": null,
+						"description": "Add border around the table",
+						"name": "border",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"columnBorder": {
+						"defaultValue": null,
+						"description": "Add border between the table columns",
+						"name": "columnBorder",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
+				"exportName": "Table"
 			}
 		},
 		"components-tabs": {
@@ -1794,71 +9549,196 @@
 			"path": "./src/components/Tabs/tests/Tabs.stories.tsx",
 			"stories": [
 				{
+					"id": "components-tabs--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Tabs>\n        <Tabs.List>\n            <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n            <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n        </Tabs.List>\n\n        <Tabs.Panel value=\"1\">\n            <View padding={4}>Content 1</View>\n        </Tabs.Panel>\n        <Tabs.Panel value=\"2\">\n            <View padding={4}>Content 2</View>\n        </Tabs.Panel>\n    </Tabs>\n);"
 				},
 				{
+					"id": "components-tabs--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Tabs defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills\">\n            <Tabs variant=\"pills\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills-elevated\">\n            <Tabs variant=\"pills-elevated\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: borderless\">\n            <Tabs variant=\"borderless\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"variant: default, size: large\">\n            <Tabs size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills, size: large\">\n            <Tabs variant=\"pills\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills-elevated, size: large\">\n            <Tabs variant=\"pills-elevated\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: borderless, size: large\">\n            <Tabs variant=\"borderless\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example>\n        <Example.Item title=\"direction: column, variant: underline\">\n            <Tabs direction=\"column\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: pills\">\n            <Tabs direction=\"column\" variant=\"pills\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: pills-elevated\">\n            <Tabs direction=\"column\" variant=\"pills-elevated\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: borderless\">\n            <Tabs direction=\"column\" variant=\"borderless\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Tabs>\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"1\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"icon only\">\n            <Tabs variant=\"pills-elevated\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap} attributes={{ \"aria-label\": \"Tab 1\" }} />\n                    <Tabs.Item value=\"1\" icon={IconZap} attributes={{ \"aria-label\": \"Tab 2\" }} />\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "equalWidth",
+					"id": "components-tabs--equal-width",
+					"name": "itemWidth",
 					"snippet": "const equalWidth = () => (\n    <Example>\n        <Example.Item title=\"equal width items\">\n            <Tabs onChange={console.log} itemWidth=\"equal\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"1\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                    <Tabs.Item value=\"2\" icon={IconZap}>\n                        Very long item 3\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--href",
 					"name": "href",
 					"snippet": "const href = () => (\n    <Example>\n        <Example.Item title=\"href, no onChange\">\n            <Tabs value=\"2\">\n                <Tabs.List>\n                    <Tabs.Item value=\"1\" href=\"#item-1\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"2\" href=\"#item-2\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                    <Tabs.Item value=\"3\" href=\"#item-3\" icon={IconZap}>\n                        Very long item 3\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "disabled",
+					"id": "components-tabs--disabled",
+					"name": "item, disabled",
 					"snippet": "const disabled = () => {\n    return (\n        <Example>\n            <Example.Item title=\"disabled\">\n                <Tabs defaultValue=\"1\">\n                    <Tabs.List>\n                        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"2\" disabled icon={IconZap}>\n                            Item 2\n                        </Tabs.Item>\n                        <Tabs.Item value=\"3\">Item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"1\">\n                        <View padding={4}>Content 1</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <View padding={4}>Content 2</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"3\">\n                        <View padding={4}>Content 3</View>\n                    </Tabs.Panel>\n                </Tabs>\n            </Example.Item>\n\n            <Example.Item title=\"disabled, href\">\n                <Tabs defaultValue=\"1\">\n                    <Tabs.List>\n                        <Tabs.Item href=\"#item1\" value=\"1\">\n                            Item 1\n                        </Tabs.Item>\n                        <Tabs.Item href=\"#item2\" value=\"2\" disabled icon={IconZap}>\n                            Item 2\n                        </Tabs.Item>\n                        <Tabs.Item href=\"#item3\" value=\"3\">\n                            Item 3\n                        </Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"1\">\n                        <View padding={4}>Content 1</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <View padding={4}>Content 2</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"3\">\n                        <View padding={4}>Content 3</View>\n                    </Tabs.Panel>\n                </Tabs>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-tabs--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <Tabs defaultValue=\"2\" onChange={fn()}>\n    <Tabs.List>\n        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n        <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n    </Tabs.List>\n    <Tabs.Panel value=\"1\">Content 1</Tabs.Panel>\n    <Tabs.Panel value=\"2\">Content 2</Tabs.Panel>\n</Tabs>;"
 				},
 				{
-					"name": "value",
+					"id": "components-tabs--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <Tabs value=\"2\" onChange={fn()}>\n    <Tabs.List>\n        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n        <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n    </Tabs.List>\n    <Tabs.Panel value=\"1\">Content 1</Tabs.Panel>\n    <Tabs.Panel value=\"2\">Content 2</Tabs.Panel>\n</Tabs>;"
 				},
 				{
-					"name": "className",
+					"id": "components-tabs--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Tabs>\n            <Tabs.List attributes={{ id: \"test-list-id\" }} className=\"test-list-classname\">\n                <Tabs.Item attributes={{ id: \"test-item-id\" }} value=\"1\">\n                    Item\n                </Tabs.Item>\n            </Tabs.List>\n\n            <Tabs.Panel\n                attributes={{ \"data-testid\": \"test-panel-id\" }}\n                className=\"test-panel-classname\"\n                value=\"1\"\n            />\n        </Tabs>\n    </div>\n);"
 				},
 				{
-					"name": "testFocusableContent",
+					"id": "components-tabs--test-focusable-content",
+					"name": "test: focusable content",
 					"snippet": "const testFocusableContent = () => (\n    <Example>\n        <Example.Item title=\"panels without focusable content\">\n            <Tabs>\n                <View gap={4}>\n                    <Tabs.List>\n                        <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                        <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"0\">Tab 1</Tabs.Panel>\n                    <Tabs.Panel value=\"1\">Tab 2</Tabs.Panel>\n                    <Tabs.Panel value=\"2\">Tab 3</Tabs.Panel>\n                </View>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"panels with focusable content\">\n            <Tabs>\n                <View gap={4}>\n                    <Tabs.List>\n                        <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                        <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"0\">\n                        <Button onClick={() => {}}>Tab 1 action</Button>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"1\">\n                        <Button onClick={() => {}}>Tab 2 action</Button>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <Button onClick={() => {}}>Tab 3 action</Button>\n                    </Tabs.Panel>\n                </View>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "components-tabs--test-composition",
+					"name": "test: composition",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item title=\"Viewport overflow\">\n            <Tabs>\n                <Tabs.List>\n                    {[...Array(8)].map((_, i) => (\n                        <Tabs.Item value={`${i}`} key={i} icon={IconZap}>\n                            Very long item {i}\n                        </Tabs.Item>\n                    ))}\n                </Tabs.List>\n\n                {[...Array(8)].map((_, i) => (\n                    <Tabs.Panel value={`${i}`} key={i}>\n                        Tab {i}\n                    </Tabs.Panel>\n                ))}\n            </Tabs>\n        </Example.Item>\n        <Example.Item>\n            <Tabs onChange={console.log} variant=\"pills-elevated\" name=\"hey\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">\n                        <View borderColor=\"neutral-faded\" padding={5}>\n                            Item 3\n                        </View>\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"Custom non-interactive list children\">\n            <Tabs direction=\"column\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <View height={6} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testEdgeCaseDom",
+					"id": "components-tabs--test-edge-case-dom",
+					"name": "test: scroll subscription",
 					"snippet": "const testEdgeCaseDom = () => {\n    const [activeItem, setActiveItem] = React.useState(\"1\");\n    const sectionsRef = React.useRef(null);\n\n    return (\n        <Example>\n            <Example.Item title=\"active item changes on scroll\">\n                <View justify=\"center\" align=\"center\" padding={10}>\n                    <View width={60} gap={2}>\n                        <Tabs value={activeItem} onChange={(args) => setActiveItem(args.value)}>\n                            <Tabs.List>\n                                <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                                <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n                                <Tabs.Item value=\"3\">Item 3</Tabs.Item>\n                                <Tabs.Item value=\"4\">Item 4</Tabs.Item>\n                            </Tabs.List>\n                        </Tabs>\n\n                        <ScrollArea\n                            attributes={{ ref: sectionsRef }}\n                            height={70}\n                            onScroll={(args) => {\n                                setActiveItem(Math.min(4, Math.floor(args.y * 10) + 1).toString());\n                            }}\n                        >\n                            <View gap={4}>\n                                <View gap={2}>\n                                    <Text>Section 1</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View grow height=\"100px\" backgroundColor=\"neutral-faded\" key={i} />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 2</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 3</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 4</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n                            </View>\n                        </ScrollArea>\n                    </View>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Example, ScrollArea, Tabs, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Tabs/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Tabs",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Tabs/Tabs.tsx",
-				"actualName": "Tabs",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Direction of the tab buttons",
+						"name": "direction",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"itemWidth": {
+						"defaultValue": null,
+						"description": "Equal width for the tab buttons",
+						"name": "itemWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"equal\"", "value": [{ "value": "\"equal\"" }] }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Render variant for component",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"bordered\" | \"borderless\" | \"pills\" | \"pills-elevated\"",
+							"value": [
+								{ "value": "\"bordered\"" },
+								{ "value": "\"borderless\"" },
+								{ "value": "\"pills\"" },
+								{ "value": "\"pills-elevated\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"large\" | \"medium\"",
+							"value": [{ "value": "\"large\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the tab buttons group when used as a form control",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the active tab value changes",
+						"name": "onChange",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((args: { value: string; name?: string; }) => void)" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the active tab, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the active tab, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "Tabs"
 			}
 		},
 		"components-textarea": {
@@ -1867,71 +9747,315 @@
 			"path": "./src/components/TextArea/tests/TextArea.stories.tsx",
 			"stories": [
 				{
-					"name": "variants",
+					"id": "components-textarea--variants",
+					"name": "variant",
 					"snippet": "const variants = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <TextArea variant=\"faded\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless\">\n            <TextArea variant=\"headless\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: medium\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"medium\" />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"large\" />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"xlarge\" />\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] large\", \"[m+] medium\"]}>\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size={{ s: \"xlarge\", m: \"medium\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--resize",
 					"name": "resize",
 					"snippet": "const resize = () => (\n    <Example>\n        <Example.Item title=\"resize: none\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" resize=\"none\" />\n        </Example.Item>\n        <Example.Item title=\"resize: auto\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" resize=\"auto\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-textarea--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" hasError />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner\">\n            <View gap={2}>\n                <Text variant=\"featured-2\">What problem are you trying to solve?</Text>\n                <TextArea.Aligner>\n                    <TextArea\n                        variant=\"headless\"\n                        placeholder=\"Try something like 'I have a job'\"\n                        name=\"description\"\n                    />\n                </TextArea.Aligner>\n                <View.Item>\n                    <Button>Next</Button>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-textarea--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"long value without breaks\">\n            <TextArea\n                name=\"hey\"\n                defaultValue={`<div style=\"position:relative;width:100%;padding-top:calc(150% + 72px)\">\n<iframe src=\"nskjdfdsdkjfsjkdfhbsjlhdfbsjlhfbs;jhbsdljfhsbljhfsbljhfbsjlfdhbsljhfbsdljhfbsljhfbslufbhsdlfds\" />\n</div>`}\n                resize=\"auto\"\n                placeholder=\"Placeholder\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-textarea--render",
+					"name": "base",
 					"snippet": "const render = () => <TextArea name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-textarea--placeholder",
 					"name": "placeholder",
 					"snippet": "const placeholder = () => (\n    <TextArea\n        name=\"test-name\"\n        placeholder=\"Placeholder\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-textarea--id",
 					"name": "id",
 					"snippet": "const id = () => (\n    <TextArea name=\"test-name\" id=\"test-id\" inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
+					"id": "components-textarea--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <TextArea name=\"test-name\" disabled inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-textarea--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <TextArea\n    name=\"test-name\"\n    defaultValue=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-textarea--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <TextArea\n    name=\"test-name\"\n    value=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-textarea--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <TextArea\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-textarea--form-control",
+					"name": "test: form control",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"with helper\">\n            <FormControl>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextArea name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n        <Example.Item title=\"with error\">\n            <FormControl hasError>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextArea name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, FormControl, Text, TextArea, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/TextArea/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "TextArea",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/TextArea/TextArea.tsx",
-				"actualName": "TextArea",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text area",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text area input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text area user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text area value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLTextAreaElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text area is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLTextAreaElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text area is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLTextAreaElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"textarea\">" }
+					},
+					"resize": {
+						"defaultValue": null,
+						"description": "Enable or disable the text area resizing, supports auto-sizing",
+						"name": "resize",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"none\" | \"auto\"",
+							"value": [{ "value": "\"none\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "TextArea"
 			}
 		},
 		"components-textfield": {
@@ -1940,71 +10064,445 @@
 			"path": "./src/components/TextField/tests/TextField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-textfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <TextField variant=\"faded\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless\">\n            <TextField variant=\"headless\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded\">\n            <TextField\n                rounded\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                icon={IconZap}\n                prefix=\"+31\"\n                endSlot={<Button rounded size=\"small\" icon={IconZap} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"rounded, variant: faded\">\n            <View direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <TextField\n                        rounded\n                        variant=\"faded\"\n                        name=\"Name\"\n                        placeholder=\"Enter your name\"\n                        startSlot={\n                            <Badge rounded size=\"small\">\n                                Hello\n                            </Badge>\n                        }\n                    />\n                </View.Item>\n                <Button rounded>Submit</Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-textfield--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" hasError />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "attachments",
+					"id": "components-textfield--attachments",
+					"name": "icon, endIcon, suffix, prefix, startSlot, endSlot, startSlotPadding, endSlotPadding",
 					"snippet": "const attachments = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" value=\"Reshaped\" icon={IconZap} />\n        </Example.Item>\n        <Example.Item title=\"endIcon\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" value=\"Reshaped\" endIcon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title={[\"startSlot\", \"vertical and horizontal padding aligned\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title={[\"endSlot\", \"vertical and horizontal padding aligned\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                endSlot={\n                    <Button\n                        icon={IconZap}\n                        size=\"small\"\n                        onClick={() => {}}\n                        attributes={{ \"aria-label\": \"Action\" }}\n                    />\n                }\n            />\n        </Example.Item>\n\n        <Example.Item title=\"paddingSlotStart=4, paddingSlotEnd=2\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlotPadding={4}\n                endSlotPadding={2}\n                startSlot={<Placeholder h={20} />}\n                endSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"with all affixes\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                endIcon={IconZap}\n                icon={IconZap}\n                prefix=\"Estimated value\"\n                suffix=\"m2\"\n                startSlot={<Placeholder h={20} />}\n                endSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"multiline wrap\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlot={[...Array(10).keys()].map((i) => (\n                    <Badge size=\"small\" key={i}>\n                        Item {i + 1}\n                    </Badge>\n                ))}\n                multiline\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"small\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"medium\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"large\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"xlarge\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] xlarge\", \"[m+] medium\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                size={{ s: \"xlarge\", m: \"medium\" }}\n                icon={IconZap}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner\">\n            <View gap={2}>\n                <Text variant=\"featured-2\">What problem are you trying to solve?</Text>\n                <TextField.Aligner>\n                    <TextField\n                        variant=\"headless\"\n                        placeholder=\"Try something like 'I have a job'\"\n                        name=\"description\"\n                    />\n                </TextField.Aligner>\n                <View.Item>\n                    <Button>Next</Button>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-textfield--render",
+					"name": "base",
 					"snippet": "const render = () => <TextField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-textfield--placeholder",
 					"name": "placeholder",
 					"snippet": "const placeholder = () => (\n    <TextField\n        name=\"test-name\"\n        placeholder=\"Placeholder\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-textfield--id",
 					"name": "id",
 					"snippet": "const id = () => (\n    <TextField name=\"test-name\" id=\"test-id\" inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
+					"id": "components-textfield--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <TextField name=\"test-name\" disabled inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-textfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <TextField\n    name=\"test-name\"\n    defaultValue=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-textfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <TextField\n    name=\"test-name\"\n    value=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-textfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <TextField\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-textfield--form-control",
+					"name": "test: form control",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"with helper\">\n            <FormControl>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextField name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n        <Example.Item title=\"with error\">\n            <FormControl hasError>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextField name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Badge, Button, Example, FormControl, Placeholder, Text, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/TextField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "TextField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/TextField/TextField.tsx",
-				"actualName": "TextField",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"multiline": {
+						"defaultValue": null,
+						"description": "Enable multiline text field wrapping",
+						"name": "multiline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to be fully rounded",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content after the text field value",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text field value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the text field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the text field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "TextField"
 			}
 		},
 		"components-timeline": {
@@ -2013,27 +10511,71 @@
 			"path": "./src/components/Timeline/tests/Timeline.stories.tsx",
 			"stories": [
 				{
+					"id": "components-timeline--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"children passed directly\">\n            <Timeline>\n                <Placeholder />\n                <Placeholder />\n                <Placeholder />\n            </Timeline>\n        </Example.Item>\n        <Example.Item title=\"children wrapped with Timeline.Item\">\n            <Timeline>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "marker",
+					"id": "components-timeline--marker",
+					"name": "markerSlot",
 					"snippet": "const marker = () => (\n    <Example>\n        <Example.Item title=\"slot\">\n            <Timeline>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n\n        <Example.Item title=\"null marker\">\n            <Timeline>\n                <Timeline.Item markerSlot={null}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={null}>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-timeline--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Timeline className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Timeline.Item className=\"test-item-classname\" attributes={{ id: \"test-item-id\" }}>\n                Content\n            </Timeline.Item>\n            <Timeline.Item>Content</Timeline.Item>\n        </Timeline>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Placeholder, Timeline } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Timeline/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Timeline",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Timeline/Timeline.tsx",
-				"actualName": "Timeline",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"ul\">" }
+					}
+				},
+				"exportName": "Timeline"
 			}
 		},
 		"components-toast": {
@@ -2041,32 +10583,54 @@
 			"name": "Toast",
 			"path": "./src/components/Toast/tests/Toast.stories.tsx",
 			"stories": [
-				{ "name": "size", "snippet": "const size = () => <Size />;" },
 				{
+					"id": "components-toast--size",
+					"name": "size",
+					"snippet": "const size = () => <Size />;"
+				},
+				{
+					"id": "components-toast--position",
 					"name": "position",
 					"snippet": "const position = () => <Position />;"
 				},
-				{ "name": "color", "snippet": "const color = () => <Color />;" },
-				{ "name": "timeout", "snippet": "const timeout = () => <Timeout />;" },
 				{
-					"name": "regionOptions",
+					"id": "components-toast--color",
+					"name": "color",
+					"snippet": "const color = () => <Color />;"
+				},
+				{
+					"id": "components-toast--timeout",
+					"name": "timeout",
+					"snippet": "const timeout = () => <Timeout />;"
+				},
+				{
+					"id": "components-toast--region-options",
+					"name": "expanded",
 					"snippet": "const regionOptions = () => <Expanded />;"
 				},
-				{ "name": "slots", "snippet": "const slots = () => <Slots />;" },
 				{
+					"id": "components-toast--slots",
+					"name": "slots",
+					"snippet": "const slots = () => <Slots />;"
+				},
+				{
+					"id": "components-toast--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const toast = useToast();\n\n    return (\n        <Button\n            onClick={() => {\n                const id = toast.show({\n                    title: \"Title\",\n                    text: \"Text\",\n                    children: \"Children\",\n                    startSlot: \"Slot\",\n                    actionsSlot: (\n                        <Button attributes={{ \"data-testid\": \"trigger-id\" }} onClick={() => toast.hide(id)}>\n                            Trigger\n                        </Button>\n                    ),\n                });\n            }}\n        >\n            Show toast\n        </Button>\n    );\n};"
 				},
 				{
-					"name": "nested",
+					"id": "components-toast--nested",
+					"name": "ToastProvider",
 					"snippet": "const nested = () => {\n    return (\n        <div data-testid=\"test-container-id\">\n            <ToastProvider>\n                <NestedDemo />\n            </ToastProvider>\n        </div>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-toast--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => {\n    const toast = useToast();\n\n    return (\n        <Button\n            onClick={() => {\n                const id = toast.show({\n                    text: \"Content\",\n                    attributes: { \"data-testid\": \"test-id\" },\n                    className: \"test-classname\",\n                });\n            }}\n        >\n            Show toast\n        </Button>\n    );\n};"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-toast--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"Multiline, should support dynamic height\">\n            <Multiline />\n        </Example.Item>\n        <Example.Item title=\"Nested ToastProvider\">\n            <ToastProvider>\n                <Nested />\n            </ToastProvider>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
@@ -2083,30 +10647,601 @@
 			"path": "./src/components/ToggleButton/tests/ToggleButton.stories.tsx",
 			"stories": [
 				{
+					"id": "components-togglebutton--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"outline\">\n            <ToggleButton>Button</ToggleButton>\n        </Example.Item>\n        <Example.Item title=\"ghost\">\n            <ToggleButton variant=\"ghost\">Button</ToggleButton>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-togglebutton--selected-color",
 					"name": "selectedColor",
 					"snippet": "const selectedColor = () => (\n    <Example>\n        <Example.Item title=\"selectedColor: primary\">\n            <ToggleButton selectedColor=\"primary\" defaultChecked>\n                Button\n            </ToggleButton>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onChange",
+					"id": "components-togglebutton--on-change",
+					"name": "checked, defaultChecked, onChange",
 					"snippet": "const onChange = () => <Example>\n    <Example.Item title=\"defaultChecked, onChange\">\n        <ToggleButton defaultChecked onChange={fn()} value=\"1\">Button\n                                </ToggleButton>\n    </Example.Item>\n    <Example.Item title=\"checked, onChange\">\n        <ToggleButton checked onChange={fn()} value=\"2\">Button\n                                </ToggleButton>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-togglebutton--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <ToggleButton onClick={fn()}>Button</ToggleButton>;"
 				}
 			],
 			"import": "import { Example, ToggleButton } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ToggleButton/ToggleButton.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "ToggleButton",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ToggleButton/ToggleButton.tsx",
-				"actualName": "ToggleButton",
+				"methods": [],
+				"props": {
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loading": {
+						"defaultValue": null,
+						"description": "Show loading state",
+						"name": "loading",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loadingAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the loading indicator",
+						"name": "loadingAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Make the component take the full width of the parent element",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"ghost\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"ghost\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"selectedColor": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme when selected",
+						"name": "selectedColor",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the toggle button, enables controlled mode for the ToggleButtonGroup",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the toggle button value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { checked: boolean; value: string; event: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>; }) => void)"
+						}
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default value of the toggle button, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Value of the toggle button, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2116,34 +11251,194 @@
 			"path": "./src/components/ToggleButtonGroup/tests/ToggleButtonGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "single",
+					"id": "components-togglebuttongroup--single",
+					"name": "checked, defaultChecked, onChange",
 					"snippet": "const single = () => <Example>\n    <Example.Item title=\"single, uncontrolled, onChange\">\n        <ToggleButtonGroup onChange={fn()}>\n            <ToggleButton value=\"1\" onChange={fn()}>Button\n                                    </ToggleButton>\n            <ToggleButton value=\"2\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n    <Example.Item title=\"single, controlled, onChange\">\n        <ToggleButtonGroup onChange={fn()} value={[]}>\n            <ToggleButton value=\"3\" onChange={fn()}>Button\n                                    </ToggleButton>\n            <ToggleButton value=\"4\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "multiple",
+					"id": "components-togglebuttongroup--multiple",
+					"name": "selectionMode, checked, defaultChecked, onChange",
 					"snippet": "const multiple = () => <Example>\n    <Example.Item title=\"multiple, uncontrolled, onChange\">\n        <ToggleButtonGroup onChange={fn()} selectionMode=\"multiple\">\n            <ToggleButton value=\"1\">Button</ToggleButton>\n            <ToggleButton value=\"2\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n    <Example.Item title=\"multiple, controlled, onChange\">\n        <ToggleButtonGroup onChange={fn()} value={[]} selectionMode=\"multiple\">\n            <ToggleButton value=\"3\">Button</ToggleButton>\n            <ToggleButton value=\"4\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "selectedColor",
+					"id": "components-togglebuttongroup--selected-color",
+					"name": "color,selectedColor",
 					"snippet": "const selectedColor = () => (\n    <Example>\n        <Example.Item title=\"selectedColor: primary\">\n            <ToggleButtonGroup selectedColor=\"primary\" defaultValue={[\"2\"]}>\n                <ToggleButton value=\"1\">Button</ToggleButton>\n                <ToggleButton value=\"2\">Button</ToggleButton>\n                <ToggleButton value=\"3\">Button</ToggleButton>\n            </ToggleButtonGroup>\n        </Example.Item>\n        <Example.Item title=\"color: primary, selectedColor: critical\">\n            <ToggleButtonGroup color=\"primary\" selectedColor=\"critical\" defaultValue={[\"2\"]}>\n                <ToggleButton value=\"1\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n                <ToggleButton value=\"2\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n                <ToggleButton value=\"3\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n            </ToggleButtonGroup>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-togglebuttongroup--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ToggleButtonGroup className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <ToggleButton>Button 1</ToggleButton>\n            <ToggleButton>Button 1</ToggleButton>\n        </ToggleButtonGroup>\n    </div>\n);"
 				},
 				{
-					"name": "testIcon",
+					"id": "components-togglebuttongroup--test-icon",
+					"name": "test: icon only",
 					"snippet": "const testIcon = () => (\n    <Example>\n        <Example.Item title=\"icon only\">\n            <ToggleButtonGroup selectedColor=\"primary\">\n                <ToggleButton value=\"1\" icon={IconPlus} />\n                <ToggleButton value=\"2\" icon={IconMinus} />\n                <ToggleButton value=\"3\" icon={IconCheckmark} />\n            </ToggleButtonGroup>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, ToggleButton, ToggleButtonGroup } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ToggleButtonGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ToggleButtonGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx",
-				"actualName": "ToggleButtonGroup",
+				"methods": [],
+				"props": {
+					"selectionMode": {
+						"defaultValue": { "value": "\"single\"" },
+						"description": "Selection mode for the toggle button group",
+						"name": "selectionMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"single\" | \"multiple\"",
+							"value": [{ "value": "\"single\"" }, { "value": "\"multiple\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme applied to each button",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"selectedColor": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme for the selected button",
+						"name": "selectedColor",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the toggle button group value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { value: string[]; event: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>; }) => void)"
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting child Button components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Selected values in the group, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default selected values in the group, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2153,30 +11448,269 @@
 			"path": "./src/components/Tooltip/tests/Tooltip.stories.tsx",
 			"stories": [
 				{
+					"id": "components-tooltip--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: bottom-start\">\n            <View direction=\"row\" gap={2}>\n                <Demo position=\"bottom-start\" text=\"Tooltip 1\" />\n                <Demo position=\"bottom-start\" text=\"Tooltip 2\" />\n                <Demo position=\"bottom-start\" text=\"Tooltip 3\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: bottom\">\n            <Demo position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"position: bottom-end\">\n            <Demo position=\"bottom-end\" />\n        </Example.Item>\n        <Example.Item title=\"position: top-start\">\n            <Demo position=\"top-start\" />\n        </Example.Item>\n        <Example.Item title=\"position: top\">\n            <Demo position=\"top\" />\n        </Example.Item>\n        <Example.Item title=\"position: top-end\">\n            <Demo position=\"top-end\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: start\">\n            <View align=\"end\">\n                <Demo position=\"start\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: start-top\">\n            <View align=\"end\">\n                <Demo position=\"start-top\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: start-bottom\">\n            <View align=\"end\">\n                <Demo position=\"start-bottom\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <Demo position=\"end\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: end-top\">\n            <Demo position=\"end-top\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: end-bottom\">\n            <Demo position=\"end-bottom\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tooltip--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: inverted\">\n            <Demo color=\"inverted\" position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"color: dark\">\n            <Demo color=\"dark\" position=\"bottom\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-tooltip--default-active",
+					"name": "uncontrolled",
 					"snippet": "const defaultActive = () => <Tooltip text=\"Content\" onOpen={fn()} onClose={fn()}>\n    {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n</Tooltip>;"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-tooltip--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"responsive visibility\">\n            <DemoResponsive text=\"Responsive\" />\n        </Example.Item>\n\n        <Example.Item title=\"without text\">\n            <Tooltip>{() => <Button>Button</Button>}</Tooltip>\n        </Example.Item>\n\n        <Example.Item title=\"tooltip with popover\">\n            <Tooltip text=\"Tooltip\" position=\"top\">\n                {(attributes) => (\n                    <Popover position=\"bottom\">\n                        <Popover.Trigger>\n                            {(popoverAttributes) => (\n                                <Button attributes={{ ...attributes, ...popoverAttributes }}>Action</Button>\n                            )}\n                        </Popover.Trigger>\n                        <Popover.Content>Popover</Popover.Content>\n                    </Popover>\n                )}\n            </Tooltip>\n        </Example.Item>\n\n        <Example.Item title=\"nested popovers inside a tooltip\">\n            <View direction=\"row\" gap={2}>\n                <Tooltip position=\"top\" text=\"Hello\">\n                    {(tooltipAttributes) => (\n                        <Popover position=\"bottom\" width=\"300px\">\n                            <Popover.Trigger>\n                                {(attributes) => (\n                                    <Button attributes={{ ...tooltipAttributes, ...attributes }}>\n                                        Tooltip with popover\n                                    </Button>\n                                )}\n                            </Popover.Trigger>\n                            <Popover.Content>\n                                <View gap={2} align=\"center\" direction=\"row\" justify=\"space-between\">\n                                    Popover content\n                                    <Popover position=\"bottom\" width=\"300px\">\n                                        <Popover.Trigger>\n                                            {(attributes) => <Button attributes={attributes}>Open</Button>}\n                                        </Popover.Trigger>\n                                        <Popover.Content>\n                                            <Popover.Dismissible align=\"center\" closeAriaLabel=\"Close\">\n                                                Another popover content\n                                            </Popover.Dismissible>\n                                        </Popover.Content>\n                                    </Popover>\n                                </View>\n                            </Popover.Content>\n                        </Popover>\n                    )}\n                </Tooltip>\n                <Tooltip position=\"top\" text=\"Hello\">\n                    {(tooltipAttributes) => <Button attributes={tooltipAttributes}>Just a tooltip</Button>}\n                </Tooltip>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, Popover, Tooltip, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Tooltip/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Tooltip",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Tooltip/Tooltip.tsx",
-				"actualName": "Tooltip",
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the flyout content interactivity",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"contentAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the content element",
+						"name": "contentAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"contentClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the content element",
+						"name": "contentClassName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "(attributes: TriggerAttributes) => ReactNode" }
+					},
+					"text": {
+						"defaultValue": null,
+						"description": "Text content for the tooltip",
+						"name": "text",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"inverted\"" },
+						"description": "Color of the tooltip",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"dark\" | \"inverted\"",
+							"value": [{ "value": "\"dark\"" }, { "value": "\"inverted\"" }]
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2186,51 +11720,191 @@
 			"path": "./src/components/Accordion/tests/Accordion.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-accordion--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Accordion defaultActive>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--icon-size",
 					"name": "iconSize",
 					"snippet": "const iconSize = () => (\n    <Accordion iconSize={6}>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--icon-position",
 					"name": "iconPosition",
 					"snippet": "const iconPosition = () => (\n    <Accordion iconPosition=\"start\">\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Accordion defaultActive gap={4}>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <Placeholder />\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--on-toggle",
 					"name": "onToggle",
 					"snippet": "const onToggle = () => <Accordion onToggle={fn()}>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
+					"id": "utility-components-accordion--active",
 					"name": "active",
 					"snippet": "const active = () => <Accordion onToggle={fn()} active>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
+					"id": "utility-components-accordion--default-active",
 					"name": "defaultActive",
 					"snippet": "const defaultActive = () => <Accordion onToggle={fn()} defaultActive>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
-					"name": "renderProps",
+					"id": "utility-components-accordion--render-props",
+					"name": "children: render props",
 					"snippet": "const renderProps = () => <Accordion onToggle={fn()}>\n    <Accordion.Trigger>\n        {(attributes, { active }) => (\n            <Button attributes={{ ...attributes, \"data-active\": active }}>Trigger</Button>\n        )}\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-accordion--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Accordion className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Accordion.Trigger>\n                <Placeholder>Trigger</Placeholder>\n            </Accordion.Trigger>\n            <Accordion.Content>\n                <View paddingTop={2}>\n                    <Placeholder />\n                </View>\n            </Accordion.Content>\n        </Accordion>\n    </div>\n);"
 				}
 			],
 			"import": "import { Accordion, Button, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Accordion/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Accordion",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Accordion/Accordion.tsx",
-				"actualName": "Accordion",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"iconSize": {
+						"defaultValue": null,
+						"description": "Expand / collapse icon size in units",
+						"name": "iconSize",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"iconPosition": {
+						"defaultValue": null,
+						"description": "Position of the expand / collapse icon",
+						"name": "iconPosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"start\" | \"end\"",
+							"value": [{ "value": "\"start\"" }, { "value": "\"end\"" }]
+						}
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between the trigger and the content",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the trigger and the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onToggle": {
+						"defaultValue": null,
+						"description": "Callback when the accordion is expanded or collapsed",
+						"name": "onToggle",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((active: boolean) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control whether the accordion is expanded or collapsed, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control whether the accordion is expanded or collapsed by default, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Accordion"
 			}
 		},
 		"utility-components-actionable": {
@@ -2239,54 +11913,456 @@
 			"path": "./src/components/Actionable/tests/Actionable.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "utility-components-actionable--base",
+					"name": "href, onClick",
 					"snippet": "const base = () => <Example>\n    <Example.Item title=\"span\">\n        <Actionable>Span</Actionable>\n    </Example.Item>\n    <Example.Item title=\"onClick\">\n        <Actionable onClick={fn()}>Button</Actionable>\n    </Example.Item>\n    <Example.Item title=\"href\">\n        <Actionable href=\"https://reshaped.so\" attributes={{ target: \"_blank\" }}>Link\n                            </Actionable>\n    </Example.Item>\n    <Example.Item title=\"attributes.href\">\n        <Actionable attributes={{ href: \"https://reshaped.so\" }}>Link with attributes</Actionable>\n    </Example.Item>\n    <Example.Item title=\"href, onClick\">\n        <Actionable\n            onClick={(e) => {\n                e.preventDefault();\n                args.handleSecondClick(e);\n            }}\n            href=\"https://reshaped.so\">Link with onClick\n                            </Actionable>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "utility-components-actionable--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, button\">\n            <Actionable disabled onClick={() => {}}>\n                Button\n            </Actionable>\n        </Example.Item>\n        <Example.Item title=\"disabled, link\">\n            <Actionable disabled href=\"https://reshaped.so\">\n                Link\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--full-width",
 					"name": "fullWidth",
 					"snippet": "const fullWidth = () => (\n    <Example>\n        <Example.Item title=\"fullWidth\">\n            <Actionable fullWidth href=\"https://reshaped.so\">\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--inset-focus",
 					"name": "insetFocus",
 					"snippet": "const insetFocus = () => (\n    <Example>\n        <Example.Item title=\"insetFocus\">\n            <Actionable insetFocus onClick={() => {}}>\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--disable-focus-ring",
 					"name": "disableFocusRing",
 					"snippet": "const disableFocusRing = () => (\n    <Example>\n        <Example.Item title=\"disableFocusRing\">\n            <Actionable disableFocusRing onClick={() => {}}>\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--border-radius",
 					"name": "borderRadius",
 					"snippet": "const borderRadius = () => (\n    <Example>\n        <Example.Item title=\"borderRadius: inherit\">\n            <Actionable borderRadius=\"inherit\" onClick={() => {}}>\n                <View borderRadius=\"large\">Actionable</View>\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--type",
 					"name": "type",
 					"snippet": "const type = (args) => (\n    <Example>\n        <Example.Item title=\"type: submit\">\n            <form\n                onSubmit={(e) => {\n                    e.preventDefault();\n                    args.handleSubmit();\n                }}\n            >\n                <Actionable onClick={() => {}} type=\"submit\">\n                    Submit\n                </Actionable>\n            </form>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "as",
+					"id": "utility-components-actionable--as",
+					"name": "as, render",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"as: span\">\n            <Actionable onClick={() => {}} as=\"span\">\n                Trigger\n            </Actionable>\n        </Example.Item>\n        <Example.Item title=\"render, disabled\">\n            <Actionable disabled onClick={() => {}} render={(props) => <section {...props} />}>\n                Trigger\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--stop-propagation",
 					"name": "stopPropagation",
 					"snippet": "const stopPropagation = () => <div onClick={fn()}>\n    <Actionable stopPropagation onClick={() => {}}>Trigger\n                    </Actionable>\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-actionable--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Actionable className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Actionable>\n    </div>\n);"
 				}
 			],
 			"import": "import { Actionable, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Actionable/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Actionable",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Actionable/Actionable.tsx",
-				"actualName": "Actionable",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"touchHitbox": {
+						"defaultValue": null,
+						"description": "Enable a minimum required touch hitbox",
+						"name": "touchHitbox",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Take up the full width of its parent",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"insetFocus": {
+						"defaultValue": null,
+						"description": "Enable a focus ring inside the element bounds",
+						"name": "insetFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableFocusRing": {
+						"defaultValue": null,
+						"description": "Don't show a focus ring on focus, can be used when it is within a container with a focus ring",
+						"name": "disableFocusRing",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Apply the focus ring to the child and rely on its border radius",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"inherit\"", "value": [{ "value": "\"inherit\"" }] }
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2296,30 +12372,149 @@
 			"path": "./src/components/Container/tests/Container.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-container--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: default\">\n            <Container>\n                <Placeholder />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"padding: 0\">\n            <Container padding={0}>\n                <Placeholder />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "utility-components-container--size",
+					"name": "width, height, maxHeight",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"width: 200px, height: 200px\">\n            <Container width=\"200px\" height=\"200px\">\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width: 200px, height: 200px, maxHeight: 100px\">\n            <Container width=\"200px\" height=\"200px\" maxHeight=\"100px\">\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width, height: [s] 100px, [m+] 200px\">\n            <Container width={{ s: \"100px\", m: \"200px\" }} height={{ s: \"100px\", m: \"200px\" }}>\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width, height: [s] 100px, [m+] 200px, maxHeight: [s] 50px, [m+]: 100px\">\n            <Container\n                width={{ s: \"100px\", m: \"200px\" }}\n                height={{ s: \"100px\", m: \"200px\" }}\n                maxHeight={{ s: \"50px\", m: \"100px\" }}\n            >\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "flex",
+					"id": "utility-components-container--flex",
+					"name": "align, justify",
 					"snippet": "const flex = () => (\n    <Example>\n        <Example.Item title=\"align: center, justify: center\">\n            <Container align=\"center\" justify=\"center\" height=\"200px\">\n                <Placeholder />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-container--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Container className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </Container>\n    </div>\n);"
 				}
 			],
 			"import": "import { Container, Example, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Container/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Container",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Container/Container.tsx",
-				"actualName": "Container",
+				"methods": [],
+				"props": {
+					"align": {
+						"defaultValue": null,
+						"description": "Flex align-items for the content",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Flex justify-content for the content",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier\nComponent height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" },
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height style, literal string value or a base unit token number multiplier\nComponent max height, literal css value or unit token multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" },
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Component inline padding",
+						"name": "padding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Component width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2329,34 +12524,157 @@
 			"path": "./src/components/Dismissible/tests/Dismissible.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-dismissible--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Dismissible closeAriaLabel=\"Close banner\" onClose={() => {}}>\n                <Placeholder />\n            </Dismissible>\n        </Example.Item>\n        <Example.Item title=\"variant: media\">\n            <View width=\"300px\">\n                <Dismissible variant=\"media\" closeAriaLabel=\"Close banner\" onClose={() => {}}>\n                    <View aspectRatio={16 / 9}>\n                        <Image\n                            height=\"100%\"\n                            src=\"https://images.unsplash.com/photo-1607030529528-ca6923e27f77?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1867&q=80)\"\n                        />\n                    </View>\n                </Dismissible>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-dismissible--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: center\">\n            <Dismissible align=\"center\" closeAriaLabel=\"Close\" onClose={() => {}}>\n                <Placeholder />\n            </Dismissible>\n        </Example.Item>\n\n        <Example.Item title=\"align: center, variant: media\">\n            <Dismissible align=\"center\" closeAriaLabel=\"Close\" variant=\"media\" onClose={() => {}}>\n                <View aspectRatio={16 / 9}>\n                    <Image\n                        height=\"100%\"\n                        src=\"https://images.unsplash.com/photo-1607030529528-ca6923e27f77?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1867&q=80)\"\n                    />\n                </View>\n            </Dismissible>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-dismissible--hide-close-button",
 					"name": "hideCloseButton",
 					"snippet": "const hideCloseButton = () => (\n    <Example>\n        <Example.Item title=\"hide close button\">\n            <div id=\"root\">\n                <Dismissible hideCloseButton>\n                    <Placeholder />\n                </Dismissible>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "closeAriaLabel",
+					"id": "utility-components-dismissible--close-aria-label",
+					"name": "onClose, closeAriaLabel",
 					"snippet": "const closeAriaLabel = () => <Dismissible closeAriaLabel=\"Close\" onClose={fn()}>\n    <Placeholder />\n</Dismissible>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-dismissible--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Dismissible\n            closeAriaLabel=\"Close\"\n            onClose={() => {}}\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n        >\n            <Placeholder />\n        </Dismissible>\n    </div>\n);"
 				}
 			],
 			"import": "import { Dismissible, Example, Image, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Dismissible/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Dismissible",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Dismissible/Dismissible.tsx",
-				"actualName": "Dismissible",
+				"methods": [],
+				"props": {
+					"hideCloseButton": {
+						"defaultValue": null,
+						"description": "Hide the close button\nShow the close button",
+						"name": "hideCloseButton",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"closeAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the close button",
+						"name": "closeAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"media\"", "value": [{ "value": "\"media\"" }] }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Close button alignment",
+						"name": "align",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"center\"",
+							"value": [{ "value": "\"top\"" }, { "value": "\"center\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is dismissed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2366,135 +12684,577 @@
 			"path": "./src/components/Flyout/tests/Flyout.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-flyout--position",
 					"name": "position",
 					"snippet": "const position = () => {\n    return (\n        <View gap={4} padding={50} align=\"center\" justify=\"center\" height=\"100vh\" width=\"120%\">\n            <View gap={4} direction=\"row\">\n                <Demo position=\"top-start\" defaultActive />\n                <Demo position=\"top\" />\n                <Demo position=\"top-end\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"end-top\" />\n                <Demo position=\"end\" />\n                <Demo position=\"end-bottom\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"start-top\" />\n                <Demo position=\"start\" />\n                <Demo position=\"start-bottom\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"bottom-start\" />\n                <Demo position=\"bottom\" />\n                <Demo position=\"bottom-end\" />\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "defaultActive",
+					"id": "utility-components-flyout--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <Flyout onOpen={fn()} onClose={fn()} defaultActive>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "active",
+					"id": "utility-components-flyout--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <Flyout onOpen={fn()} onClose={fn()} active>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "utility-components-flyout--active-false",
+					"name": "active: false, controlled",
 					"snippet": "const activeFalse = () => <Flyout onOpen={fn()} onClose={fn()} active={false}>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "modes",
+					"id": "utility-components-flyout--modes",
+					"name": "triggerType, trapFocusMode",
 					"snippet": "const modes = () => {\n    return (\n        <Example>\n            <Example.Item title=\"triggerType: click\">\n                <View direction=\"row\" gap={4}>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"dialog\" text=\"dialog\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"action-menu\" text=\"action-menu\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"action-bar\" text=\"action-bar\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"content-menu\" text=\"content-menu\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode={false} text=\"false\">\n                        {modeContent}\n                    </Demo>\n                </View>\n            </Example.Item>\n\n            <Example.Item title=\"triggerType: hover\">\n                <View direction=\"row\" gap={4}>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"dialog\" triggerType=\"hover\" text=\"dialog\">\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"action-menu\"\n                        triggerType=\"hover\"\n                        text=\"action-menu\"\n                    >\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"action-bar\"\n                        triggerType=\"hover\"\n                        text=\"action-bar\"\n                    >\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"content-menu\"\n                        triggerType=\"hover\"\n                        text=\"content-menu\"\n                    >\n                        {modeContent}\n                    </Demo>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "positionFallbacks",
+					"id": "utility-components-flyout--position-fallbacks",
+					"name": "fallbackPositions",
 					"snippet": "const positionFallbacks = () => {\n    return (\n        <Example>\n            <Example.Item title=\"position: top, default fallbacks\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" />\n                </View>\n            </Example.Item>\n            <Example.Item title=\"position: top, fallbackPositions: [start]\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" fallbackPositions={[\"start\"]} contentHeight={200} defaultActive />\n                </View>\n            </Example.Item>\n            <Example.Item title=\"position: top, fallbackPositions: false\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" fallbackPositions={false} contentHeight={400} />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--fallback-adjust-layout",
 					"name": "fallbackAdjustLayout",
 					"snippet": "const fallbackAdjustLayout = () => {\n    return (\n        <Demo\n            contentHeight={false}\n            position=\"bottom-start\"\n            width=\"200px\"\n            fallbackAdjustLayout\n            defaultActive\n        >\n            <div style={{ height: \"600px\" }}>Content</div>\n        </Demo>\n    );\n};"
 				},
 				{
-					"name": "fallbackAdjustLayoutShift",
+					"id": "utility-components-flyout--fallback-adjust-layout-shift",
+					"name": "fallbackAdjustLayout, shift",
 					"snippet": "const fallbackAdjustLayoutShift = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={10}>\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    attributes={{ ref: containerRef }}\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls containerRef={containerRef} />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <FallbackAdjustLayoutControls />\n            <div style={{ height: \"100vh\", width: \"250%\" }} />\n        </View>\n    );\n};"
 				},
 				{
-					"name": "fallbackAdjustLayoutSize",
+					"id": "utility-components-flyout--fallback-adjust-layout-size",
+					"name": "fallbackAdjustLayout, size",
 					"snippet": "const fallbackAdjustLayoutSize = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={10}>\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls large />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    attributes={{ ref: containerRef }}\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls containerRef={containerRef} large />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <FallbackAdjustLayoutControls large />\n            <div style={{ height: \"100vh\", width: \"250%\" }} />\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--origin-coordinates",
 					"name": "originCoordinates",
 					"snippet": "const originCoordinates = () => {\n    return (\n        <View gap={4} direction=\"row\">\n            <Demo position=\"bottom-start\" originCoordinates={{ x: 150, y: 150 }} defaultActive />\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--width",
 					"name": "width",
 					"snippet": "const width = () => (\n    <Example>\n        <Example.Item title=\"width: 300px\">\n            <Demo width=\"300px\" position=\"bottom\" />\n        </Example.Item>\n\n        <Example.Item title=\"width: trigger\">\n            <Demo width=\"trigger\" contentWidth={false} defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-flyout--content-gap",
 					"name": "contentGap",
 					"snippet": "const contentGap = () => <Demo contentGap={10} defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--content-shift",
 					"name": "contentShift",
 					"snippet": "const contentShift = () => <Demo contentShift={10} defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-content-hover",
 					"name": "disableContentHover",
 					"snippet": "const disableContentHover = () => <Demo triggerType=\"hover\" disableContentHover />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-close-on-outside-click",
 					"name": "disableCloseOnOutsideClick",
 					"snippet": "const disableCloseOnOutsideClick = () => <Demo disableCloseOnOutsideClick />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-hide-animation",
 					"name": "disableHideAnimation",
 					"snippet": "const disableHideAnimation = () => <Demo disableHideAnimation defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Flyout disabled>\n        <Flyout.Trigger>\n            {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n        </Flyout.Trigger>\n        <Flyout.Content>\n            <Content />\n        </Flyout.Content>\n    </Flyout>\n);"
 				},
 				{
+					"id": "utility-components-flyout--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const portalRef = React.useRef<HTMLDivElement>(null);\n    const portalRef2 = React.useRef<HTMLDivElement>(null);\n    const portalRef3 = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={4} direction=\"row\">\n            <View\n                grow\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef, \"data-testid\": \"container\" }}\n                justify=\"end\"\n                align=\"start\"\n                padding={4}\n            >\n                <Demo containerRef={portalRef} position=\"bottom-start\" defaultActive />\n            </View>\n            <View\n                grow\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef2 }}\n                justify=\"start\"\n                align=\"end\"\n                padding={4}\n            >\n                <Demo containerRef={portalRef2} position=\"top-end\" />\n            </View>\n            <View\n                width={50}\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef3 }}\n                padding={4}\n                overflow=\"auto\"\n            >\n                <View height={120} width=\"120%\" justify=\"center\" align=\"center\">\n                    <Demo containerRef={portalRef3} position=\"bottom-end\" />\n                </View>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--initial-focus-ref",
 					"name": "initialFocusRef",
 					"snippet": "const initialFocusRef = () => {\n    const initialFocusRef = React.useRef<HTMLInputElement>(null);\n\n    return (\n        <Demo initialFocusRef={initialFocusRef}>\n            <View gap={4}>\n                <Button onClick={() => {}}>Action 1</Button>\n                <TextField name=\"foo\" inputAttributes={{ ref: initialFocusRef }} />\n            </View>\n        </Demo>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--instance-ref",
 					"name": "instanceRef",
 					"snippet": "const instanceRef = () => {\n    const flyoutRef = React.useRef<FlyoutInstance>(null);\n\n    return (\n        <View direction=\"row\" gap={4}>\n            <Demo\n                instanceRef={flyoutRef}\n                disableCloseOnOutsideClick\n                onOpen={fn()}\n                onClose={fn()} />\n            <Button onClick={() => flyoutRef.current?.open()}>Open</Button>\n            <Button onClick={() => flyoutRef.current?.close()}>Close</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "contentAttributes",
+					"id": "utility-components-flyout--content-attributes",
+					"name": "content: className, attributes",
 					"snippet": "const contentAttributes = () => {\n    return (\n        <Flyout position=\"bottom\" defaultActive>\n            <Flyout.Trigger>\n                {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n            </Flyout.Trigger>\n            <Flyout.Content attributes={{ \"data-testid\": \"test-id\" }} className=\"test-classname\">\n                <Content />\n            </Flyout.Content>\n        </Flyout>\n    );\n};"
 				},
 				{
-					"name": "testShadowDom",
+					"id": "utility-components-flyout--test-shadow-dom",
+					"name": "test: shadow dom",
 					"snippet": "const testShadowDom = () => <custom-element-flyout />;"
 				},
 				{
-					"name": "testInsideFixed",
+					"id": "utility-components-flyout--test-inside-fixed",
+					"name": "test: inside position fixed",
 					"snippet": "const testInsideFixed = () => (\n    <React.Fragment>\n        <View\n            position=\"fixed\"\n            insetBottom={2}\n            insetStart={2}\n            insetEnd={2}\n            backgroundColor=\"elevation-overlay\"\n            borderColor=\"neutral-faded\"\n            borderRadius=\"small\"\n            padding={4}\n            zIndex={10}\n            attributes={{ \"data-testid\": \"container\" }}\n            height={20}\n        >\n            <Demo defaultActive position=\"top-start\" />\n        </View>\n        <View paddingTop={18} gap={4}>\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n        </View>\n    </React.Fragment>\n);"
 				},
 				{
-					"name": "testInsideSticky",
+					"id": "utility-components-flyout--test-inside-sticky",
+					"name": "test: inside position sticky",
 					"snippet": "const testInsideSticky = () => (\n    <React.Fragment>\n        <View\n            position=\"sticky\"\n            insetTop={4}\n            insetStart={0}\n            insetEnd={0}\n            backgroundColor=\"elevation-overlay\"\n            borderColor=\"neutral-faded\"\n            borderRadius=\"small\"\n            padding={4}\n            zIndex={10}\n            attributes={{ \"data-testid\": \"container\" }}\n        >\n            <Demo defaultActive />\n        </View>\n        <View gap={4} paddingTop={2}>\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n        </View>\n    </React.Fragment>\n);"
 				},
 				{
-					"name": "testInsideScrollable",
+					"id": "utility-components-flyout--test-inside-scrollable",
+					"name": "test: inside scrollable",
 					"snippet": "const testInsideScrollable = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View padding={20}>\n            <View height={30} overflow=\"auto\" backgroundColor=\"neutral-faded\" borderRadius=\"small\">\n                <View height={50} attributes={{ ref: containerRef }} padding={20} paddingBottom={30}>\n                    <Demo position=\"bottom\" />\n                </View>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testInsideModal",
+					"id": "utility-components-flyout--test-inside-modal",
+					"name": "test: inside modal",
 					"snippet": "const testInsideModal = () => {\n    return (\n        <Modal active position=\"end\">\n            <View gap={4} align=\"start\">\n                <Modal.Title>Title</Modal.Title>\n                <Demo position=\"bottom-start\" />\n                <View height={300} width={25} backgroundColor=\"neutral-faded\" />\n                <Demo position=\"start\" />\n                <View height={300} width={25} backgroundColor=\"neutral-faded\" />\n                <Demo position=\"bottom-start\" />\n            </View>\n        </Modal>\n    );\n};"
 				},
 				{
-					"name": "testDynamicBounds",
+					"id": "utility-components-flyout--test-dynamic-bounds",
+					"name": "test: auto position update",
 					"snippet": "const testDynamicBounds = () => {\n    const [left, setLeft] = React.useState(50);\n    const [top, setTop] = React.useState(50);\n    const [size, setSize] = React.useState<\"medium\" | \"large\">(\"medium\");\n    const flyoutRef = React.useRef<FlyoutInstance>(null);\n\n    React.useEffect(() => {\n        flyoutRef.current?.updatePosition();\n    }, [left, top]);\n\n    return (\n        <View gap={4}>\n            <View direction=\"row\" gap={2}>\n                <Button onClick={() => setLeft((prev) => prev - 10)}>Left</Button>\n                <Button onClick={() => setLeft((prev) => prev + 10)}>Right</Button>\n                <Button onClick={() => setTop((prev) => prev - 10)}>Up</Button>\n                <Button onClick={() => setTop((prev) => prev + 10)}>Down</Button>\n                <Button\n                    onClick={() => {\n                        setLeft(50);\n                        setTop(50);\n                    }}\n                >\n                    Center\n                </Button>\n                <Button onClick={() => setSize(\"large\")}>Large button</Button>\n                <Button onClick={() => setSize(\"medium\")}>Small button</Button>\n            </View>\n            <View height={100}>\n                <Flyout\n                    position=\"bottom\"\n                    instanceRef={flyoutRef}\n                    disableCloseOnOutsideClick\n                    defaultActive\n                >\n                    <Flyout.Trigger>\n                        {(attributes) => (\n                            <div style={{ position: \"absolute\", left: `${left}%`, top: `${top}%` }}>\n                                <Button color=\"primary\" attributes={attributes} size={size}>\n                                    Open\n                                </Button>\n                            </div>\n                        )}\n                    </Flyout.Trigger>\n                    <Flyout.Content>\n                        <Content />\n                    </Flyout.Content>\n                </Flyout>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testScopedTheming",
+					"id": "utility-components-flyout--test-scoped-theming",
+					"name": "test: content uses scope theme",
 					"snippet": "const testScopedTheming = () => (\n    <View gap={3} align=\"start\">\n        <Button color=\"primary\">Slate button</Button>\n        <Theme name=\"reshaped\">\n            <Flyout triggerType=\"click\" active position=\"bottom-start\">\n                <Flyout.Trigger>\n                    {(attributes) => (\n                        <Button color=\"primary\" attributes={attributes}>\n                            Reshaped button\n                        </Button>\n                    )}\n                </Flyout.Trigger>\n                <Flyout.Content>\n                    <Content>\n                        <View gap={1}>\n                            <View.Item>Portal content, rendered in body</View.Item>\n                            <Button color=\"primary\">Reshaped button</Button>\n                        </View>\n                    </Content>\n                </Flyout.Content>\n            </Flyout>\n        </Theme>\n    </View>\n);"
 				},
 				{
-					"name": "testWithoutFocusable",
+					"id": "utility-components-flyout--test-without-focusable",
+					"name": "test: without focusable content",
 					"snippet": "const testWithoutFocusable = () => <Demo position=\"bottom-start\" />;"
 				},
 				{
-					"name": "testChangeSize",
+					"id": "utility-components-flyout--test-change-size",
+					"name": "test: size updates",
 					"snippet": "const testChangeSize = () => {\n    const [position, setPosition] = React.useState<FlyoutProps[\"position\"]>(\"bottom-start\");\n    const [updatedHeight, setUpdatedHeight] = React.useState(false);\n\n    return (\n        <>\n            <View direction=\"row\" gap={4} align=\"center\">\n                <Select\n                    name=\"position\"\n                    options={[\n                        \"bottom-start\",\n                        \"bottom\",\n                        \"bottom-end\",\n                        \"top-start\",\n                        \"top\",\n                        \"top-end\",\n                        \"start-top\",\n                        \"start\",\n                        \"start-bottom\",\n                        \"end-top\",\n                        \"end\",\n                        \"end-bottom\",\n                    ].map((p) => ({ label: p, value: p }))}\n                    onChange={(args) => setPosition(args.value as FlyoutProps[\"position\"])}\n                    value={position}\n                />\n                <Switch name=\"height\" onChange={(args) => setUpdatedHeight(args.checked)}>\n                    Change height\n                </Switch>\n            </View>\n            <div\n                style={{\n                    position: \"fixed\",\n                    top: \"50%\",\n                    left: \"50%\",\n                    transform: \"translate(-50%, -50%)\",\n                }}\n            >\n                <Demo position={position} disableCloseOnOutsideClick active contentHeight={false}>\n                    <View\n                        backgroundColor=\"neutral-faded\"\n                        borderRadius=\"small\"\n                        height={updatedHeight ? 50 : 25}\n                        attributes={{ style: { transition: \"0.2s ease-in-out\" } }}\n                    />\n                </Demo>\n            </div>\n        </>\n    );\n};"
 				}
 			],
 			"import": "import {\n    Button,\n    Example,\n    Flyout,\n    Modal,\n    Reshaped,\n    Select,\n    Switch,\n    TextField,\n    Theme,\n    View,\n} from \"reshaped\";\nimport React from \"react\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Flyout/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Flyout",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Flyout/Flyout.tsx",
-				"actualName": "Flyout",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"groupTimeouts": {
+						"defaultValue": null,
+						"description": "Removes the content display delay if another flyout is already active",
+						"name": "groupTimeouts",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | TrapMode" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the flyout content interactivity",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Automatically focus the first focusable element in the content, when false the content container will be focused instead",
+						"name": "autoFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the content element",
+						"name": "contentClassName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"contentAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the content element",
+						"name": "contentAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Flyout"
 			}
 		},
 		"utility-components-formcontrol": {
@@ -2503,43 +13263,147 @@
 			"path": "./src/components/FormControl/tests/FormControl.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-formcontrol--status",
 					"name": "status",
 					"snippet": "const status = () => (\n    <Example>\n        <Example.Item title=\"status: default\">\n            <FormControl>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"status: error\">\n            <FormControl hasError>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: medium\">\n            <FormControl size=\"medium\">\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <FormControl size=\"large\">\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" size=\"large\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <FormControl disabled>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--required",
 					"name": "required",
 					"snippet": "const required = () => (\n    <Example>\n        <Example.Item title=\"required\">\n            <FormControl required>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "utility-components-formcontrol--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"horizontal\">\n            <FormControl>\n                <View direction=\"row\" gap={10} align=\"center\">\n                    <View width=\"100px\">\n                        <FormControl.Label>Label</FormControl.Label>\n                    </View>\n                    <View.Item grow>\n                        <TextField name=\"name\" placeholder=\"Enter value\" />\n                    </View.Item>\n                </View>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-formcontrol--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <FormControl id=\"test-id\" hasError>\n        <FormControl.Label>Label</FormControl.Label>\n        <TextField name=\"name\" />\n        <FormControl.Helper>Caption</FormControl.Helper>\n        <FormControl.Error>Error</FormControl.Error>\n    </FormControl>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--group",
 					"name": "group",
 					"snippet": "const group = () => (\n    <FormControl group>\n        <FormControl.Label>Label</FormControl.Label>\n        <RadioGroup name=\"name\">\n            <View gap={2}>\n                <Radio value=\"1\">One</Radio>\n                <Radio value=\"2\">Two</Radio>\n            </View>\n        </RadioGroup>\n    </FormControl>\n);"
 				}
 			],
 			"import": "import { Example, FormControl, Radio, RadioGroup, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/FormControl/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "FormControl",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/FormControl/FormControl.tsx",
-				"actualName": "FormControl",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size, to be used together with the other form component sizes",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"large\" | \"medium\"",
+							"value": [{ "value": "\"large\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"required": {
+						"defaultValue": null,
+						"description": "Change component to show a required indicator",
+						"name": "required",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Apply disabled styles",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"group": {
+						"defaultValue": null,
+						"description": "Apply semantic html markup when used for displaying multiple form fields together with a single label",
+						"name": "group",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Custom id for the form control",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "FormControl"
 			}
 		},
 		"utility-components-grid": {
@@ -2548,43 +13412,421 @@
 			"path": "./src/components/Grid/tests/Grid.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "utility-components-grid--base",
+					"name": "gap, columnGap, rowGap, align, justify, maxWidth, width, height",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"gap: 2\">\n            <Grid gap={2} columns={2}>\n                {[1, 2].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"columnGap: 2, rowGap: 4\">\n            <Grid columnGap={2} rowGap={4} columns={2}>\n                {[1, 2, 3, 4].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"align: center\">\n            <Grid gap={2} columns={2} align=\"center\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={8}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"justify: center\">\n            <Grid gap={2} columns=\"200px 200px\" justify=\"center\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"maxWidth: 400px\">\n            <Grid gap={2} columns=\"200px 200px\" maxWidth=\"400px\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"width: 400px, height: 200px\">\n            <Grid gap={2} columns={2} width=\"400px\" height=\"200px\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "layout",
+					"id": "utility-components-grid--layout",
+					"name": "rows, columns",
 					"snippet": "const layout = () => (\n    <Example>\n        <Example.Item title=\"simple: 2 rows, 3 columns\">\n            <Grid gap={4} columns={3} rows={2}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"columns template, 1fr 2fr 1fr\">\n            <Grid gap={4} columns=\"1fr 2fr 1fr\" rows={2}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"rows template, 1fr 2fr\">\n            <Grid gap={4} columns={3} rows=\"1fr 2fr\">\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"responsive\">\n            <Grid gap={4} columns={{ s: 3, m: \"1fr 2fr 1fr\" }} rows={{ s: 2, m: \"1fr 2fr\" }}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemLayout",
+					"id": "utility-components-grid--item-layout",
+					"name": "colStart, colEnd, rowStart, rowEnd",
 					"snippet": "const itemLayout = () => (\n    <Example>\n        <Example.Item title=\"column, start 1, end 3\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item colStart={1} colEnd={3}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"column, start 1, span 2\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item colStart={1} colSpan={2}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"row, start 1, end 3\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowEnd={3}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"row, start 1, span 2\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowSpan={2}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"responsive\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowSpan={{ s: 1, m: 2 }} colStart={1} colSpan={{ s: 1, m: 2 }}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-grid--areas",
 					"name": "areas",
 					"snippet": "const areas = () => (\n    <Example>\n        <Example.Item title=\"simple: 2 rows, 3 columns\">\n            <Grid gap={4} rows={2} areas={[\"a .\", \"a b\"]}>\n                {[\"a\", \"b\"].map((area) => (\n                    <Grid.Item area={area} key={area}>\n                        <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                            {area}\n                        </View>\n                    </Grid.Item>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "auto",
+					"id": "utility-components-grid--auto",
+					"name": "autoFlow, autoColumns, autoRows",
 					"snippet": "const auto = () => (\n    <Example>\n        <Example.Item title=\"auto flow: column\">\n            <Grid gap={4} autoFlow=\"column\" rows={2} columns={2}>\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"auto rows\">\n            <Grid gap={4} autoRows=\"100px\" columns={2}>\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"auto columns\">\n            <Grid gap={4} autoColumns=\"100px\" autoFlow=\"column\">\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-grid--as",
 					"name": "as",
 					"snippet": "const as = () => (\n    <Grid as=\"ul\">\n        <Grid.Item as=\"li\">Content</Grid.Item>\n    </Grid>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-grid--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Grid className=\"test-class\" attributes={{ id: \"test-id\" }}>\n            <Grid.Item className=\"test-item-class\" attributes={{ id: \"test-item-id\" }}>\n                Content\n            </Grid.Item>\n        </Grid>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Grid, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Grid/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Grid",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Grid/Grid.tsx",
-				"actualName": "Grid",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between grid items",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"columnGap": {
+						"defaultValue": null,
+						"description": "Horizontal gap between grid items",
+						"name": "columnGap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"rowGap": {
+						"defaultValue": null,
+						"description": "Vertical gap between grid items",
+						"name": "rowGap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Align grid items vertically",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Justify grid items horizontally",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"rows": {
+						"defaultValue": null,
+						"description": "Grid template rows",
+						"name": "rows",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<number | \"inherit\" | \"none\" | \"auto\" | (string & {}) | \"-moz-initial\" | \"initial\" | \"revert\" | \"revert-layer\" | \"unset\" | \"max-content\" | \"min-content\" | \"subgrid\">"
+						}
+					},
+					"columns": {
+						"defaultValue": null,
+						"description": "Grid template columns",
+						"name": "columns",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<number | \"inherit\" | \"none\" | \"auto\" | (string & {}) | \"-moz-initial\" | \"initial\" | \"revert\" | \"revert-layer\" | \"unset\" | \"max-content\" | \"min-content\" | \"subgrid\">"
+						}
+					},
+					"areas": {
+						"defaultValue": null,
+						"description": "Grid areas for template syntax",
+						"name": "areas",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string[]>" }
+					},
+					"autoFlow": {
+						"defaultValue": null,
+						"description": "Grid auto flow",
+						"name": "autoFlow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoFlow>" }
+					},
+					"autoColumns": {
+						"defaultValue": null,
+						"description": "Grid auto columns",
+						"name": "autoColumns",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoColumns<0 | (string & {})>>" }
+					},
+					"autoRows": {
+						"defaultValue": null,
+						"description": "Grid auto rows",
+						"name": "autoRows",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoRows<0 | (string & {})>>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Maximum width of the grid container, literal css value or unit token multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width of the grid container, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height of the grid container, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Custom root element html tag",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					}
+				},
+				"exportName": "Grid"
 			}
 		},
 		"utility-components-hidden": {
@@ -2593,22 +13835,261 @@
 			"path": "./src/components/Hidden/tests/Hidden.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-hidden--visibility",
 					"name": "visibility",
 					"snippet": "const visibility = () => (\n    <Example>\n        <Example.Item title=\"hide: always\">\n            <Hidden hide={true}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on s\">\n            <Hidden hide={{ s: false, m: true }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on l/xl\">\n            <Hidden hide={{ s: true, l: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on m/l/xl\">\n            <Hidden hide={{ s: true, m: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on m\">\n            <Hidden hide={{ s: true, m: false, l: true }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on s/xl\">\n            <Hidden hide={{ s: false, m: true, xl: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"hide: always, visibility\">\n            <Hidden hide visibility>\n                Content\n            </Hidden>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-hidden--as",
 					"name": "as",
 					"snippet": "const as = () => <Hidden as=\"span\">Content</Hidden>;"
 				}
 			],
 			"import": "import { Example, Hidden } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Hidden/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Hidden",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Hidden/Hidden.tsx",
-				"actualName": "Hidden",
+				"methods": [],
+				"props": {
+					"hide": {
+						"defaultValue": null,
+						"description": "Pick at which viewport sizes to hide the children",
+						"name": "hide",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"visibility": {
+						"defaultValue": null,
+						"description": "Use visibility hidden instead of display none",
+						"name": "visibility",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Custom root element html tag",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2618,22 +14099,39 @@
 			"path": "./src/components/HiddenVisually/tests/HiddenVisually.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-hiddenvisually--visibility",
 					"name": "visibility",
 					"snippet": "const visibility = () => (\n    <Example>\n        <Example.Item title=\"pronounced by screen readers\">\n            <HiddenVisually>Screen-reader only</HiddenVisually>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-hiddenvisually--children",
 					"name": "children",
 					"snippet": "const children = () => <HiddenVisually>Content</HiddenVisually>;"
 				}
 			],
 			"import": "import { Example, HiddenVisually } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/HiddenVisually/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "HiddenVisually",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/HiddenVisually/HiddenVisually.tsx",
-				"actualName": "HiddenVisually",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/HiddenVisually/HiddenVisually.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2643,34 +14141,115 @@
 			"path": "./src/components/Icon/tests/Icon.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-icon--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: 4\">\n            <Icon svg={IconZap} size={4} />\n        </Example.Item>\n        <Example.Item title=\"size: 8\">\n            <Icon svg={IconZap} size={8} />\n        </Example.Item>\n        <Example.Item title=\"size: 100%\">\n            <View width={25} height={25}>\n                <Icon svg={IconZap} size=\"100%\" />\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive size\", \"[s] 5\", \"[m]: 10\"]}>\n            <Icon svg={IconZap} size={{ s: 5, m: 10 }} />\n        </Example.Item>\n        <Example.Item title=\"size: inherit from font\">\n            <Text variant=\"title-6\">\n                <View direction=\"row\" align=\"center\" gap={2}>\n                    <Icon svg={IconZap} />\n                    <View.Item>Reshaped</View.Item>\n                </View>\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-icon--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <Icon svg={IconZap} color=\"neutral\" />\n        </Example.Item>\n        <Example.Item title=\"color: neutral-faded\">\n            <Icon svg={IconZap} color=\"neutral-faded\" />\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <Icon svg={IconZap} color=\"primary\" />\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Icon svg={IconZap} color=\"critical\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Icon svg={IconZap} color=\"positive\" />\n        </Example.Item>\n        <Example.Item title=\"color: disabled\">\n            <Icon svg={IconZap} color=\"disabled\" />\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <div style={{ color: \"tomato\" }}>\n                <Icon svg={IconZap} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "autoWidth",
+					"id": "utility-components-icon--auto-width",
+					"name": "autoWidth, blank",
 					"snippet": "const autoWidth = () => (\n    <Example>\n        <Example.Item title=\"square boundaries\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={IconMic} size={10} />\n            </div>\n        </Example.Item>\n        <Example.Item title=\"auto width boundaries\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={IconMic} size={10} autoWidth />\n            </div>\n        </Example.Item>\n        <Example.Item title=\"blank\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={null} size={10} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-icon--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Icon svg={IconZap} className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				},
 				{
-					"name": "render",
+					"id": "utility-components-icon--render",
+					"name": "test: hidden from sr",
 					"snippet": "const render = () => (\n    <div data-testid=\"root\">\n        <Icon svg={IconZap} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Icon, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Icon/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Icon",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Icon/Icon.tsx",
-				"actualName": "Icon",
+				"methods": [],
+				"props": {
+					"svg": {
+						"defaultValue": null,
+						"description": "Icon svg component or node",
+						"name": "svg",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Icon size, literal css value or unit token multiplier",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Icon color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"warning\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"autoWidth": {
+						"defaultValue": null,
+						"description": "Use the width of the svg asset instead of providing a square bounding box",
+						"name": "autoWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2680,54 +14259,230 @@
 			"path": "./src/components/Image/tests/Image.stories.tsx",
 			"stories": [
 				{
-					"name": "src",
+					"id": "utility-components-image--src",
+					"name": "src, alt",
 					"snippet": "const src = () => (\n    <Example>\n        <Example.Item title=\"src, alt\">\n            <Image src={imgUrl} alt=\"Image alt\" />\n        </Example.Item>\n\n        <Example.Item title=\"src\">\n            <Image src={imgUrl} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "utility-components-image--size",
+					"name": "width, height, maxWidth, aspectRatio",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"width: 200px\">\n            <Image src={imgUrl} width=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"height: 200px\">\n            <Image src={imgUrl} height=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"maxWidth: 200px\">\n            <Image src={imgUrl} maxWidth=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"aspectRatio: 1/1\">\n            <Image src={imgUrl} aspectRatio={1 / 1} width=\"300px\" />\n        </Example.Item>\n        <Example.Item title={[\"responsive width\", \"[s] 200px\", \"[m+] 300px\"]}>\n            <Image src={imgUrl} width={{ s: \"200px\", m: \"300px\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "radius",
+					"id": "utility-components-image--radius",
+					"name": "borderRadius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius: small\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"small\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"radius: medium\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"medium\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"radius: large\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--display-mode",
 					"name": "displayMode",
 					"snippet": "const displayMode = () => (\n    <Example>\n        <Example.Item title=\"mode: cover\">\n            <Image src={imgUrl} height=\"200px\" width=\"100%\" displayMode=\"cover\" />\n        </Example.Item>\n        <Example.Item title=\"mode: contain\">\n            <Image src={imgUrl} height=\"200px\" width=\"100%\" displayMode=\"contain\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--on-load",
 					"name": "onLoad",
 					"snippet": "const onLoad = () => <Image src={imgUrl} alt=\"photo\" onLoad={fn()} />;"
 				},
 				{
+					"id": "utility-components-image--on-error",
 					"name": "onError",
 					"snippet": "const onError = () => <Image src=\"/invalid.png\" alt=\"photo\" onError={fn()} />;"
 				},
 				{
+					"id": "utility-components-image--fallback",
 					"name": "fallback",
 					"snippet": "const fallback = () => (\n    <Example>\n        <Example.Item title=\"fallback, background, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"fallback, image, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback={imgUrl} />\n                </View>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"fallback, icon, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback={<Icon svg={IconZap} size={10} />} />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"fallback, icon, no url\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image fallback={<Icon svg={IconZap} size={10} />} />\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--render-image",
 					"name": "renderImage",
 					"snippet": "const renderImage = () => (\n    <Example>\n        <Example.Item title=\"renderImage\">\n            <Image\n                src={imgUrl}\n                alt=\"Amsterdam canal\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image\" />}\n            />\n        </Example.Item>\n        <Example.Item title=\"renderImage, fallback\">\n            <Image\n                src=\"error\"\n                fallback={imgUrl}\n                alt=\"Amsterdam canal 2\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image-fallback\" />}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "imageAttributes",
+					"id": "utility-components-image--image-attributes",
+					"name": "className, attributes,imageAttributes",
 					"snippet": "const imageAttributes = () => (\n    <div data-testid=\"root\">\n        <Image\n            src={imgUrl}\n            alt=\"photo\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            imageAttributes={{ \"data-testid\": \"test-img-id\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "ratio",
+					"id": "utility-components-image--ratio",
+					"name": "test: aspectRatio",
 					"snippet": "const ratio = () => (\n    <Example>\n        <Example.Item title=\"ratio: 16/9\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"ratio: 16/9, displayMode: contain\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} displayMode=\"contain\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Icon, Image, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Image/Image.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Image",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Image/Image.tsx",
-				"actualName": "Image",
+				"methods": [],
+				"props": {
+					"src": {
+						"defaultValue": null,
+						"description": "Image URL",
+						"name": "src",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"alt": {
+						"defaultValue": null,
+						"description": "Image alt text",
+						"name": "alt",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Image width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Image height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Image max width, literal css value or unit token multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"aspectRatio": {
+						"defaultValue": null,
+						"description": "Image aspect ratio, width / height",
+						"name": "aspectRatio",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Image border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"large\" | \"medium\"",
+							"value": [
+								{ "value": "\"small\"" },
+								{ "value": "\"large\"" },
+								{ "value": "\"medium\"" }
+							]
+						}
+					},
+					"displayMode": {
+						"defaultValue": null,
+						"description": "Image display mode for controlling how it fits into the provided boundaries",
+						"name": "displayMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"cover\" | \"contain\"",
+							"value": [{ "value": "\"cover\"" }, { "value": "\"contain\"" }]
+						}
+					},
+					"onLoad": {
+						"defaultValue": null,
+						"description": "Image on load event",
+						"name": "onLoad",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: SyntheticEvent<Element, Event>) => void)" }
+					},
+					"onError": {
+						"defaultValue": null,
+						"description": "Image on error event",
+						"name": "onError",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: SyntheticEvent<Element, Event>) => void)" }
+					},
+					"fallback": {
+						"defaultValue": null,
+						"description": "Image fallback content if the image fails to load or was not provided",
+						"name": "fallback",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"renderImage": {
+						"defaultValue": null,
+						"description": "Image render function, can be used for integrating with Image component in 3rd party frameworks",
+						"name": "renderImage",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Omit<Attributes<\"img\">, \"src\" | \"alt\"> & { src: string; alt: string; }) => ReactNode)"
+						}
+					},
+					"imageAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the image element",
+						"name": "imageAttributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"img\">" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(Attributes<\"div\"> & Attributes<\"img\">)" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2737,46 +14492,229 @@
 			"path": "./src/components/Overlay/tests/Overlay.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-overlay--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate}>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--transparent",
 					"name": "transparent",
 					"snippet": "const transparent = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate} transparent>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--blurred",
 					"name": "blurred",
 					"snippet": "const blurred = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate} blurred>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "renderProps",
+					"id": "utility-components-overlay--render-props",
+					"name": "children, render props",
 					"snippet": "const renderProps = () => (\n    <Overlay active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        {(args) => (args.active ? \"Opened\" : \"Closed\")}\n    </Overlay>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "utility-components-overlay--handlers",
+					"name": "onOpen, onClose, onAfterOpen, onAfterClose",
 					"snippet": "const handlers = () => {\n    const overlayToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => overlayToggle.toggle()}>Open overlay</Button>\n            <Overlay\n                active={overlayToggle.active}\n                onClose={(closeArgs) => {\n                    overlayToggle.deactivate();\n                    args.handleClose(closeArgs);\n                }}\n                onOpen={fn()}\n                onAfterOpen={fn()}\n                onAfterClose={fn()}>Content\n                                </Overlay>\n        </>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--disable-close-on-click",
 					"name": "disableCloseOnClick",
 					"snippet": "const disableCloseOnClick = (args) => (\n    <Overlay\n        active\n        disableCloseOnClick\n        onClose={(closeArgs) => {\n            args.handleClose(closeArgs);\n        }}\n    >\n        Content\n    </Overlay>\n);"
 				},
 				{
+					"id": "utility-components-overlay--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <>\n            <div ref={containerRef} data-testid=\"test-id\" style={{ height: 200 }} />\n            <Overlay active containerRef={containerRef}>\n                Content\n            </Overlay>\n        </>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-overlay--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <Overlay active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        Content\n    </Overlay>\n);"
 				}
 			],
 			"import": "import { Button, Example, Overlay } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Overlay/index.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Overlay",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Overlay/Overlay.tsx",
-				"actualName": "Overlay",
+				"methods": [],
+				"props": {
+					"transparent": {
+						"defaultValue": null,
+						"description": "Make the overlay transparent",
+						"name": "transparent",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number | boolean" }
+					},
+					"blurred": {
+						"defaultValue": null,
+						"description": "Make the overlay blurred",
+						"name": "blurred",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Control the overflow of the component content",
+						"name": "overflow",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"auto\"",
+							"value": [{ "value": "\"hidden\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, render function receives the state of the component as an argument",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode | ((props: { active: boolean; }) => ReactNode)" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the visibility of the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason: CloseReason; }) => void)" }
+					},
+					"onAfterClose": {
+						"defaultValue": null,
+						"description": "Callback after the component close transition is complete",
+						"name": "onAfterClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the component is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onAfterOpen": {
+						"defaultValue": null,
+						"description": "Callback after the component open transition is complete",
+						"name": "onAfterOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"disableCloseOnClick": {
+						"defaultValue": null,
+						"description": "Disable closing the component on outside click",
+						"name": "disableCloseOnClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": null,
+						"description": "Element to render the component in",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2786,42 +14724,213 @@
 			"path": "./src/components/Reshaped/tests/Reshaped.stories.tsx",
 			"stories": [
 				{
-					"name": "rtl",
+					"id": "utility-components-reshaped--rtl",
+					"name": "defaultRTL",
 					"snippet": "const rtl = () => (\n    <Reshaped defaultRTL theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				},
 				{
-					"name": "controlledMode",
+					"id": "utility-components-reshaped--controlled-mode",
+					"name": "colorMode, controlled",
 					"snippet": "const controlledMode = () => {\n    const [mode, setMode] = useState<G.ColorMode>(\"dark\");\n\n    return (\n        <Reshaped theme=\"reshaped\" colorMode={mode}>\n            <Button\n                onClick={() => {\n                    setMode(mode === \"dark\" ? \"light\" : \"dark\");\n                }}\n            >\n                Toggle color mode\n            </Button>\n        </Reshaped>\n    );\n};"
 				},
 				{
-					"name": "lightMode",
+					"id": "utility-components-reshaped--light-mode",
+					"name": "defaultColorMode=light",
 					"snippet": "const lightMode = () => <Reshaped theme=\"reshaped\">Hello</Reshaped>;"
 				},
 				{
-					"name": "darkMode",
+					"id": "utility-components-reshaped--dark-mode",
+					"name": "defaultColorMode=dark",
 					"snippet": "const darkMode = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				},
 				{
+					"id": "utility-components-reshaped--scoped",
 					"name": "scoped",
 					"snippet": "const scoped = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\" scoped>\n        Hello\n    </Reshaped>\n);"
 				},
 				{
-					"name": "testScoped",
+					"id": "utility-components-reshaped--test-scoped",
+					"name": "test: scoped switch",
 					"snippet": "const testScoped = () => (\n    <Reshaped theme=\"reshaped\">\n        <Reshaped theme=\"slate\" scoped>\n            <ScopedComponent />\n        </Reshaped>\n    </Reshaped>\n);"
 				},
 				{
-					"name": "keyboardMode",
+					"id": "utility-components-reshaped--keyboard-mode",
+					"name": "test: keyboard mode",
 					"snippet": "const keyboardMode = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				}
 			],
 			"import": "import { Button, Reshaped } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Reshaped/Reshaped.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Reshaped",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Reshaped/Reshaped.tsx",
-				"actualName": "Reshaped",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"theme": {
+						"defaultValue": null,
+						"description": "Theme of the application, enables controlled mode",
+						"name": "theme",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NonNullable<Theme>" }
+					},
+					"defaultTheme": {
+						"defaultValue": null,
+						"description": "Default theme of the application, enables uncontrolled mode",
+						"name": "defaultTheme",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NonNullable<Theme>" }
+					},
+					"defaultRTL": {
+						"defaultValue": null,
+						"description": "Default content direction of the application",
+						"name": "defaultRTL",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode of the application, enables controlled mode",
+						"name": "colorMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode",
+							"value": [{ "value": "\"light\"" }, { "value": "\"dark\"" }]
+						}
+					},
+					"defaultColorMode": {
+						"defaultValue": null,
+						"description": "Default color mode of the application, enables uncontrolled mode",
+						"name": "defaultColorMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode",
+							"value": [{ "value": "\"light\"" }, { "value": "\"dark\"" }]
+						}
+					},
+					"defaultViewport": {
+						"defaultValue": null,
+						"description": "Default viewport size of the application",
+						"name": "defaultViewport",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Viewport",
+							"value": [
+								{ "value": "\"s\"" },
+								{ "value": "\"m\"" },
+								{ "value": "\"l\"" },
+								{ "value": "\"xl\"" }
+							]
+						}
+					},
+					"toastOptions": {
+						"defaultValue": null,
+						"description": "Global options for the ToastProvider",
+						"name": "toastOptions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "Partial<Record<Position, { width?: string; expanded?: boolean; }>> | undefined"
+						}
+					},
+					"scoped": {
+						"defaultValue": null,
+						"description": "Enable scoped mode for applications not using Reshaped provider at the application root",
+						"name": "scoped",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2831,42 +14940,150 @@
 			"path": "./src/components/ScrollArea/tests/ScrollArea.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-scrollarea--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"vertical scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"horizontal scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\" height=\"100px\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"horizontal and vertical scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-scrollarea--scrollbar-display",
 					"name": "scrollbarDisplay",
 					"snippet": "const scrollbarDisplay = () => (\n    <Example>\n        <Example.Item title=\"scrollbarDisplay: hover\">\n            <ScrollArea height=\"100px\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"scrollbarDisplay: hidden\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"hidden\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"scrollbarDisplay: visible\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "height",
+					"id": "utility-components-scrollarea--height",
+					"name": "height, maxHeight",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"height: 80px\">\n            <ScrollArea height=\"80px\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"responsive height: s 80px, m: 120px\">\n            <ScrollArea height={{ s: \"80px\", m: \"120px\" }}>\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"maxHeight: 80px\">\n            <ScrollArea maxHeight=\"80px\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"responsive max height: s 80px, m: 200px\">\n            <ScrollArea maxHeight={{ s: \"80px\", m: \"200px\" }}>\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onScroll",
+					"id": "utility-components-scrollarea--on-scroll",
+					"name": "ref, onScroll",
 					"snippet": "const onScroll = () => {\n    const ref = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={4}>\n            <View.Item>\n                <Button onClick={() => ref.current?.scrollBy({ top: 50, left: 50 })}>Scroll</Button>\n            </View.Item>\n            <ScrollArea height=\"100px\" ref={ref} scrollbarDisplay=\"visible\" onScroll={fn()}>\n                <View backgroundColor=\"neutral-faded\" padding={4} width=\"1000px\" height=\"200px\">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                                            has been the industry's standard dummy text ever since the 1500s, when an unknown\n                                            printer took a galley of type and scrambled it to make a type specimen book. It has\n                                            survived not only five centuries, but also the leap into electronic typesetting,\n                                            remaining essentially unchanged. It was popularised in the 1960s with the release of\n                                            Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                                            publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                                        </View>\n            </ScrollArea>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-scrollarea--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ScrollArea className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </ScrollArea>\n    </div>\n);"
 				},
 				{
-					"name": "testNested",
+					"id": "utility-components-scrollarea--test-nested",
+					"name": "test: nested",
 					"snippet": "const testNested = () => (\n    <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n        <View padding={4} paddingInline={16}>\n            <ScrollArea height=\"200px\" scrollbarDisplay=\"visible\">\n                {Array(20)\n                    .fill(\"\")\n                    .map((_, index) => {\n                        return <div key={index}>Item {index + 1}</div>;\n                    })}\n            </ScrollArea>\n        </View>\n    </ScrollArea>\n);"
 				},
 				{
-					"name": "testDynamicHeight",
+					"id": "utility-components-scrollarea--test-dynamic-height",
+					"name": "test: dynamic height change",
 					"snippet": "const testDynamicHeight = () => {\n    const [count, setCount] = React.useState(10);\n\n    return (\n        <View gap={4}>\n            <View.Item>\n                <Button onClick={() => setCount((prev) => prev + 10)}>Add more items</Button>\n            </View.Item>\n\n            <ScrollArea height=\"200px\" scrollbarDisplay=\"visible\">\n                <View gap={2}>\n                    {new Array(count).fill(\"\").map((_, i) => (\n                        <View.Item key={i}>Item {i + 1}</View.Item>\n                    ))}\n                </View>\n            </ScrollArea>\n        </View>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Example, ScrollArea, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ScrollArea/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ScrollArea",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ScrollArea/ScrollArea.tsx",
-				"actualName": "ScrollArea",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"scrollbarDisplay": {
+						"defaultValue": null,
+						"description": "Scrollbar visibility behavior based on the user interaction",
+						"name": "scrollbarDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"hover\" | \"visible\"",
+							"value": [
+								{ "value": "\"hidden\"" },
+								{ "value": "\"hover\"" },
+								{ "value": "\"visible\"" }
+							]
+						}
+					},
+					"onScroll": {
+						"defaultValue": null,
+						"description": "Callback when the scroll area is scrolled",
+						"name": "onScroll",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: Coordinates) => void)" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height of the scroll area, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height of the scroll area, literal css value or unit token multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2876,54 +15093,387 @@
 			"path": "./src/components/Text/tests/Text.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-text--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: title-1\">\n            <Text variant=\"title-1\">Title 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-2\">\n            <Text variant=\"title-2\">Title 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-3\">\n            <Text variant=\"title-3\">Title 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-4\">\n            <Text variant=\"title-4\">Title 4</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-5\">\n            <Text variant=\"title-5\">Title 5</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-6\">\n            <Text variant=\"title-6\">Title 6</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-1\">\n            <Text variant=\"featured-1\">Featured 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-2\">\n            <Text variant=\"featured-2\">Featured 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-3\">\n            <Text variant=\"featured-3\">Featured 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-1\">\n            <Text variant=\"body-1\">Body 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-2\">\n            <Text variant=\"body-2\">Body 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-3\">\n            <Text variant=\"body-3\">Body 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: caption-1\">\n            <Text variant=\"caption-1\">Caption 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: caption-2\">\n            <Text variant=\"caption-2\">Caption 2</Text>\n        </Example.Item>\n        <Example.Item title={[\"responsive variant\", \"[s] body-3\", \"[m+] title-4\"]}>\n            <Text variant={{ s: \"body-3\", m: \"title-4\" }}>Responsive</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--weight",
 					"name": "weight",
 					"snippet": "const weight = () => (\n    <Example>\n        <Example.Item title=\"weight: regular\">\n            <Text weight=\"regular\">Regular</Text>\n        </Example.Item>\n        <Example.Item title=\"weight: medium\">\n            <Text weight=\"medium\">Medium</Text>\n        </Example.Item>\n        <Example.Item title=\"weight: bold\">\n            <Text weight=\"bold\">Bold</Text>\n        </Example.Item>\n        <Example.Item title={[\"responsive\", \"[s] weight: regular\", \"[m+] bold\"]}>\n            <Text weight={{ s: \"regular\", m: \"bold\" }}>Responsive</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: inherit\">\n            <Text>Neutral</Text>\n        </Example.Item>\n        <Example.Item title=\"color: neutral-faded\">\n            <Text color=\"neutral-faded\">Faded</Text>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Text color=\"positive\">Positive</Text>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <Text color=\"warning\">Warning</Text>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Text color=\"critical\">Critical</Text>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <Text color=\"primary\">Primary</Text>\n        </Example.Item>\n        <Example.Item title=\"color: disabled\">\n            <Text color=\"disabled\" attributes={{ \"aria-disabled\": true }}>\n                Disabled\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--decoration",
 					"name": "decoration",
 					"snippet": "const decoration = () => (\n    <Example>\n        <Example.Item title=\"decoration: line-through\">\n            <Text decoration=\"line-through\">Line through</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--wrap",
 					"name": "wrap",
 					"snippet": "const wrap = () => (\n    <Example>\n        <Example.Item title=\"wrap: balance\">\n            <Text wrap=\"balance\" variant=\"title-3\">\n                The design system you want to build\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "mono",
+					"id": "utility-components-text--mono",
+					"name": "monospace",
 					"snippet": "const mono = () => (\n    <Example>\n        <Example.Item title=\"monospace\">\n            <Text monospace>Content</Text>\n        </Example.Item>\n        <Example.Item title=\"monospace, variant, weight\">\n            <Text monospace variant=\"title-1\" weight=\"regular\">\n                Content\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--max-lines",
 					"name": "maxLines",
 					"snippet": "const maxLines = () => (\n    <Example>\n        <Example.Item title=\"maxLines: 2\">\n            <Text maxLines={2}>\n                There are many variations of passages of Lorem Ipsum available, but the majority have\n                suffered alteration in some form, by injected humour, or randomised words which don't look\n                even slightly believable. If you are going to use a passage of Lorem Ipsum, you need to be\n                sure there isn't anything embarrassing hidden in the middle of text. All the Lorem Ipsum\n                generators on the Internet tend to repeat predefined chunks as necessary, making this the\n                first true generator on the Internet. It uses a dictionary of over 200 Latin words,\n                combined with a handful of model sentence structures, to generate Lorem Ipsum which looks\n                reasonable. The generated Lorem Ipsum is therefore always free from repetition, injected\n                humour, or non-characteristic words etc.\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: start\">\n            <Text align=\"start\">Text content</Text>\n        </Example.Item>\n        <Example.Item title=\"align: center\">\n            <Text align=\"center\">Text content</Text>\n        </Example.Item>\n        <Example.Item title=\"align: end\">\n            <Text align=\"end\">Text content</Text>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive alignment\", \"[s]: center\", \"[m+] start\"]}>\n            <Text align={{ s: \"center\", m: \"start\" }}>Text content</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "asProp",
+					"id": "utility-components-text--as-prop",
+					"name": "as",
 					"snippet": "const asProp = () => (\n    <>\n        <Text as=\"h1\">Content</Text>\n        <Text variant=\"title-3\">Content</Text>\n        <Text variant={{ s: \"title-3\", m: \"title-4\" }}>Content</Text>\n    </>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-text--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Text className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Text>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Text/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Text",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Text/Text.tsx",
-				"actualName": "Text",
+				"methods": [],
+				"props": {
+					"variant": {
+						"defaultValue": null,
+						"description": "Text render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Variant>" }
+					},
+					"weight": {
+						"defaultValue": null,
+						"description": "Text font weight",
+						"name": "weight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"medium\" | \"bold\" | \"regular\">" }
+					},
+					"monospace": {
+						"defaultValue": null,
+						"description": "Render monospace font",
+						"name": "monospace",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Text color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"warning\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Text alignment",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"center\" | \"start\" | \"end\">" }
+					},
+					"wrap": {
+						"defaultValue": null,
+						"description": "CSS wrapping style",
+						"name": "wrap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"balance\"", "value": [{ "value": "\"balance\"" }] }
+					},
+					"decoration": {
+						"defaultValue": null,
+						"description": "CSS text decoration style",
+						"name": "decoration",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"line-through\"",
+							"value": [{ "value": "\"line-through\"" }]
+						}
+					},
+					"maxLines": {
+						"defaultValue": null,
+						"description": "Maximum number of lines to render, used for text truncation",
+						"name": "maxLines",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different html tag",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2933,46 +15483,114 @@
 			"path": "./src/components/Theme/tests/Theme.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-theme--scoped",
 					"name": "scoped",
 					"snippet": "const scoped = () => (\n    <Example>\n        <Example.Item title=\"scoped, single\">\n            <Theme name=\"reshaped\">\n                <Card attributes={{ \"data-testid\": \"test-id\" }}>\n                    <Button color=\"primary\">Action</Button>\n                </Card>\n            </Theme>\n        </Example.Item>\n\n        <Example.Item title=\"scoped, multiple\">\n            <Theme name={[\"reshaped\", \"figma\"]}>\n                <Card attributes={{ \"data-testid\": \"test-id-multi\" }}>\n                    <View direction=\"row\" gap={4}>\n                        <Button color=\"primary\">Action</Button>\n\n                        <Popover>\n                            <Popover.Trigger>\n                                {(attributes) => <Button attributes={attributes}>Popover</Button>}\n                            </Popover.Trigger>\n                            <Popover.Content>Content</Popover.Content>\n                        </Popover>\n                    </View>\n                </Card>\n            </Theme>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-theme--light",
 					"name": "light",
 					"snippet": "const light = () => (\n    <Theme name=\"reshaped\" colorMode=\"light\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--dark",
 					"name": "dark",
 					"snippet": "const dark = () => (\n    <Theme name=\"reshaped\" colorMode=\"dark\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--inherited",
 					"name": "inherited",
 					"snippet": "const inherited = () => (\n    <Theme name=\"reshaped\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--inverted",
 					"name": "inverted",
 					"snippet": "const inverted = () => (\n    <Theme name=\"reshaped\" colorMode=\"inverted\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--controlled",
 					"name": "controlled",
 					"snippet": "const controlled = () => {\n    const Internal = () => {\n        const { setTheme, theme } = useTheme();\n\n        return (\n            <Button color=\"primary\" onClick={() => setTheme(\"slate\")}>\n                Switch to slate\n            </Button>\n        );\n    };\n\n    return (\n        <div data-testid=\"root\">\n            <Theme name=\"reshaped\">\n                <Internal />\n            </Theme>\n        </div>\n    );\n};"
 				},
 				{
+					"id": "utility-components-theme--uncontrolled",
 					"name": "uncontrolled",
 					"snippet": "const uncontrolled = () => {\n    const Internal = () => {\n        const { setTheme } = useTheme();\n\n        return (\n            <Button color=\"primary\" onClick={() => setTheme(\"slate\")}>\n                Switch to slate\n            </Button>\n        );\n    };\n\n    return (\n        <div data-testid=\"root\">\n            <Theme defaultName=\"reshaped\">\n                <Internal />\n            </Theme>\n        </div>\n    );\n};"
 				},
 				{
-					"name": "disabledTransition",
+					"id": "utility-components-theme--disabled-transition",
+					"name": "disabled transitions",
 					"snippet": "const disabledTransition = () => {\n    const { invertColorMode } = useTheme();\n\n    return (\n        <Example>\n            <Example.Item title=\"should have no transitions while switching color mode\">\n                <View gap={3}>\n                    <Button onClick={invertColorMode}>Invert mode</Button>\n\n                    <MenuItem selected>Test transition</MenuItem>\n\n                    <Card>Default card</Card>\n\n                    <Theme colorMode=\"inverted\">\n                        <Card>Inverted card</Card>\n                    </Theme>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Card, Example, MenuItem, Popover, Theme, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Theme/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Theme",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Theme/Theme.tsx",
-				"actualName": "Theme",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the theme to use, enables controlled mode",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"defaultName": {
+						"defaultValue": null,
+						"description": "Default name of the theme to use, enables uncontrolled mode",
+						"name": "defaultName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode to use",
+						"name": "colorMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode | \"inverted\"",
+							"value": [
+								{ "value": "\"light\"" },
+								{ "value": "\"dark\"" },
+								{ "value": "\"inverted\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2982,147 +15600,880 @@
 			"path": "./src/components/View/tests/View.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-view--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example title=\"Border is used to highlight the padding value\">\n        <Example.Item title=\"padding: 4\">\n            <View padding={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <View padding={6} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: 0\">\n            <View padding={0} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: vertical 2, horizontal 4\">\n            <View paddingInline={4} paddingBlock={2} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingTop: 4\">\n            <View paddingTop={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingBottom: 4\">\n            <View paddingBottom={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingStart: 4\">\n            <View paddingStart={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingEnd: 4\">\n            <View paddingEnd={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive padding:\",\n                \"[s] vertical 2, horizontal 4\",\n                \"[m+] vertical 4, horizontal 8\",\n            ]}\n        >\n            <View paddingInline={{ s: 4, m: 8 }} paddingBlock={{ s: 2, m: 4 }} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"responsive padding:\", \"[s] top 2, bottom 4\", \"[m+] top 4, bottom 0, start: 8\"]}\n        >\n            <View\n                paddingTop={{ s: 2, m: 4 }}\n                paddingBottom={{ s: 4, m: 0 }}\n                paddingStart={{ s: 0, m: 8 }}\n                borderColor=\"neutral\"\n            >\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"nested padding, child view should have no horizontal padding\">\n            <View paddingStart={4} borderColor=\"neutral\">\n                <View borderColor=\"primary\" paddingBlock={4}>\n                    <Placeholder />\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example title=\"Item 1 is another component, Item 2 is View.Item, Item 3 is text\">\n        <Example.Item title=\"direction: column as default\">\n            <View gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <View gap={3} direction=\"column\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column-reverse\">\n            <View gap={3} direction=\"column-reverse\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row\">\n            <View gap={3} direction=\"row\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row-reverse\">\n            <View gap={3} direction=\"row-reverse\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"responsive direction\", \"[s] column-reverse\", \"[m] row-reverse\", \"[l+] row\"]}\n        >\n            <View direction={{ s: \"column-reverse\", m: \"row-reverse\", l: \"row\" }} gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 4, direction: row\">\n            <View direction=\"row\" gap={4} divided>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n                <Placeholder>Item 3</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 0, direction: row\">\n            <View direction=\"row\" gap={0}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap, direction: row\", \"[s] 4\", \"[m+] 8\"]}>\n            <View direction=\"row\" gap={{ s: 4, m: 8 }}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 4, direction: column\">\n            <View gap={4}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 0, direction: column\">\n            <View gap={0}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap, direction: column\", \"[s] 4\", \"[m+] 8\"]}>\n            <View gap={{ s: 4, m: 8 }}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--divided",
 					"name": "divided",
 					"snippet": "const divided = () => (\n    <Example>\n        <Example.Item title=\"direction: row\">\n            <View divided direction=\"row\" gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <View divided gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive divided\", \"[s] direction: row\", \"[m+] direction: column\"]}>\n            <View divided direction={{ s: \"row\", m: \"column\" }} gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row, columns\">\n            <View divided gap={3} direction=\"row\">\n                <View.Item columns={2}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={8}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={2}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"with React.Fragment\">\n            <View direction=\"row\" gap={4} divided>\n                <Placeholder>Item 1</Placeholder>\n                <>\n                    <Placeholder>Item 2</Placeholder>\n                    <Placeholder>Item 3</Placeholder>\n                </>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example title=\"Removes side borders and border radius when applied\">\n        <Example.Item title=\"bleed: 4\">\n            <View bleed={4} padding={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive bleed\", \"[s] 4\", \"[m+] 0\"]}>\n            <View bleed={{ s: 4, m: 0 }} padding={4} borderRadius=\"small\" borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--wrap",
 					"name": "wrap",
 					"snippet": "const wrap = () => (\n    <Example>\n        <Example.Item title=\"wrap: false\">\n            <View direction=\"row\" wrap={false} gap={3}>\n                <Placeholder w={600} h={100} />\n                <Placeholder w={600} h={100} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: start, direction: row\">\n            <View align=\"start\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: center, direction: row\">\n            <View align=\"center\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: end, direction: row\">\n            <View align=\"end\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"align: stretch, direction: row\",\n                \"2nd item is stretched based on the 1st item height\",\n            ]}\n        >\n            <View align=\"stretch\" direction=\"row\" gap={3}>\n                <Placeholder h={100} />\n                <Placeholder h=\"auto\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: baseline, direction: row\">\n            <View align=\"baseline\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Text variant=\"title-6\">Content</Text>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"align: start, direction: column\">\n            <View align=\"start\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: center, direction: column\">\n            <View align=\"center\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: end, direction: row\">\n            <View align=\"end\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"align: stretch, direction: column\",\n                \"1st item uses its own width, 2nd item is stretched to full width\",\n            ]}\n        >\n            <View align=\"stretch\" direction=\"column\" gap={3}>\n                <Placeholder w={100} />\n                <Placeholder w=\"auto\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--justify",
 					"name": "justify",
 					"snippet": "const justify = () => (\n    <Example>\n        <Example.Item title=\"justify: start, direction: row\">\n            <View justify=\"start\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: center, direction: row\">\n            <View justify=\"center\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: end, direction: row\">\n            <View justify=\"end\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: space-between, direction: row\">\n            <View justify=\"space-between\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"justify: start, direction: column, height: 200px\">\n            <View height=\"200px\" justify=\"start\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: center, direction: column, height: 200px\">\n            <View height=\"200px\" justify=\"center\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: end, direction: column, height: 200px\">\n            <View justify=\"end\" height=\"200px\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: space-between, direction: column, height: 200px\">\n            <View justify=\"space-between\" height=\"200px\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--text-align",
 					"name": "textAlign",
 					"snippet": "const textAlign = () => (\n    <Example>\n        <Example.Item title=\"textAlign: start\">\n            <View textAlign=\"start\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: center\">\n            <View textAlign=\"center\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: end\">\n            <View textAlign=\"end\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: [s] start, [m+] end\">\n            <View textAlign={{ s: \"start\", m: \"end\" }}>Content</View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"height: 100px, width: 100px\">\n            <View backgroundColor=\"neutral-faded\" height=\"100px\" width=\"100px\" />\n        </Example.Item>\n        <Example.Item title=\"height: 25, width: 25\">\n            <View backgroundColor=\"neutral-faded\" height={25} width={25} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive height and width\",\n                \"[s] height: 25, width: 25\",\n                \"[m+] height: 200px, width: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                height={{ s: 25, m: \"200px\" }}\n                width={{ s: 25, m: \"200px\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "ratio",
+					"id": "utility-components-view--ratio",
+					"name": "aspectRatio",
 					"snippet": "const ratio = () => (\n    <Example>\n        <Example.Item title=\"ratio: 16 / 9\">\n            <View backgroundColor=\"neutral-faded\" aspectRatio={16 / 9} width=\"200px\" />\n        </Example.Item>\n        <Example.Item title={[\"responsive ratio\", \"[s] 1/1\", \"[m+] 16/9\"]}>\n            <View backgroundColor=\"neutral-faded\" aspectRatio={{ s: 1, m: 16 / 9 }} width=\"200px\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "maxSize",
+					"id": "utility-components-view--max-size",
+					"name": "width, height, maxWidth, maxHeight",
 					"snippet": "const maxSize = () => (\n    <Example>\n        <Example.Item title=\"maxHeight: 150px, maxWidth: 150px, height: 300px\">\n            <View backgroundColor=\"neutral-faded\" maxHeight=\"150px\" maxWidth=\"150px\" height=\"300px\" />\n        </Example.Item>\n        <Example.Item title=\"maxHeight: 25, maxWidth: 25, height: 50\">\n            <View backgroundColor=\"neutral-faded\" maxHeight={25} maxWidth={25} height={50} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive maxHeight and maxWidth, height: 300\",\n                \"[s] maxHeight: 25, maxWidth: 25\",\n                \"[m+] maxHeight: 200px, maxWidth: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                maxHeight={{ s: 25, m: \"200px\" }}\n                maxWidth={{ s: 25, m: \"200px\" }}\n                height=\"300px\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "minSize",
+					"id": "utility-components-view--min-size",
+					"name": "width, height, minWidth, minHeight",
 					"snippet": "const minSize = () => (\n    <Example>\n        <Example.Item title=\"minHeight: 150px, minWidth: 150px, height: 50px, width: 50px\">\n            <View\n                backgroundColor=\"neutral-faded\"\n                minHeight=\"150px\"\n                minWidth=\"150px\"\n                height=\"50px\"\n                width=\"50px\"\n            />\n        </Example.Item>\n        <Example.Item title=\"minHeight: 25, minWidth: 25, height: 5, width: 5\">\n            <View backgroundColor=\"neutral-faded\" minHeight={25} minWidth={25} height={5} width={5} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive minHeight and minWidth, height: 50px, width: 50px\",\n                \"[s] minHeight: 25, minWidth: 25\",\n                \"[m+] minHeight: 200px, minWidth: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                minHeight={{ s: 25, m: \"200px\" }}\n                minWidth={{ s: 25, m: \"200px\" }}\n                height=\"50px\"\n                width=\"50px\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "background",
+					"id": "utility-components-view--background",
+					"name": "backgroundColor",
 					"snippet": "const background = () => (\n    <Example title=\"border is used to highlight the backround value when it's similar to the page background, text color changes based on the background\">\n        <Example.Item title=\"bg: page\">\n            <View backgroundColor=\"page\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: page-faded\">\n            <View backgroundColor=\"page-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: disabled\">\n            <View backgroundColor=\"disabled\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: disabled-faded\">\n            <View backgroundColor=\"disabled-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-base\">\n            <View backgroundColor=\"elevation-base\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-raised\">\n            <View backgroundColor=\"elevation-raised\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-overlay\">\n            <View backgroundColor=\"elevation-overlay\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: neutral\">\n            <View backgroundColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: neutral-faded\">\n            <View backgroundColor=\"neutral-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: primary\">\n            <View backgroundColor=\"primary\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: primary-faded\">\n            <View backgroundColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: critical\">\n            <View backgroundColor=\"critical\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: critical-faded\">\n            <View backgroundColor=\"critical-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: warning\">\n            <View backgroundColor=\"warning\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: warning-faded\">\n            <View backgroundColor=\"warning-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: positive\">\n            <View backgroundColor=\"positive\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: positive-faded\">\n            <View backgroundColor=\"positive-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--border-color",
 					"name": "borderColor",
 					"snippet": "const borderColor = () => (\n    <Example>\n        <Example.Item title=\"border: neutral\">\n            <View borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: neutral-faded\">\n            <View borderColor=\"neutral-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: primary\">\n            <View borderColor=\"primary\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: primary-faded\">\n            <View borderColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: critical\">\n            <View borderColor=\"critical\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: critical-faded\">\n            <View borderColor=\"critical-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: warning\">\n            <View borderColor=\"warning\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: warning-faded\">\n            <View borderColor=\"warning-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: positive\">\n            <View borderColor=\"positive\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: positive-faded\">\n            <View borderColor=\"positive-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: transparent, background: primary-faded\">\n            <View borderColor=\"transparent\" backgroundColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive\", \"[s] primary\", \"[m+] neutral\"]}>\n            <View borderColor={{ s: \"primary\", m: \"neutral\" }} padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--border",
 					"name": "border",
 					"snippet": "const border = () => (\n    <Example>\n        <Example.Item title=\"border: true\">\n            <View border borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderTop: true\">\n            <View borderTop borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderBottom: true\">\n            <View borderBottom borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderStart: true\">\n            <View borderStart borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderEnd: true\">\n            <View borderEnd borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderInline: true\">\n            <View borderInline borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderBlock: true\">\n            <View borderBlock borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderTop: true, borderStart: true, \">\n            <View borderColor=\"neutral\" borderTop borderStart padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"responsive\",\n                \"[s] borderTop: true, borderStart: true\",\n                \"[m+] borderBottom: true, borderEnd: true\",\n            ]}\n        >\n            <View\n                borderColor=\"neutral\"\n                borderTop={{ s: true, m: false }}\n                borderStart={{ s: true, m: false }}\n                borderBottom={{ s: false, m: true }}\n                borderEnd={{ s: false, m: true }}\n                padding={4}\n            >\n                Content\n            </View>\n        </Example.Item>\n\n        <div style={{ height: 100 }} />\n    </Example>\n);"
 				},
 				{
-					"name": "radius",
+					"id": "utility-components-view--radius",
+					"name": "borderRadius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius: small\">\n            <View borderRadius=\"small\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: medium\">\n            <View borderRadius=\"medium\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: large\">\n            <View borderRadius=\"large\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: circular\">\n            <View borderRadius=\"circular\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--shadow",
 					"name": "shadow",
 					"snippet": "const shadow = () => (\n    <Example>\n        <Example.Item title=\"shadow: raised, radius: medium\">\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                shadow=\"raised\"\n                borderRadius=\"medium\"\n                backgroundColor=\"elevation-raised\"\n            />\n        </Example.Item>\n        <Example.Item title=\"shadow: overlay, radius: medium\">\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                shadow=\"overlay\"\n                borderRadius=\"medium\"\n                backgroundColor=\"elevation-overlay\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--overflow",
 					"name": "overflow",
 					"snippet": "const overflow = () => (\n    <Example>\n        <Example.Item\n            title={[\"overflow: hidden, radius: medium\", \"child background should have radius\"]}\n        >\n            <View height=\"100px\" width=\"100px\" shadow=\"raised\" borderRadius=\"medium\" overflow=\"hidden\">\n                <View backgroundColor=\"primary\" height=\"100%\" width=\"100%\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positioning",
+					"id": "utility-components-view--positioning",
+					"name": "position",
 					"snippet": "const positioning = () => (\n    <Example>\n        <Example.Item title=\"position: relative + absolute\">\n            <View borderColor=\"neutral\" position=\"relative\">\n                <Placeholder />\n                <View\n                    position=\"absolute\"\n                    insetTop={0}\n                    insetEnd={0}\n                    backgroundColor=\"critical\"\n                    zIndex={5}\n                    height={10}\n                    width={10}\n                />\n                <View\n                    position=\"absolute\"\n                    insetTop={0}\n                    insetEnd={0}\n                    backgroundColor=\"primary\"\n                    height={15}\n                    width={15}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: sticky\">\n            <div style={{ overflow: \"auto\", height: 100 }} tabIndex={0}>\n                <View position=\"sticky\" borderColor=\"primary\" insetTop={0}>\n                    Content\n                </View>\n                <Placeholder h={1000} />\n            </div>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive\", \"[s] position: absolute\", \"[m+]: position: relative\"]}>\n            <div style={{ overflow: \"auto\", height: 100, position: \"relative\" }} tabIndex={0}>\n                <View position={{ s: \"absolute\", m: \"relative\" }} borderColor=\"primary\" insetTop={0}>\n                    Content\n                </View>\n                <Placeholder h={1000} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--inset",
 					"name": "inset",
 					"snippet": "const inset = () => (\n    <Example>\n        <Example.Item title=\"inset: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" inset={4} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetTop: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" insetTop={4} height={10} width={10} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetStart: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetStart={4}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetEnd: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" insetEnd={4} height={10} width={10} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetBottom: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetBottom={4}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"responsive, [s] insetBottom: 4 [m+] insetEnd: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetBottom={{ s: 4, m: \"auto\" }}\n                    insetEnd={{ s: \"auto\", m: 4 }}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--animated",
 					"name": "animated",
 					"snippet": "const animated = () => {\n    const [background, setBackground] = React.useState<ViewProps[\"backgroundColor\"]>(\"neutral\");\n\n    return (\n        <View gap={3} align=\"start\">\n            <Button\n                onClick={() => setBackground((prev) => (prev === \"neutral\" ? \"primary\" : \"neutral\"))}\n            >\n                Change background\n            </Button>\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                backgroundColor={background}\n                align=\"center\"\n                justify=\"center\"\n                animated\n            >\n                Content\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "itemGapBefore",
+					"id": "utility-components-view--item-gap-before",
+					"name": "item, gapBefore",
 					"snippet": "const itemGapBefore = () => (\n    <Example>\n        <Example.Item title={[\"gap: 4, 3rd item gapBefore: 10, direction: row\", \"increased gap\"]}>\n            <View direction=\"row\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={10}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 4, direction: row\", \"reduced gap\"]}>\n            <View direction=\"row\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={4}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 0, direction: row\", \"removed gap\"]}>\n            <View direction=\"row\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={0}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"gap: 4, direction: row, 2nd item gap: auto\">\n            <View direction=\"row\" gap={4}>\n                <Placeholder w={200} />\n                <View.Item gapBefore=\"auto\">\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"gap: 4, 3rd item gapBefore: 10, direction: column\", \"increased gap\"]}>\n            <View direction=\"column\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={10}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 4, direction: column\", \"reduced gap\"]}>\n            <View direction=\"column\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={4}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 0, direction: column\", \"removed gap\"]}>\n            <View direction=\"column\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={0}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"gap: 4, direction: column, height: 200px, 2nd item gap: auto\">\n            <View height=\"200px\" gap={4}>\n                <Placeholder />\n                <View.Item gapBefore=\"auto\">\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"responsive item gap\",\n                \"gap: 4, direction: row\",\n                \"[s] 3rd item gapBefore: 10\",\n                \"[m+] 3rd item gapBefore: 0\",\n            ]}\n        >\n            <View direction=\"row\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={{ s: 10, m: 0 }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemGrow",
+					"id": "utility-components-view--item-grow",
+					"name": "item, grow",
 					"snippet": "const itemGrow = () => (\n    <Example>\n        <Example.Item title=\"direction: row, 2nd item grow\">\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column, height: 200px, 2nd item grow\">\n            <View direction=\"column\" gap={3} height=\"200px\">\n                <Placeholder />\n                <View.Item grow>\n                    <Placeholder h=\"100%\" />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row, 2nd item grow, applied to View\">\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View grow>\n                    <Placeholder />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive item grow, direction: row\",\n                \"[s] 2nd item grow\",\n                \"[m+] 2nd item doesn't grow\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View.Item grow={{ s: true, m: false }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive item grow, direction: column, height: 200px\",\n                \"[s] 2nd item grow\",\n                \"[m+] 2nd item doesn't grow\",\n            ]}\n        >\n            <View direction=\"column\" gap={3} height=\"200px\">\n                <Placeholder />\n                <View.Item grow={{ s: true, m: false }}>\n                    <Placeholder h=\"100%\" />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemColumns",
+					"id": "utility-components-view--item-columns",
+					"name": "item, columns",
 					"snippet": "const itemColumns = () => (\n    <Example>\n        <Example.Item title=\"columns 6, 6, gap: 0\">\n            <View direction=\"row\">\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 3, 9, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={3}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, 9, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive columns\", \"[s] columns 6, 6, 12, gap: 4\", \"[m+]: 4, 4, 4\"]}>\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={{ s: 6, m: 4 }}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 6, m: 4 }}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 12, m: 4 }}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, 9, gap: 4, 2nd item gapBefore: 20\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6} gapBefore={20}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemOrder",
+					"id": "utility-components-view--item-order",
+					"name": "item, order",
 					"snippet": "const itemOrder = () => (\n    <Example>\n        <Example.Item title=\"order: 1 3 2\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={4}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={4} order={1}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={4}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive order\", \"[s] 1 2 3\", \"[m+] 1 3 2\"]}>\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={4}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={4} order={{ s: 0, m: 1 }}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={4}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive order\",\n                \"[s]: 1 3 2, 2 is full width on second row\",\n                \"[m+]: 1 2 3, 2 has grow in the center of the first row\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <View.Item columns={{ s: 6, m: \"auto\" }}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item\n                    grow={{ s: false, m: true }}\n                    order={{ s: 1, m: 0 }}\n                    columns={{ s: 12, m: \"auto\" }}\n                >\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 6, m: \"auto\" }}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "hiddenItem",
+					"id": "utility-components-view--hidden-item",
+					"name": "composition, Hidden item",
 					"snippet": "const hiddenItem = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"[s] 2nd item: visible, grow, 3rd item: !grow\",\n                \"[m+] 2nd item: hidden, 2nd item divider: hidden, 3rd item: grow\",\n            ]}\n        >\n            <View direction=\"row\" divided gap={3}>\n                <Placeholder />\n                <Hidden hide={{ s: false, m: true }}>\n                    <View.Item grow key=\"3\">\n                        <Placeholder />\n                    </View.Item>\n                </Hidden>\n                <View.Item grow={{ s: false, m: true }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"[s] 2nd item: visible, grow, 3rd item: !grow\",\n                \"[m+] 2nd item: hidden, 2nd item: grow doesn't push 3rd item, 3rd item: grow\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Placeholder />\n                <Hidden hide={{ s: false, m: true }}>\n                    <View.Item grow>\n                        <Placeholder />\n                    </View.Item>\n                </Hidden>\n                <View.Item grow={{ s: false, m: true }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "keys",
+					"id": "utility-components-view--keys",
+					"name": "item, key",
 					"snippet": "const keys = () => {\n    const toggle = useToggle();\n\n    return (\n        <View gap={2}>\n            <Button onClick={() => toggle.toggle()}>Toggle</Button>\n            <View.Item>Item 1</View.Item>\n            {toggle.active && <KeyItem>Item 2</KeyItem>}\n            <KeyItem>Item 3</KeyItem>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "nestedGaps",
+					"id": "utility-components-view--nested-gaps",
+					"name": "composition, nested gap",
 					"snippet": "const nestedGaps = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"direction: column, gap: 10\",\n                \"Child 1: direction: column, gap: 2\",\n                \"Child 2: direction column, gap: 6\",\n                \"Child 3: gapBefore: 0\",\n                \"Child 3 view: direction: row, gap: 2\",\n            ]}\n        >\n            <View gap={10}>\n                <View gap={2}>\n                    <Placeholder>Child 1</Placeholder>\n                    <Placeholder>Child 1</Placeholder>\n                </View>\n\n                <View gap={6}>\n                    <Placeholder>Child 2</Placeholder>\n                    <Placeholder>Child 2</Placeholder>\n                </View>\n\n                <View.Item gapBefore={0}>\n                    <View direction=\"row\" gap={2}>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "utility-components-view--test-composition",
+					"name": "composition, edge cases",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item>\n            <View direction=\"row\" align=\"center\" gap={4} padding={4}>\n                <View width=\"80px\" height=\"60px\" backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n\n                <View direction=\"row\" align=\"center\" gap={1} grow>\n                    <View.Item shrink>\n                        <Text>Text (like Jeff's Puzzles)</Text>\n                    </View.Item>\n\n                    <View minWidth=\"auto\" grow>\n                        <Button size=\"small\" color=\"neutral\" icon={IconPlus} />\n                    </View>\n                </View>\n\n                <Button color=\"primary\" rounded>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"View.Item, MenuItem, Aspect ratio\",\n                \"ratio should increase height on viewport change\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <View.Item>\n                    <Placeholder />\n                </View.Item>\n                <MenuItem selected roundedCorners>\n                    Menu\n                </MenuItem>\n                <View.Item grow>\n                    <View aspectRatio={16 / 9}>\n                        <Placeholder h=\"100%\" />\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"Scrollable tabs inside View.Item with grow\">\n            <View direction=\"row\" align=\"center\" gap={3}>\n                <Placeholder />\n                <View.Item grow>\n                    <View padding={0} align=\"center\">\n                        <Tabs variant=\"pills\">\n                            <Tabs.List>\n                                <Tabs.Item value=\"1\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"2\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"3\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"4\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"5\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"6\">Very long item</Tabs.Item>\n                            </Tabs.List>\n                            {[1, 2, 3, 5, 6].map((i) => (\n                                <Tabs.Panel key={i} value={i.toString()} />\n                            ))}\n                        </Tabs>\n                    </View>\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"2nd item has grow, Avatar stays circle\">\n            <View direction=\"row\" gap={3}>\n                <Avatar initials=\"DB\" />\n                <View.Item grow>\n                    Veggies sunt bona vobis, proinde vos postulo esse magis grape pea sprouts horseradish\n                    courgette maize spinach prairie turnip jícama coriander quandong gourd broccoli seakale\n                    gumbo. Parsley corn lentil zucchini radicchio maize burdock avocado sea lettuce.\n                    Garbanzo tigernut earthnut pea fennel.\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"item gapBefore from parent doesn't affect the child view\",\n                \"columns should take full width\",\n            ]}\n        >\n            <View>\n                <View.Item gapBefore={20}>\n                    <View direction=\"row\" gap={4}>\n                        <View.Item columns={6}>\n                            <Placeholder />\n                        </View.Item>\n                        <View.Item columns={6}>\n                            <Placeholder />\n                        </View.Item>\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"View becomes flexbox if there is a child with grow\">\n            <View height=\"300px\" borderColor=\"neutral-faded\">\n                <View height=\"50px\" />\n                <View grow backgroundColor=\"neutral-faded\" padding={4}>\n                    Grow\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "asProp",
+					"id": "utility-components-view--as-prop",
+					"name": "as",
 					"snippet": "const asProp = () => (\n    <View as=\"ul\">\n        <View.Item as=\"li\">Content</View.Item>\n    </View>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-view--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <View className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </View>\n    </div>\n);"
 				},
 				{
-					"name": "itemClassName",
+					"id": "utility-components-view--item-class-name",
+					"name": "item className, attributes",
 					"snippet": "const itemClassName = () => (\n    <div data-testid=\"root\">\n        <View.Item className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </View.Item>\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Button, Example, Hidden, MenuItem, Placeholder, Tabs, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/View/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "View",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/View/View.tsx",
-				"actualName": "View",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"divided": {
+						"defaultValue": null,
+						"description": "Render a divider between each child",
+						"name": "divided",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Flex direction for the content",
+						"name": "direction",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Direction>" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between children, base unit token number multiplier",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"wrap": {
+						"defaultValue": null,
+						"description": "Flex wrap for the content",
+						"name": "wrap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Flex align-items for the content",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Flex justify-content for the content",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width style, literal string value or a base unit token number multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"aspectRatio": {
+						"defaultValue": null,
+						"description": "Aspect ratio style, represented as width / height",
+						"name": "aspectRatio",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height style, literal string value or a base unit token number multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Maximum width style, literal string value or a base unit token number multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"minHeight": {
+						"defaultValue": null,
+						"description": "Minimum height style, literal string value or a base unit token number multiplier",
+						"name": "minHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"minWidth": {
+						"defaultValue": null,
+						"description": "Minimum width style, literal string value or a base unit token number multiplier",
+						"name": "minWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Padding style for all sides, base unit token number multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingTop": {
+						"defaultValue": null,
+						"description": "Padding top, base unit token number multiplier",
+						"name": "paddingTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingBottom": {
+						"defaultValue": null,
+						"description": "Padding bottom, base unit token number multiplier",
+						"name": "paddingBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingStart": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "paddingStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingEnd": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "paddingEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingInline": {
+						"defaultValue": null,
+						"description": "Padding inline, base unit token number multiplier",
+						"name": "paddingInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingBlock": {
+						"defaultValue": null,
+						"description": "Padding block, base unit token number multiplier",
+						"name": "paddingBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margin and remove side borders, base unit token number multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"textAlign": {
+						"defaultValue": null,
+						"description": "Text align for the content",
+						"name": "textAlign",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<TextAlign>" }
+					},
+					"backgroundColor": {
+						"defaultValue": null,
+						"description": "Background color, based on the color tokens",
+						"name": "backgroundColor",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"critical-faded\" | \"warning\" | \"warning-faded\" | \"positive-faded\" | \"primary-faded\" | \"elevation-base\" | \"elevation-raised\" | \"elevation-overlay\" | \"page\" | \"page-faded\" | \"disabled-faded\" | \"brand\" | \"white\" | \"black\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"critical-faded\"" },
+								{ "value": "\"warning\"" },
+								{ "value": "\"warning-faded\"" },
+								{ "value": "\"positive-faded\"" },
+								{ "value": "\"primary-faded\"" },
+								{ "value": "\"elevation-base\"" },
+								{ "value": "\"elevation-raised\"" },
+								{ "value": "\"elevation-overlay\"" },
+								{ "value": "\"page\"" },
+								{ "value": "\"page-faded\"" },
+								{ "value": "\"disabled-faded\"" },
+								{ "value": "\"brand\"" },
+								{ "value": "\"white\"" },
+								{ "value": "\"black\"" }
+							]
+						}
+					},
+					"borderColor": {
+						"defaultValue": null,
+						"description": "Border color, based on the color tokens",
+						"name": "borderColor",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<BorderColor>" }
+					},
+					"border": {
+						"defaultValue": null,
+						"description": "Add border to all sides",
+						"name": "border",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderTop": {
+						"defaultValue": null,
+						"description": "Add border to the top side",
+						"name": "borderTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderBottom": {
+						"defaultValue": null,
+						"description": "Add border to the bottom side",
+						"name": "borderBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderStart": {
+						"defaultValue": null,
+						"description": "Add border to the inline start side",
+						"name": "borderStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderEnd": {
+						"defaultValue": null,
+						"description": "Add border to the inline end side",
+						"name": "borderEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderInline": {
+						"defaultValue": null,
+						"description": "Add border to the inline direction",
+						"name": "borderInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderBlock": {
+						"defaultValue": null,
+						"description": "Add border to the block direction",
+						"name": "borderBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Radius>" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Position style",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Position>" }
+					},
+					"inset": {
+						"defaultValue": null,
+						"description": "Inset style, base unit token number multiplier when used as a number",
+						"name": "inset",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetStart": {
+						"defaultValue": null,
+						"description": "Inset start, base unit token number multiplier when used as a number",
+						"name": "insetStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetEnd": {
+						"defaultValue": null,
+						"description": "Inset end, base unit token number multiplier when used as a number",
+						"name": "insetEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetTop": {
+						"defaultValue": null,
+						"description": "Inset top, base unit token number multiplier when used as a number",
+						"name": "insetTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetBottom": {
+						"defaultValue": null,
+						"description": "Inset bottom, base unit token number multiplier when used as a number",
+						"name": "insetBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"zIndex": {
+						"defaultValue": null,
+						"description": "z-index style",
+						"name": "zIndex",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"shadow": {
+						"defaultValue": null,
+						"description": "Shadow style, based on the shadow tokens",
+						"name": "shadow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Overflow style",
+						"name": "overflow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"auto\"",
+							"value": [{ "value": "\"hidden\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"animated": {
+						"defaultValue": null,
+						"description": "Add transition for the properties",
+						"name": "animated",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					},
+					"grow": {
+						"defaultValue": null,
+						"description": "Apply flex-grow, using it on View.Item applies additional styles on the parent View",
+						"name": "grow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"shrink": {
+						"defaultValue": null,
+						"description": "Apply flex-shrink",
+						"name": "shrink",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "View"
 			}
 		},
 		"hooks-useelementid": {
@@ -3131,7 +16482,8 @@
 			"path": "./src/hooks/tests/useElementId.stories.tsx",
 			"stories": [
 				{
-					"name": "id",
+					"id": "hooks-useelementid--id",
+					"name": "passed id",
 					"snippet": "const id = () => {\n    return <Component id=\"hey\" />;\n};"
 				}
 			],
@@ -3148,6 +16500,7 @@
 			"path": "./src/hooks/tests/useHandlerRef.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usehandlerref--base",
 					"name": "base",
 					"snippet": "const base = (args) => {\n    const [count, setCount] = React.useState(0);\n\n    // Creating a new handler on each render\n    const handleEffect = () => {\n        args.handleEffect(0);\n    };\n\n    return (\n        <View gap={4}>\n            <Button onClick={() => setCount((prev) => prev + 1)}>Increase count</Button>\n            <Component onEffect={handleEffect} count={count} />\n        </View>\n    );\n};"
 				}
@@ -3165,43 +16518,53 @@
 			"path": "./src/hooks/tests/useHotkeys.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usehotkeys--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const { checkHotkeyState } = useHotkeys({\n        \"shift + b + n\": () => console.log(\"pressed\"),\n        \"c + v\": () => console.log(\"c + v\"),\n        \"Meta + k\": () => console.log(\"meta + k\"),\n        \"Meta + f\": () => console.log(\"meta + f\"),\n        \"Meta + v\": () => console.log(\"meta + v\"),\n        \"Meta + b\": () => console.log(\"meta + b\"),\n        \"control + enter\": () => console.log(\"control + enter\"),\n        \"meta + enter\": () => console.log(\"meta + enter\"),\n        \"mod + enter\": () => console.log(\"mod + enter\"),\n        \"mod + ArrowRight\": () => console.log(\"right\"),\n        \"mod + ArrowUp\": () => console.log(\"top\"),\n        \"shift + ArrowRight\": () => console.log(\"right\"),\n        \"shift + ArrowUp\": () => console.log(\"top\"),\n        \"alt+shift+n\": () => console.log(\"alt+shift+n\"),\n        \"shift+alt+n\": () => console.log(\"shift+alt+n\"),\n        \"alt+shiftLeft+n\": () => console.log(\"alt+shiftLeft+n\"),\n    });\n    const active = checkHotkeyState(\"shift + b + n\");\n    const shiftActive = checkHotkeyState(\"shift\");\n    const bActive = checkHotkeyState(\"b\");\n    const nActive = checkHotkeyState(\"n\");\n\n    return (\n        <View\n            animated\n            gap={2}\n            direction=\"row\"\n            backgroundColor={active ? \"positive-faded\" : undefined}\n            padding={2}\n            borderRadius=\"small\"\n        >\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={shiftActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={shiftActive ? undefined : \"raised\"}\n            >\n                Shift\n            </View>\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={bActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={bActive ? undefined : \"raised\"}\n            >\n                b\n            </View>\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={nActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={nActive ? undefined : \"raised\"}\n            >\n                n\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "singleKey",
+					"id": "hooks-usehotkeys--single-key",
+					"name": "single key",
 					"snippet": "const singleKey = (args) => <Component hotkeys={{ a: args.handleHotkey }} />;"
 				},
 				{
-					"name": "modKey",
+					"id": "hooks-usehotkeys--mod-key",
+					"name": "mod key",
 					"snippet": "const modKey = (args) => <Component hotkeys={{ mod: args.handleHotkey }} />;"
 				},
 				{
-					"name": "modKeyHold",
+					"id": "hooks-usehotkeys--mod-key-hold",
+					"name": "mod key on hold",
 					"snippet": "const modKeyHold = (args) => <Component hotkeys={{ \"Meta + b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyList",
+					"id": "hooks-usehotkeys--key-list",
+					"name": "key list",
 					"snippet": "const keyList = (args) => <Component hotkeys={{ \"a,b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombination",
+					"id": "hooks-usehotkeys--key-combination",
+					"name": "key combination",
 					"snippet": "const keyCombination = (args) => <Component hotkeys={{ \"a+b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationFormat",
+					"id": "hooks-usehotkeys--key-combination-format",
+					"name": "key combination without formatting",
 					"snippet": "const keyCombinationFormat = (args) => <Component hotkeys={{ \"A  + b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationOrder",
+					"id": "hooks-usehotkeys--key-combination-order",
+					"name": "key combination without order",
 					"snippet": "const keyCombinationOrder = (args) => <Component hotkeys={{ \"b+a\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationMoreThanRequired",
+					"id": "hooks-usehotkeys--key-combination-more-than-required",
+					"name": "key combination, more keys pressed",
 					"snippet": "const keyCombinationMoreThanRequired = (args) => <Component hotkeys={{ \"z + x\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "optionModified",
+					"id": "hooks-usehotkeys--option-modified",
+					"name": "modified with alt/option",
 					"snippet": "const optionModified = (args) => (\n    <Component hotkeys={{ \"alt+n\": args.handleHotkeyModified, \"alt+shift\": args.handleHotkey }} />\n);"
 				}
 			],
@@ -3218,22 +16581,27 @@
 			"path": "./src/hooks/tests/useKeyboardArrowNavigation.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usekeyboardarrownavigation--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "horizontal",
+					"id": "hooks-usekeyboardarrownavigation--horizontal",
+					"name": "orientation: horizontal",
 					"snippet": "const horizontal = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, orientation: \"horizontal\" });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "vertical",
+					"id": "hooks-usekeyboardarrownavigation--vertical",
+					"name": "orientation: vertical",
 					"snippet": "const vertical = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, orientation: \"vertical\" });\n\n    return (\n        <View gap={2} direction=\"column\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-usekeyboardarrownavigation--circular",
 					"name": "circular",
 					"snippet": "const circular = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, circular: true });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-usekeyboardarrownavigation--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, disabled: true });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				}
@@ -3249,7 +16617,13 @@
 			"id": "hooks-usekeyboardmode",
 			"name": "useKeyboardMode",
 			"path": "./src/hooks/tests/useKeyboardMode.stories.tsx",
-			"stories": [{ "name": "base", "snippet": "const base = () => <Component />;" }],
+			"stories": [
+				{
+					"id": "hooks-usekeyboardmode--base",
+					"name": "base",
+					"snippet": "const base = () => <Component />;"
+				}
+			],
 			"import": "import { Button, View } from \"reshaped\";",
 			"jsDocTags": {},
 			"error": {
@@ -3263,19 +16637,23 @@
 			"path": "./src/hooks/tests/useOnClickOutside.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-useonclickoutside--base",
 					"name": "base",
 					"snippet": "const base = (args) => {\n    const ref = React.useRef(null);\n    const [target, setTarget] = React.useState<\"inside\" | \"outside\" | null>(null);\n\n    useOnClickOutside([ref], () => {\n        args.handleOutsideClick();\n        setTarget(\"outside\");\n    });\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }} onClick={() => setTarget(\"inside\")}>\n                Trigger\n            </Button>\n            {target && `Clicked ${target}`}\n        </View>\n    );\n};"
 				},
 				{
-					"name": "refs",
+					"id": "hooks-useonclickoutside--refs",
+					"name": "multiple refs",
 					"snippet": "const refs = (args) => {\n    const ref = React.useRef(null);\n    const ref2 = React.useRef(null);\n\n    useOnClickOutside([ref, ref2], () => {\n        args.handleOutsideClick();\n    });\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }}>Trigger</Button>\n            <Button attributes={{ ref: ref2 }}>Trigger 2</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-useonclickoutside--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = (args) => {\n    const ref = React.useRef(null);\n\n    useOnClickOutside(\n        [ref],\n        () => {\n            args.handleOutsideClick();\n        },\n        {\n            disabled: true,\n        }\n    );\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }}>Trigger</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "deps",
+					"id": "hooks-useonclickoutside--deps",
+					"name": "test: handler uses latest state",
 					"snippet": "const deps = (args) => {\n    const ref = React.useRef(null);\n    const [count, setCount] = React.useState(0);\n\n    useOnClickOutside([ref], () => {\n        args.handleOutsideClick({ count });\n    });\n\n    return (\n        <Button attributes={{ ref }} onClick={() => setCount((prev) => prev + 1)}>\n            Trigger\n        </Button>\n    );\n};"
 				}
 			],
@@ -3290,7 +16668,13 @@
 			"id": "hooks-usertl",
 			"name": "useRTL",
 			"path": "./src/hooks/tests/useRTL.stories.tsx",
-			"stories": [{ "name": "setRTL", "snippet": "const setRTL = () => <Component />;" }],
+			"stories": [
+				{
+					"id": "hooks-usertl--set-rtl",
+					"name": "setRTL",
+					"snippet": "const setRTL = () => <Component />;"
+				}
+			],
 			"import": "",
 			"jsDocTags": {},
 			"error": {
@@ -3304,10 +16688,12 @@
 			"path": "./src/hooks/tests/useResponsiveClientValue.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-useresponsiveclientvalue--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const value = useResponsiveClientValue<ViewProps[\"backgroundColor\"]>({\n        s: \"neutral\",\n        m: \"critical\",\n        l: \"positive\",\n    });\n\n    return <View width={25} height={25} backgroundColor={value} />;\n};"
 				},
 				{
+					"id": "hooks-useresponsiveclientvalue--boolean",
 					"name": "boolean",
 					"snippet": "const boolean = () => {\n    const value = useResponsiveClientValue<boolean>({\n        s: true,\n        l: false,\n    });\n\n    return <div>{value?.toString()}</div>;\n};"
 				}
@@ -3325,19 +16711,23 @@
 			"path": "./src/hooks/tests/useScrollLock.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usescrolllock--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock();\n\n    return (\n        <React.Fragment>\n            <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n            <div style={{ height: \"150vh\" }} />\n        </React.Fragment>\n    );\n};"
 				},
 				{
-					"name": "origin",
+					"id": "hooks-usescrolllock--origin",
+					"name": "originRef",
 					"snippet": "const origin = () => {\n    const originRef = React.useRef<HTMLDivElement>(null);\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock({ originRef });\n\n    return (\n        <View overflow=\"auto\" height={25} attributes={{ ref: originRef, \"data-testid\": \"root\" }}>\n            <View height={50} padding={4} backgroundColor=\"neutral-faded\" borderRadius=\"medium\">\n                <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "container",
+					"id": "hooks-usescrolllock--container",
+					"name": "containerRef",
 					"snippet": "const container = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock({ containerRef });\n\n    return (\n        <View height={25} attributes={{ ref: containerRef, \"data-testid\": \"root\" }}>\n            <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testContainerAsync",
+					"id": "hooks-usescrolllock--test-container-async",
+					"name": "test: containerRef locked count",
 					"snippet": "const testContainerAsync = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const globalLock = useScrollLock();\n    const scopedLock = useScrollLock({ containerRef });\n\n    return (\n        <Example>\n            <Example.Item title=\"calling regular lock and lock with a container only requires a single unlock to remove overflow\">\n                <View attributes={{ ref: containerRef }} gap={4} direction=\"row\">\n                    <Button\n                        onClick={globalLock.scrollLocked ? globalLock.unlockScroll : globalLock.lockScroll}\n                    >\n                        Toggle\n                    </Button>\n                    <Button\n                        onClick={scopedLock.scrollLocked ? scopedLock.unlockScroll : scopedLock.lockScroll}\n                    >\n                        Toggle\n                    </Button>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
@@ -3354,14 +16744,17 @@
 			"path": "./src/hooks/tests/useToggle.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usetoggle--toggle",
 					"name": "toggle",
 					"snippet": "const toggle = () => {\n    const { toggle, active } = useToggle();\n\n    return (\n        <Button onClick={() => toggle()} attributes={{ \"data-active\": active }}>\n            {active ? \"Deactivate\" : \"Activate\"}\n        </Button>\n    );\n};"
 				},
 				{
+					"id": "hooks-usetoggle--activate",
 					"name": "activate",
 					"snippet": "const activate = () => {\n    const { activate, active } = useToggle();\n\n    return (\n        <React.Fragment>\n            <Button onClick={activate} attributes={{ \"data-active\": active }}>\n                Activate\n            </Button>\n        </React.Fragment>\n    );\n};"
 				},
 				{
+					"id": "hooks-usetoggle--deactivate",
 					"name": "deactivate",
 					"snippet": "const deactivate = () => {\n    const { deactivate, active } = useToggle(true);\n\n    return (\n        <Button onClick={deactivate} attributes={{ \"data-active\": active }}>\n            Deactivate\n        </Button>\n    );\n};"
 				}
@@ -3379,39 +16772,48 @@
 			"path": "./src/utilities/a11y/tests/TrapFocus.stories.tsx",
 			"stories": [
 				{
-					"name": "modeDialog",
+					"id": "utilities-trapfocus--mode-dialog",
+					"name": "mode: dialog",
 					"snippet": "const modeDialog = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, { mode: \"dialog\" });\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\"mode: dialog\", \"tab navigation, always stays inside until released\"]}\n            >\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View.Item>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeActionMenu",
+					"id": "utilities-trapfocus--mode-action-menu",
+					"name": "mode: action-menu",
 					"snippet": "const modeActionMenu = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"action-menu\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: action-menu\",\n                    \"up/down arrow navigation, tab and shift+tab release the focus and follows natural tab order\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeActionBar",
+					"id": "utilities-trapfocus--mode-action-bar",
+					"name": "mode: action-bar",
 					"snippet": "const modeActionBar = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"action-bar\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: action-bar\",\n                    \"left/right arrow navigation, tab and shift+tab release the focus and follows natural tab order\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeContentMenu",
+					"id": "utilities-trapfocus--mode-content-menu",
+					"name": "mode: content-menu",
 					"snippet": "const modeContentMenu = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"content-menu\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: content-menu\",\n                    \"tab navigation, tabbing outside the content will trigger the release\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utilities-trapfocus--include-trigger",
 					"name": "includeTrigger",
 					"snippet": "const includeTrigger = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n            includeTrigger: true,\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utilities-trapfocus--initial-focus-el",
 					"name": "initialFocusEl",
 					"snippet": "const initialFocusEl = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const initialFocusRef = React.useRef<HTMLButtonElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n            initialFocusEl: initialFocusRef.current,\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View\n                            gap={4}\n                            direction=\"row\"\n                            padding={4}\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            attributes={{ ref: rootRef }}\n                        >\n                            <Button onClick={() => {}}>Action 1</Button>\n                            <Button onClick={() => {}} attributes={{ ref: initialFocusRef }}>\n                                Action 2\n                            </Button>\n                            <Button onClick={() => {}}>Action 3</Button>\n                            <Button onClick={trapToggle.deactivate}>Release</Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "focusableElements",
+					"id": "utilities-trapfocus--focusable-elements",
+					"name": "test: focusable elements",
 					"snippet": "const focusableElements = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current);\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title=\"test with all types of focusable elements\">\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={trapToggle.activate}>Activate</Button>\n                    </View.Item>\n\n                    {trapToggle.active && (\n                        <View\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            padding={4}\n                            gap={4}\n                            attributes={{ ref: rootRef }}\n                            align=\"start\"\n                        >\n                            <Link href=\"#\" attributes={{ \"data-testid\": \"test-link\" }}>\n                                Link\n                            </Link>\n\n                            <TextField\n                                name=\"input\"\n                                placeholder=\"Input\"\n                                inputAttributes={{ \"data-testid\": \"test-text-field\" }}\n                            />\n\n                            <TextArea name=\"textarea\" inputAttributes={{ \"data-testid\": \"test-text-area\" }} />\n\n                            <Select\n                                name=\"select\"\n                                options={[\n                                    { label: \"Option 1\", value: \"1\" },\n                                    { label: \"Option 2\", value: \"2\" },\n                                ]}\n                                inputAttributes={{ \"data-testid\": \"test-select\" }}\n                            />\n\n                            <RadioGroup name=\"radio\">\n                                <Radio value=\"1\" inputAttributes={{ \"data-testid\": \"test-radio-1\" }}>\n                                    Option 1\n                                </Radio>\n                                <Radio value=\"2\" inputAttributes={{ \"data-testid\": \"test-radio-2\" }}>\n                                    Option 2\n                                </Radio>\n                            </RadioGroup>\n\n                            <Editor />\n\n                            <div tabIndex={0} role=\"button\" data-testid=\"test-tabindex\">\n                                div with tabIndex\n                            </div>\n\n                            <div style={{ display: \"none\" }}>\n                                <Button onClick={() => {}} attributes={{ \"data-testid\": \"test-hidden-button\" }}>\n                                    Hidden\n                                </Button>\n                            </div>\n\n                            <Button\n                                onClick={() => {}}\n                                attributes={{ tabIndex: -1, \"data-testid\": \"test-button-negative-tabindex\" }}\n                            >\n                                Excluded\n                            </Button>\n\n                            <input type=\"hidden\" data-testid=\"test-input-hidden\" />\n\n                            <Button\n                                onClick={trapToggle.deactivate}\n                                attributes={{ \"data-testid\": \"test-button\" }}\n                            >\n                                Release button\n                            </Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "nested",
+					"id": "utilities-trapfocus--nested",
+					"name": "test: nested",
 					"snippet": "const nested = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const innerRootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n    const innerTrapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    React.useEffect(() => {\n        if (!innerTrapToggle.active) return;\n        if (!innerRootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(innerRootRef.current, {\n            mode: \"dialog\",\n        });\n\n        return () => trapFocus.release();\n    }, [innerTrapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"nested, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View gap={4}>\n                            <View\n                                gap={4}\n                                direction=\"row\"\n                                padding={4}\n                                backgroundColor=\"neutral-faded\"\n                                borderRadius=\"medium\"\n                                attributes={{ ref: rootRef }}\n                            >\n                                <Button onClick={() => {}}>Action</Button>\n                                <Button onClick={innerTrapToggle.activate}>Inner trap focus</Button>\n                                <Button onClick={trapToggle.deactivate}>Release</Button>\n                            </View>\n\n                            {innerTrapToggle.active && (\n                                <View\n                                    gap={4}\n                                    direction=\"row\"\n                                    padding={4}\n                                    backgroundColor=\"neutral-faded\"\n                                    borderRadius=\"medium\"\n                                    attributes={{ ref: innerRootRef }}\n                                >\n                                    <Button onClick={() => {}}>Action</Button>\n                                    <Button onClick={innerTrapToggle.deactivate}>Release</Button>\n                                </View>\n                            )}\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "mutationObserver",
+					"id": "utilities-trapfocus--mutation-observer",
+					"name": "test: mutation observer",
 					"snippet": "const mutationObserver = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n    const [mutated, setMutated] = React.useState(false);\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n        });\n\n        setTimeout(() => {\n            setMutated(true);\n        }, 50);\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View\n                            gap={4}\n                            direction=\"row\"\n                            padding={4}\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            attributes={{ ref: rootRef }}\n                        >\n                            {!mutated && (\n                                <>\n                                    <Button onClick={() => {}}>Action 1</Button>\n                                    <Button onClick={() => {}}>Action 2</Button>\n                                </>\n                            )}\n                            <Button onClick={() => {}}>Action 3</Button>\n                            <Button onClick={trapToggle.deactivate}>Release</Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
@@ -3428,15 +16830,35 @@
 			"path": "./src/components/_private/Portal/tests/Portal.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "internal-portal--base",
+					"name": "Base",
 					"snippet": "const base = () => {\n\tconst ref = React.useRef<HTMLDivElement>(null);\n\tconst [mounted, setMounted] = React.useState(false);\n\n\tReact.useEffect(() => {\n\t\tsetMounted(true);\n\t}, []);\n\n\treturn (\n\t\t<>\n\t\t\t<div style={{ border: \"2px solid #333\", padding: 16 }}>\n\t\t\t\tApp\n\t\t\t\t{mounted && <Portal targetRef={ref}>Ported to green</Portal>}\n\t\t\t</div>\n\t\t\t<div ref={ref} style={{ border: \"2px solid green\", padding: 16 }} />\n\t\t</>\n\t);\n};"
 				}
 			],
 			"import": "import { Portal } from \"reshaped\";",
 			"jsDocTags": {},
-			"error": {
-				"name": "No component definition found",
-				"message": "File: /Users/shilman/projects/design-systems/reshaped/src/components/_private/Portal/index.ts\nError:\nNo suitable component definition found.\nYou can debug your component file in this playground: https://react-docgen.dev/playground\nCode:\nimport Portal, { PortalScope } from \"./Portal\";\n\nconst PortalRoot = Portal as typeof Portal & {\n\tScope: typeof PortalScope;\n};\n\nPortalRoot.Scope = PortalScope;\n\nexport default PortalRoot;\nexport type { Props as PortalProps } from \"./Portal.types\";\n\n\nFile: /Users/shilman/projects/design-systems/reshaped/src/components/_private/Portal/Portal.types.ts\nError:\nNo suitable component definition found.\nYou can debug your component file in this playground: https://react-docgen.dev/playground\nCode:\nimport React from \"react\";\n\nexport type Props = {\n\tchildren?: React.ReactNode;\n\ttargetRef?: React.RefObject<HTMLElement | ShadowRoot | null>;\n};\n\nexport type ScopeProps<T extends HTMLElement> = {\n\tchildren: (ref: React.RefObject<T | null>) => React.ReactNode;\n};\n\nexport type Context = {\n\tscopeRef: React.RefObject<HTMLElement | null>;\n};\n"
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/_private/Portal/index.ts",
+				"description": "",
+				"displayName": "Portal",
+				"methods": [],
+				"props": {
+					"targetRef": {
+						"defaultValue": null,
+						"description": "",
+						"name": "targetRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/_private/Portal/Portal.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | ShadowRoot | null>" }
+					}
+				},
+				"exportName": "Portal"
 			}
 		},
 		"internal-usedrag": {
@@ -3444,24 +16866,33 @@
 			"name": "useDrag",
 			"path": "./src/hooks/tests/useDrag.stories.tsx",
 			"stories": [
-				{ "name": "base", "snippet": "const base = () => <Example />;" },
 				{
-					"name": "mouseEvents",
+					"id": "internal-usedrag--base",
+					"name": "base",
+					"snippet": "const base = () => <Example />;"
+				},
+				{
+					"id": "internal-usedrag--mouse-events",
+					"name": "onDrag, mouse events",
 					"snippet": "const mouseEvents = () => {\n    return <Demo onDrag={fn()} />;\n};"
 				},
 				{
-					"name": "touchEvents",
+					"id": "internal-usedrag--touch-events",
+					"name": "onDrag, touch events",
 					"snippet": "const touchEvents = () => {\n    return <Demo onDrag={fn()} />;\n};"
 				},
 				{
-					"name": "orientationHorizontal",
+					"id": "internal-usedrag--orientation-horizontal",
+					"name": "orientation horizontal",
 					"snippet": "const orientationHorizontal = () => {\n    return <Demo onDrag={fn()} orientation=\"horizontal\" />;\n};"
 				},
 				{
-					"name": "orientationVertical",
+					"id": "internal-usedrag--orientation-vertical",
+					"name": "orientation vertical",
 					"snippet": "const orientationVertical = () => {\n    return <Demo onDrag={fn()} orientation=\"vertical\" />;\n};"
 				},
 				{
+					"id": "internal-usedrag--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => {\n    return <Demo onDrag={fn()} disabled />;\n};"
 				}
@@ -3479,7 +16910,8 @@
 			"path": "./src/tests/ShadowDOM.stories.tsx",
 			"stories": [
 				{
-					"name": "behavior",
+					"id": "internal-shadowdom--behavior",
+					"name": "Behavior",
 					"snippet": "const behavior = () => (\n\t<Example>\n\t\t<Example.Item title=\"base\">\n\t\t\t<Component />\n\t\t</Example.Item>\n\t</Example>\n);"
 				}
 			],
@@ -3496,30 +16928,94 @@
 			"path": "./src/tests/themes.stories.tsx",
 			"stories": [
 				{
-					"name": "test",
+					"id": "internal-themes--test",
+					"name": "Test",
 					"snippet": "const test = () => {\n\tconst { colorMode } = useTheme();\n\tconst [activeColor, setColor] = useState(colors[0]);\n\tconst [theme, setTheme] = useState(\"\");\n\tconst [algo, setAlgo] = useState<\"wcag\" | \"apca\">(\"wcag\");\n\n\tuseLayoutEffect(() => {\n\t\tsetTheme(\n\t\t\tgetThemeCSS(\n\t\t\t\t\"test\",\n\t\t\t\t{\n\t\t\t\t\tcolor: generateThemeColors({\n\t\t\t\t\t\tprimary: activeColor === colors[0] ? undefined : activeColor,\n\t\t\t\t\t}),\n\t\t\t\t},\n\t\t\t\t{\n\t\t\t\t\tcolorContrastAlgorithm: algo,\n\t\t\t\t}\n\t\t\t)\n\t\t);\n\t}, [activeColor, algo]);\n\n\treturn (\n\t\t<>\n\t\t\t<style>{theme}</style>\n\t\t\t<Theme name=\"test\">\n\t\t\t\t<View gap={4}>\n\t\t\t\t\t<View direction=\"row\" align=\"center\" gap={4}>\n\t\t\t\t\t\t{colors.map((color) => {\n\t\t\t\t\t\t\tconst hex = colorMode === \"dark\" && color === \"#000000\" ? \"#ffffff\" : color;\n\n\t\t\t\t\t\t\treturn (\n\t\t\t\t\t\t\t\t<Actionable key={color} onClick={() => setColor(color)} borderRadius=\"inherit\">\n\t\t\t\t\t\t\t\t\t<View\n\t\t\t\t\t\t\t\t\t\twidth={5}\n\t\t\t\t\t\t\t\t\t\theight={5}\n\t\t\t\t\t\t\t\t\t\tborderRadius=\"circular\"\n\t\t\t\t\t\t\t\t\t\tattributes={{\n\t\t\t\t\t\t\t\t\t\t\tstyle: {\n\t\t\t\t\t\t\t\t\t\t\t\ttransition: `box-shadow var(--rs-duration-fast) var(--rs-easing-standard)`,\n\t\t\t\t\t\t\t\t\t\t\t\tbackground: hex,\n\t\t\t\t\t\t\t\t\t\t\t\tboxShadow:\n\t\t\t\t\t\t\t\t\t\t\t\t\tcolor === activeColor\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t? `0 0 0 3px var(--rs-color-background-elevation-base), 0 0 0 5px ${hex}`\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t: undefined,\n\t\t\t\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t\t\t\t}}\n\t\t\t\t\t\t\t\t\t/>\n\t\t\t\t\t\t\t\t</Actionable>\n\t\t\t\t\t\t\t);\n\t\t\t\t\t\t})}\n\t\t\t\t\t\t<View.Item gapBefore=\"auto\">\n\t\t\t\t\t\t\t<Switch name=\"algo\" onChange={(args) => setAlgo(args.checked ? \"apca\" : \"wcag\")}>\n\t\t\t\t\t\t\t\tUse APCA\n\t\t\t\t\t\t\t</Switch>\n\t\t\t\t\t\t</View.Item>\n\t\t\t\t\t</View>\n\n\t\t\t\t\t<ThemePlayground />\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</>\n\t);\n};"
 				},
 				{
-					"name": "base",
+					"id": "internal-themes--base",
+					"name": "Base",
 					"snippet": "const base = () => (\n\t<Example>\n\t\t<Example.Item title=\"custom runtime theme\">\n\t\t\t<style>{css}</style>\n\t\t\t<Theme name=\"green\">\n\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"on colors generation\">\n\t\t\t<style>{css2}</style>\n\t\t\t<Theme name=\"peach\">\n\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "generation",
+					"id": "internal-themes--generation",
+					"name": "Generation",
 					"snippet": "const generation = () => (\n\t<div>\n\t\t<style>{cssGenerated}</style>\n\t\t<Theme name=\"generated\">{componentExamples}</Theme>\n\t</div>\n);"
 				},
 				{
-					"name": "onColors",
+					"id": "internal-themes--on-colors",
+					"name": "On Colors",
 					"snippet": "const onColors = () => (\n\t<Example>\n\t\t<Example.Item title=\"custom on color values\">\n\t\t\t<style>{onColorsCss}</style>\n\t\t\t<Theme name=\"on-color\">\n\t\t\t\t<View gap={2} direction=\"row\">\n\t\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t\t\t<Button color=\"critical\">Critical button</Button>\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"custom on color values, apca\">\n\t\t\t<style>{onColorsCssApca}</style>\n\t\t\t<Theme name=\"on-color-apca\">\n\t\t\t\t<View gap={2} direction=\"row\">\n\t\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t\t\t<Button color=\"critical\">Critical button</Button>\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t</Example>\n);"
 				}
 			],
 			"import": "import {\n    Actionable,\n    Alert,\n    Avatar,\n    Badge,\n    Button,\n    Card,\n    DropdownMenu,\n    Example,\n    Link,\n    Switch,\n    Text,\n    TextField,\n    Theme,\n    ThemePlayground,\n    View,\n} from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Theme/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Theme",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Theme/Theme.tsx",
-				"actualName": "Theme",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the theme to use, enables controlled mode",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"defaultName": {
+						"defaultValue": null,
+						"description": "Default name of the theme to use, enables uncontrolled mode",
+						"name": "defaultName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode to use",
+						"name": "colorMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode | \"inverted\"",
+							"value": [
+								{ "value": "\"light\"" },
+								{ "value": "\"dark\"" },
+								{ "value": "\"inverted\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -3529,7 +17025,8 @@
 			"path": "./src/Sandbox.stories.tsx",
 			"stories": [
 				{
-					"name": "preview",
+					"id": "sandbox--preview",
+					"name": "Preview",
 					"snippet": "const preview = () => {\n\treturn (\n\t\t<Preview>\n\t\t\t<Component />\n\t\t</Preview>\n\t);\n};"
 				}
 			],
@@ -3540,5 +17037,6 @@
 				"message": "We could not detect the component from your story file. Specify meta.component.\n   7 | import MenuItem from \"components/MenuItem\";\n   8 |\n>  9 | export default {\n     | ^\n  10 | \ttitle: \"Sandbox\",\n  11 | \tchromatic: { disableSnapshot: true },\n  12 | };\n\n./src/Sandbox.stories.tsx:\nimport View from \"components/View\";\nimport Image from \"components/Image\";\nimport React from \"react\";\nimport Select from \"components/Select\";\nimport useToggle from \"hooks/useToggle\";\nimport Modal from \"components/Modal\";\nimport MenuItem from \"components/MenuItem\";\n\nexport default {\n\ttitle: \"Sandbox\",\n\tchromatic: { disableSnapshot: true },\n};\n\nconst Preview: React.FC<{ children: React.ReactNode }> = (props) => {\n\treturn (\n\t\t<View padding={20} gap={6}>\n\t\t\t<View position=\"absolute\" insetTop={0} insetStart={0}>\n\t\t\t\t<Image src=\"./logo.svg\" />\n\t\t\t</View>\n\n\t\t\t{props.children}\n\t\t</View>\n\t);\n};\n\nexport const preview = () => {\n\treturn (\n\t\t<Preview>\n\t\t\t<Component />\n\t\t</Preview>\n\t);\n};\n\nconst Component = () => {\n\tconst toggle = useToggle();\n\tconst [value, setValue] = React.useState(\"Dog\");\n\n\tconst handleClick = () => {\n\t\ttoggle.toggle();\n\t};\n\n\treturn (\n\t\t<>\n\t\t\t<Select name=\"animal\" placeholder=\"Select an animal\" onClick={handleClick}>\n\t\t\t\t{value}\n\t\t\t</Select>\n\t\t\t<Modal active={toggle.active} onClose={toggle.deactivate} position=\"bottom\" padding={2}>\n\t\t\t\t<MenuItem\n\t\t\t\t\troundedCorners\n\t\t\t\t\tonClick={() => {\n\t\t\t\t\t\tsetValue(\"Dog\");\n\t\t\t\t\t\ttoggle.deactivate();\n\t\t\t\t\t}}\n\t\t\t\t\tattributes={{\n\t\t\t\t\t\trole: \"option\",\n\t\t\t\t\t}}\n\t\t\t\t>\n\t\t\t\t\tDog\n\t\t\t\t</MenuItem>\n\t\t\t\t<MenuItem\n\t\t\t\t\troundedCorners\n\t\t\t\t\tattributes={{\n\t\t\t\t\t\trole: \"option\",\n\t\t\t\t\t}}\n\t\t\t\t\tonClick={() => {\n\t\t\t\t\t\tsetValue(\"Turtle\");\n\t\t\t\t\t\ttoggle.deactivate();\n\t\t\t\t\t}}\n\t\t\t\t>\n\t\t\t\t\tTurtle\n\t\t\t\t</MenuItem>\n\t\t\t</Modal>\n\t\t</>\n\t);\n};\n"
 			}
 		}
-	}
+	},
+	"meta": { "docgen": "react-docgen-typescript", "durationMs": 2919 }
 }

--- a/eval/tasks/907-existing-component-change-component-reshaped/manifests/components.json
+++ b/eval/tasks/907-existing-component-change-component-reshaped/manifests/components.json
@@ -7,46 +7,201 @@
 			"path": "./src/components/ActionBar/tests/ActionBar.stories.tsx",
 			"stories": [
 				{
-					"name": "positionRelative",
+					"id": "components-actionbar--position-relative",
+					"name": "position, positionType: relative",
 					"snippet": "const positionRelative = () => (\n    <Example>\n        <Example.Item title=\"position: top\">\n            <ActionBar position=\"top\">\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <ActionBar position=\"bottom\">\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positionAbsolute",
+					"id": "components-actionbar--position-absolute",
+					"name": "position, positionType: absolute",
 					"snippet": "const positionAbsolute = () => (\n    <Example>\n        <Example.Item title=\"position: top-start\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top-start\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: top\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: top-end\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"top-end\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom-start\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom-start\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar padding={2} position=\"bottom-end\" positionType=\"absolute\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positionFixed",
+					"id": "components-actionbar--position-fixed",
+					"name": "position, positionType: fixed",
 					"snippet": "const positionFixed = () => (\n    <>\n        <ActionBar padding={2} position=\"top-start\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"top\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"top-end\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom-start\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <ActionBar padding={2} position=\"bottom-end\" positionType=\"fixed\">\n            <Fixtures.Actions />\n        </ActionBar>\n\n        <div style={{ height: 2000 }} />\n    </>\n);"
 				},
 				{
+					"id": "components-actionbar--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated, position: top\">\n            <ActionBar position=\"top\" elevated>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"elevated, position: bottom\">\n            <ActionBar elevated>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"auto elevated, position: bottom\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\">\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-actionbar--offset",
 					"name": "offset",
 					"snippet": "const offset = () => (\n    <Example>\n        <Example.Item title=\"offset 2, position: top\">\n            <Fixtures.Container>\n                <ActionBar position=\"top\" positionType=\"absolute\" offset={2}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"offset 2, position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\" offset={2}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n\n        <Example.Item title=\"offset s: 2, m: 4, position: bottom-end\">\n            <Fixtures.Container>\n                <ActionBar position=\"bottom-end\" offset={{ s: 2, m: 4 }}>\n                    <Fixtures.Actions />\n                </ActionBar>\n            </Fixtures.Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-actionbar--active",
 					"name": "active",
 					"snippet": "const active = () => {\n    const barToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => barToggle.toggle()}>Toggle</Button>\n            <ActionBar active={barToggle.active} positionType=\"fixed\" position=\"top-end\">\n                <Fixtures.Actions />\n            </ActionBar>\n        </>\n    );\n};"
 				},
 				{
-					"name": "padding",
+					"id": "components-actionbar--padding",
+					"name": "padding, paddingBlock, paddingInline",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 6\">\n            <ActionBar padding={6}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"paddingBlock: 2, paddingInline: 4\">\n            <ActionBar paddingBlock={2} paddingInline={4}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n\n        <Example.Item title=\"padding: [s] 4, [m+] 6\">\n            <ActionBar padding={{ s: 4, m: 6 }}>\n                <Placeholder />\n            </ActionBar>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-actionbar--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ActionBar className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </ActionBar>\n    </div>\n);"
 				}
 			],
 			"import": "import { ActionBar, Button, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ActionBar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ActionBar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ActionBar/ActionBar.tsx",
-				"actualName": "ActionBar",
+				"methods": [],
+				"props": {
+					"paddingBlock": {
+						"defaultValue": null,
+						"description": "Padding block, base unit token number multiplier",
+						"name": "paddingBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingInline": {
+						"defaultValue": null,
+						"description": "Padding inline, base unit token number multiplier",
+						"name": "paddingInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Padding style for all sides, base unit token number multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Show or hide the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"offset": {
+						"defaultValue": null,
+						"description": "Offset from the container bounds",
+						"name": "offset",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"position": {
+						"defaultValue": { "value": "\"bottom\"" },
+						"description": "Position based on the container bounds",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"top-end\" | \"top-start\" | \"bottom\" | \"bottom-start\" | \"bottom-end\"",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" }
+							]
+						}
+					},
+					"positionType": {
+						"defaultValue": null,
+						"description": "CSS position style",
+						"name": "positionType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"relative\" | \"absolute\" | \"fixed\">" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Display above the content with elevated shadow and background",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ActionBar/ActionBar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -56,30 +211,138 @@
 			"path": "./src/components/Alert/tests/Alert.stories.tsx",
 			"stories": [
 				{
+					"id": "components-alert--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        {([\"neutral\", \"primary\", \"critical\", \"positive\", \"warning\"] as const).map((color) => (\n            <Example.Item title={`color: ${color}`} key={color}>\n                <Alert\n                    color={color}\n                    title=\"Alert title goes here\"\n                    icon={IconZap}\n                    actionsSlot={\n                        <>\n                            <Link\n                                variant=\"plain\"\n                                color={color === \"neutral\" ? \"primary\" : color}\n                                onClick={() => {}}\n                            >\n                                View now\n                            </Link>\n                            <Link\n                                variant=\"plain\"\n                                color={color === \"neutral\" ? \"primary\" : color}\n                                onClick={() => {}}\n                            >\n                                Dismiss\n                            </Link>\n                        </>\n                    }\n                >\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard\n                </Alert>\n            </Example.Item>\n        ))}\n    </Example>\n);"
 				},
 				{
+					"id": "components-alert--inline",
 					"name": "inline",
 					"snippet": "const inline = () => (\n    <Example>\n        <Example.Item title=\"inline: true\">\n            <Alert\n                inline\n                title=\"Alert title goes here\"\n                icon={IconZap}\n                actionsSlot={\n                    <>\n                        <Link variant=\"plain\" onClick={() => {}}>\n                            View now\n                        </Link>\n                        <Link variant=\"plain\" onClick={() => {}}>\n                            Dismiss\n                        </Link>\n                    </>\n                }\n            >\n                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has\n                been the industry's standard\n            </Alert>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-alert--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4\">\n            <Alert bleed={4} icon={IconZap}>\n                Content\n            </Alert>\n        </Example.Item>\n        <Example.Item title=\"bleed: [s] 4, [m+] 0\">\n            <Alert bleed={{ s: 4, m: 0 }} icon={IconZap}>\n                Content\n            </Alert>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-alert--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Alert className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </Alert>\n    </div>\n);"
 				}
 			],
 			"import": "import { Alert, Example, Link, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Alert/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Alert",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Alert/Alert.tsx",
-				"actualName": "Alert",
+				"methods": [],
+				"props": {
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"title": {
+						"defaultValue": null,
+						"description": "Title slot",
+						"name": "title",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Slot for rendering the main content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"actionsSlot": {
+						"defaultValue": null,
+						"description": "Actions slot, usually used for Buttons and Links, automatically adds a gap between the actions",
+						"name": "actionsSlot",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Color scheme of the alert elements",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"inline": {
+						"defaultValue": null,
+						"description": "Display action to the right of the content",
+						"name": "inline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margin and remove side borders, base unit token number multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Alert/Alert.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -89,35 +352,573 @@
 			"path": "./src/components/Autocomplete/tests/Autocomplete.stories.tsx",
 			"stories": [
 				{
-					"name": "active",
+					"id": "components-autocomplete--active",
+					"name": "active, onOpen, onClose",
 					"snippet": "const active = (args) => {\n    const toggle = useToggle(true);\n\n    return (\n        <Example>\n            <Example.Item title=\"active, onOpen, onClose\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete\n                        name=\"fruit\"\n                        placeholder=\"Pick your food\"\n                        active={toggle.active}\n                        onOpen={() => {\n                            args.handleOpen();\n                            toggle.activate();\n                        }}\n                        onClose={() => {\n                            args.handleClose();\n                            toggle.deactivate();\n                        }}\n                        onChange={(args) => console.log(args)}\n                    >\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "base",
+					"id": "components-autocomplete--base",
+					"name": "onInput, onItemSelect, onBackspace",
 					"snippet": "const base = () => {\n    const [value, setValue] = React.useState(\"\");\n\n    return (\n        <Example>\n            <Example.Item title=\"Base\">\n                <FormControl>\n                    <FormControl.Label>Food</FormControl.Label>\n                    <Autocomplete\n                        name=\"fruit\"\n                        placeholder=\"Pick your food\"\n                        value={value}\n                        onChange={(args) => setValue(args.value)}\n                        onBackspace={fn()}\n                        onItemSelect={fn()}>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "itemData",
+					"id": "components-autocomplete--item-data",
+					"name": "item data",
 					"snippet": "const itemData = () => {\n    return (\n        <Example>\n            <Example.Item title=\"item data\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete name=\"fruit\" placeholder=\"Pick your food\" onItemSelect={fn()} active>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v} data={i === 1 ? { foo: true } : undefined}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "itemDisabled",
+					"id": "components-autocomplete--item-disabled",
+					"name": "item disabled",
 					"snippet": "const itemDisabled = () => {\n    return (\n        <Example>\n            <Example.Item title=\"item disabled\">\n                <FormControl>\n                    <FormControl.Label>Label</FormControl.Label>\n                    <Autocomplete name=\"fruit\" placeholder=\"Pick your food\" active>\n                        {[\"Pizza\", \"Pie\", \"Ice-cream\"].map((v, i) => {\n                            return (\n                                <Autocomplete.Item key={v} value={v} disabled={i === 1}>\n                                    {v}\n                                </Autocomplete.Item>\n                            );\n                        })}\n                    </Autocomplete>\n                </FormControl>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "multiselect",
+					"id": "components-autocomplete--multiselect",
+					"name": "test: multiselect",
 					"snippet": "const multiselect = () => {\n    const options = [\n        \"Pizza\",\n        \"Pie\",\n        \"Ice-cream\",\n        \"Fries\",\n        \"Salad\",\n        \"Option 4\",\n        \"Option 5\",\n        \"Option 6\",\n    ];\n\n    const inputRef = React.useRef<HTMLInputElement>(null);\n    const [values, setValues] = React.useState<string[]>([\n        \"Option 4\",\n        \"Option 5\",\n        \"Option 6\",\n        \"Pizza\",\n        \"Ice-cream\",\n    ]);\n    const [query, setQuery] = React.useState(\"\");\n\n    const handleDismiss = (dismissedValue: string) => {\n        const nextValues = values.filter((value) => value !== dismissedValue);\n        setValues(nextValues);\n        inputRef.current?.focus();\n    };\n\n    const valuesNode = values.map((value) => (\n        <Badge dismissAriaLabel=\"Dismiss value\" onDismiss={() => handleDismiss(value)} key={value}>\n            {value}\n        </Badge>\n    ));\n\n    return (\n        <FormControl>\n            <FormControl.Label>Food</FormControl.Label>\n            <Autocomplete\n                name=\"fruit\"\n                value={query}\n                placeholder=\"Pick your food\"\n                startSlot={valuesNode}\n                multiline\n                inputAttributes={{ ref: inputRef }}\n                onChange={(args) => setQuery(args.value)}\n                onBackspace={() => {\n                    if (query.length === 0) {\n                        setValues((prev) => prev.slice(0, -1));\n                    }\n                }}\n                onItemSelect={(args) => {\n                    setQuery(\"\");\n                    setValues((prev) => [...prev, args.value]);\n                }}\n            >\n                {options.map((v) => {\n                    if (!v.toLowerCase().includes(query.toLowerCase())) return;\n                    if (values.includes(v)) return;\n\n                    return (\n                        <Autocomplete.Item key={v} value={v}>\n                            {v}\n                        </Autocomplete.Item>\n                    );\n                })}\n            </Autocomplete>\n        </FormControl>\n    );\n};"
 				}
 			],
 			"import": "import { Autocomplete, Badge, Example, FormControl } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Autocomplete/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Autocomplete",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Autocomplete/Autocomplete.tsx",
-				"actualName": "Autocomplete",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"multiline": {
+						"defaultValue": null,
+						"description": "Enable multiline text field wrapping",
+						"name": "multiline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to be fully rounded",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content after the text field value",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text field value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the text field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the text field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"onInput": {
+						"defaultValue": null,
+						"description": "Callback for when value changes from user input",
+						"name": "onInput",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onItemSelect": {
+						"defaultValue": null,
+						"description": "Callback for when an item is selected in the dropdown",
+						"name": "onItemSelect",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: SelectArgs) => void)" }
+					},
+					"onBackspace": {
+						"defaultValue": null,
+						"description": "Callback for when the backspace key is pressed while the input is focused",
+						"name": "onBackspace",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onEnter": {
+						"defaultValue": null,
+						"description": "Callback for when the enter key is pressed while the input is focused",
+						"name": "onEnter",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Slot for rendering the Autocomplete.Item components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Autocomplete/Autocomplete.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					}
+				},
+				"exportName": "Autocomplete"
 			}
 		},
 		"components-avatar": {
@@ -126,46 +927,230 @@
 			"path": "./src/components/Avatar/tests/Avatar.stories.tsx",
 			"stories": [
 				{
-					"name": "src",
+					"id": "components-avatar--src",
+					"name": "src, alt",
 					"snippet": "const src = () => (\n    <Example>\n        <Example.Item title=\"src, alt\">\n            <Avatar\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n                alt=\"Amsterdam canal\"\n                size={12}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"src\">\n            <Avatar src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "initials",
+					"id": "components-avatar--initials",
+					"name": "initials, icon",
 					"snippet": "const initials = () => (\n    <Example>\n        <Example.Item title=\"initials\">\n            <Avatar initials=\"RS\" />\n        </Example.Item>\n\n        <Example.Item title=\"icon\">\n            <Avatar icon={IconZap} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-avatar--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: 6\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={6} icon={IconZap} />\n                <Avatar size={6} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: 15\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={15} icon={IconZap} />\n                <Avatar size={15} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: 40\">\n            <View direction=\"row\" gap={3}>\n                <Avatar size={40} icon={IconZap} />\n                <Avatar size={40} initials=\"RS\" squared />\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] 10\", \"[m+] 20\"]}>\n            <View direction=\"row\" gap={3}>\n                <Avatar size={{ s: 10, m: 20 }} icon={IconZap} />\n                <Avatar size={{ s: 10, m: 20 }} icon={IconZap} squared />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-avatar--squared",
 					"name": "squared",
 					"snippet": "const squared = () => (\n    <Example>\n        <Example.Item title=\"squared, with image\">\n            <Avatar\n                squared\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n            />\n        </Example.Item>\n        <Example.Item title=\"squared, with initials\">\n            <Avatar squared initials=\"RS\" />\n        </Example.Item>\n        <Example.Item title=\"squared, with initials\">\n            <Avatar squared icon={IconZap} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "colors",
+					"id": "components-avatar--colors",
+					"name": "color, variant",
 					"snippet": "const colors = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"neutral\" icon={IconZap} />\n                <Avatar color=\"neutral\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"primary\" icon={IconZap} />\n                <Avatar color=\"primary\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"positive\" icon={IconZap} />\n                <Avatar color=\"positive\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"warning\" icon={IconZap} />\n                <Avatar color=\"warning\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <View gap={4} direction=\"row\">\n                <Avatar color=\"critical\" icon={IconZap} />\n                <Avatar color=\"critical\" variant=\"faded\" icon={IconZap} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "fallback",
+					"id": "components-avatar--fallback",
+					"name": "test: fallback",
 					"snippet": "const fallback = (args) => {\n    const [error, setError] = useState(false);\n\n    return (\n        <Avatar\n            src={error ? undefined : \"/foo\"}\n            icon={IconZap}\n            imageAttributes={{\n                onError: () => {\n                    setError(true);\n                    args.handleError();\n                },\n            }}\n        />\n    );\n};"
 				},
 				{
+					"id": "components-avatar--render-image",
 					"name": "renderImage",
 					"snippet": "const renderImage = () => (\n    <Example>\n        <Example.Item title=\"renderImage\">\n            <Avatar\n                src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n                alt=\"Amsterdam canal\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image\" />}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-avatar--class-name",
+					"name": "className, attributes, imageAttributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Avatar\n            src=\"https://images.unsplash.com/photo-1536880756060-98a6a140f0a7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1600&q=80\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            imageAttributes={{ id: \"test-image-id\", alt: \"test image\" }}\n        />\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Avatar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Avatar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Avatar/Avatar.tsx",
-				"actualName": "Avatar",
+				"methods": [],
+				"props": {
+					"src": {
+						"defaultValue": null,
+						"description": "Image URL",
+						"name": "src",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"alt": {
+						"defaultValue": null,
+						"description": "Image alt text",
+						"name": "alt",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"imageAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the image element",
+						"name": "imageAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"img\">" }
+					},
+					"renderImage": {
+						"defaultValue": null,
+						"description": "Render prop for the image element, useful for integrating with the Image component from third party frameworks",
+						"name": "renderImage",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Omit<Attributes<\"img\">, \"src\" | \"alt\"> & { src: string; alt: string; }) => ReactNode)"
+						}
+					},
+					"initials": {
+						"defaultValue": null,
+						"description": "Initials to display if no image is provided",
+						"name": "initials",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon, used when no image is provided",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"squared": {
+						"defaultValue": null,
+						"description": "Change the shape to rounded square",
+						"name": "squared",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"faded\"",
+							"value": [{ "value": "\"solid\"" }, { "value": "\"faded\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "12" },
+						"description": "Size of the component, base unit token number multiplier",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Avatar/Avatar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -175,63 +1160,273 @@
 			"path": "./src/components/Badge/tests/Badge.stories.tsx",
 			"stories": [
 				{
+					"id": "components-badge--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Badge>Badge</Badge>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <Badge variant=\"faded\">Badge</Badge>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <Badge variant=\"outline\">Badge</Badge>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"primary\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"primary\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"primary\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: positive, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"positive\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"positive\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"positive\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: critical, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"critical\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"critical\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"critical\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"color: warning, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge color=\"warning\">Badge</Badge>\n                <Badge variant=\"faded\" color=\"warning\">\n                    Badge\n                </Badge>\n                <Badge variant=\"outline\" color=\"warning\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"small\">Badge</Badge>\n                <Badge rounded size=\"small\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge>Badge</Badge>\n                <Badge rounded>Badge</Badge>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large, not rounded and rounded\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"large\">Badge</Badge>\n                <Badge rounded size=\"large\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={3} direction=\"row\">\n                <Badge icon={IconCheckmark} endIcon={IconChevronRight} size=\"small\">\n                    Badge\n                </Badge>\n                <Badge icon={IconCheckmark} size=\"small\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={3} direction=\"row\">\n                <Badge icon={IconCheckmark} endIcon={IconChevronRight}>\n                    Badge\n                </Badge>\n                <Badge icon={IconCheckmark} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={3} direction=\"row\">\n                <Badge size=\"large\" icon={IconCheckmark} endIcon={IconChevronRight}>\n                    Badge\n                </Badge>\n\n                <Badge icon={IconCheckmark} size=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onDismiss",
+					"id": "components-badge--on-dismiss",
+					"name": "onDismiss, dismissAriaLabel",
 					"snippet": "const onDismiss = () => <Example>\n    <Example.Item title=\"onDismiss\">\n        <Badge onDismiss={fn()} dismissAriaLabel=\"Dismiss\">Badge\n                            </Badge>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-badge--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded, all variants\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded>Badge</Badge>\n                <Badge rounded variant=\"faded\">\n                    Badge\n                </Badge>\n                <Badge rounded variant=\"outline\">\n                    Badge\n                </Badge>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"rounded, all sizes, color: critical\", \"one character, renders as circle\"]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Badge rounded color=\"critical\" size=\"small\">\n                    2\n                </Badge>\n                <Badge rounded color=\"critical\">\n                    2\n                </Badge>\n                <Badge rounded color=\"critical\" size=\"large\">\n                    2\n                </Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--empty",
 					"name": "empty",
 					"snippet": "const empty = () => (\n    <Example>\n        <Example.Item title=\"empty, not rounded, all sizes, color: critical\">\n            <View direction=\"row\" gap={3}>\n                <Badge size=\"small\" color=\"critical\" />\n                <Badge color=\"critical\" />\n                <Badge size=\"large\" color=\"critical\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"empty, rounded, all sizes, color: critical\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded size=\"small\" color=\"critical\" />\n                <Badge rounded color=\"critical\" />\n                <Badge rounded size=\"large\" color=\"critical\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"empty, rounded, all sizes, color: neutral\">\n            <View direction=\"row\" gap={3}>\n                <Badge rounded size=\"small\" color=\"neutral\" />\n                <Badge rounded />\n                <Badge rounded size=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--highlighted",
 					"name": "highlighted",
 					"snippet": "const highlighted = () => (\n    <Example>\n        <Example.Item title=\"highlighted, color: neutral\">\n            <View gap={3} direction=\"row\">\n                <Badge highlighted>Badge</Badge>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-badge--container",
 					"name": "container",
 					"snippet": "const container = () => {\n    const [hidden, setHidden] = React.useState(false);\n\n    return (\n        <Example title={<Button onClick={() => setHidden(!hidden)}>Toggle badges</Button>}>\n            <Example.Item title=\"position: top-end\">\n                <Badge.Container>\n                    <Badge color=\"primary\" hidden={hidden}>\n                        5\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: bottom-end\">\n                <Badge.Container position=\"bottom-end\">\n                    <Badge color=\"primary\" hidden={hidden}>\n                        5\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: top-end, rounded, multiple digits\">\n                <Badge.Container>\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        123\n                    </Badge>\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title=\"position: top-end, rounded, empty\">\n                <Badge.Container>\n                    <Badge color=\"primary\" rounded hidden={hidden} />\n                    <Avatar initials=\"A\" squared />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: top-end, overlap\", \"should cover the circular avatar\"]}>\n                <Badge.Container overlap>\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        2\n                    </Badge>\n                    <Avatar initials=\"A\" />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: bottom-end, overlap\", \"should cover the circular avatar\"]}>\n                <Badge.Container overlap position=\"bottom-end\">\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden}>\n                        2\n                    </Badge>\n                    <Avatar initials=\"A\" />\n                </Badge.Container>\n            </Example.Item>\n\n            <Example.Item title={[\"position: top-end, overlap\", \"should cover the icon\"]}>\n                <Badge.Container overlap position=\"top-end\">\n                    <Badge size=\"small\" color=\"primary\" rounded hidden={hidden} />\n                    <Icon svg={IconCheckmark} size={5} />\n                </Badge.Container>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-badge--href",
 					"name": "href",
 					"snippet": "const href = () => (\n    <Badge href=\"https://reshaped.so\" dismissAriaLabel=\"Dismiss\">\n        Badge\n    </Badge>\n);"
 				},
 				{
+					"id": "components-badge--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Badge onClick={fn()}>Badge</Badge>;"
 				},
 				{
-					"name": "className",
+					"id": "components-badge--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Badge color=\"primary\" className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Badge, Button, Example, Icon, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Badge/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Badge",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Badge/Badge.tsx",
-				"actualName": "Badge",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"large\" | \"medium\"",
+							"value": [
+								{ "value": "\"small\"" },
+								{ "value": "\"large\"" },
+								{ "value": "\"medium\"" }
+							]
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "highlighted",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hidden": {
+						"defaultValue": null,
+						"description": "Transition the component to hidden state",
+						"name": "hidden",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting text or other content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"onDismiss": {
+						"defaultValue": null,
+						"description": "Callback triggered when the dismiss button is pressed",
+						"name": "onDismiss",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"dismissAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the dismiss button",
+						"name": "dismissAriaLabel",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Badge/Badge.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "Badge"
 			}
 		},
 		"components-breadcrumbs": {
@@ -240,51 +1435,185 @@
 			"path": "./src/components/Breadcrumbs/tests/Breadcrumbs.stories.tsx",
 			"stories": [
 				{
+					"id": "components-breadcrumbs--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <Breadcrumbs ariaLabel=\"breadcrumb neutral\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"color: primary\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb primary\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "item",
+					"id": "components-breadcrumbs--item",
+					"name": "item, disabled",
 					"snippet": "const item = () => (\n    <Example>\n        <Example.Item title=\"disabled item\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb disabled\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}} disabled>\n                    Disabled item 2\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "icon",
+					"id": "components-breadcrumbs--icon",
+					"name": "item, icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"item with icon\">\n            <Breadcrumbs color=\"primary\" ariaLabel=\"breadcrumb with icon\">\n                <Breadcrumbs.Item icon={IconZap} onClick={() => {}}>\n                    Item 1\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "slots",
+					"id": "components-breadcrumbs--slots",
+					"name": "separator, children",
 					"snippet": "const slots = () => (\n    <Example>\n        <Example.Item title=\"slot: separator\">\n            <Breadcrumbs color=\"primary\" separator=\"/\" ariaLabel=\"breadcrumb with separator\">\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"custom child content\">\n            <Breadcrumbs ariaLabel=\"breadcrumb with custom children\">\n                <Breadcrumbs.Item onClick={() => {}}>\n                    <Badge>Item 1</Badge>\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>\n                    <Badge>Item 2</Badge>\n                </Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 3</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-breadcrumbs--collapsed",
 					"name": "collapsed",
 					"snippet": "const collapsed = () => (\n    <Example>\n        <Example.Item title=\"collapsed, 3 items shown by default\">\n            <Breadcrumbs\n                defaultVisibleItems={3}\n                ariaLabel=\"breadcrumbs one\"\n                expandAriaLabel=\"Expand items\"\n            >\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"collapsed, 4 items shown by default\">\n            <Breadcrumbs\n                defaultVisibleItems={4}\n                ariaLabel=\"breadcrumb two\"\n                expandAriaLabel=\"Expand items\"\n            >\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n\n        <Example.Item title=\"collapsed, 3 items shown by default, not expandable\">\n            <Breadcrumbs defaultVisibleItems={3} ariaLabel=\"breadcrumb three\" disableExpand>\n                <Breadcrumbs.Item onClick={() => {}}>Item 1</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 2</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 3</Breadcrumbs.Item>\n                <Breadcrumbs.Item onClick={() => {}}>Item 4</Breadcrumbs.Item>\n                <Breadcrumbs.Item>Item 5</Breadcrumbs.Item>\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "multiline",
+					"id": "components-breadcrumbs--multiline",
+					"name": "composition, multiline",
 					"snippet": "const multiline = () => (\n    <Example>\n        <Example.Item title=\"wraps content when multiline\">\n            <Breadcrumbs ariaLabel=\"breadcrumb multiline\">\n                {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((i) => (\n                    <Breadcrumbs.Item onClick={() => {}} key={i}>\n                        Item {i}\n                    </Breadcrumbs.Item>\n                ))}\n            </Breadcrumbs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onClick",
+					"id": "components-breadcrumbs--on-click",
+					"name": "item, onClick, disabled",
 					"snippet": "const onClick = () => <Breadcrumbs>\n    <Breadcrumbs.Item onClick={fn()}>Trigger</Breadcrumbs.Item>\n    <Breadcrumbs.Item onClick={fn()} disabled>Trigger\n                    </Breadcrumbs.Item>\n</Breadcrumbs>;"
 				},
 				{
-					"name": "href",
+					"id": "components-breadcrumbs--href",
+					"name": "item, href",
 					"snippet": "const href = () => (\n    <Breadcrumbs>\n        <Breadcrumbs.Item href=\"https://reshaped.so\">Trigger</Breadcrumbs.Item>\n    </Breadcrumbs>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-breadcrumbs--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Breadcrumbs className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Breadcrumbs.Item>Trigger</Breadcrumbs.Item>\n        </Breadcrumbs>\n    </div>\n);"
 				}
 			],
 			"import": "import { Badge, Breadcrumbs, Example } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Breadcrumbs/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Breadcrumbs",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Breadcrumbs/Breadcrumbs.tsx",
-				"actualName": "Breadcrumbs",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children to position items",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ReactElement<unknown, string | JSXElementConstructor<any>>[]"
+						}
+					},
+					"separator": {
+						"defaultValue": null,
+						"description": "Node for defining custom separator between items",
+						"name": "separator",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"neutral\"",
+							"value": [{ "value": "\"primary\"" }, { "value": "\"neutral\"" }]
+						}
+					},
+					"defaultVisibleItems": {
+						"defaultValue": null,
+						"description": "Number of items to show by default, others will be hidden and can be expanded",
+						"name": "defaultVisibleItems",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"expandAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the expand button",
+						"name": "expandAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disableExpand": {
+						"defaultValue": null,
+						"description": "Turn expand button into static text and disable the expand functionality",
+						"name": "disableExpand",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the component",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Breadcrumbs/Breadcrumbs.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"nav\">" }
+					}
+				},
+				"exportName": "Breadcrumbs"
 			}
 		},
 		"components-button": {
@@ -293,87 +1622,599 @@
 			"path": "./src/components/Button/tests/Button.stories.tsx",
 			"stories": [
 				{
-					"name": "variantAndColor",
+					"id": "components-button--variant-and-color",
+					"name": "variant, color",
 					"snippet": "const variantAndColor = () => (\n    <Example>\n        <Example.Item title=\"variant: solid\">\n            <View gap={4} direction=\"row\">\n                <Button onClick={() => {}}>Button</Button>\n                <Button onClick={() => {}} color=\"primary\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"faded\">\n                    Button\n                </Button>\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"faded\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"outline\">\n                    Button\n                </Button>\n\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"outline\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: ghost\">\n            <View direction=\"row\" gap={4}>\n                <Button onClick={() => {}} variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"primary\" variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"critical\" variant=\"ghost\">\n                    Button\n                </Button>\n                <Button onClick={() => {}} color=\"positive\" variant=\"ghost\">\n                    Button\n                </Button>\n                <View padding={4} borderRadius=\"medium\" attributes={{ style: { color: \"#029CFD\" } }}>\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n\n                <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n                <View padding={4} backgroundColor=\"white\" borderRadius=\"medium\">\n                    <Button onClick={() => {}} color=\"inherit\" variant=\"ghost\">\n                        Inherit\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"color: media\">\n            <View backgroundColor=\"primary\" borderRadius=\"medium\" padding={4} direction=\"row\" gap={4}>\n                <Button onClick={() => {}} color=\"media\">\n                    Button\n                </Button>\n\n                <Button onClick={() => {}} color=\"media\" variant=\"faded\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Button onClick={() => {}} icon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"endIcon\">\n            <Button onClick={() => {}} endIcon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"icon, endIcon\">\n            <Button onClick={() => {}} icon={IconZap} endIcon={IconZap}>\n                Button\n            </Button>\n        </Example.Item>\n\n        <Example.Item title=\"icon only\">\n            <Button onClick={() => {}} icon={IconZap} attributes={{ \"aria-label\": \"Action\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"small\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"small\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Button icon={IconZap}>Button</Button>\n                <Button variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"large\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"large\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <View gap={4} direction=\"row\">\n                <Button size=\"xlarge\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"xlarge\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button size=\"xlarge\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large, [m+] medium\">\n            <Button size={{ s: \"large\", m: \"medium\" }} icon={IconZap}>\n                Responsive\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated, color: neutral\">\n            <View direction=\"row\" gap={4}>\n                <Button elevated onClick={() => {}}>\n                    Button\n                </Button>\n                <Button elevated variant=\"outline\" onClick={() => {}}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"elevated, color\">\n            <View direction=\"row\" gap={4}>\n                <Button elevated color=\"primary\">\n                    Button\n                </Button>\n                <Button elevated variant=\"outline\" color=\"primary\">\n                    Button\n                </Button>\n                <View backgroundColor=\"primary\" padding={4} borderRadius=\"medium\">\n                    <Button color=\"media\" elevated>\n                        Button\n                    </Button>\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded, size: small, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" size=\"small\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, size: medium, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, size: large, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"outline\" size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button rounded variant=\"ghost\" size=\"large\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"rounded, icon only, all sizes\">\n            <View gap={3} direction=\"row\">\n                <Button rounded size=\"small\" icon={IconZap} />\n                <Button rounded icon={IconZap} />\n                <Button rounded size=\"large\" icon={IconZap} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--full-width",
 					"name": "fullWidth",
 					"snippet": "const fullWidth = () => (\n    <Example>\n        <Example.Item title=\"fullWidth, all variants\">\n            <View gap={3}>\n                <Button fullWidth>Neutral</Button>\n                <Button fullWidth variant=\"faded\">\n                    Faded\n                </Button>\n                <Button fullWidth variant=\"outline\">\n                    Outline\n                </Button>\n                <Button fullWidth variant=\"ghost\">\n                    Ghost\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive fullWidth\", \"[s] true\", \"[m+] false\"]}>\n            <Button fullWidth={{ s: true, m: false }}>Button</Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--loading",
 					"name": "loading",
 					"snippet": "const loading = () => (\n    <Example>\n        <Example.Item title=\"loading, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"loading, color critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"critical\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"loading, color positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"faded\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"outline\">\n                    Button\n                </Button>\n                <Button loading loadingAriaLabel=\"Loading\" color=\"positive\" variant=\"ghost\">\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"loading, color: media\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n\n                <div style={{ position: \"absolute\", top: 16, left: 16 }}>\n                    <View gap={3} direction=\"row\">\n                        <Button color=\"media\" loading loadingAriaLabel=\"Loading\">\n                            Button\n                        </Button>\n                        <Button color=\"media\" variant=\"faded\" loading loadingAriaLabel=\"Loading\">\n                            Button\n                        </Button>\n                    </View>\n                </div>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"loading, long button text\", \"button size should stay the same\"]}>\n            <Button loading loadingAriaLabel=\"Loading\" color=\"primary\">\n                Long button text\n            </Button>\n        </Example.Item>\n\n        <Example.Item title={[\"loading, icon only\", \"button keep square 1/1 ratio\"]}>\n            <Button icon={IconZap} rounded loading loadingAriaLabel=\"Loading\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--highlighted",
 					"name": "highlighted",
 					"snippet": "const highlighted = () => (\n    <Example>\n        <Example.Item title=\"highlighted, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"highlighted, color: critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted color=\"critical\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"critical\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"highlighted, color: positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button highlighted color=\"positive\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button highlighted color=\"positive\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, color: neutral, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled icon={IconZap} onClick={() => {}}>\n                    Button\n                </Button>\n                <Button disabled variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"disabled, color: critical, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled color=\"critical\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"critical\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"disabled, color: positive, all variants\">\n            <View gap={3} direction=\"row\">\n                <Button disabled color=\"positive\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"faded\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"outline\" icon={IconZap}>\n                    Button\n                </Button>\n                <Button disabled color=\"positive\" variant=\"ghost\" icon={IconZap}>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"disabled, color: media\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n\n                <div style={{ position: \"absolute\", top: 16, left: 16 }}>\n                    <View gap={3} direction=\"row\">\n                        <Button color=\"media\" disabled>\n                            Button\n                        </Button>\n                        <Button color=\"media\" variant=\"faded\" disabled>\n                            Button\n                        </Button>\n                    </View>\n                </div>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner: all\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>Content</View.Item>\n                <Button.Aligner>\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: top\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"top\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: top and end\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side={[\"top\", \"end\"]}>\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: bottom\">\n            <View padding={4} borderColor=\"neutral-faded\" direction=\"row\" gap={2} align=\"end\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"bottom\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: start\">\n            <View padding={4} borderColor=\"neutral-faded\" gap={2} align=\"start\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"start\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"aligner: end\">\n            <View padding={4} borderColor=\"neutral-faded\" gap={2} align=\"end\">\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n                <Button.Aligner side=\"end\">\n                    <Button icon={IconZap} variant=\"ghost\" />\n                </Button.Aligner>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "components-button--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"slot gap\">\n            <Button variant=\"outline\">\n                <Avatar size={6} initials=\"RS\" />\n                Label\n                <Hotkey>B</Hotkey>\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-button--href",
 					"name": "href",
 					"snippet": "const href = () => <Button href=\"https://reshaped.so\">Trigger</Button>;"
 				},
 				{
+					"id": "components-button--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Button onClick={fn()}>Trigger</Button>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-button--href-on-click",
+					"name": "href, onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <Button\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </Button>\n);"
 				},
 				{
+					"id": "components-button--as",
 					"name": "as",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"as: span\">\n            <Button onClick={() => {}} as=\"span\">\n                Trigger\n            </Button>\n        </Example.Item>\n        <Example.Item title=\"render, disabled\">\n            <Button\n                disabled\n                onClick={() => {}}\n                render={(props) => <section {...props} />}\n                attributes={{ \"data-testid\": \"render-el\" }}\n            >\n                Trigger\n            </Button>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-button--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Button className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Button>\n    </div>\n);"
 				},
 				{
+					"id": "components-button--group",
 					"name": "group",
 					"snippet": "const group = () => (\n    <Example>\n        <Example.Item title=\"with icon\">\n            <Button.Group>\n                <Button rounded>Submit</Button>\n                <Button rounded icon={IconZap} />\n            </Button.Group>\n        </Example.Item>\n        <Example.Item title=\"variant: solid\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\", \"media\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color}>One</Button>\n                        <Button color={color}>Two</Button>\n                        <Button color={color}>Three</Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: outline\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"outline\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"outline\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"outline\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n        <Example.Item title=\"variant: faded\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\", \"media\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"faded\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"faded\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"faded\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"variant: ghost\">\n            <View gap={2}>\n                {([\"neutral\", \"primary\", \"critical\", \"positive\"] as const).map((color) => (\n                    <Button.Group key={color}>\n                        <Button color={color} variant=\"ghost\">\n                            One\n                        </Button>\n                        <Button color={color} variant=\"ghost\">\n                            Two\n                        </Button>\n                        <Button color={color} variant=\"ghost\">\n                            Three\n                        </Button>\n                    </Button.Group>\n                ))}\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "groupClassName",
+					"id": "components-button--group-class-name",
+					"name": "group className, attributes",
 					"snippet": "const groupClassName = () => (\n    <div data-testid=\"root\">\n        <Button.Group className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Button>Trigger</Button>\n        </Button.Group>\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Button, Example, Hotkey, Image, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Button/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Button",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Button/Button.tsx",
-				"actualName": "Button",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"solid\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"ghost\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"ghost\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loading": {
+						"defaultValue": null,
+						"description": "Show loading state",
+						"name": "loading",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loadingAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the loading indicator",
+						"name": "loadingAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Make the component take the full width of the parent element",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "highlighted",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Button"
 			}
 		},
 		"components-calendar": {
@@ -382,54 +2223,363 @@
 			"path": "./src/components/Calendar/tests/Calendar.stories.tsx",
 			"stories": [
 				{
+					"id": "components-calendar--default-month",
 					"name": "defaultMonth",
 					"snippet": "const defaultMonth = () => (\n    <Example>\n        <Example.Item title=\"defaultMonth: 2020 January\">\n            <Calendar defaultMonth={new Date(2020, 0)} range />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "uncontrolled",
+					"id": "components-calendar--uncontrolled",
+					"name": "defaultValue, range",
 					"snippet": "const uncontrolled = () => <Example>\n    <Example.Item title=\"defaultValue\">\n        <Calendar\n            defaultMonth={new Date(2020, 0)}\n            defaultValue={new Date(2020, 0, 10)}\n            onChange={fn()} />\n    </Example.Item>\n    <Example.Item title=\"defaultValue, range\">\n        <Calendar\n            range\n            defaultMonth={new Date(2020, 0)}\n            defaultValue={{ start: new Date(2020, 0, 10), end: new Date(2020, 0, 15) }}\n            onChange={fn()} />\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "controlled",
+					"id": "components-calendar--controlled",
+					"name": "value, range",
 					"snippet": "const controlled = () => <Example>\n    <Example.Item title=\"value\">\n        <Calendar\n            defaultMonth={new Date(2020, 0)}\n            value={new Date(2020, 0, 10)}\n            onChange={fn()} />\n    </Example.Item>\n    <Example.Item title=\"defaultValue, range\">\n        <Calendar\n            range\n            defaultMonth={new Date(2020, 0)}\n            value={{ start: new Date(2020, 0, 10), end: new Date(2020, 0, 15) }}\n            onChange={fn()} />\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-calendar--selected-dates",
 					"name": "selectedDates",
 					"snippet": "const selectedDates = () => (\n    <Example>\n        <Example.Item title=\"selectedDates: [4,8]\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                value={null}\n                selectedDates={[new Date(2020, 0, 4), new Date(2020, 0, 8)]}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "minMax",
+					"id": "components-calendar--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <Example>\n        <Example.Item title=\"min: 4, max: 20\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                min={new Date(2020, 0, 4)}\n                max={new Date(2020, 0, 20)}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-calendar--first-week-day",
 					"name": "firstWeekDay",
 					"snippet": "const firstWeekDay = () => (\n    <Example>\n        <Example.Item title=\"firstWeekDay: 3 (Wed)\">\n            <Calendar defaultMonth={new Date(2020, 0)} firstWeekDay={3} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "translation",
+					"id": "components-calendar--translation",
+					"name": "render functions",
 					"snippet": "const translation = () => (\n    <Example>\n        <Example.Item title=\"translated to NL\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                renderMonthLabel={({ date }) => date.toLocaleDateString(\"nl\", { month: \"short\" })}\n                renderSelectedMonthLabel={({ date }) =>\n                    date.toLocaleDateString(\"nl\", { month: \"long\", year: \"numeric\" })\n                }\n                renderWeekDay={({ date }) => date.toLocaleDateString(\"nl\", { weekday: \"short\" })}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "ariaLabels",
+					"id": "components-calendar--aria-labels",
+					"name": "aria labels",
 					"snippet": "const ariaLabels = () => (\n    <Example>\n        <Example.Item title=\"aria labels\">\n            <Calendar\n                defaultMonth={new Date(2020, 0)}\n                nextYearAriaLabel=\"Test next year\"\n                nextMonthAriaLabel=\"Test next month\"\n                renderDateAriaLabel={() => \"Test date\"}\n                renderMonthAriaLabel={() => \"Test month\"}\n                previousYearAriaLabel=\"Test previous year\"\n                previousMonthAriaLabel=\"Test previous month\"\n                monthSelectionAriaLabel=\"Test month selection\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "monthSelection",
+					"id": "components-calendar--month-selection",
+					"name": "test: month selection",
 					"snippet": "const monthSelection = () => (\n    <Example>\n        <Example.Item title=\"month selection\">\n            <Calendar defaultMonth={new Date(2020, 1)} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "keyboardNavigation",
+					"id": "components-calendar--keyboard-navigation",
+					"name": "test: keyboard navigation",
 					"snippet": "const keyboardNavigation = () => (\n    <Example>\n        <Example.Item title=\"keyboard navigation\">\n            <Calendar defaultMonth={new Date(2020, 0)} />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Calendar, Example } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Calendar/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Calendar",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Calendar/Calendar.tsx",
-				"actualName": "Calendar",
+				"methods": [],
+				"props": {
+					"range": {
+						"defaultValue": null,
+						"description": "Disable range selection\nEnable range selection",
+						"name": "range",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Current selected date value, enables controlled mode\nCurrent selected range value, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date | RangeValue | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default selected date value, enables uncontrolled mode\nDefault selected range value, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date | RangeValue" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when date selection changes\nCallback when range selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { value: Date; }) => void) | ((args: { value: Date; }) => void) | ((args: { value: RangeValue; }) => void) | ((args: { value: RangeValue; }) => void)"
+						}
+					},
+					"defaultMonth": {
+						"defaultValue": { "value": "Date.now()" },
+						"description": "Default month to display",
+						"name": "defaultMonth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum date that can be selected",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum date that can be selected",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date" }
+					},
+					"firstWeekDay": {
+						"defaultValue": { "value": "1, Monday" },
+						"description": "First day of the week",
+						"name": "firstWeekDay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"selectedDates": {
+						"defaultValue": null,
+						"description": "Dates that are selected",
+						"name": "selectedDates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Date[]" }
+					},
+					"renderWeekDay": {
+						"defaultValue": null,
+						"description": "Render a custom weekday label, can be used for localization",
+						"name": "renderWeekDay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { weekDay: number; date: Date; }) => string)" }
+					},
+					"renderSelectedMonthLabel": {
+						"defaultValue": null,
+						"description": "Render a custom month label, can be used for localization",
+						"name": "renderSelectedMonthLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { date: Date; }) => string)" }
+					},
+					"renderMonthLabel": {
+						"defaultValue": null,
+						"description": "Render a custom month label, can be used for localization",
+						"name": "renderMonthLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { month: number; date: Date; }) => string)" }
+					},
+					"previousMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the previous month button",
+						"name": "previousMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"nextMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "",
+						"name": "nextMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"previousYearAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the previous year button",
+						"name": "previousYearAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"nextYearAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the next year button",
+						"name": "nextYearAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"monthSelectionAriaLabel": {
+						"defaultValue": null,
+						"description": "Aria label for the month selection button",
+						"name": "monthSelectionAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"renderDateAriaLabel": {
+						"defaultValue": null,
+						"description": "Dynamic aria label applied to each date cell based on the arguments",
+						"name": "renderDateAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { date: Date; }) => string)" }
+					},
+					"renderMonthAriaLabel": {
+						"defaultValue": null,
+						"description": "Dynamic aria label applied to each month element based on the arguments",
+						"name": "renderMonthAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Calendar/Calendar.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { month: number; }) => string)" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -439,50 +2589,356 @@
 			"path": "./src/components/Card/tests/Card.stories.tsx",
 			"stories": [
 				{
+					"id": "components-card--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: default\">\n            <Card>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title=\"padding: 2\">\n            <Card padding={2}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title=\"padding: 0\">\n            <Card padding={0}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive padding\", \"[s] 4\", \"[m+] 8\"]}>\n            <Card padding={{ s: 4, m: 8 }}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--selected",
 					"name": "selected",
 					"snippet": "const selected = () => (\n    <Example>\n        <Example.Item title=\"selected\">\n            <Card selected>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--elevated",
 					"name": "elevated",
 					"snippet": "const elevated = () => (\n    <Example>\n        <Example.Item title=\"elevated\">\n            <Card elevated>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4\">\n            <Card bleed={4}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n        <Example.Item title={[\"responsive bleed\", \"[s] 4\", \"[m+] 0\"]}>\n            <Card bleed={{ s: 4, m: 0 }}>\n                <Placeholder />\n            </Card>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--height",
 					"name": "height",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"height: 200px\">\n            <Card height=\"200px\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-card--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Card onClick={fn()}>Trigger</Card>;"
 				},
 				{
+					"id": "components-card--href",
 					"name": "href",
 					"snippet": "const href = () => <Card href=\"https://reshaped.so\">Trigger</Card>;"
 				},
 				{
+					"id": "components-card--as",
 					"name": "as",
 					"snippet": "const as = () => <Card as=\"span\" attributes={{ \"data-testid\": \"root\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-card--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Card className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Card, Example, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Card/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Card",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Card/Card.tsx",
-				"actualName": "Card",
+				"methods": [],
+				"props": {
+					"padding": {
+						"defaultValue": null,
+						"description": "Component padding, base unit multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Remove side borders and apply negative margins, base unit multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"selected": {
+						"defaultValue": null,
+						"description": "Highlight the component when component is used for an active state",
+						"name": "selected",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when the component is clicked, turns component into a button",
+						"name": "onClick",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL to navigate to when the component is clicked, turns component into a link",
+						"name": "href",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"as": {
+						"defaultValue": { "value": "\"div\"" },
+						"description": "Custom component tag name",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Card/Card.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(Attributes<keyof IntrinsicElements> & (Attributes))" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -492,56 +2948,181 @@
 			"path": "./src/components/Carousel/tests/Carousel.stories.tsx",
 			"stories": [
 				{
+					"id": "components-carousel--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Carousel attributes={{ \"data-testid\": \"test-id\" }} visibleItems={3}>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n        <Placeholder h={100}>Content</Placeholder>\n    </Carousel>\n);"
 				},
 				{
+					"id": "components-carousel--visible-items",
 					"name": "visibleItems",
 					"snippet": "const visibleItems = () => (\n    <Example>\n        <Example.Item title=\"visibleItems: 3\">\n            <Carousel visibleItems={3}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive visibleItems\", \"s: 2, m+ 3\"]}>\n            <Carousel visibleItems={{ s: 2, m: 3 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title=\"visibleItems: auto\">\n            <Carousel>\n                <Placeholder h={100} />\n                <Placeholder h={100} w={200} />\n                <Placeholder h={100} w={300} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 2, visibleItems 3\">\n            <Carousel visibleItems={3} gap={2}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"gap: responsive, visibleItems: 3\", \"s: 2, l: 8\"]}>\n            <Carousel visibleItems={3} gap={{ s: 2, l: 8 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example>\n        <Example.Item title=\"bleed: 4, visibleItems: 3\">\n            <Carousel visibleItems={3} bleed={4}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive bleed, visibleItems: 3\", \"[s] 4, [l+] 0\"]}>\n            <Carousel visibleItems={3} bleed={{ s: 4, l: 0 }}>\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-carousel--navigation-display",
 					"name": "navigationDisplay",
 					"snippet": "const navigationDisplay = () => (\n    <Example>\n        <Example.Item title=\"navigationDisplay: hidden\">\n            <Carousel\n                visibleItems={3}\n                navigationDisplay=\"hidden\"\n                attributes={{ \"data-testid\": \"test-id\" }}\n            >\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n                <Placeholder h={100} />\n            </Carousel>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "instanceRef",
+					"id": "components-carousel--instance-ref",
+					"name": "instanceRef, onChange",
 					"snippet": "const instanceRef = (args) => {\n    const carouselRef = React.useRef<CarouselInstanceRef>(null);\n    const [index, setIndex] = React.useState(0);\n\n    return (\n        <Example>\n            <Example.Item title=\"instanceRef, onChange\">\n                <View gap={3}>\n                    <View gap={3} direction=\"row\" align=\"center\">\n                        <Button onClick={() => carouselRef.current?.navigateBack()}>Back</Button>\n                        <Button onClick={() => carouselRef.current?.navigateForward()}>Forward</Button>\n                        <Button onClick={() => carouselRef.current?.navigateTo(3)}>To 3</Button>\n                        <View.Item>Index: {index}</View.Item>\n                    </View>\n                    <Carousel\n                        visibleItems={2}\n                        instanceRef={carouselRef}\n                        navigationDisplay=\"hidden\"\n                        onChange={(changeArgs) => {\n                            args.handleChange(changeArgs);\n                            setIndex(changeArgs.index);\n                        }}\n                    >\n                        <Placeholder h={100}>Item 0</Placeholder>\n                        <Placeholder h={100}>Item 1</Placeholder>\n                        <Placeholder h={100}>Item 2</Placeholder>\n                        <Placeholder h={100}>Item 3</Placeholder>\n                        <Placeholder h={100}>Item 4</Placeholder>\n                        <Placeholder h={100}>Item 5</Placeholder>\n                    </Carousel>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-carousel--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Carousel visibleItems={2} className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder h={100}>Item 0</Placeholder>\n            <Placeholder h={100}>Item 1</Placeholder>\n            <Placeholder h={100}>Item 2</Placeholder>\n            <Placeholder h={100}>Item 3</Placeholder>\n            <Placeholder h={100}>Item 4</Placeholder>\n            <Placeholder h={100}>Item 5</Placeholder>\n        </Carousel>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Carousel, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Carousel/index.ts",
 				"description": "",
-				"methods": [
-					{
-						"name": "navigateTo",
-						"docblock": null,
-						"modifiers": [],
-						"params": [
+				"displayName": "Carousel",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, each child is rendered as a carousel item",
+						"name": "children",
+						"declarations": [
 							{
-								"name": "index",
-								"optional": false,
-								"type": { "name": "number" }
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
 							}
 						],
-						"returns": null
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"visibleItems": {
+						"defaultValue": null,
+						"description": "Number of items visible at once in the container",
+						"name": "visibleItems",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between items in the container, base unit multiplier",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margins, base unit multiplier, can be used to make sure the items don't get clipped when scrolling",
+						"name": "bleed",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"navigationDisplay": {
+						"defaultValue": null,
+						"description": "Hide navigation controls",
+						"name": "navigationDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"hidden\"", "value": [{ "value": "\"hidden\"" }] }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the carousel methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the first visible carousel index changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { index: number; }) => void)" }
+					},
+					"onScroll": {
+						"defaultValue": null,
+						"description": "Callback when the carousel scrolls",
+						"name": "onScroll",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: UIEvent<HTMLUListElement, UIEvent>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Carousel/Carousel.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
 					}
-				],
-				"displayName": "Carousel",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Carousel/Carousel.tsx",
-				"actualName": "Carousel",
+				},
 				"exportName": "default"
 			}
 		},
@@ -551,46 +3132,259 @@
 			"path": "./src/components/Checkbox/tests/Checkbox.stories.tsx",
 			"stories": [
 				{
-					"name": "render",
+					"id": "components-checkbox--render",
+					"name": "name, value",
 					"snippet": "const render = () => (\n    <Checkbox name=\"test-name\" value=\"test-value\">\n        Content\n    </Checkbox>\n);"
 				},
 				{
+					"id": "components-checkbox--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"small\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"small\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"medium\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"medium\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size=\"large\" defaultChecked>\n                    Checkbox\n                </Checkbox>\n                <Checkbox name=\"animal\" value=\"dog\" size=\"large\" indeterminate>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: responsive, s: small, m: large\">\n            <View gap={4} direction=\"row\">\n                <Checkbox name=\"animal\" value=\"dog\" size={{ s: \"small\", m: \"large\" }} defaultChecked>\n                    Checkbox\n                </Checkbox>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-checkbox--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Checkbox name=\"animal\" value=\"dog\" hasError>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-checkbox--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n        <Example.Item title=\"disabled, checked\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled checked>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n        <Example.Item title=\"disabled, indeterminate\">\n            <Checkbox name=\"animal\" value=\"dog\" disabled indeterminate>\n                Checkbox\n            </Checkbox>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "checked",
+					"id": "components-checkbox--checked",
+					"name": "checked, controlled",
 					"snippet": "const checked = () => <Checkbox name=\"test-name\" value=\"test-value\" checked onChange={fn()}>Content\n            </Checkbox>;"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-checkbox--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Checkbox name=\"test-name\" value=\"test-value\" defaultChecked onChange={fn()}>Content\n            </Checkbox>;"
 				},
 				{
+					"id": "components-checkbox--indeterminate",
 					"name": "indeterminate",
 					"snippet": "const indeterminate = () => (\n    <Checkbox name=\"test-name\" value=\"test-value\" indeterminate>\n        Content\n    </Checkbox>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-checkbox--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Checkbox className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Checkbox>\n    </div>\n);"
 				}
 			],
 			"import": "import { Checkbox, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Checkbox/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Checkbox",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Checkbox/Checkbox.tsx",
-				"actualName": "Checkbox",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the label",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Component name attribute",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the component",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Component value used for form submission",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"indeterminate": {
+						"defaultValue": null,
+						"description": "Show a indeterminate state, used for \"select all\" checkboxes with some of the individual checkboxes selected",
+						"name": "indeterminate",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the component is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the component is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Component checked state, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default checked state, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Checkbox/Checkbox.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -600,26 +3394,143 @@
 			"path": "./src/components/CheckboxGroup/tests/CheckboxGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "value",
+					"id": "components-checkboxgroup--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <View gap={2}>\n    <CheckboxGroup name=\"test-name\" value={[\"1\"]} onChange={fn()}>\n        {/* checked should be ignored */}\n        <Checkbox value=\"1\" checked={false}>Content\n                            </Checkbox>\n        <Checkbox value=\"2\">Content 2</Checkbox>\n    </CheckboxGroup>\n</View>;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-checkboxgroup--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <View gap={2}>\n    <CheckboxGroup name=\"test-name\" defaultValue={[\"1\"]} onChange={fn()}>\n        {/* checked should be ignored */}\n        <Checkbox value=\"1\" checked={false}>Content\n                            </Checkbox>\n        <Checkbox value=\"2\">Content 2</Checkbox>\n    </CheckboxGroup>\n</View>;"
 				},
 				{
+					"id": "components-checkboxgroup--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <CheckboxGroup name=\"test-name\" disabled>\n        <Checkbox value=\"test-value\">Item 1</Checkbox>\n        <Checkbox value=\"test-value-2\">Item 2</Checkbox>\n    </CheckboxGroup>\n);"
 				}
 			],
 			"import": "import { Checkbox, CheckboxGroup, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/CheckboxGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "CheckboxGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/CheckboxGroup/CheckboxGroup.tsx",
-				"actualName": "CheckboxGroup",
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Component id attribute",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting checkboxes or custom layout components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the component from form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Component name attribute",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component selection changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string[], ChangeEvent<HTMLInputElement>>" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Component value, enables controlled mode\nComponent value, enables uncontrolled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/CheckboxGroup/CheckboxGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -629,23 +3540,346 @@
 			"path": "./src/components/ContextMenu/tests/ContextMenu.stories.tsx",
 			"stories": [
 				{
+					"id": "components-contextmenu--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"base\">\n            <div style={{ height: 200, overflow: \"auto\" }}>\n                <ContextMenu>\n                    <View height=\"400px\" backgroundColor=\"neutral-faded\" borderRadius=\"medium\" />\n\n                    <ContextMenu.Content>\n                        <ContextMenu.Item>Item 1</ContextMenu.Item>\n                        <ContextMenu.Item>Item 2</ContextMenu.Item>\n                    </ContextMenu.Content>\n                </ContextMenu>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "components-contextmenu--handlers",
+					"name": "handleOpen, handleClose",
 					"snippet": "const handlers = () => <div style={{ height: 200, overflow: \"auto\" }} data-testid=\"scroll\">\n    <ContextMenu onOpen={fn()} onClose={fn()}>\n        <View\n            height=\"400px\"\n            backgroundColor=\"neutral-faded\"\n            borderRadius=\"medium\"\n            attributes={{ \"data-testid\": \"root\" }} />\n        <ContextMenu.Content>\n            <ContextMenu.Item>Item</ContextMenu.Item>\n        </ContextMenu.Content>\n    </ContextMenu>\n</div>;"
 				}
 			],
 			"import": "import { ContextMenu, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ContextMenu/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ContextMenu",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ContextMenu/ContextMenu.tsx",
-				"actualName": "ContextMenu",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/DropdownMenu/DropdownMenu.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | \"action-menu\" | \"selection-menu\"" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					}
+				},
+				"exportName": "ContextMenu"
 			}
 		},
 		"components-divider": {
@@ -654,30 +3888,118 @@
 			"path": "./src/components/Divider/tests/Divider.stories.tsx",
 			"stories": [
 				{
-					"name": "rendering",
+					"id": "components-divider--rendering",
+					"name": "base",
 					"snippet": "const rendering = () => (\n    <Example>\n        <Example.Item title=\"default rendering\">\n            <Divider />\n        </Example.Item>\n\n        <Example.Item title={[\"blank rendering\", \"box should overlap with divider\"]}>\n            <View width=\"40px\" height=\"10px\" backgroundColor=\"primary\" />\n            <Divider blank />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-divider--vertical",
 					"name": "vertical",
 					"snippet": "const vertical = () => (\n    <Example>\n        <Example.Item title=\"vertical\">\n            <View gap={3} direction=\"row\" align=\"stretch\">\n                <Placeholder />\n                <View.Item>\n                    <Divider vertical />\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive vertical\", \"[s] true\", \"[m+]: false\"]}>\n            <View gap={3} direction={{ s: \"row\", m: \"column\" }} align=\"stretch\">\n                <Placeholder />\n                <View.Item>\n                    <Divider vertical={{ s: true, m: false }} />\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "label",
+					"id": "components-divider--label",
+					"name": "children, contentPosition",
 					"snippet": "const label = () => {\n    return (\n        <Example>\n            <Example.Item title=\"alignment\">\n                <View gap={4}>\n                    <Divider>Centered label</Divider>\n                    <Divider contentPosition=\"start\">Start label</Divider>\n                    <Divider contentPosition=\"end\">End label</Divider>\n                </View>\n            </Example.Item>\n\n            <Example.Item title=\"responsive\">\n                <View gap={3} direction={{ s: \"column\", m: \"row\" }} align=\"stretch\">\n                    <Placeholder />\n                    <View.Item>\n                        <Divider vertical={{ s: false, m: true }}>or pick second option</Divider>\n                    </View.Item>\n                    <Placeholder />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-divider--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Divider className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Divider, Example, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Divider/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Divider",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Divider/Divider.tsx",
-				"actualName": "Divider",
+				"methods": [],
+				"props": {
+					"blank": {
+						"defaultValue": null,
+						"description": "Change component to take no space, useful for using it as a border in components like Tabs",
+						"name": "blank",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"vertical": {
+						"defaultValue": null,
+						"description": "Change component to render vertically",
+						"name": "vertical",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"contentPosition": {
+						"defaultValue": null,
+						"description": "Position for rendering children",
+						"name": "contentPosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"center\" | \"start\" | \"end\"",
+							"value": [{ "value": "\"center\"" }, { "value": "\"start\"" }, { "value": "\"end\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting text labels or custom components as a part of divider",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Divider/Divider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"hr\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -687,51 +4009,415 @@
 			"path": "./src/components/DropdownMenu/tests/DropdownMenu.stories.tsx",
 			"stories": [
 				{
+					"id": "components-dropdownmenu--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: default\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <DropdownMenu position=\"end\">\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n\n        <Example.Item title={[\"position: top-start\", \"should change to top-start to fit viewport\"]}>\n            <DropdownMenu position=\"top-end\">\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item icon={IconCheckmark}>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n        <div style={{ height: 2000 }} />\n    </Example>\n);"
 				},
 				{
+					"id": "components-dropdownmenu--sections",
 					"name": "sections",
 					"snippet": "const sections = () => (\n    <Example>\n        <Example.Item title=\"2 sections\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Section>\n                        <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                    </DropdownMenu.Section>\n\n                    <DropdownMenu.Section>\n                        <DropdownMenu.Item>Item 3</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 4</DropdownMenu.Item>\n                    </DropdownMenu.Section>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-dropdownmenu--submenu",
 					"name": "submenu",
 					"snippet": "const submenu = () => (\n    <Example>\n        <Example.Item title=\"submenu\">\n            <DropdownMenu>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item onClick={() => {}}>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger>Item 2</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger>Item 3</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2-1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 2-2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n\n                    <DropdownMenu.SubMenu>\n                        <DropdownMenu.SubTrigger disabled>Item 4, disabled</DropdownMenu.SubTrigger>\n                        <DropdownMenu.Content>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 3-1</DropdownMenu.Item>\n                            <DropdownMenu.Item onClick={() => {}}>SubItem 3-2</DropdownMenu.Item>\n                        </DropdownMenu.Content>\n                    </DropdownMenu.SubMenu>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-dropdownmenu--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <DropdownMenu onOpen={fn()} onClose={fn()} defaultActive>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "active",
+					"id": "components-dropdownmenu--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <DropdownMenu onOpen={fn()} onClose={fn()} active>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "components-dropdownmenu--active-false",
+					"name": "active false, controlled",
 					"snippet": "const activeFalse = () => <DropdownMenu onOpen={fn()} onClose={fn()} active={false}>\n    <DropdownMenu.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </DropdownMenu.Trigger>\n    <DropdownMenu.Content>\n        <DropdownMenu.Item>Item</DropdownMenu.Item>\n    </DropdownMenu.Content>\n</DropdownMenu>;"
 				},
 				{
-					"name": "className",
+					"id": "components-dropdownmenu--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <DropdownMenu active>\n            <DropdownMenu.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </DropdownMenu.Trigger>\n            <DropdownMenu.Content className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n                <DropdownMenu.Item>Item</DropdownMenu.Item>\n            </DropdownMenu.Content>\n        </DropdownMenu>\n    </div>\n);"
 				},
 				{
-					"name": "testScroll",
+					"id": "components-dropdownmenu--test-scroll",
+					"name": "test: scroll",
 					"snippet": "const testScroll = () => (\n    <Example>\n        <Example.Item title=\"Scrolls on page mount to the dropdown\">\n            <div style={{ height: 1000 }} />\n            <DropdownMenu position=\"end\" key=\"scroll\" defaultActive>\n                <DropdownMenu.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </DropdownMenu.Trigger>\n                <DropdownMenu.Content>\n                    <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                    <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                </DropdownMenu.Content>\n            </DropdownMenu>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testTheme",
+					"id": "components-dropdownmenu--test-theme",
+					"name": "test: theme",
 					"snippet": "const testTheme = () => (\n    <Example>\n        <Example.Item title=\"switch color mode while dropdown is active and check that it still works\">\n            <ThemeSwitching />\n        </Example.Item>\n        <Example.Item title=\"dropdown inherits multiple themes\">\n            <ThemeMultiple />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, DropdownMenu, Example, Theme, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/DropdownMenu/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "DropdownMenu",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/DropdownMenu/DropdownMenu.tsx",
-				"actualName": "DropdownMenu",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/DropdownMenu/DropdownMenu.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | \"action-menu\" | \"selection-menu\"" }
+					}
+				},
+				"exportName": "DropdownMenu"
 			}
 		},
 		"components-fileupload": {
@@ -740,35 +4426,165 @@
 			"path": "./src/components/FileUpload/tests/FileUpload.stories.tsx",
 			"stories": [
 				{
+					"id": "components-fileupload--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"Base upload with previews\">\n            <Demo />\n        </Example.Item>\n        <Example.Item title=\"With trigger\">\n            <FileUpload name=\"file\">\n                <div>\n                    Drop files to attach, or{\" \"}\n                    <FileUpload.Trigger>\n                        <Link variant=\"plain\">browse</Link>\n                    </FileUpload.Trigger>\n                </div>\n            </FileUpload>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "inline",
+					"id": "components-fileupload--inline",
+					"name": "inline, variant, render props",
 					"snippet": "const inline = () => {\n    return (\n        <Example>\n            <Example.Item title=\"inline\">\n                <FileUpload name=\"file\" inline onChange={console.log}>\n                    <View padding={2} paddingInline={3}>\n                        Upload\n                    </View>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"variant headless\">\n                <FileUpload name=\"file2\" variant=\"headless\" onChange={console.log}>\n                    <Button variant=\"outline\" fullWidth>\n                        Upload\n                    </Button>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"variant headless, inline\">\n                <FileUpload name=\"file2\" variant=\"headless\" inline onChange={console.log}>\n                    <Button>Upload</Button>\n                </FileUpload>\n            </Example.Item>\n            <Example.Item title=\"inline, render props\">\n                <FileUpload name=\"file3\" variant=\"headless\" inline onChange={console.log}>\n                    {(props) => <Button highlighted={props.highlighted}>Upload</Button>}\n                </FileUpload>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-fileupload--height",
 					"name": "height",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"Custom height\">\n            <FileUpload name=\"file\" height=\"300px\">\n                <View gap={3}>\n                    <Icon svg={IconMic} size={8} />\n                    Drop files to attach\n                </View>\n            </FileUpload>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onChange",
+					"id": "components-fileupload--on-change",
+					"name": "name, onChange",
 					"snippet": "const onChange = () => <div data-testid=\"root\">\n    <FileUpload name=\"test-name\" onChange={fn()}>Content\n                    </FileUpload>\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "components-fileupload--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <FileUpload\n            name=\"name\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ id: \"test-input-id\" }}\n        >\n            Content\n        </FileUpload>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, FileUpload, Icon, Image, Link, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/FileUpload/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "FileUpload",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/FileUpload/FileUpload.tsx",
-				"actualName": "FileUpload",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, can be a render function that receives component state",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode | ((props: { highlighted?: boolean; }) => ReactNode)" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component value is changed",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ChangeHandler<File[], ChangeEvent<HTMLInputElement> | DragEvent<HTMLDivElement>>"
+						}
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Component height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component variant, headless variant is useful for rendering custom triggers like a Button",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"headless\"",
+							"value": [{ "value": "\"outline\"" }, { "value": "\"headless\"" }]
+						}
+					},
+					"inline": {
+						"defaultValue": null,
+						"description": "Change component to render inline making it more compact",
+						"name": "inline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FileUpload/FileUpload.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					}
+				},
+				"exportName": "FileUpload"
 			}
 		},
 		"components-hotkey": {
@@ -777,22 +4593,78 @@
 			"path": "./src/components/Hotkey/tests/Hotkey.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "components-hotkey--base",
+					"name": "Base",
 					"snippet": "const base = () => (\n\t<Example>\n\t\t<Example.Item title=\"Base\">\n\t\t\t<Demo />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"Active\">\n\t\t\t<Hotkey active>⌘K</Hotkey>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"Inside input slot\">\n\t\t\t<View width=\"300px\">\n\t\t\t\t<TextField\n\t\t\t\t\tname=\"hey\"\n\t\t\t\t\tendSlot={<Demo />}\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"hotkey test\" }}\n\t\t\t\t/>\n\t\t\t</View>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-hotkey--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Hotkey className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            ⌘K\n        </Hotkey>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Hotkey, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Hotkey/Hotkey.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Hotkey",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Hotkey/Hotkey.tsx",
-				"actualName": "Hotkey",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Highlight the component, can be used to show when hotkey is pressed",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hotkey/Hotkey.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -802,54 +4674,241 @@
 			"path": "./src/components/Link/tests/Link.stories.tsx",
 			"stories": [
 				{
+					"id": "components-link--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: underline\">\n            <Link href=\"http://reshaped.so\" attributes={{ target: \"_blank\" }}>\n                Reshaped\n            </Link>\n        </Example.Item>\n        <Example.Item title=\"variant: plain\">\n            <Link onClick={() => {}} variant=\"plain\">\n                Link\n            </Link>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary\">\n            <Link color=\"primary\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Link color=\"critical\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Link color=\"positive\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <Link color=\"warning\">Link</Link>\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <Link color=\"inherit\">Link</Link>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon, variant: underline\">\n            <Link icon={IconZap}>Link</Link>\n        </Example.Item>\n        <Example.Item title=\"icon, variant: plain\">\n            <Link icon={IconZap} variant=\"plain\">\n                Link\n            </Link>\n        </Example.Item>\n        <Example.Item\n            title={[\"icon, variant: underline\", \"should inherit display-1 size from the parent\"]}\n        >\n            <Text variant=\"title-3\">\n                <Link icon={IconZap} variant=\"underline\">\n                    Instant delivery\n                </Link>\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-link--href",
 					"name": "href",
 					"snippet": "const href = () => <Link href=\"https://reshaped.so\">Trigger</Link>;"
 				},
 				{
+					"id": "components-link--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <Link onClick={fn()}>Trigger</Link>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-link--href-on-click",
+					"name": "href + onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <Link\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </Link>\n);"
 				},
 				{
+					"id": "components-link--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Link disabled onClick={() => {}}>\n        Trigger\n    </Link>\n);"
 				},
 				{
+					"id": "components-link--render",
 					"name": "render",
 					"snippet": "const render = () => <Link render={(props) => <section {...props} />}>Trigger</Link>;"
 				},
 				{
-					"name": "className",
+					"id": "components-link--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Link className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Link>\n    </div>\n);"
 				},
 				{
-					"name": "testMultilineInText",
+					"id": "components-link--test-multiline-in-text",
+					"name": "test: multiline",
 					"snippet": "const testMultilineInText = () => (\n    <Example>\n        <Example.Item title=\"should wrap inside the text\">\n            <div>\n                Someone asked me to write this text that is boring to ready for everyone and to add&nbsp;\n                <Link href=\"/\">this very very long link</Link> to it.\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Link, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Link/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Link",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Link/Link.tsx",
-				"actualName": "Link",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon at the start position",
+						"name": "icon",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"primary\"" },
+						"description": "Link color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"inherit\" | \"warning\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"inherit\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"variant": {
+						"defaultValue": { "value": "\"underline\"" },
+						"description": "Link render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Link/Link.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"plain\" | \"underline\"",
+							"value": [{ "value": "\"plain\"" }, { "value": "\"underline\"" }]
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -859,30 +4918,110 @@
 			"path": "./src/components/Loader/tests/Loader.stories.tsx",
 			"stories": [
 				{
+					"id": "components-loader--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: medium\">\n                <Loader size=\"medium\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title=\"size: small\">\n                <Loader size=\"small\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title=\"size: large\">\n                <Loader size=\"large\" ariaLabel=\"Loading\" />\n            </Example.Item>\n            <Example.Item title={[\"responsive size\", \"[s] small\", \"[m+] medium\"]}>\n                <Loader size={{ s: \"small\", m: \"medium\" }} ariaLabel=\"Loading\" />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-loader--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: primary\">\n            <Loader ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Loader color=\"critical\" ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Loader color=\"positive\" ariaLabel=\"Loading\" />\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <Loader color=\"inherit\" ariaLabel=\"Loading\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-loader--aria-label",
 					"name": "ariaLabel",
 					"snippet": "const ariaLabel = () => <Loader ariaLabel=\"Loading\" attributes={{ \"data-testid\": \"root\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-loader--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Loader className=\"test-classname\" attributes={{ id: \"test-id\" }} ariaLabel=\"Loading\" />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Loader } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Loader/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Loader",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Loader/Loader.tsx",
-				"actualName": "Loader",
+				"methods": [],
+				"props": {
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"positive\" | \"inherit\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Loader/Loader.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -892,67 +5031,504 @@
 			"path": "./src/components/MenuItem/tests/MenuItem.stories.tsx",
 			"stories": [
 				{
+					"id": "components-menuitem--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <MenuItem size=\"small\" icon={IconZap} onClick={() => {}} endSlot={<Hotkey>⌘K</Hotkey>}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <MenuItem icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <MenuItem size=\"large\" icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title={[\"responsive size\", \"[s] small\", \"[m] medium\", \"[l+] large\"]}>\n            <MenuItem size={{ s: \"small\", m: \"medium\", l: \"large\" }} icon={IconZap} onClick={() => {}}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <MenuItem color=\"neutral\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <MenuItem color=\"primary\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <MenuItem color=\"critical\" icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--selected",
 					"name": "selected",
 					"snippet": "const selected = () => (\n    <Example>\n        <Example.Item title=\"selected, color: neutral\">\n            <MenuItem color=\"neutral\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"selected, color: primary\">\n            <MenuItem color=\"primary\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n        <Example.Item title=\"selected, color: critical\">\n            <MenuItem color=\"critical\" selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--rounded-corners",
 					"name": "roundedCorners",
 					"snippet": "const roundedCorners = () => (\n    <Example>\n        <Example.Item title=\"roundedCorners\">\n            <MenuItem roundedCorners selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive roundedCorners\", \"[s]: false\", \"[m+]: true\"]}>\n            <MenuItem roundedCorners={{ s: false, m: true }} selected icon={IconZap}>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "slots",
+					"id": "components-menuitem--slots",
+					"name": "startSlot, endSlot",
 					"snippet": "const slots = () => (\n    <Example>\n        <Example.Item title=\"startSlot, endSlot, selected\">\n            <MenuItem startSlot={<Placeholder h={20} />} endSlot={<Placeholder h={20} />} selected>\n                Menu item\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem size=\"small\" selected onClick={() => {}}>\n                        Menu item\n                    </MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem selected>Menu item</MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <View gap={2}>\n                <Text variant=\"title-6\">Heading</Text>\n                <MenuItem.Aligner>\n                    <MenuItem size=\"large\" selected>\n                        Menu item\n                    </MenuItem>\n                </MenuItem.Aligner>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-menuitem--href",
 					"name": "href",
 					"snippet": "const href = () => <MenuItem href=\"https://reshaped.so\">Trigger</MenuItem>;"
 				},
 				{
+					"id": "components-menuitem--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <MenuItem onClick={fn()}>Trigger</MenuItem>;"
 				},
 				{
-					"name": "hrefOnClick",
+					"id": "components-menuitem--href-on-click",
+					"name": "href + onClick",
 					"snippet": "const hrefOnClick = (args) => (\n    <MenuItem\n        onClick={(e) => {\n            e.preventDefault();\n            args.handleClick(e);\n        }}\n        href=\"https://reshaped.so\"\n    >\n        Trigger\n    </MenuItem>\n);"
 				},
 				{
+					"id": "components-menuitem--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <MenuItem disabled onClick={() => {}}>\n        Trigger\n    </MenuItem>\n);"
 				},
 				{
-					"name": "as",
+					"id": "components-menuitem--as",
+					"name": "as, render",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"render, disabled\">\n            <MenuItem\n                disabled\n                onClick={() => {}}\n                render={(props) => <section {...props} />}\n                attributes={{ \"data-testid\": \"render-el\" }}\n            >\n                Trigger\n            </MenuItem>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-menuitem--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <MenuItem className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </MenuItem>\n    </div>\n);"
 				},
 				{
-					"name": "alignerClassName",
+					"id": "components-menuitem--aligner-class-name",
+					"name": "aligner, className, attributes",
 					"snippet": "const alignerClassName = () => (\n    <div data-testid=\"root\">\n        <MenuItem.Aligner className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <MenuItem>Trigger</MenuItem>\n        </MenuItem.Aligner>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Hotkey, MenuItem, Placeholder, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/MenuItem/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "MenuItem",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/MenuItem/MenuItem.tsx",
-				"actualName": "MenuItem",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content\nNode for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"primary\" | \"critical\" | \"neutral\"",
+							"value": [
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"neutral\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content at the start side of the component",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content at the end side of the component",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"highlighted": {
+						"defaultValue": null,
+						"description": "Highlight the component as hovered or focused. For example, when displaying currently focused item in Autocomplete",
+						"name": "highlighted",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"selected": {
+						"defaultValue": null,
+						"description": "Highlight the component as selected",
+						"name": "selected",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"roundedCorners": {
+						"defaultValue": null,
+						"description": "Round the corners of the component",
+						"name": "roundedCorners",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/MenuItem/MenuItem.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					}
+				},
+				"exportName": "MenuItem"
 			}
 		},
 		"components-modal": {
@@ -961,67 +5537,301 @@
 			"path": "./src/components/Modal/tests/Modal.stories.tsx",
 			"stories": [
 				{
+					"id": "components-modal--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title={[\"responsive position\", \"[s] full-screen\", \"[m] center\", \"[l] end\"]}>\n            <Demo position={{ s: \"full-screen\", m: \"center\", l: \"end\" }} />\n        </Example.Item>\n        <Example.Item title=\"position: center\">\n            <Demo position=\"center\" />\n        </Example.Item>\n        <Example.Item title=\"position: bottom\">\n            <Demo position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"position: start\">\n            <Demo position=\"start\" />\n        </Example.Item>\n        <Example.Item title=\"position: end\">\n            <Demo position=\"end\" />\n        </Example.Item>\n        <Example.Item title=\"position: full-screen\">\n            <Demo position=\"full-screen\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: default\">\n                <Demo />\n            </Example.Item>\n            <Example.Item title=\"size: 300px\">\n                <Demo size=\"300px\" />\n            </Example.Item>\n            <Example.Item\n                title={[\"size: 800px\", \"should have max width of 100% minus gaps on the sides\"]}\n            >\n                <Demo size=\"800px\" />\n            </Example.Item>\n            <Example.Item\n                title={[\n                    \"responsive size, responsive position\",\n                    \"[s] auto\",\n                    \"[m+] 600px\",\n                    \"bottom position changes height instead of width\",\n                ]}\n            >\n                <Demo\n                    position={{ s: \"bottom\", m: \"center\", l: \"end\" }}\n                    size={{ s: \"auto\", m: \"600px\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-modal--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 0\">\n            <Demo padding={0} />\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <Demo padding={6} />\n        </Example.Item>\n        <Example.Item title={[\"responsive padding\", \"[s] 2\", \"[m+]: 6\"]}>\n            <Demo padding={{ s: 2, m: 6 }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--overflow",
 					"name": "overflow",
 					"snippet": "const overflow = () => (\n    <Example>\n        <Example.Item title=\"default overflow\">\n            <Demo>\n                <div\n                    style={{\n                        position: \"absolute\",\n                        top: -32,\n                        left: -32,\n                        height: 100,\n                        width: 100,\n                        background: \"tomato\",\n                    }}\n                />\n            </Demo>\n        </Example.Item>\n\n        <Example.Item title=\"overflow: visible\">\n            <Demo overflow=\"visible\">\n                <div\n                    style={{\n                        position: \"absolute\",\n                        top: -32,\n                        left: -32,\n                        height: 100,\n                        width: 100,\n                        background: \"tomato\",\n                    }}\n                />\n            </Demo>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--composition",
 					"name": "composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"title, subtitle, dismissible\">\n            <Demo title=\"Modal title\" subtitle=\"Modal subtitle\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-modal--overlay",
 					"name": "overlay",
 					"snippet": "const overlay = () => (\n    <Example>\n        <Example.Item title=\"transparentOverlay, doesn't lock scroll\">\n            <Demo transparentOverlay />\n        </Example.Item>\n        <Example.Item title=\"blurredOverlay\">\n            <Demo blurredOverlay />\n        </Example.Item>\n        <View height=\"1000px\" />\n    </Example>\n);"
 				},
 				{
-					"name": "flags",
+					"id": "components-modal--flags",
+					"name": "disableCloseOnOutsideClick",
 					"snippet": "const flags = () => {\n    return (\n        <Example>\n            <Example.Item title=\"disableCloseOnOutsideClick\">\n                <Demo disableCloseOnOutsideClick onClose={fn()} active />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-modal--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const containerRef2 = React.useRef<HTMLDivElement>(null);\n    const toggle = useToggle();\n    const toggle2 = useToggle();\n\n    return (\n        <Example>\n            <Example.Item title={[\"in scrollable container\", \"scroll and then open\"]}>\n                <View\n                    attributes={{ ref: containerRef2 }}\n                    borderRadius=\"medium\"\n                    height=\"400px\"\n                    overflow=\"auto\"\n                    backgroundColor=\"neutral-faded\"\n                    padding={4}\n                >\n                    <View gap={4} align=\"start\">\n                        <Button onClick={toggle2.activate}>Open modal</Button>\n                        <View height=\"500px\" backgroundColor=\"primary\" width=\"500px\" borderRadius=\"medium\" />\n                    </View>\n                    <Modal\n                        containerRef={containerRef2}\n                        active={toggle2.active}\n                        onClose={toggle2.deactivate}\n                        position=\"end\"\n                    >\n                        <Placeholder />\n                    </Modal>\n                </View>\n            </Example.Item>\n            <Example.Item title=\"in static container\">\n                <View\n                    attributes={{ ref: containerRef }}\n                    borderRadius=\"medium\"\n                    height=\"400px\"\n                    overflow=\"hidden\"\n                    backgroundColor=\"neutral-faded\"\n                    padding={4}\n                >\n                    <Button onClick={toggle.activate}>Open modal</Button>\n                    <Modal\n                        containerRef={containerRef}\n                        active={toggle.active}\n                        onClose={toggle.deactivate}\n                        position=\"end\"\n                    >\n                        <Placeholder />\n                    </Modal>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "renderProps",
+					"id": "components-modal--render-props",
+					"name": "children, render props",
 					"snippet": "const renderProps = () => (\n    <Modal active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        <Modal.Title>Title</Modal.Title>\n        Content\n    </Modal>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "components-modal--handlers",
+					"name": "onOpen, onClose, onAfterOpen, onAfterClose",
 					"snippet": "const handlers = () => {\n    const overlayToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => overlayToggle.toggle()}>Open overlay</Button>\n            <Modal\n                active={overlayToggle.active}\n                onClose={(closeArgs) => {\n                    overlayToggle.deactivate();\n                    args.handleClose(closeArgs);\n                }}\n                onOpen={fn()}\n                onAfterOpen={fn()}\n                onAfterClose={fn()}>\n                <Modal.Title>Title</Modal.Title>Content\n                                </Modal>\n        </>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-modal--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <Modal active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        <Modal.Title>Title</Modal.Title>\n        Content\n    </Modal>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-modal--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => {\n    const menuModalToggle = useToggle();\n    const menuModalToggleInner = useToggle();\n    const scrollModalToggle = useToggle();\n    const inputRef = React.useRef<HTMLInputElement>(null);\n\n    return (\n        <Example>\n            <Example.Item title=\"Scrolls with long content on touch devices\">\n                <Demo position=\"center\">\n                    <Button onClick={() => {}}>Action</Button>\n                    <View height=\"2000px\" backgroundColor=\"primary-faded\" />\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"keyboard focus stays on the modal first\">\n                <Demo title=\"Modal title\" autoFocus={false} />\n            </Example.Item>\n            <Example.Item title=\"trap focus works with custom children components\">\n                <Demo title=\"Modal title\">\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <Switch name=\"switch\" />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"focus moves to the input\">\n                <Demo\n                    title=\"Modal title\"\n                    onOpen={() => {\n                        inputRef.current?.focus();\n                    }}\n                >\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <TextField name=\"name\" inputAttributes={{ ref: inputRef }} />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"Focus moves to the input with autoFocus\">\n                <Demo title=\"Modal title\">\n                    <View gap={3} direction=\"row\">\n                        <Button onClick={() => {}}>Button</Button>\n                        <TextField\n                            name=\"name\"\n                            placeholder=\"autofocus\"\n                            inputAttributes={{ autoFocus: true }}\n                        />\n                    </View>\n                </Demo>\n            </Example.Item>\n            <Example.Item title=\"scrollable area in modal ignores swipe-to-close\">\n                <View gap={3} direction=\"row\">\n                    <Button onClick={scrollModalToggle.activate}>Open</Button>\n                    <Modal\n                        active={scrollModalToggle.active}\n                        onClose={scrollModalToggle.deactivate}\n                        size=\"300px\"\n                        position=\"bottom\"\n                    >\n                        <View\n                            height=\"1000px\"\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            padding={4}\n                        >\n                            Content\n                        </View>\n                    </Modal>\n                </View>\n            </Example.Item>\n            <Example.Item\n                title={[\n                    \"trap focus works correctly when it was already trapped\",\n                    \"focus return back to the dropdown trigger on modal close\",\n                    \"closing dropdown inside the modal doesn't close the modal\",\n                ]}\n            >\n                <DropdownMenu>\n                    <DropdownMenu.Trigger>\n                        {(attributes) => <Button attributes={attributes}>Open menu</Button>}\n                    </DropdownMenu.Trigger>\n                    <DropdownMenu.Content>\n                        <DropdownMenu.Item onClick={menuModalToggle.activate}>Open dialog</DropdownMenu.Item>\n                        <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                    </DropdownMenu.Content>\n                </DropdownMenu>\n                <Modal active={menuModalToggle.active} onClose={menuModalToggle.deactivate}>\n                    <View gap={3}>\n                        <DropdownMenu>\n                            <DropdownMenu.Trigger>\n                                {(attributes) => <Button attributes={attributes}>Open menu</Button>}\n                            </DropdownMenu.Trigger>\n                            <DropdownMenu.Content>\n                                <DropdownMenu.Item>Item 1</DropdownMenu.Item>\n                                <DropdownMenu.Item>Item 2</DropdownMenu.Item>\n                            </DropdownMenu.Content>\n                        </DropdownMenu>\n                        <Button onClick={menuModalToggleInner.activate}>Open dialog</Button>\n                        <Button onClick={menuModalToggle.deactivate}>Close</Button>\n                        <Modal active={menuModalToggleInner.active} onClose={menuModalToggleInner.deactivate}>\n                            <Button onClick={menuModalToggleInner.deactivate}>Close</Button>\n                        </Modal>\n                    </View>\n                </Modal>\n            </Example.Item>\n\n            <Example.Item title=\"disableSwipeGesture\">\n                <Demo disableSwipeGesture position=\"start\" />\n            </Example.Item>\n\n            <Example.Item title=\"scroll locks on open\">\n                <Demo />\n                <View height=\"1000px\" />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "trapFocusEdgeCases",
+					"id": "components-modal--trap-focus-edge-cases",
+					"name": "test: trap focus edge cases",
 					"snippet": "const trapFocusEdgeCases = () => {\n    const toggle = useToggle();\n\n    return (\n        <Example>\n            <Example.Item title=\"Radio should be navigatable with arrow keys\">\n                <Button onClick={toggle.activate}>Open modal</Button>\n                <Modal active={toggle.active} onClose={toggle.deactivate}>\n                    <View gap={2}>\n                        <Button onClick={() => {}}>Action 1</Button>\n                        <Radio name=\"radio\" value=\"1\">\n                            Option 1\n                        </Radio>\n                        <Radio name=\"radio\" value=\"2\">\n                            Option 2\n                        </Radio>\n                        <Button onClick={() => {}}>Action 2</Button>\n                    </View>\n                </Modal>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import {\n    Button,\n    Dismissible,\n    DropdownMenu,\n    Example,\n    Modal,\n    Placeholder,\n    Radio,\n    Switch,\n    TextField,\n    View,\n} from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Modal/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Modal",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Modal/Modal.tsx",
-				"actualName": "Modal",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Component position on the screen",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<\"bottom\" | \"center\" | \"start\" | \"end\" | \"full-screen\">"
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size, literal css value",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Component padding, unit token multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Remove overflow from the component content",
+						"name": "overflow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"visible\"", "value": [{ "value": "\"visible\"" }] }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is closed",
+						"name": "onClose",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((args: { reason: CloseReason | \"drag\"; }) => void)" }
+					},
+					"transparentOverlay": {
+						"defaultValue": null,
+						"description": "Make the overlay transparent",
+						"name": "transparentOverlay",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"blurredOverlay": {
+						"defaultValue": null,
+						"description": "Make the overlay blurred",
+						"name": "blurredOverlay",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableSwipeGesture": {
+						"defaultValue": null,
+						"description": "Disable swipe gesture to close the component on touch devices",
+						"name": "disableSwipeGesture",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable closing the component on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Focus the first focusable element in the component when it is opened, when false, focus will be set on the component content container",
+						"name": "autoFocus",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element, useful when there is no visible title",
+						"name": "ariaLabel",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"overlayClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the overlay element",
+						"name": "overlayClassName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Modal/Modal.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "(Attributes<\"div\"> & { ref?: RefObject<HTMLDivElement | null>; })"
+						}
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the visibility of the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the component is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"containerRef": {
+						"defaultValue": null,
+						"description": "Element to render the component in",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"onAfterOpen": {
+						"defaultValue": null,
+						"description": "Callback after the component open transition is complete",
+						"name": "onAfterOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onAfterClose": {
+						"defaultValue": null,
+						"description": "Callback after the component close transition is complete",
+						"name": "onAfterClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					}
+				},
+				"exportName": "Modal"
 			}
 		},
 		"components-numberfield": {
@@ -1030,54 +5840,450 @@
 			"path": "./src/components/NumberField/tests/NumberField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-numberfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => {\n    return (\n        <Example>\n            <Example.Item title=\"variant: outline\">\n                <NumberField\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"variant: faded\">\n                <NumberField\n                    variant=\"faded\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"variant: headless\">\n                <NumberField\n                    variant=\"headless\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-numberfield--size",
 					"name": "size",
 					"snippet": "const size = () => {\n    return (\n        <Example>\n            <Example.Item title=\"size: small\">\n                <NumberField\n                    size=\"small\"\n                    name=\"test-name\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    suffix=\"m2\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: medium\">\n                <NumberField\n                    size=\"medium\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: large\">\n                <NumberField\n                    size=\"large\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n            <Example.Item title=\"size: xlarge\">\n                <NumberField\n                    size=\"xlarge\"\n                    name=\"test-name\"\n                    suffix=\"m2\"\n                    increaseAriaLabel=\"Increase\"\n                    decreaseAriaLabel=\"Decrease\"\n                    inputAttributes={{ \"aria-label\": \"Label\" }}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-numberfield--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <NumberField\n    name=\"test-name\"\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    disabled\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-numberfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <NumberField\n    name=\"test-name\"\n    defaultValue={2}\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-numberfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <NumberField\n    name=\"test-name\"\n    value={2}\n    onChange={fn()}\n    increaseAriaLabel=\"Increase\"\n    decreaseAriaLabel=\"Decrease\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "minMax",
+					"id": "components-numberfield--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <NumberField\n        name=\"test-name\"\n        defaultValue={6}\n        min={5}\n        max={10}\n        increaseAriaLabel=\"Increase\"\n        decreaseAriaLabel=\"Decrease\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-numberfield--step",
 					"name": "step",
 					"snippet": "const step = () => (\n    <NumberField\n        name=\"test-name\"\n        defaultValue={6}\n        step={0.5}\n        increaseAriaLabel=\"Increase\"\n        decreaseAriaLabel=\"Decrease\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-numberfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <NumberField\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n            increaseAriaLabel=\"Increase\"\n            decreaseAriaLabel=\"Decrease\"\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-numberfield--form-control",
+					"name": "test: FormControl",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"FormControl\">\n            <FormControl>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"FormControl, disabled\">\n            <FormControl disabled>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"FormControl, error\">\n            <FormControl hasError>\n                <FormControl.Label>Label</FormControl.Label>\n                <NumberField name=\"name\" increaseAriaLabel=\"Increase\" decreaseAriaLabel=\"Decrease\" />\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "valueChanges",
+					"id": "components-numberfield--value-changes",
+					"name": "test: keyboard",
 					"snippet": "const valueChanges = () => (\n    <Example>\n        <Example.Item title=\"keyboard\">\n            <NumberField\n                name=\"name\"\n                increaseAriaLabel=\"Increase\"\n                decreaseAriaLabel=\"Decrease\"\n                inputAttributes={{ \"aria-label\": \"Label\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, FormControl, NumberField } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/NumberField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "NumberField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/NumberField/NumberField.tsx",
-				"actualName": "NumberField",
+				"methods": [],
+				"props": {
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the component value is changed",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<number, ChangeEvent<HTMLInputElement>>" }
+					},
+					"increaseAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the increase button",
+						"name": "increaseAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"decreaseAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the decrease button",
+						"name": "decreaseAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum value supported in the form field",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum value supported in the form field",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"step": {
+						"defaultValue": null,
+						"description": "Step at which the value will increase or decrease when clicking the button controls",
+						"name": "step",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the form field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the form field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/NumberField/NumberField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1087,34 +6293,166 @@
 			"path": "./src/components/Pagination/tests/Pagination.stories.tsx",
 			"stories": [
 				{
+					"id": "components-pagination--truncate",
 					"name": "truncate",
 					"snippet": "const truncate = () => {\n    return (\n        <Example>\n            <Example.Item title=\"start\">\n                <Pagination\n                    total={10}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"middle\">\n                <Pagination\n                    total={10}\n                    defaultPage={5}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"end\">\n                <Pagination\n                    total={10}\n                    defaultPage={10}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n            <Example.Item title=\"no truncation\">\n                <Pagination\n                    total={4}\n                    previousAriaLabel=\"Previous page\"\n                    nextAriaLabel=\"Next page\"\n                    pageAriaLabel={(args) => `Page ${args.page}`}\n                />\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "render",
+					"id": "components-pagination--render",
+					"name": "rendering",
 					"snippet": "const render = () => (\n    <div data-testid=\"root\">\n        <Pagination\n            total={10}\n            previousAriaLabel=\"Previous\"\n            nextAriaLabel=\"Next\"\n            pageAriaLabel={(args) => `Page ${args.page}`}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "defaultPage",
+					"id": "components-pagination--default-page",
+					"name": "defaultPage, uncontrolled",
 					"snippet": "const defaultPage = () => <div data-testid=\"root\">\n    <Pagination\n        total={10}\n        defaultPage={2}\n        onChange={fn()}\n        previousAriaLabel=\"Previous\"\n        nextAriaLabel=\"Next\" />\n</div>;"
 				},
 				{
-					"name": "page",
+					"id": "components-pagination--page",
+					"name": "page, controlled",
 					"snippet": "const page = () => <div data-testid=\"root\">\n    <Pagination\n        total={10}\n        page={2}\n        onChange={fn()}\n        previousAriaLabel=\"Previous\"\n        nextAriaLabel=\"Next\" />\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "components-pagination--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Pagination\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            total={10}\n            previousAriaLabel=\"Previous\"\n            nextAriaLabel=\"Next\"\n        />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Pagination } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Pagination/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Pagination",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Pagination/Pagination.tsx",
-				"actualName": "Pagination",
+				"methods": [],
+				"props": {
+					"total": {
+						"defaultValue": null,
+						"description": "Total number of pages available",
+						"name": "total",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "number" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the current page changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { page: number; }) => void)" }
+					},
+					"pageAriaLabel": {
+						"defaultValue": null,
+						"description": "Function to dynamically get an aria-label for each page",
+						"name": "pageAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { page: number; }) => string)" }
+					},
+					"previousAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the previous page button",
+						"name": "previousAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"nextAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the next page button",
+						"name": "nextAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"page": {
+						"defaultValue": null,
+						"description": "Currently selected page number, starts with 1, enables controlled mode",
+						"name": "page",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultPage": {
+						"defaultValue": null,
+						"description": "Default selected page number, starts with 1, enables uncontrolled mode",
+						"name": "defaultPage",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Pagination/Pagination.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1124,54 +6462,229 @@
 			"path": "./src/components/PinField/tests/PinField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-pinfield--base",
 					"name": "base",
 					"snippet": "const base = () => <PinField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-pinfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <PinField name=\"pin\" variant=\"faded\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-pinfield--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <PinField name=\"pin\" size=\"small\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <PinField name=\"pin\" size=\"medium\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <PinField name=\"pin\" size=\"large\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <PinField name=\"pin\" size=\"xlarge\" inputAttributes={{ \"aria-label\": \"Pin\" }} />\n        </Example.Item>\n\n        <Example.Item title=\"size: responsive, s: medium, m+: xlarge\">\n            <PinField\n                name=\"pin\"\n                size={{ s: \"medium\", m: \"xlarge\" }}\n                inputAttributes={{ \"aria-label\": \"Pin\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-pinfield--value-length",
 					"name": "valueLength",
 					"snippet": "const valueLength = () => (\n    <PinField name=\"test-name\" valueLength={6} inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-pinfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <PinField\n    name=\"test-name\"\n    onChange={fn()}\n    defaultValue=\"12\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-pinfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <PinField\n    name=\"test-name\"\n    onChange={fn()}\n    value=\"12\"\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-pinfield--pattern",
 					"name": "pattern",
 					"snippet": "const pattern = () => <PinField\n    name=\"test-name\"\n    pattern=\"alphabetic\"\n    defaultValue=\"ab\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-pinfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <PinField\n            name=\"test-name\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ \"aria-label\": \"Label\", id: \"test-input-id\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-pinfield--form-control",
+					"name": "test: with FormControl",
 					"snippet": "const formControl = () => (\n    <FormControl>\n        <FormControl.Label>Label</FormControl.Label>\n        <PinField name=\"test-name\" />\n    </FormControl>\n);"
 				},
 				{
-					"name": "keyboard",
+					"id": "components-pinfield--keyboard",
+					"name": "test: keyboard navigation",
 					"snippet": "const keyboard = () => <PinField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				}
 			],
 			"import": "import { Example, FormControl, PinField } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/PinField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "PinField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/PinField/PinField.tsx",
-				"actualName": "PinField",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"valueLength": {
+						"defaultValue": null,
+						"description": "Amount of characters in the pin",
+						"name": "valueLength",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"pattern": {
+						"defaultValue": null,
+						"description": "Character pattern used in the input value",
+						"name": "pattern",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"numeric\" | \"alphabetic\" | \"alphanumeric\"",
+							"value": [
+								{ "value": "\"numeric\"" },
+								{ "value": "\"alphabetic\"" },
+								{ "value": "\"alphanumeric\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Input fields render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\"",
+							"value": [{ "value": "\"outline\"" }, { "value": "\"faded\"" }]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the input element, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/PinField/PinField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1181,75 +6694,514 @@
 			"path": "./src/components/Popover/tests/Popover.stories.tsx",
 			"stories": [
 				{
+					"id": "components-popover--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: bottom\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"bottom-start\" />\n                <Demo position=\"bottom\" />\n                <Demo position=\"bottom-end\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: top\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"top-start\" />\n                <Demo position=\"top\" />\n                <Demo position=\"top-end\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: start\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"start-top\" />\n                <Demo position=\"start\" />\n                <Demo position=\"start-bottom\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: end\">\n            <View align=\"center\" justify=\"center\" gap={8} direction=\"row\">\n                <Demo position=\"end-top\" />\n                <Demo position=\"end\" />\n                <Demo position=\"end-bottom\" defaultActive />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "widthNumber",
+					"id": "components-popover--width-number",
+					"name": "width: px",
 					"snippet": "const widthNumber = () => <Demo width=\"400px\" defaultActive />;"
 				},
 				{
-					"name": "widthFull",
+					"id": "components-popover--width-full",
+					"name": "width: 100%",
 					"snippet": "const widthFull = () => <Demo width=\"100%\" defaultActive />;"
 				},
 				{
+					"id": "components-popover--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: 0\">\n            <Demo padding={0} />\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <Demo padding={6} defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-popover--elevation",
 					"name": "elevation",
 					"snippet": "const elevation = () => (\n    <Example>\n        <Example.Item title=\"elevation: raised\">\n            <Demo elevation=\"raised\" defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-popover--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <Popover onOpen={fn()} onClose={fn()} defaultActive>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "active",
+					"id": "components-popover--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <Popover onOpen={fn()} onClose={fn()} active>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "components-popover--active-false",
+					"name": "active false, controlled",
 					"snippet": "const activeFalse = () => <Popover onOpen={fn()} onClose={fn()} active={false}>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>Content</Popover.Content>\n</Popover>;"
 				},
 				{
-					"name": "dismissible",
+					"id": "components-popover--dismissible",
+					"name": "dismissible, onClose, className, attributes, closeAriaLabel",
 					"snippet": "const dismissible = () => <Popover onClose={fn()} defaultActive>\n    <Popover.Trigger>\n        {(attributes) => <Button attributes={attributes}>Open</Button>}\n    </Popover.Trigger>\n    <Popover.Content>\n        <Popover.Dismissible\n            closeAriaLabel=\"Close\"\n            attributes={{ \"data-testid\": \"test-id\" }}\n            className=\"test-classname\">Content\n                            </Popover.Dismissible>\n    </Popover.Content>\n</Popover>;"
 				},
 				{
+					"id": "components-popover--auto-focus",
 					"name": "autoFocus",
 					"snippet": "const autoFocus = () => (\n    <Example>\n        <Example.Item title=\"autoFocus=false\">\n            <Demo autoFocus={false} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-popover--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Popover active>\n            <Popover.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </Popover.Trigger>\n            <Popover.Content className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n                Content\n            </Popover.Content>\n        </Popover>\n    </div>\n);"
 				},
 				{
-					"name": "testNested",
+					"id": "components-popover--test-nested",
+					"name": "test: nested",
 					"snippet": "const testNested = () => (\n    <Popover position=\"bottom\">\n        <Popover.Trigger>\n            {(attributes) => <Button attributes={attributes}>Open</Button>}\n        </Popover.Trigger>\n        <Popover.Content>\n            <View gap={2} align=\"start\">\n                Popover content\n                <Popover>\n                    <Popover.Trigger>\n                        {(attributes) => <Button attributes={attributes}>Open</Button>}\n                    </Popover.Trigger>\n                    <Popover.Content>Hello</Popover.Content>\n                </Popover>\n            </View>\n        </Popover.Content>\n    </Popover>\n);"
 				},
 				{
-					"name": "testWithTooltip",
+					"id": "components-popover--test-with-tooltip",
+					"name": "test: with tooltip",
 					"snippet": "const testWithTooltip = () => (\n    <View paddingTop={10}>\n        <Tooltip position=\"top\" text=\"Hello\">\n            {(tooltipAttributes) => (\n                <Popover position=\"bottom\">\n                    <Popover.Trigger>\n                        {(attributes) => (\n                            <Button\n                                attributes={{\n                                    ...attributes,\n                                    ...tooltipAttributes,\n                                }}\n                            >\n                                Open\n                            </Button>\n                        )}\n                    </Popover.Trigger>\n                    <Popover.Content>\n                        <View gap={2} align=\"start\">\n                            Popover content\n                            <Button onClick={() => {}}>Button</Button>\n                        </View>\n                    </Popover.Content>\n                </Popover>\n            )}\n        </Tooltip>\n    </View>\n);"
 				},
 				{
-					"name": "testContentEditable",
+					"id": "components-popover--test-content-editable",
+					"name": "test: contenteditable",
 					"snippet": "const testContentEditable = () => {\n    const [active, setActive] = useState(false);\n\n    return (\n        <Popover>\n            <Popover.Trigger>\n                {(attributes) => <Button attributes={attributes}>Open</Button>}\n            </Popover.Trigger>\n            <Popover.Content>\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={() => {}}>Hello</Button>\n                    </View.Item>\n\n                    <ScrollArea height=\"100px\">\n                        <div\n                            style={{ height: \"200px\" }}\n                            contentEditable\n                            tabIndex={0}\n                            onInput={(e) => {\n                                setActive(e.currentTarget.innerText.startsWith(\"@\"));\n                            }}\n                            onKeyDown={(e) => {\n                                console.log(e.key);\n                                if (e.key === \"Enter\" && active) {\n                                    e.preventDefault();\n                                    e.currentTarget.innerText = \"@hello\";\n                                    setActive(false);\n                                }\n                            }}\n                        />\n                    </ScrollArea>\n\n                    <Popover\n                        active={active}\n                        onClose={() => setActive(false)}\n                        originCoordinates={{ x: 300, y: 300 }}\n                        trapFocusMode=\"selection-menu\"\n                    >\n                        <Popover.Content>\n                            <View gap={4}>\n                                <MenuItem onClick={() => {}}>Action</MenuItem>\n                                <MenuItem onClick={() => {}}>Close</MenuItem>\n                            </View>\n                        </Popover.Content>\n                    </Popover>\n                </View>\n            </Popover.Content>\n        </Popover>\n    );\n};"
 				},
 				{
-					"name": "variant",
+					"id": "components-popover--variant",
+					"name": "variant [deprecated]",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: headless\">\n            <Popover variant=\"headless\" defaultActive position=\"bottom-start\">\n                <Popover.Trigger>\n                    {(attributes) => <Button attributes={attributes}>Open</Button>}\n                </Popover.Trigger>\n                <Popover.Content>\n                    <View\n                        height=\"100px\"\n                        width=\"100px\"\n                        borderColor=\"primary\"\n                        borderRadius=\"medium\"\n                        backgroundColor=\"primary-faded\"\n                    />\n                </Popover.Content>\n            </Popover>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, MenuItem, Popover, ScrollArea, Tooltip, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Popover/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Popover",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Popover/Popover.tsx",
-				"actualName": "Popover",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Automatically focus the first focusable element in the content, when false the content container will be focused instead",
+						"name": "autoFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | TrapMode" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Content element padding, unit token multiplier",
+						"name": "padding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"elevation": {
+						"defaultValue": null,
+						"description": "Component elevation level",
+						"name": "elevation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius for the content",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "@deprecated use Flyout utility instead, will be removed in v4",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Popover/Popover.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"elevated\" | \"headless\"",
+							"value": [{ "value": "\"elevated\"" }, { "value": "\"headless\"" }]
+						}
+					}
+				},
+				"exportName": "Popover"
 			}
 		},
 		"components-progress": {
@@ -1258,38 +7210,177 @@
 			"path": "./src/components/Progress/tests/Progress.stories.tsx",
 			"stories": [
 				{
+					"id": "components-progress--value",
 					"name": "value",
 					"snippet": "const value = () => (\n    <Example>\n        <Example.Item title=\"value: 50\">\n            <Progress value={50} ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"value: 20, min: 0, max: 40\">\n            <Progress value={20} min={0} max={40} ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"value: 50, min: 0, max: 40\">\n            <Progress value={50} min={0} max={40} ariaLabel=\"rating value\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small, value: 50\">\n            <Progress value={50} size=\"small\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"size: medium, value: 50\">\n            <Progress value={50} size=\"medium\" ariaLabel=\"rating value\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: critical, value: 50\">\n            <Progress value={50} color=\"critical\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: warning, value: 50\">\n            <Progress value={50} color=\"warning\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive, value: 50\">\n            <Progress value={50} color=\"positive\" ariaLabel=\"rating value\" />\n        </Example.Item>\n        <Example.Item title=\"color: media, value: 50\">\n            <View padding={4} backgroundColor=\"black\" borderRadius=\"medium\">\n                <Progress value={50} color=\"media\" ariaLabel=\"rating value\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-progress--duration",
 					"name": "duration",
 					"snippet": "const duration = () => {\n    const [active, setActive] = React.useState(false);\n\n    const handleChange = () => {\n        setActive((state) => !state);\n    };\n\n    return (\n        <Example>\n            <Example.Item title=\"duration: 2000\">\n                <View gap={3}>\n                    <View.Item>\n                        <Button onClick={handleChange}>Change</Button>\n                    </View.Item>\n\n                    <Progress value={active ? 100 : 0} duration={2000} ariaLabel=\"rating value\" />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "render",
+					"id": "components-progress--render",
+					"name": "rendering",
 					"snippet": "const render = () => <Progress value={75} min={50} max={100} ariaLabel=\"progress\" />;"
 				},
 				{
-					"name": "className",
+					"id": "components-progress--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Progress className=\"test-classname\" attributes={{ id: \"test-id\" }} ariaLabel=\"progress\" />\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, Progress, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Progress/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Progress",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Progress/Progress.tsx",
-				"actualName": "Progress",
+				"methods": [],
+				"props": {
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the progress bar controlling the size of the fill",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Lower value boundary of the progress bar",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Upper value boundary of the progress bar",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"warning\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"duration": {
+						"defaultValue": null,
+						"description": "Duration of the progress bar animation in milliseconds",
+						"name": "duration",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Progress/Progress.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1299,30 +7390,135 @@
 			"path": "./src/components/ProgressIndicator/tests/ProgressIndicator.stories.tsx",
 			"stories": [
 				{
+					"id": "components-progressindicator--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const [activeIndex, setActiveIndex] = React.useState(0);\n    const total = 10;\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <View gap={4}>\n                    <View direction=\"row\" gap={2} align=\"center\">\n                        <Button\n                            onClick={() => {\n                                setActiveIndex((prev) => Math.max(0, prev - 1));\n                            }}\n                        >\n                            Previous\n                        </Button>\n                        <Button\n                            onClick={() => {\n                                setActiveIndex((prev) => Math.min(total - 1, prev + 1));\n                            }}\n                        >\n                            Next\n                        </Button>\n                        <Text weight=\"medium\">Index: {activeIndex}</Text>\n                    </View>\n\n                    <View borderRadius=\"medium\" overflow=\"hidden\" width=\"300px\">\n                        <Scrim\n                            position=\"bottom\"\n                            backgroundSlot={<View aspectRatio={16 / 9} backgroundColor=\"neutral-faded\" />}\n                        >\n                            <View align=\"center\">\n                                <ProgressIndicator total={total} activeIndex={activeIndex} color=\"media\" />\n                            </View>\n                        </Scrim>\n                    </View>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-progressindicator--color",
 					"name": "color",
 					"snippet": "const color = () => {\n    return (\n        <Example>\n            <Example.Item title=\"color: primary\">\n                <ProgressIndicator total={10} activeIndex={5} color=\"primary\" />\n            </Example.Item>\n            <Example.Item title=\"color: media\">\n                <View borderRadius=\"medium\" overflow=\"hidden\" width=\"300px\">\n                    <Scrim\n                        position=\"bottom\"\n                        backgroundSlot={<View aspectRatio={16 / 9} backgroundColor=\"neutral-faded\" />}\n                    >\n                        <View align=\"center\">\n                            <ProgressIndicator total={10} activeIndex={5} color=\"media\" />\n                        </View>\n                    </Scrim>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-progressindicator--aria-label",
 					"name": "ariaLabel",
 					"snippet": "const ariaLabel = () => <ProgressIndicator total={10} className=\"test-classname\" ariaLabel=\"Progress\" />;"
 				},
 				{
-					"name": "className",
+					"id": "components-progressindicator--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ProgressIndicator total={10} className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, ProgressIndicator, Scrim, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ProgressIndicator/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ProgressIndicator",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ProgressIndicator/ProgressIndicator.tsx",
-				"actualName": "ProgressIndicator",
+				"methods": [],
+				"props": {
+					"total": {
+						"defaultValue": null,
+						"description": "Total amount of progress indicator dots",
+						"name": "total",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "number" }
+					},
+					"activeIndex": {
+						"defaultValue": null,
+						"description": "Index of the active progress indicator dot",
+						"name": "activeIndex",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"medium\"",
+							"value": [{ "value": "\"small\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\"",
+							"value": [{ "value": "\"media\"" }, { "value": "\"primary\"" }]
+						}
+					},
+					"ariaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the root element",
+						"name": "ariaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ProgressIndicator/ProgressIndicator.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1332,50 +7528,203 @@
 			"path": "./src/components/Radio/tests/Radio.stories.tsx",
 			"stories": [
 				{
+					"id": "components-radio--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"small\" defaultChecked>\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"medium\">\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size=\"large\">\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"size: responsive, s: small, m: large\">\n            <View gap={4} direction=\"row\">\n                <Radio name=\"animal\" value=\"dog\" size={{ s: \"small\", m: \"large\" }}>\n                    Radio\n                </Radio>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-radio--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Radio name=\"error\" value=\"dog\" hasError>\n                Radio\n            </Radio>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-radio--render",
+					"name": "name, value",
 					"snippet": "const render = () => (\n    <Radio name=\"test-name\" value=\"test-value\">\n        Content\n    </Radio>\n);"
 				},
 				{
-					"name": "checked",
+					"id": "components-radio--checked",
+					"name": "checked, controlled",
 					"snippet": "const checked = () => <Radio name=\"test-name\" value=\"test-value\" checked onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "checkedFalse",
+					"id": "components-radio--checked-false",
+					"name": "checked false, controlled",
 					"snippet": "const checkedFalse = () => <Radio name=\"test-name\" value=\"test-value\" checked={false} onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-radio--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Radio name=\"test-name\" value=\"test-value\" defaultChecked onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
-					"name": "defaultCheckedFalse",
+					"id": "components-radio--default-checked-false",
+					"name": "defaultChecked false, uncontrolled",
 					"snippet": "const defaultCheckedFalse = () => <Radio name=\"test-name\" value=\"test-value\" onChange={fn()}>Content\n            </Radio>;"
 				},
 				{
+					"id": "components-radio--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Radio name=\"test-name\" value=\"test-value\" disabled>\n        Content\n    </Radio>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-radio--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Radio className=\"test-classname\" attributes={{ id: \"test-id\" }} value=\"value\">\n            Content\n        </Radio>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Radio, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Radio/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Radio",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Radio/Radio.tsx",
-				"actualName": "Radio",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the form field from the form submission",
+						"name": "disabled",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Indicate that the form field has an error",
+						"name": "hasError",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element",
+						"name": "value",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the input is focused",
+						"name": "onFocus",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the input is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "",
+						"name": "checked",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultChecked",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Radio/Radio.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1385,26 +7734,169 @@
 			"path": "./src/components/RadioGroup/tests/RadioGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "value",
+					"id": "components-radiogroup--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <RadioGroup name=\"test-name\" value=\"1\" onChange={fn()}>\n    {/* checked should be ignored */}\n    <Radio value=\"1\" checked={false}>Content\n                    </Radio>\n    <Radio value=\"2\">Content 2</Radio>\n</RadioGroup>;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-radiogroup--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <RadioGroup name=\"test-name\" defaultValue=\"1\" onChange={fn()}>\n    {/* checked should be ignored */}\n    <Radio value=\"1\" checked={false}>Content\n                    </Radio>\n    <Radio value=\"2\">Content 2</Radio>\n</RadioGroup>;"
 				},
 				{
+					"id": "components-radiogroup--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <RadioGroup name=\"test-name\" disabled>\n        <Radio value=\"test-value\">Content</Radio>\n    </RadioGroup>\n);"
 				}
 			],
 			"import": "import { Radio, RadioGroup } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/RadioGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "RadioGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/RadioGroup/RadioGroup.tsx",
-				"actualName": "RadioGroup",
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the radio group",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the form field from the form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Indicate that the form field has an error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the input value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the input element, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string | null" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the input element, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/RadioGroup/RadioGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1414,39 +7906,131 @@
 			"path": "./src/components/Resizable/tests/Resizable.stories.tsx",
 			"stories": [
 				{
+					"id": "components-resizable--direction",
 					"name": "direction",
 					"snippet": "const direction = () => {\n    return (\n        <Example>\n            <Example.Item title=\"row\">\n                <Resizable height=\"200px\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n            <Example.Item title=\"column\">\n                <Resizable height=\"400px\" direction=\"column\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n\n            {/* Test that page doesn't scroll on dragging */}\n            <div style={{ height: 2000 }} />\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-resizable--children",
 					"name": "children",
 					"snippet": "const children = () => {\n    return (\n        <Example>\n            <Example.Item title=\"render props, row\">\n                <Resizable height=\"200px\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n            <Example.Item title=\"render props, column\">\n                <Resizable height=\"400px\" direction=\"column\">\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Resizable.Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                    <Handle />\n                    <Resizable.Item>\n                        <Panel />\n                    </Resizable.Item>\n                </Resizable>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-resizable--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"bordered, row\">\n            <Resizable height=\"200px\" variant=\"bordered\">\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n            </Resizable>\n        </Example.Item>\n        <Example.Item title=\"bordered, column\">\n            <Resizable height=\"400px\" direction=\"column\" variant=\"bordered\">\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n                <Resizable.Handle />\n                <Resizable.Item>\n                    <Panel />\n                </Resizable.Item>\n            </Resizable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "components-resizable--size",
+					"name": "minSize, maxSize, defaultSize",
 					"snippet": "const size = () => (\n    <Resizable className=\"test-classname\" attributes={{ id: \"test-id\" }} height=\"200px\">\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n        <Resizable.Handle />\n        <Resizable.Item minSize=\"200px\" maxSize=\"500px\" defaultSize=\"300px\">\n            <Panel />\n        </Resizable.Item>\n    </Resizable>\n);"
 				},
 				{
-					"name": "layout",
+					"id": "components-resizable--layout",
+					"name": "height, gap",
 					"snippet": "const layout = () => (\n    <Resizable height=\"100px\" gap={8}>\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n        <Resizable.Handle />\n        <Resizable.Item>\n            <Panel />\n        </Resizable.Item>\n    </Resizable>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-resizable--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Resizable className=\"test-classname\" attributes={{ id: \"test-id\" }} height=\"200px\">\n            <Resizable.Item>\n                <Panel />\n            </Resizable.Item>\n            <Resizable.Handle />\n            <Resizable.Item>\n                <Panel />\n            </Resizable.Item>\n        </Resizable>\n    </div>\n);"
 				}
 			],
 			"import": "import { Button, Example, Resizable, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Resizable/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Resizable",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Resizable/Resizable.tsx",
-				"actualName": "Resizable",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Resizable/Resizable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"bordered\" | \"borderless\"",
+							"value": [{ "value": "\"bordered\"" }, { "value": "\"borderless\"" }]
+						}
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Component content direction with the resize handle rendered in between the chidlren",
+						"name": "direction",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Resizable/Resizable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between children, base unit token number multiplier",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					}
+				},
+				"exportName": "Resizable"
 			}
 		},
 		"components-scrim": {
@@ -1455,26 +8039,101 @@
 			"path": "./src/components/Scrim/tests/Scrim.stories.tsx",
 			"stories": [
 				{
+					"id": "components-scrim--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: center\">\n            <Scrim backgroundSlot={<Placeholder h={200} />}>Scrim</Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: bottom\">\n            <Scrim position=\"bottom\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: top\">\n            <Scrim position=\"top\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: start\">\n            <Scrim position=\"start\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <Scrim position=\"end\" backgroundSlot={<Placeholder h={200} />}>\n                Scrim\n            </Scrim>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-scrim--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Scrim className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Scrim>\n    </div>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "components-scrim--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"without backgroundSlot, size is based on the parent component\">\n            <div style={{ height: 300, position: \"relative\" }}>\n                <Scrim>Text</Scrim>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Placeholder, Scrim } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Scrim/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Scrim",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Scrim/Scrim.tsx",
-				"actualName": "Scrim",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"backgroundSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting background content behind the scrim",
+						"name": "backgroundSlot",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Component content position",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"bottom\" | \"start\" | \"end\" | \"full\"",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"full\"" }
+							]
+						}
+					},
+					"scrimClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the scrim element",
+						"name": "scrimClassName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Scrim/Scrim.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1484,79 +8143,398 @@
 			"path": "./src/components/Select/tests/Select.stories.tsx",
 			"stories": [
 				{
-					"name": "nativeRender",
+					"id": "components-select--native-render",
+					"name": "native rendering, options, name, id",
 					"snippet": "const nativeRender = () => (\n    <Example>\n        <Example.Item title=\"native with options prop\">\n            <Select\n                name=\"animal\"\n                id=\"animal-1\"\n                placeholder=\"Select an animal\"\n                options={[\n                    { label: \"Dog\", value: \"dog\" },\n                    { label: \"Turtle\", value: \"turtle\" },\n                ]}\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            />\n        </Example.Item>\n        <Example.Item title=\"native with option tags\">\n            <Select\n                name=\"animal\"\n                id=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "customRender",
+					"id": "components-select--custom-render",
+					"name": "custom rendering, name, id, option groups",
 					"snippet": "const customRender = () => (\n    <Example>\n        <Example.Item title=\"custom with options\">\n            <Select.Custom\n                name=\"animal\"\n                id=\"animal-1\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"native with option tags\">\n            <Select.Custom\n                name=\"animal-2\"\n                id=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Group label=\"Birds\">\n                    <Select.Option value=\"pigeon\">Pigeon</Select.Option>\n                    <Select.Option value=\"parrot\">Parrot</Select.Option>\n                </Select.Group>\n                <Select.Group label=\"Sea Mammals\">\n                    <Select.Option value=\"whale\">Whale</Select.Option>\n                    <Select.Option value=\"dolphin\">Dolphin</Select.Option>\n                </Select.Group>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "nativeHandlers",
+					"id": "components-select--native-handlers",
+					"name": "native, controlled, uncontrolled, onFocus, onBlur, onChange",
 					"snippet": "const nativeHandlers = () => <Example>\n    <Example.Item title=\"native, uncontrolled, onChange\">\n        <Select\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n    <Example.Item title=\"native, controlled, onChange\">\n        <Select\n            name=\"animal-2\"\n            placeholder=\"Select an animal\"\n            value=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n    <Example.Item title=\"native, onFocus, onBlur, onClick\">\n        <Select\n            name=\"animal-3\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onFocus={fn()}\n            onBlur={fn()}\n            onClick={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <option value=\"dog\">Dog</option>\n            <option value=\"turtle\">Turtle</option>\n        </Select>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "customHandlers",
+					"id": "components-select--custom-handlers",
+					"name": "custom, controlled, uncontrolled, onFocus, onBlur, onChange",
 					"snippet": "const customHandlers = () => <Example>\n    <Example.Item title=\"custom, uncontrolled, onChange\">\n        <Select.Custom\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n    <Example.Item title=\"custom, controlled, onChange\">\n        <Select.Custom\n            name=\"animal-2\"\n            placeholder=\"Select an animal\"\n            value=\"dog\"\n            onChange={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n    <Example.Item title=\"native, onFocus, onBlur, onClick\">\n        <Select.Custom\n            name=\"animal-3\"\n            placeholder=\"Select an animal\"\n            defaultValue=\"dog\"\n            onFocus={fn()}\n            onBlur={fn()}\n            onClick={fn()}\n            inputAttributes={{\n                \"aria-label\": \"Select an animal\",\n            }}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "triggerOnly",
+					"id": "components-select--trigger-only",
+					"name": "trigger only, onClick",
 					"snippet": "const triggerOnly = (args) => {\n    const toggle = useToggle();\n    const [value, setValue] = React.useState(\"Dog\");\n\n    const handleClick: SelectProps[\"onClick\"] = (e) => {\n        args.handleClick(e);\n        toggle.toggle();\n    };\n\n    return (\n        <Example>\n            <Example.Item title=\"trigger only, onClick\">\n                <Select\n                    name=\"animal\"\n                    placeholder=\"Select an animal\"\n                    onClick={handleClick}\n                    value=\"dog\"\n                    inputAttributes={{\n                        \"aria-label\": \"Select an animal\",\n                    }}\n                >\n                    {value}\n                </Select>\n                <Modal\n                    active={toggle.active}\n                    onClose={toggle.deactivate}\n                    position=\"bottom\"\n                    padding={2}\n                    attributes={{ \"aria-label\": \"Select an animal\" }}\n                >\n                    <div role=\"listbox\" aria-label=\"Select an animal\">\n                        <MenuItem\n                            roundedCorners\n                            onClick={() => {\n                                setValue(\"Dog\");\n                                toggle.deactivate();\n                            }}\n                            attributes={{\n                                role: \"option\",\n                            }}\n                        >\n                            Dog\n                        </MenuItem>\n                        <MenuItem\n                            roundedCorners\n                            attributes={{\n                                role: \"option\",\n                            }}\n                            onClick={() => {\n                                setValue(\"Turtle\");\n                                toggle.deactivate();\n                            }}\n                        >\n                            Turtle\n                        </MenuItem>\n                    </div>\n                </Modal>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-select--multiple",
 					"name": "multiple",
 					"snippet": "const multiple = () => <Example>\n    <Example.Item title=\"multiple\">\n        <Select.Custom\n            multiple\n            name=\"animal\"\n            placeholder=\"Select an animal\"\n            defaultValue={[\"dog\"]}\n            onChange={fn()}>\n            <Select.Option value=\"dog\">Dog</Select.Option>\n            <Select.Option value=\"turtle\">Turtle</Select.Option>\n        </Select.Custom>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-select--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded, native\">\n            <Select\n                variant=\"faded\"\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n\n        <Example.Item title=\"variant: faded, custom\">\n            <Select.Custom\n                variant=\"faded\"\n                name=\"animal-2\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless, native\">\n            <Select\n                variant=\"headless\"\n                name=\"animal-3\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless, custom\">\n            <Select.Custom\n                variant=\"headless\"\n                name=\"animal-4\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <Select.Custom size=\"small\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: medium\">\n            <Select.Custom size=\"medium\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: large\">\n            <Select.Custom size=\"large\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n        <Example.Item title=\"size: xlarge\">\n            <Select.Custom size=\"xlarge\" name=\"animal\" placeholder=\"Select an animal\">\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "startSlot",
+					"id": "components-select--start-slot",
+					"name": "icon,startSlot",
 					"snippet": "const startSlot = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Select.Custom name=\"animal\" placeholder=\"Select an animal\" icon={IconZap}>\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n\n        <Example.Item title=\"startSlot\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                startSlot={<Placeholder h={20} />}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--render-value",
 					"name": "renderValue",
 					"snippet": "const renderValue = () => {\n    const options = [\n        {\n            value: \"1\",\n            label: \"Title 1\",\n            subtitle: \"Subtitle 1\",\n        },\n        {\n            value: \"2\",\n            label: \"Title 2\",\n            subtitle: \"Subtitle 2\",\n        },\n    ];\n\n    return (\n        <Example>\n            <Example.Item title=\"default renderer, single\">\n                <Select.Custom name=\"animal\" defaultValue=\"1\" placeholder=\"Nothing selected\">\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"default renderer, multiple\">\n                <Select.Custom name=\"animal\" defaultValue={[\"1\"]} multiple placeholder=\"Nothing selected\">\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"renderValue, single\">\n                <Select.Custom\n                    name=\"animal\"\n                    defaultValue=\"1\"\n                    placeholder=\"Nothing selected\"\n                    renderValue={(args) => <Badge>Title {args.value}</Badge>}\n                >\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n\n            <Example.Item title=\"renderValue, multiple\">\n                <Select.Custom\n                    name=\"animal\"\n                    defaultValue={[\"1\"]}\n                    multiple\n                    placeholder=\"Nothing selected\"\n                    renderValue={(args) => <Badge>Titles {args.value.join(\", \")}</Badge>}\n                >\n                    {options.map((option) => (\n                        <Select.Option key={option.value} value={option.value}>\n                            <Text weight=\"medium\">{option.label}</Text>\n                            <Text weight=\"regular\" color=\"neutral-faded\">\n                                {option.subtitle}\n                            </Text>\n                        </Select.Option>\n                    ))}\n                </Select.Custom>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "components-select--error",
 					"name": "error",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <Select.Custom name=\"animal\" placeholder=\"Select an animal\" hasError>\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-select--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, native\">\n            <Select\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                disabled\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n        <Example.Item title=\"disabled, custom\">\n            <Select.Custom\n                name=\"animal-2\"\n                placeholder=\"Select an animal\"\n                disabled\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-select--class-name",
+					"name": "className, attributes, inputAttributes",
 					"snippet": "const className = () => (\n    <Example>\n        <Example.Item title=\"native, className, attributes, inputAttributes\">\n            <Select\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                className=\"native-class\"\n                attributes={{ id: \"test-id\" }}\n                inputAttributes={{ \"aria-label\": \"test-label\" }}\n            >\n                <option value=\"dog\">Dog</option>\n                <option value=\"turtle\">Turtle</option>\n            </Select>\n        </Example.Item>\n        <Example.Item title=\"custom, className, attributes, inputAttributes\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                className=\"custom-class\"\n                attributes={{ id: \"test-id\" }}\n                inputAttributes={{ \"aria-label\": \"test-label\" }}\n            >\n                <Select.Option value=\"dog\">Dog</Select.Option>\n                <Select.Option value=\"turtle\">Turtle</Select.Option>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "fallback",
+					"id": "components-select--fallback",
+					"name": "test: fallbackAdjustLayout",
 					"snippet": "const fallback = () => (\n    <Example>\n        <Example.Item title=\"fallback\">\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                {[...Array(100)].map((_, index) => (\n                    <Select.Option key={index} value={`item-${index}`}>\n                        Item {index + 1}\n                    </Select.Option>\n                ))}\n            </Select.Custom>\n            <div style={{ height: \"1000px\" }}></div>\n            <Select.Custom\n                name=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{ \"aria-label\": \"Select an animal\" }}\n            >\n                {[...Array(100)].map((_, index) => (\n                    <Select.Option key={index} value={`item-${index}`}>\n                        Item {index + 1}\n                    </Select.Option>\n                ))}\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-select--form-control",
+					"name": "test: with FormControl",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"FormControl\">\n            <FormControl hasError>\n                <FormControl.Label>Animal</FormControl.Label>\n                <Select.Custom name=\"animal\" placeholder=\"Select an animal\">\n                    <Select.Option value=\"dog\">Dog</Select.Option>\n                    <Select.Option value=\"turtle\">Turtle</Select.Option>\n                </Select.Custom>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "components-select--test-composition",
+					"name": "test: composition",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item title=\"custom with options\">\n            <Select.Custom\n                name=\"animal\"\n                id=\"animal\"\n                placeholder=\"Select an animal\"\n                inputAttributes={{\n                    \"aria-label\": \"Select an animal\",\n                }}\n            >\n                <Select.Group>\n                    <Select.Option value=\"dog\">Dog</Select.Option>\n                    <Select.Option value=\"turtle\">Turtle</Select.Option>\n                </Select.Group>\n                <Select.Group>Hello</Select.Group>\n            </Select.Custom>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Badge, Example, FormControl, MenuItem, Modal, Placeholder, Select, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Select/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Select",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Select/Select.tsx",
-				"actualName": "Select",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the select user interaction and form submission",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value selected",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon to display in the select start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the select value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Show an error state, automatically inherited when component is used inside FormControl",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when the trigger is clicked",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"options": {
+						"defaultValue": null,
+						"description": "@deprecated Use <option /> children instead",
+						"name": "options",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NativeOption[]" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the input is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLSelectElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the input is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLSelectElement, Element>) => void)" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"select\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"renderValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "renderValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "undefined" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Select/Select.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLSelectElement>>" }
+					}
+				},
+				"exportName": "Select"
 			}
 		},
 		"components-skeleton": {
@@ -1565,26 +8543,87 @@
 			"path": "./src/components/Skeleton/tests/Skeleton.stories.tsx",
 			"stories": [
 				{
+					"id": "components-skeleton--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"text\">\n            <Skeleton />\n        </Example.Item>\n\n        <Example.Item title=\"view, rectangle\">\n            <Skeleton width=\"100px\" height=\"100px\" />\n        </Example.Item>\n\n        <Example.Item title=\"view, circle\">\n            <Skeleton width=\"100px\" height=\"100px\" borderRadius=\"circular\" />\n        </Example.Item>\n\n        <Example.Item title=\"view, rectangle, responsive\">\n            <Skeleton width={{ s: \"100px\", m: \"200px\" }} height={{ s: \"100px\", m: \"200px\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-skeleton--radius",
 					"name": "radius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius=small\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"small\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=medium\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"medium\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=large\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"large\" />\n        </Example.Item>\n\n        <Example.Item title=\"radius=circular\">\n            <Skeleton width=\"60px\" height=\"60px\" borderRadius=\"circular\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-skeleton--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Skeleton className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Skeleton } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Skeleton/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Skeleton",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Skeleton/Skeleton.tsx",
-				"actualName": "Skeleton",
+				"methods": [],
+				"props": {
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width style, literal string value or a base unit token number multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Radius>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Skeleton/Skeleton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Skeleton/Skeleton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1594,66 +8633,421 @@
 			"path": "./src/components/Slider/tests/Slider.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "components-slider--base",
+					"name": "name, minName, maxName, range",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"single, name\">\n            <Slider name=\"slider-single\" defaultValue={30} />\n        </Example.Item>\n        <Example.Item title=\"range, name\">\n            <Slider range name=\"slider-range\" defaultMinValue={30} defaultMaxValue={85} />\n        </Example.Item>\n        <Example.Item title=\"range, minName, maxName\">\n            <Slider\n                range\n                minName=\"slider-min\"\n                maxName=\"slider-max\"\n                defaultMinValue={30}\n                defaultMaxValue={85}\n            />\n        </Example.Item>\n        <div style={{ height: 2000 }} />\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--orientation",
 					"name": "orientation",
 					"snippet": "const orientation = () => (\n    <Example>\n        <Example.Item title=\"orientation: vertical\">\n            <View height=\"200px\">\n                <Slider\n                    range\n                    name=\"slider\"\n                    defaultMinValue={30}\n                    defaultMaxValue={85}\n                    orientation=\"vertical\"\n                />\n            </View>\n        </Example.Item>\n        <View height=\"2000px\" />\n    </Example>\n);"
 				},
 				{
-					"name": "minMax",
+					"id": "components-slider--min-max",
+					"name": "min, max",
 					"snippet": "const minMax = () => (\n    <Example>\n        <Example.Item title=\"min, max\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={60} />\n        </Example.Item>\n        <Example.Item title=\"min, max, value < min\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={30} />\n        </Example.Item>\n        <Example.Item title=\"min, max, value > max\">\n            <Slider name=\"name\" min={50} max={70} defaultValue={80} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--step",
 					"name": "step",
 					"snippet": "const step = () => (\n    <Example>\n        <Example.Item title=\"step: 5\">\n            <Slider name=\"slider\" defaultValue={30} step={5} />\n        </Example.Item>\n\n        <Example.Item title=\"step: 5, defaultValue: 31, rounded down to 30\">\n            <Slider name=\"slider\" defaultValue={31} step={5} />\n        </Example.Item>\n\n        <Example.Item title=\"step: 0.01, float\">\n            <Slider name=\"slider\" defaultValue={30} step={0.01} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <Slider name=\"slider\" defaultValue={30} disabled />\n        </Example.Item>\n\n        <Example.Item title=\"disabled, range\">\n            <Slider name=\"slider\" range defaultMinValue={30} defaultMaxValue={80} disabled />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-slider--render-value",
 					"name": "renderValue",
 					"snippet": "const renderValue = () => (\n    <Example>\n        <Example.Item title=\"renderValue: $\">\n            <Slider name=\"name\" defaultValue={50} renderValue={(args) => `$${args.value}`} />\n        </Example.Item>\n        <Example.Item title=\"renderValue: false\">\n            <Slider name=\"name\" defaultValue={50} renderValue={false} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-slider--default-value",
+					"name": "defaultValue, onChange, onChangeCommit",
 					"snippet": "const defaultValue = () => <View paddingTop={10}>\n    <Slider name=\"test-name\" defaultValue={50} onChange={fn()} onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "value",
+					"id": "components-slider--value",
+					"name": "value, onChange, onChangeCommit",
 					"snippet": "const value = () => <View paddingTop={10}>\n    <Slider name=\"test-name\" value={50} onChange={fn()} onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "rangeDefaultValue",
+					"id": "components-slider--range-default-value",
+					"name": "range, defaultValue, onChange, onChangeCommit",
 					"snippet": "const rangeDefaultValue = () => <View paddingTop={10}>\n    <Slider\n        range\n        name=\"test-name\"\n        defaultMinValue={50}\n        defaultMaxValue={70}\n        onChange={fn()}\n        onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "rangeValue",
+					"id": "components-slider--range-value",
+					"name": "range, value, onChange, onChangeCommit, minName, maxName",
 					"snippet": "const rangeValue = () => <View paddingTop={10}>\n    <Slider\n        range\n        minName=\"test-name-min\"\n        maxName=\"test-name-max\"\n        minValue={50}\n        maxValue={70}\n        onChange={fn()}\n        onChangeCommit={fn()} />\n</View>;"
 				},
 				{
-					"name": "className",
+					"id": "components-slider--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Slider name=\"name\" className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				},
 				{
-					"name": "testForm",
+					"id": "components-slider--test-form",
+					"name": "test: form onChange",
 					"snippet": "const testForm = (args) => {\n    const formRef = React.useRef<HTMLFormElement>(null);\n    const [data, setData] = React.useState<[string, FormDataEntryValue][]>([]);\n\n    const handleChange = (e: React.FormEvent<HTMLFormElement>) => {\n        const formData = new FormData(e.currentTarget);\n        const nextState = [...formData.entries()];\n\n        args.handleFormChange({ formData: nextState });\n        setData(nextState);\n    };\n\n    return (\n        <View paddingTop={10} gap={4}>\n            <form onChange={handleChange} ref={formRef}>\n                <Slider\n                    range\n                    minName=\"slider-min\"\n                    maxName=\"slider-max\"\n                    defaultMinValue={30}\n                    defaultMaxValue={50}\n                />\n            </form>\n\n            {data.map((v) => v.join(\": \")).join(\", \")}\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testSwipe",
+					"id": "components-slider--test-swipe",
+					"name": "test: prevents parent swipe",
 					"snippet": "const testSwipe = () => {\n    const toggle = useToggle(true);\n\n    return (\n        <Modal active={toggle.active} onClose={toggle.deactivate} position=\"end\">\n            <View gap={4}>\n                <Modal.Title>Modal</Modal.Title>\n                <Slider name=\"slider\" defaultValue={30} />\n            </View>\n        </Modal>\n    );\n};"
 				}
 			],
 			"import": "import { Example, Modal, Slider, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Slider/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Slider",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Slider/Slider.tsx",
-				"actualName": "Slider",
+				"methods": [],
+				"props": {
+					"step": {
+						"defaultValue": null,
+						"description": "Step of the slider",
+						"name": "step",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the slider user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"min": {
+						"defaultValue": null,
+						"description": "Minimum value of the slider",
+						"name": "min",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"max": {
+						"defaultValue": null,
+						"description": "Maximum value of the slider",
+						"name": "max",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"orientation": {
+						"defaultValue": null,
+						"description": "Orientation of the slider",
+						"name": "orientation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"vertical\" | \"horizontal\"",
+							"value": [{ "value": "\"vertical\"" }, { "value": "\"horizontal\"" }]
+						}
+					},
+					"renderValue": {
+						"defaultValue": null,
+						"description": "Render a custom value in the thumb tooltip",
+						"name": "renderValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | ((args: { value: number; }) => string)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the slider, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the slider, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"range": {
+						"defaultValue": null,
+						"description": "Enables range slider with two thumbs",
+						"name": "range",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the slider input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"minName": {
+						"defaultValue": null,
+						"description": "Name of the slider min value input element, overrides the name",
+						"name": "minName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"maxName": {
+						"defaultValue": null,
+						"description": "Name of the slider max value input element, overrides the name",
+						"name": "maxName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the slider value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: SingleChangeArgs) => void) | ((args: RangeChangeArgs) => void) | ((args: RangeChangeArgs) => void)"
+						}
+					},
+					"onChangeCommit": {
+						"defaultValue": null,
+						"description": "Callback when the user commits the change by releasing the thumb\nCallback when the user commits the change by releasing the thumbs",
+						"name": "onChangeCommit",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: SingleChangeArgs) => void) | ((args: RangeChangeArgs) => void) | ((args: RangeChangeArgs) => void)"
+						}
+					},
+					"minValue": {
+						"defaultValue": null,
+						"description": "Minimum value of the slider",
+						"name": "minValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"maxValue": {
+						"defaultValue": null,
+						"description": "Maximum value of the slider",
+						"name": "maxValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultMinValue": {
+						"defaultValue": null,
+						"description": "Default minimum value of the slider, enables uncontrolled mode",
+						"name": "defaultMinValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"defaultMaxValue": {
+						"defaultValue": null,
+						"description": "Default maximum value of the slider, enables uncontrolled mode",
+						"name": "defaultMaxValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Slider/Slider.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1663,35 +9057,137 @@
 			"path": "./src/components/Stepper/tests/Stepper.stories.tsx",
 			"stories": [
 				{
+					"id": "components-stepper--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example>\n        <Example.Item title=\"direction: row\">\n            <Stepper activeId=\"1\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <Stepper activeId=\"1\" direction=\"column\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-stepper--label-display",
 					"name": "labelDisplay",
 					"snippet": "const labelDisplay = () => (\n    <Example>\n        <Example.Item title=\"direction: row, labels hidden\">\n            <Stepper activeId=\"1\" labelDisplay=\"hidden\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: column, labels hiden\">\n            <Stepper activeId=\"1\" direction=\"column\" labelDisplay=\"hidden\">\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"direction: row, labels hidden on s\">\n            <Stepper activeId=\"1\" labelDisplay={{ s: \"hidden\", m: \"inline\" }}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-stepper--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 6, direction: row\">\n            <Stepper activeId=\"1\" gap={6}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title=\"gap: 6, direction: column\">\n            <Stepper activeId=\"1\" direction=\"column\" gap={6}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap\", \"[s] 2\", \"[m+] 5\"]}>\n            <Stepper activeId=\"1\" gap={{ s: 2, m: 5 }}>\n                <Stepper.Item completed title=\"Step 1\" subtitle=\"Step subtitle\" />\n                <Stepper.Item title=\"Step 2\" />\n                <Stepper.Item title=\"Step 3 very long title\" />\n            </Stepper>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-stepper--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Stepper className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Stepper.Item attributes={{ id: \"test-item-id\" }} className=\"test-item-classname\" />\n        </Stepper>\n    </div>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-stepper--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"multiline subtitle\",\n                \"should wrap the text correctly\",\n                \"should display the connector correctly\",\n            ]}\n        >\n            <Demo\n                activeId={0}\n                subtitle=\"It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, Placeholder, Stepper, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Stepper/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Stepper",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Stepper/Stepper.tsx",
-				"actualName": "Stepper",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"activeId": {
+						"defaultValue": null,
+						"description": "Id of the item to display as active",
+						"name": "activeId",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string | number" }
+					},
+					"labelDisplay": {
+						"defaultValue": null,
+						"description": "Display variant for the item label",
+						"name": "labelDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"hidden\" | \"inline\">" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Direction of the stepper",
+						"name": "direction",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between items (default: 3)",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Stepper/Stepper.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
+				"exportName": "Stepper"
 			}
 		},
 		"components-switch": {
@@ -1700,38 +9196,236 @@
 			"path": "./src/components/Switch/tests/Switch.stories.tsx",
 			"stories": [
 				{
-					"name": "size",
+					"id": "components-switch--size",
+					"name": "Size",
 					"snippet": "const size = () => (\n\t<Example>\n\t\t<Example.Item title=\"size: medium\">\n\t\t\t<Switch name=\"active\" size=\"medium\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: small\">\n\t\t\t<Switch name=\"active\" size=\"small\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: large\">\n\t\t\t<Switch name=\"active\" size=\"large\" inputAttributes={{ \"aria-label\": \"test switch\" }} />\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: responsive, s: small, m: large\">\n\t\t\t<Switch\n\t\t\t\tname=\"active\"\n\t\t\t\tsize={{ s: \"small\", m: \"large\" }}\n\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t/>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "label",
+					"id": "components-switch--label",
+					"name": "Label",
 					"snippet": "const label = () => (\n\t<Example>\n\t\t<Example.Item title=\"size: medium\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch reversed name=\"active\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"size: small\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" size=\"small\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch\n\t\t\t\t\treversed\n\t\t\t\t\tname=\"active\"\n\t\t\t\t\tsize=\"small\"\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t\t>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\n\t\t<Example.Item title=\"size: large\">\n\t\t\t<View direction=\"row\" gap={8}>\n\t\t\t\t<Switch name=\"active\" size=\"large\" inputAttributes={{ \"aria-label\": \"test switch\" }}>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t\t<Switch\n\t\t\t\t\treversed\n\t\t\t\t\tname=\"active\"\n\t\t\t\t\tsize=\"large\"\n\t\t\t\t\tinputAttributes={{ \"aria-label\": \"test switch\" }}\n\t\t\t\t>\n\t\t\t\t\tWi-fi\n\t\t\t\t</Switch>\n\t\t\t</View>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "defaultChecked",
+					"id": "components-switch--default-checked",
+					"name": "defaultChecked, uncontrolled",
 					"snippet": "const defaultChecked = () => <Switch name=\"test-name\" defaultChecked onChange={fn()}>Label\n            </Switch>;"
 				},
 				{
-					"name": "checked",
+					"id": "components-switch--checked",
+					"name": "checked, uncontrolled",
 					"snippet": "const checked = () => <Switch name=\"test-name\" checked onChange={fn()}>Label\n            </Switch>;"
 				},
 				{
+					"id": "components-switch--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, unselected\">\n            <Switch name=\"active\" disabled inputAttributes={{ \"aria-label\": \"test switch\" }} />\n        </Example.Item>\n        <Example.Item title=\"disabled, selected\">\n            <Switch\n                name=\"active\"\n                disabled\n                defaultChecked\n                inputAttributes={{ \"aria-label\": \"test switch\" }}\n            />\n        </Example.Item>\n        <Example.Item title=\"disabled, with label\">\n            <Switch name=\"active\" disabled>\n                Switch\n            </Switch>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-switch--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Switch\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            inputAttributes={{ \"aria-label\": \"test select\", id: \"test-input-id\" }}\n            name=\"name\"\n        >\n            Label\n        </Switch>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Switch, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Switch/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Switch",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Switch/Switch.tsx",
-				"actualName": "Switch",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the switch",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the switch input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the switch user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"reversed": {
+						"defaultValue": null,
+						"description": "Reverse the children position",
+						"name": "reversed",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"small\" | \"large\" | \"medium\">" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the switch value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<boolean, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the switch is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the switch is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<Element, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"label\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default value of the switch, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Value of the switch, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Switch/Switch.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -1741,51 +9435,112 @@
 			"path": "./src/components/Table/tests/Table.stories.tsx",
 			"stories": [
 				{
-					"name": "layout",
+					"id": "components-table--layout",
+					"name": "base",
 					"snippet": "const layout = () => (\n    <Example>\n        <Example.Item title=\"base\">\n            <Table>\n                <Table.Head>\n                    <Table.Row>\n                        <Table.Heading>Column 1</Table.Heading>\n                        <Table.Heading>Column 2</Table.Heading>\n                    </Table.Row>\n                </Table.Head>\n                <Table.Body>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell>Cell 2</Table.Cell>\n                    </Table.Row>\n                </Table.Body>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"colspan: 2 for col 2, rowspan: 2 for cell 3\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading colSpan={2}>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                    <Table.Cell rowSpan={2}>Cell 3</Table.Cell>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"align: center for heading 1, align: end for heading 2\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading align=\"center\">Column 1</Table.Heading>\n                    <Table.Heading align=\"end\">Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"valign: center for cell 2, valign: end for cell 3\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>\n                        <View height={15} backgroundColor=\"neutral-faded\" />\n                    </Table.Cell>\n                    <Table.Cell verticalAlign=\"center\">Cell 2</Table.Cell>\n                    <Table.Cell verticalAlign=\"end\">Cell 3</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"width: 40%, minWidth: 200px for col 1\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"40%\" minWidth=\"200px\">\n                        Column 1\n                    </Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-table--border",
 					"name": "border",
 					"snippet": "const border = () => (\n    <Example>\n        <Example.Item title=\"border: true\">\n            <Table border>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"columnBorder: true\">\n            <Table columnBorder>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"columnBorder: true, border: true\">\n            <Table columnBorder border>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-table--rows",
 					"name": "rows",
 					"snippet": "const rows = () => (\n    <Example>\n        <Example.Item title=\"highlighted for row 2\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row highlighted>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"clickable row 2, focus ring\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading>Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row onClick={() => {}}>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-table--render",
+					"name": "rendering",
 					"snippet": "const render = () => (\n    <Table>\n        <Table.Head>\n            <Table.Row>\n                <Table.Heading>Heading</Table.Heading>\n                <Table.Heading>Heading</Table.Heading>\n            </Table.Row>\n        </Table.Head>\n        <Table.Body>\n            <Table.Row>\n                <Table.Cell>Content</Table.Cell>\n                <Table.Cell>Content</Table.Cell>\n            </Table.Row>\n        </Table.Body>\n    </Table>\n);"
 				},
 				{
-					"name": "tbody",
+					"id": "components-table--tbody",
+					"name": "tbody rendering",
 					"snippet": "const tbody = () => (\n    <Table>\n        <Table.Row>\n            <Table.Heading>Heading</Table.Heading>\n            <Table.Heading>Heading</Table.Heading>\n        </Table.Row>\n    </Table>\n);"
 				},
 				{
-					"name": "tabIndex",
+					"id": "components-table--tab-index",
+					"name": "adds tabIndex for clickable rows",
 					"snippet": "const tabIndex = () => (\n    <Table>\n        <Table.Row>\n            <Table.Cell />\n        </Table.Row>\n        <Table.Row onClick={() => {}}>\n            <Table.Cell />\n        </Table.Row>\n        <Table.Row attributes={{ onClick: () => {} }}>\n            <Table.Cell />\n        </Table.Row>\n    </Table>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-table--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Table className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Table.Row attributes={{ id: \"test-row-id\" }}>\n                <Table.Cell attributes={{ id: \"test-cell-id\" }}></Table.Cell>\n            </Table.Row>\n        </Table>\n    </div>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-table--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"scroll fade\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"500px\">Column 1</Table.Heading>\n                    <Table.Heading width=\"500px\">Column 2</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n        <Example.Item title=\"card with highlighted heading\">\n            <Card elevated padding={0}>\n                <Table>\n                    <Table.Row highlighted>\n                        <Table.Heading width=\"50%\" minWidth=\"200px\">\n                            Column 1\n                        </Table.Heading>\n                        <Table.Heading colSpan={2} align=\"end\">\n                            Column 2\n                        </Table.Heading>\n                    </Table.Row>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell align=\"center\">Cell 2</Table.Cell>\n                        <Table.Cell align=\"end\">Cell 3</Table.Cell>\n                    </Table.Row>\n                    <Table.Row>\n                        <Table.Cell>Cell 1</Table.Cell>\n                        <Table.Cell align=\"center\">Cell 2</Table.Cell>\n                        <Table.Cell align=\"end\">Cell 3</Table.Cell>\n                    </Table.Row>\n                </Table>\n            </Card>\n        </Example.Item>\n        <Example.Item title=\"width: auto, nowrap\">\n            <Table>\n                <Table.Row>\n                    <Table.Heading width=\"50%\">Column 1</Table.Heading>\n                    <Table.Heading>Column 2</Table.Heading>\n                    <Table.Heading>Column 3</Table.Heading>\n                    <Table.Heading width=\"auto\">Long heading title</Table.Heading>\n                </Table.Row>\n                <Table.Row>\n                    <Table.Cell>Cell 1</Table.Cell>\n                    <Table.Cell>Cell 2</Table.Cell>\n                    <Table.Cell>Cell 3</Table.Cell>\n                    <Table.Cell>Cell 4</Table.Cell>\n                </Table.Row>\n            </Table>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "examples",
+					"id": "components-table--examples",
+					"name": "test: selectable",
 					"snippet": "const examples = () => (\n    <Example>\n        <Example.Item title=\"selectable\">\n            <SelectionDemo />\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Card, Checkbox, Example, Table, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Table/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Table",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Table/Table.tsx",
-				"actualName": "Table",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"border": {
+						"defaultValue": null,
+						"description": "Add border around the table",
+						"name": "border",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"columnBorder": {
+						"defaultValue": null,
+						"description": "Add border between the table columns",
+						"name": "columnBorder",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Table/Table.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
+				"exportName": "Table"
 			}
 		},
 		"components-tabs": {
@@ -1794,71 +9549,196 @@
 			"path": "./src/components/Tabs/tests/Tabs.stories.tsx",
 			"stories": [
 				{
+					"id": "components-tabs--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Tabs>\n        <Tabs.List>\n            <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n            <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n        </Tabs.List>\n\n        <Tabs.Panel value=\"1\">\n            <View padding={4}>Content 1</View>\n        </Tabs.Panel>\n        <Tabs.Panel value=\"2\">\n            <View padding={4}>Content 2</View>\n        </Tabs.Panel>\n    </Tabs>\n);"
 				},
 				{
+					"id": "components-tabs--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Tabs defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills\">\n            <Tabs variant=\"pills\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills-elevated\">\n            <Tabs variant=\"pills-elevated\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: borderless\">\n            <Tabs variant=\"borderless\" defaultValue=\"0\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"variant: default, size: large\">\n            <Tabs size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills, size: large\">\n            <Tabs variant=\"pills\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: pills-elevated, size: large\">\n            <Tabs variant=\"pills-elevated\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"variant: borderless, size: large\">\n            <Tabs variant=\"borderless\" size=\"large\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example>\n        <Example.Item title=\"direction: column, variant: underline\">\n            <Tabs direction=\"column\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: pills\">\n            <Tabs direction=\"column\" variant=\"pills\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: pills-elevated\">\n            <Tabs direction=\"column\" variant=\"pills-elevated\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"direction: column, variant: borderless\">\n            <Tabs direction=\"column\" variant=\"borderless\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--icon",
 					"name": "icon",
 					"snippet": "const icon = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <Tabs>\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"1\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"icon only\">\n            <Tabs variant=\"pills-elevated\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap} attributes={{ \"aria-label\": \"Tab 1\" }} />\n                    <Tabs.Item value=\"1\" icon={IconZap} attributes={{ \"aria-label\": \"Tab 2\" }} />\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "equalWidth",
+					"id": "components-tabs--equal-width",
+					"name": "itemWidth",
 					"snippet": "const equalWidth = () => (\n    <Example>\n        <Example.Item title=\"equal width items\">\n            <Tabs onChange={console.log} itemWidth=\"equal\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"1\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                    <Tabs.Item value=\"2\" icon={IconZap}>\n                        Very long item 3\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tabs--href",
 					"name": "href",
 					"snippet": "const href = () => (\n    <Example>\n        <Example.Item title=\"href, no onChange\">\n            <Tabs value=\"2\">\n                <Tabs.List>\n                    <Tabs.Item value=\"1\" href=\"#item-1\" icon={IconZap}>\n                        Item 1\n                    </Tabs.Item>\n                    <Tabs.Item value=\"2\" href=\"#item-2\" icon={IconZap}>\n                        Long item 2\n                    </Tabs.Item>\n                    <Tabs.Item value=\"3\" href=\"#item-3\" icon={IconZap}>\n                        Very long item 3\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "disabled",
+					"id": "components-tabs--disabled",
+					"name": "item, disabled",
 					"snippet": "const disabled = () => {\n    return (\n        <Example>\n            <Example.Item title=\"disabled\">\n                <Tabs defaultValue=\"1\">\n                    <Tabs.List>\n                        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"2\" disabled icon={IconZap}>\n                            Item 2\n                        </Tabs.Item>\n                        <Tabs.Item value=\"3\">Item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"1\">\n                        <View padding={4}>Content 1</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <View padding={4}>Content 2</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"3\">\n                        <View padding={4}>Content 3</View>\n                    </Tabs.Panel>\n                </Tabs>\n            </Example.Item>\n\n            <Example.Item title=\"disabled, href\">\n                <Tabs defaultValue=\"1\">\n                    <Tabs.List>\n                        <Tabs.Item href=\"#item1\" value=\"1\">\n                            Item 1\n                        </Tabs.Item>\n                        <Tabs.Item href=\"#item2\" value=\"2\" disabled icon={IconZap}>\n                            Item 2\n                        </Tabs.Item>\n                        <Tabs.Item href=\"#item3\" value=\"3\">\n                            Item 3\n                        </Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"1\">\n                        <View padding={4}>Content 1</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <View padding={4}>Content 2</View>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"3\">\n                        <View padding={4}>Content 3</View>\n                    </Tabs.Panel>\n                </Tabs>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-tabs--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <Tabs defaultValue=\"2\" onChange={fn()}>\n    <Tabs.List>\n        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n        <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n    </Tabs.List>\n    <Tabs.Panel value=\"1\">Content 1</Tabs.Panel>\n    <Tabs.Panel value=\"2\">Content 2</Tabs.Panel>\n</Tabs>;"
 				},
 				{
-					"name": "value",
+					"id": "components-tabs--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <Tabs value=\"2\" onChange={fn()}>\n    <Tabs.List>\n        <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n        <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n    </Tabs.List>\n    <Tabs.Panel value=\"1\">Content 1</Tabs.Panel>\n    <Tabs.Panel value=\"2\">Content 2</Tabs.Panel>\n</Tabs>;"
 				},
 				{
-					"name": "className",
+					"id": "components-tabs--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Tabs>\n            <Tabs.List attributes={{ id: \"test-list-id\" }} className=\"test-list-classname\">\n                <Tabs.Item attributes={{ id: \"test-item-id\" }} value=\"1\">\n                    Item\n                </Tabs.Item>\n            </Tabs.List>\n\n            <Tabs.Panel\n                attributes={{ \"data-testid\": \"test-panel-id\" }}\n                className=\"test-panel-classname\"\n                value=\"1\"\n            />\n        </Tabs>\n    </div>\n);"
 				},
 				{
-					"name": "testFocusableContent",
+					"id": "components-tabs--test-focusable-content",
+					"name": "test: focusable content",
 					"snippet": "const testFocusableContent = () => (\n    <Example>\n        <Example.Item title=\"panels without focusable content\">\n            <Tabs>\n                <View gap={4}>\n                    <Tabs.List>\n                        <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                        <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"0\">Tab 1</Tabs.Panel>\n                    <Tabs.Panel value=\"1\">Tab 2</Tabs.Panel>\n                    <Tabs.Panel value=\"2\">Tab 3</Tabs.Panel>\n                </View>\n            </Tabs>\n        </Example.Item>\n\n        <Example.Item title=\"panels with focusable content\">\n            <Tabs>\n                <View gap={4}>\n                    <Tabs.List>\n                        <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                        <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                        <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                    </Tabs.List>\n\n                    <Tabs.Panel value=\"0\">\n                        <Button onClick={() => {}}>Tab 1 action</Button>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"1\">\n                        <Button onClick={() => {}}>Tab 2 action</Button>\n                    </Tabs.Panel>\n                    <Tabs.Panel value=\"2\">\n                        <Button onClick={() => {}}>Tab 3 action</Button>\n                    </Tabs.Panel>\n                </View>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "components-tabs--test-composition",
+					"name": "test: composition",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item title=\"Viewport overflow\">\n            <Tabs>\n                <Tabs.List>\n                    {[...Array(8)].map((_, i) => (\n                        <Tabs.Item value={`${i}`} key={i} icon={IconZap}>\n                            Very long item {i}\n                        </Tabs.Item>\n                    ))}\n                </Tabs.List>\n\n                {[...Array(8)].map((_, i) => (\n                    <Tabs.Panel value={`${i}`} key={i}>\n                        Tab {i}\n                    </Tabs.Panel>\n                ))}\n            </Tabs>\n        </Example.Item>\n        <Example.Item>\n            <Tabs onChange={console.log} variant=\"pills-elevated\" name=\"hey\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">\n                        <View borderColor=\"neutral-faded\" padding={5}>\n                            Item 3\n                        </View>\n                    </Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n        <Example.Item title=\"Custom non-interactive list children\">\n            <Tabs direction=\"column\">\n                <Tabs.List>\n                    <Tabs.Item value=\"0\">Item 1</Tabs.Item>\n                    <View height={6} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n                    <Tabs.Item value=\"1\">Long item 2</Tabs.Item>\n                    <Tabs.Item value=\"2\">Very long item 3</Tabs.Item>\n                </Tabs.List>\n            </Tabs>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testEdgeCaseDom",
+					"id": "components-tabs--test-edge-case-dom",
+					"name": "test: scroll subscription",
 					"snippet": "const testEdgeCaseDom = () => {\n    const [activeItem, setActiveItem] = React.useState(\"1\");\n    const sectionsRef = React.useRef(null);\n\n    return (\n        <Example>\n            <Example.Item title=\"active item changes on scroll\">\n                <View justify=\"center\" align=\"center\" padding={10}>\n                    <View width={60} gap={2}>\n                        <Tabs value={activeItem} onChange={(args) => setActiveItem(args.value)}>\n                            <Tabs.List>\n                                <Tabs.Item value=\"1\">Item 1</Tabs.Item>\n                                <Tabs.Item value=\"2\">Item 2</Tabs.Item>\n                                <Tabs.Item value=\"3\">Item 3</Tabs.Item>\n                                <Tabs.Item value=\"4\">Item 4</Tabs.Item>\n                            </Tabs.List>\n                        </Tabs>\n\n                        <ScrollArea\n                            attributes={{ ref: sectionsRef }}\n                            height={70}\n                            onScroll={(args) => {\n                                setActiveItem(Math.min(4, Math.floor(args.y * 10) + 1).toString());\n                            }}\n                        >\n                            <View gap={4}>\n                                <View gap={2}>\n                                    <Text>Section 1</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View grow height=\"100px\" backgroundColor=\"neutral-faded\" key={i} />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 2</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 3</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n\n                                <View gap={2}>\n                                    <Text>Section 4</Text>\n\n                                    <View gap={1} direction=\"row\">\n                                        {[...Array(4)].map((_, i) => (\n                                            <View key={i} grow height=\"100px\" backgroundColor=\"neutral-faded\" />\n                                        ))}\n                                    </View>\n                                </View>\n                            </View>\n                        </ScrollArea>\n                    </View>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Example, ScrollArea, Tabs, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Tabs/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Tabs",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Tabs/Tabs.tsx",
-				"actualName": "Tabs",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Direction of the tab buttons",
+						"name": "direction",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"row\" | \"column\"",
+							"value": [{ "value": "\"row\"" }, { "value": "\"column\"" }]
+						}
+					},
+					"itemWidth": {
+						"defaultValue": null,
+						"description": "Equal width for the tab buttons",
+						"name": "itemWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"equal\"", "value": [{ "value": "\"equal\"" }] }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Render variant for component",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"bordered\" | \"borderless\" | \"pills\" | \"pills-elevated\"",
+							"value": [
+								{ "value": "\"bordered\"" },
+								{ "value": "\"borderless\"" },
+								{ "value": "\"pills\"" },
+								{ "value": "\"pills-elevated\"" }
+							]
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"large\" | \"medium\"",
+							"value": [{ "value": "\"large\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the tab buttons group when used as a form control",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the active tab value changes",
+						"name": "onChange",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((args: { value: string; name?: string; }) => void)" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the active tab, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the active tab, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" },
+							{ "fileName": "reshaped/src/components/Tabs/Tabs.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "Tabs"
 			}
 		},
 		"components-textarea": {
@@ -1867,71 +9747,315 @@
 			"path": "./src/components/TextArea/tests/TextArea.stories.tsx",
 			"stories": [
 				{
-					"name": "variants",
+					"id": "components-textarea--variants",
+					"name": "variant",
 					"snippet": "const variants = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <TextArea variant=\"faded\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless\">\n            <TextArea variant=\"headless\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: medium\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"medium\" />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"large\" />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size=\"xlarge\" />\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] large\", \"[m+] medium\"]}>\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" size={{ s: \"xlarge\", m: \"medium\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--resize",
 					"name": "resize",
 					"snippet": "const resize = () => (\n    <Example>\n        <Example.Item title=\"resize: none\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" resize=\"none\" />\n        </Example.Item>\n        <Example.Item title=\"resize: auto\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" resize=\"auto\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-textarea--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <TextArea name=\"Name\" placeholder=\"Enter your name\" hasError />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textarea--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner\">\n            <View gap={2}>\n                <Text variant=\"featured-2\">What problem are you trying to solve?</Text>\n                <TextArea.Aligner>\n                    <TextArea\n                        variant=\"headless\"\n                        placeholder=\"Try something like 'I have a job'\"\n                        name=\"description\"\n                    />\n                </TextArea.Aligner>\n                <View.Item>\n                    <Button>Next</Button>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-textarea--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"long value without breaks\">\n            <TextArea\n                name=\"hey\"\n                defaultValue={`<div style=\"position:relative;width:100%;padding-top:calc(150% + 72px)\">\n<iframe src=\"nskjdfdsdkjfsjkdfhbsjlhdfbsjlhfbs;jhbsdljfhsbljhfsbljhfbsjlfdhbsljhfbsdljhfbsljhfbslufbhsdlfds\" />\n</div>`}\n                resize=\"auto\"\n                placeholder=\"Placeholder\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-textarea--render",
+					"name": "base",
 					"snippet": "const render = () => <TextArea name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-textarea--placeholder",
 					"name": "placeholder",
 					"snippet": "const placeholder = () => (\n    <TextArea\n        name=\"test-name\"\n        placeholder=\"Placeholder\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-textarea--id",
 					"name": "id",
 					"snippet": "const id = () => (\n    <TextArea name=\"test-name\" id=\"test-id\" inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
+					"id": "components-textarea--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <TextArea name=\"test-name\" disabled inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-textarea--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <TextArea\n    name=\"test-name\"\n    defaultValue=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-textarea--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <TextArea\n    name=\"test-name\"\n    value=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-textarea--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <TextArea\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-textarea--form-control",
+					"name": "test: form control",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"with helper\">\n            <FormControl>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextArea name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n        <Example.Item title=\"with error\">\n            <FormControl hasError>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextArea name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, FormControl, Text, TextArea, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/TextArea/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "TextArea",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/TextArea/TextArea.tsx",
-				"actualName": "TextArea",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text area",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text area input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text area user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text area value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLTextAreaElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text area is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLTextAreaElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text area is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLTextAreaElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"textarea\">" }
+					},
+					"resize": {
+						"defaultValue": null,
+						"description": "Enable or disable the text area resizing, supports auto-sizing",
+						"name": "resize",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"none\" | \"auto\"",
+							"value": [{ "value": "\"none\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextArea/TextArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "TextArea"
 			}
 		},
 		"components-textfield": {
@@ -1940,71 +10064,445 @@
 			"path": "./src/components/TextField/tests/TextField.stories.tsx",
 			"stories": [
 				{
+					"id": "components-textfield--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: faded\">\n            <TextField variant=\"faded\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n\n        <Example.Item title=\"variant: headless\">\n            <TextField variant=\"headless\" name=\"Name\" placeholder=\"Enter your name\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--rounded",
 					"name": "rounded",
 					"snippet": "const rounded = () => (\n    <Example>\n        <Example.Item title=\"rounded\">\n            <TextField\n                rounded\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                icon={IconZap}\n                prefix=\"+31\"\n                endSlot={<Button rounded size=\"small\" icon={IconZap} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"rounded, variant: faded\">\n            <View direction=\"row\" gap={2}>\n                <View.Item grow>\n                    <TextField\n                        rounded\n                        variant=\"faded\"\n                        name=\"Name\"\n                        placeholder=\"Enter your name\"\n                        startSlot={\n                            <Badge rounded size=\"small\">\n                                Hello\n                            </Badge>\n                        }\n                    />\n                </View.Item>\n                <Button rounded>Submit</Button>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "error",
+					"id": "components-textfield--error",
+					"name": "hasError",
 					"snippet": "const error = () => (\n    <Example>\n        <Example.Item title=\"error\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" hasError />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "attachments",
+					"id": "components-textfield--attachments",
+					"name": "icon, endIcon, suffix, prefix, startSlot, endSlot, startSlotPadding, endSlotPadding",
 					"snippet": "const attachments = () => (\n    <Example>\n        <Example.Item title=\"icon\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" value=\"Reshaped\" icon={IconZap} />\n        </Example.Item>\n        <Example.Item title=\"endIcon\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" value=\"Reshaped\" endIcon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title={[\"startSlot\", \"vertical and horizontal padding aligned\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title={[\"endSlot\", \"vertical and horizontal padding aligned\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                endSlot={\n                    <Button\n                        icon={IconZap}\n                        size=\"small\"\n                        onClick={() => {}}\n                        attributes={{ \"aria-label\": \"Action\" }}\n                    />\n                }\n            />\n        </Example.Item>\n\n        <Example.Item title=\"paddingSlotStart=4, paddingSlotEnd=2\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlotPadding={4}\n                endSlotPadding={2}\n                startSlot={<Placeholder h={20} />}\n                endSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"with all affixes\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                endIcon={IconZap}\n                icon={IconZap}\n                prefix=\"Estimated value\"\n                suffix=\"m2\"\n                startSlot={<Placeholder h={20} />}\n                endSlot={<Placeholder h={20} />}\n            />\n        </Example.Item>\n\n        <Example.Item title=\"multiline wrap\">\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                value=\"Reshaped\"\n                startSlot={[...Array(10).keys()].map((i) => (\n                    <Badge size=\"small\" key={i}>\n                        Item {i + 1}\n                    </Badge>\n                ))}\n                multiline\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: small\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"small\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: medium\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"medium\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"large\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title=\"size: xlarge\">\n            <TextField name=\"Name\" placeholder=\"Enter your name\" size=\"xlarge\" icon={IconZap} />\n        </Example.Item>\n\n        <Example.Item title={[\"responsive size\", \"[s] xlarge\", \"[m+] medium\"]}>\n            <TextField\n                name=\"Name\"\n                placeholder=\"Enter your name\"\n                size={{ s: \"xlarge\", m: \"medium\" }}\n                icon={IconZap}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-textfield--aligner",
 					"name": "aligner",
 					"snippet": "const aligner = () => (\n    <Example>\n        <Example.Item title=\"aligner\">\n            <View gap={2}>\n                <Text variant=\"featured-2\">What problem are you trying to solve?</Text>\n                <TextField.Aligner>\n                    <TextField\n                        variant=\"headless\"\n                        placeholder=\"Try something like 'I have a job'\"\n                        name=\"description\"\n                    />\n                </TextField.Aligner>\n                <View.Item>\n                    <Button>Next</Button>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "render",
+					"id": "components-textfield--render",
+					"name": "base",
 					"snippet": "const render = () => <TextField name=\"test-name\" inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
+					"id": "components-textfield--placeholder",
 					"name": "placeholder",
 					"snippet": "const placeholder = () => (\n    <TextField\n        name=\"test-name\"\n        placeholder=\"Placeholder\"\n        inputAttributes={{ \"aria-label\": \"Label\" }}\n    />\n);"
 				},
 				{
+					"id": "components-textfield--id",
 					"name": "id",
 					"snippet": "const id = () => (\n    <TextField name=\"test-name\" id=\"test-id\" inputAttributes={{ \"aria-label\": \"Label\" }} />\n);"
 				},
 				{
+					"id": "components-textfield--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => <TextField name=\"test-name\" disabled inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "defaultValue",
+					"id": "components-textfield--default-value",
+					"name": "defaultValue, uncontrolled",
 					"snippet": "const defaultValue = () => <TextField\n    name=\"test-name\"\n    defaultValue=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "value",
+					"id": "components-textfield--value",
+					"name": "value, controlled",
 					"snippet": "const value = () => <TextField\n    name=\"test-name\"\n    value=\"value\"\n    onChange={fn()}\n    inputAttributes={{ \"aria-label\": \"Label\" }} />;"
 				},
 				{
-					"name": "className",
+					"id": "components-textfield--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <TextField\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            name=\"name\"\n            inputAttributes={{ id: \"test-input-id\", \"aria-label\": \"Label\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "formControl",
+					"id": "components-textfield--form-control",
+					"name": "test: form control",
 					"snippet": "const formControl = () => (\n    <Example>\n        <Example.Item title=\"with helper\">\n            <FormControl>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextField name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Helper>Helper</FormControl.Helper>\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n        <Example.Item title=\"with error\">\n            <FormControl hasError>\n                <FormControl.Label>Name</FormControl.Label>\n                <TextField name=\"name\" placeholder=\"Enter your name\" />\n                <FormControl.Error>This field is required</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Badge, Button, Example, FormControl, Placeholder, Text, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/TextField/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "TextField",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/TextField/TextField.tsx",
-				"actualName": "TextField",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique identifier for the text field",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the text field input element",
+						"name": "name",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "string" }
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Size" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the text field user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"focused": {
+						"defaultValue": null,
+						"description": "Render in the focused state",
+						"name": "focused",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"multiline": {
+						"defaultValue": null,
+						"description": "Enable multiline text field wrapping",
+						"name": "multiline",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to be fully rounded",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"placeholder": {
+						"defaultValue": null,
+						"description": "Placeholder text when there is no value",
+						"name": "placeholder",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the start position",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "Icon of the text field at the end position",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"startSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content before the text field value",
+						"name": "startSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"endSlot": {
+						"defaultValue": null,
+						"description": "Node for inserting content after the text field value",
+						"name": "endSlot",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"prefix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content before the text field value",
+						"name": "prefix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"suffix": {
+						"defaultValue": null,
+						"description": "Node for inserting text content after the text field value",
+						"name": "suffix",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"startSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "startSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"endSlotPadding": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "endSlotPadding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"outline\" | \"faded\" | \"headless\"",
+							"value": [
+								{ "value": "\"outline\"" },
+								{ "value": "\"faded\"" },
+								{ "value": "\"headless\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the text field value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ChangeHandler<string, ChangeEvent<HTMLInputElement>>" }
+					},
+					"onFocus": {
+						"defaultValue": null,
+						"description": "Callback when the text field is focused",
+						"name": "onFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"onBlur": {
+						"defaultValue": null,
+						"description": "Callback when the text field is blurred",
+						"name": "onBlur",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((e: FocusEvent<HTMLInputElement, Element>) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"inputAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the input element",
+						"name": "inputAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"input\">" }
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the text field, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default value of the text field, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/TextField/TextField.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "TextField"
 			}
 		},
 		"components-timeline": {
@@ -2013,27 +10511,71 @@
 			"path": "./src/components/Timeline/tests/Timeline.stories.tsx",
 			"stories": [
 				{
+					"id": "components-timeline--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"children passed directly\">\n            <Timeline>\n                <Placeholder />\n                <Placeholder />\n                <Placeholder />\n            </Timeline>\n        </Example.Item>\n        <Example.Item title=\"children wrapped with Timeline.Item\">\n            <Timeline>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "marker",
+					"id": "components-timeline--marker",
+					"name": "markerSlot",
 					"snippet": "const marker = () => (\n    <Example>\n        <Example.Item title=\"slot\">\n            <Timeline>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={<Placeholder h=\"20px\" w=\"20px\" />}>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n\n        <Example.Item title=\"null marker\">\n            <Timeline>\n                <Timeline.Item markerSlot={null}>\n                    <Placeholder />\n                </Timeline.Item>\n                <Timeline.Item markerSlot={null}>\n                    <Placeholder />\n                </Timeline.Item>\n            </Timeline>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-timeline--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Timeline className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Timeline.Item className=\"test-item-classname\" attributes={{ id: \"test-item-id\" }}>\n                Content\n            </Timeline.Item>\n            <Timeline.Item>Content</Timeline.Item>\n        </Timeline>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Placeholder, Timeline } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Timeline/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Timeline",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Timeline/Timeline.tsx",
-				"actualName": "Timeline",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Timeline/Timeline.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"ul\">" }
+					}
+				},
+				"exportName": "Timeline"
 			}
 		},
 		"components-toast": {
@@ -2041,32 +10583,54 @@
 			"name": "Toast",
 			"path": "./src/components/Toast/tests/Toast.stories.tsx",
 			"stories": [
-				{ "name": "size", "snippet": "const size = () => <Size />;" },
 				{
+					"id": "components-toast--size",
+					"name": "size",
+					"snippet": "const size = () => <Size />;"
+				},
+				{
+					"id": "components-toast--position",
 					"name": "position",
 					"snippet": "const position = () => <Position />;"
 				},
-				{ "name": "color", "snippet": "const color = () => <Color />;" },
-				{ "name": "timeout", "snippet": "const timeout = () => <Timeout />;" },
 				{
-					"name": "regionOptions",
+					"id": "components-toast--color",
+					"name": "color",
+					"snippet": "const color = () => <Color />;"
+				},
+				{
+					"id": "components-toast--timeout",
+					"name": "timeout",
+					"snippet": "const timeout = () => <Timeout />;"
+				},
+				{
+					"id": "components-toast--region-options",
+					"name": "expanded",
 					"snippet": "const regionOptions = () => <Expanded />;"
 				},
-				{ "name": "slots", "snippet": "const slots = () => <Slots />;" },
 				{
+					"id": "components-toast--slots",
+					"name": "slots",
+					"snippet": "const slots = () => <Slots />;"
+				},
+				{
+					"id": "components-toast--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const toast = useToast();\n\n    return (\n        <Button\n            onClick={() => {\n                const id = toast.show({\n                    title: \"Title\",\n                    text: \"Text\",\n                    children: \"Children\",\n                    startSlot: \"Slot\",\n                    actionsSlot: (\n                        <Button attributes={{ \"data-testid\": \"trigger-id\" }} onClick={() => toast.hide(id)}>\n                            Trigger\n                        </Button>\n                    ),\n                });\n            }}\n        >\n            Show toast\n        </Button>\n    );\n};"
 				},
 				{
-					"name": "nested",
+					"id": "components-toast--nested",
+					"name": "ToastProvider",
 					"snippet": "const nested = () => {\n    return (\n        <div data-testid=\"test-container-id\">\n            <ToastProvider>\n                <NestedDemo />\n            </ToastProvider>\n        </div>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "components-toast--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => {\n    const toast = useToast();\n\n    return (\n        <Button\n            onClick={() => {\n                const id = toast.show({\n                    text: \"Content\",\n                    attributes: { \"data-testid\": \"test-id\" },\n                    className: \"test-classname\",\n                });\n            }}\n        >\n            Show toast\n        </Button>\n    );\n};"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-toast--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"Multiline, should support dynamic height\">\n            <Multiline />\n        </Example.Item>\n        <Example.Item title=\"Nested ToastProvider\">\n            <ToastProvider>\n                <Nested />\n            </ToastProvider>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
@@ -2083,30 +10647,601 @@
 			"path": "./src/components/ToggleButton/tests/ToggleButton.stories.tsx",
 			"stories": [
 				{
+					"id": "components-togglebutton--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"outline\">\n            <ToggleButton>Button</ToggleButton>\n        </Example.Item>\n        <Example.Item title=\"ghost\">\n            <ToggleButton variant=\"ghost\">Button</ToggleButton>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-togglebutton--selected-color",
 					"name": "selectedColor",
 					"snippet": "const selectedColor = () => (\n    <Example>\n        <Example.Item title=\"selectedColor: primary\">\n            <ToggleButton selectedColor=\"primary\" defaultChecked>\n                Button\n            </ToggleButton>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onChange",
+					"id": "components-togglebutton--on-change",
+					"name": "checked, defaultChecked, onChange",
 					"snippet": "const onChange = () => <Example>\n    <Example.Item title=\"defaultChecked, onChange\">\n        <ToggleButton defaultChecked onChange={fn()} value=\"1\">Button\n                                </ToggleButton>\n    </Example.Item>\n    <Example.Item title=\"checked, onChange\">\n        <ToggleButton checked onChange={fn()} value=\"2\">Button\n                                </ToggleButton>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "components-togglebutton--on-click",
 					"name": "onClick",
 					"snippet": "const onClick = () => <ToggleButton onClick={fn()}>Button</ToggleButton>;"
 				}
 			],
 			"import": "import { Example, ToggleButton } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ToggleButton/ToggleButton.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "ToggleButton",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ToggleButton/ToggleButton.tsx",
-				"actualName": "ToggleButton",
+				"methods": [],
+				"props": {
+					"elevated": {
+						"defaultValue": null,
+						"description": "Apply elevated styles to the component",
+						"name": "elevated",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"icon": {
+						"defaultValue": null,
+						"description": "SVG component for the icon",
+						"name": "icon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"endIcon": {
+						"defaultValue": null,
+						"description": "SVG component for the end position icon",
+						"name": "endIcon",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": { "value": "\"medium\"" },
+						"description": "Component size",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<Size>" }
+					},
+					"rounded": {
+						"defaultValue": null,
+						"description": "Change border radius to fully rounded corners",
+						"name": "rounded",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loading": {
+						"defaultValue": null,
+						"description": "Show loading state",
+						"name": "loading",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"loadingAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the loading indicator",
+						"name": "loadingAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Make the component take the full width of the parent element",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"variant": {
+						"defaultValue": { "value": "\"outline\"" },
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"solid\" | \"outline\" | \"ghost\" | \"faded\"",
+							"value": [
+								{ "value": "\"solid\"" },
+								{ "value": "\"outline\"" },
+								{ "value": "\"ghost\"" },
+								{ "value": "\"faded\"" }
+							]
+						}
+					},
+					"selectedColor": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme when selected",
+						"name": "selectedColor",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Value of the toggle button, enables controlled mode for the ToggleButtonGroup",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the toggle button value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { checked: boolean; value: string; event: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>; }) => void)"
+						}
+					},
+					"defaultChecked": {
+						"defaultValue": null,
+						"description": "Default value of the toggle button, enables uncontrolled mode",
+						"name": "defaultChecked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"checked": {
+						"defaultValue": null,
+						"description": "Value of the toggle button, enables controlled mode",
+						"name": "checked",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButton/ToggleButton.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2116,34 +11251,194 @@
 			"path": "./src/components/ToggleButtonGroup/tests/ToggleButtonGroup.stories.tsx",
 			"stories": [
 				{
-					"name": "single",
+					"id": "components-togglebuttongroup--single",
+					"name": "checked, defaultChecked, onChange",
 					"snippet": "const single = () => <Example>\n    <Example.Item title=\"single, uncontrolled, onChange\">\n        <ToggleButtonGroup onChange={fn()}>\n            <ToggleButton value=\"1\" onChange={fn()}>Button\n                                    </ToggleButton>\n            <ToggleButton value=\"2\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n    <Example.Item title=\"single, controlled, onChange\">\n        <ToggleButtonGroup onChange={fn()} value={[]}>\n            <ToggleButton value=\"3\" onChange={fn()}>Button\n                                    </ToggleButton>\n            <ToggleButton value=\"4\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "multiple",
+					"id": "components-togglebuttongroup--multiple",
+					"name": "selectionMode, checked, defaultChecked, onChange",
 					"snippet": "const multiple = () => <Example>\n    <Example.Item title=\"multiple, uncontrolled, onChange\">\n        <ToggleButtonGroup onChange={fn()} selectionMode=\"multiple\">\n            <ToggleButton value=\"1\">Button</ToggleButton>\n            <ToggleButton value=\"2\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n    <Example.Item title=\"multiple, controlled, onChange\">\n        <ToggleButtonGroup onChange={fn()} value={[]} selectionMode=\"multiple\">\n            <ToggleButton value=\"3\">Button</ToggleButton>\n            <ToggleButton value=\"4\">Button</ToggleButton>\n        </ToggleButtonGroup>\n    </Example.Item>\n</Example>;"
 				},
 				{
-					"name": "selectedColor",
+					"id": "components-togglebuttongroup--selected-color",
+					"name": "color,selectedColor",
 					"snippet": "const selectedColor = () => (\n    <Example>\n        <Example.Item title=\"selectedColor: primary\">\n            <ToggleButtonGroup selectedColor=\"primary\" defaultValue={[\"2\"]}>\n                <ToggleButton value=\"1\">Button</ToggleButton>\n                <ToggleButton value=\"2\">Button</ToggleButton>\n                <ToggleButton value=\"3\">Button</ToggleButton>\n            </ToggleButtonGroup>\n        </Example.Item>\n        <Example.Item title=\"color: primary, selectedColor: critical\">\n            <ToggleButtonGroup color=\"primary\" selectedColor=\"critical\" defaultValue={[\"2\"]}>\n                <ToggleButton value=\"1\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n                <ToggleButton value=\"2\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n                <ToggleButton value=\"3\" variant=\"ghost\">\n                    Button\n                </ToggleButton>\n            </ToggleButtonGroup>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "components-togglebuttongroup--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ToggleButtonGroup className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <ToggleButton>Button 1</ToggleButton>\n            <ToggleButton>Button 1</ToggleButton>\n        </ToggleButtonGroup>\n    </div>\n);"
 				},
 				{
-					"name": "testIcon",
+					"id": "components-togglebuttongroup--test-icon",
+					"name": "test: icon only",
 					"snippet": "const testIcon = () => (\n    <Example>\n        <Example.Item title=\"icon only\">\n            <ToggleButtonGroup selectedColor=\"primary\">\n                <ToggleButton value=\"1\" icon={IconPlus} />\n                <ToggleButton value=\"2\" icon={IconMinus} />\n                <ToggleButton value=\"3\" icon={IconCheckmark} />\n            </ToggleButtonGroup>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, ToggleButton, ToggleButtonGroup } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ToggleButtonGroup/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ToggleButtonGroup",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx",
-				"actualName": "ToggleButtonGroup",
+				"methods": [],
+				"props": {
+					"selectionMode": {
+						"defaultValue": { "value": "\"single\"" },
+						"description": "Selection mode for the toggle button group",
+						"name": "selectionMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"single\" | \"multiple\"",
+							"value": [{ "value": "\"single\"" }, { "value": "\"multiple\"" }]
+						}
+					},
+					"color": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme applied to each button",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"selectedColor": {
+						"defaultValue": { "value": "\"neutral\"" },
+						"description": "Component color scheme for the selected button",
+						"name": "selectedColor",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"media\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"inherit\"",
+							"value": [
+								{ "value": "\"media\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"inherit\"" }
+							]
+						}
+					},
+					"onChange": {
+						"defaultValue": null,
+						"description": "Callback when the toggle button group value changes",
+						"name": "onChange",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((args: { value: string[]; event: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>; }) => void)"
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting child Button components",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Button/Button.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"value": {
+						"defaultValue": null,
+						"description": "Selected values in the group, enables controlled mode",
+						"name": "value",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					},
+					"defaultValue": {
+						"defaultValue": null,
+						"description": "Default selected values in the group, enables uncontrolled mode",
+						"name": "defaultValue",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string[]" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2153,30 +11448,269 @@
 			"path": "./src/components/Tooltip/tests/Tooltip.stories.tsx",
 			"stories": [
 				{
+					"id": "components-tooltip--position",
 					"name": "position",
 					"snippet": "const position = () => (\n    <Example>\n        <Example.Item title=\"position: bottom-start\">\n            <View direction=\"row\" gap={2}>\n                <Demo position=\"bottom-start\" text=\"Tooltip 1\" />\n                <Demo position=\"bottom-start\" text=\"Tooltip 2\" />\n                <Demo position=\"bottom-start\" text=\"Tooltip 3\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"position: bottom\">\n            <Demo position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"position: bottom-end\">\n            <Demo position=\"bottom-end\" />\n        </Example.Item>\n        <Example.Item title=\"position: top-start\">\n            <Demo position=\"top-start\" />\n        </Example.Item>\n        <Example.Item title=\"position: top\">\n            <Demo position=\"top\" />\n        </Example.Item>\n        <Example.Item title=\"position: top-end\">\n            <Demo position=\"top-end\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: start\">\n            <View align=\"end\">\n                <Demo position=\"start\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: start-top\">\n            <View align=\"end\">\n                <Demo position=\"start-top\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: start-bottom\">\n            <View align=\"end\">\n                <Demo position=\"start-bottom\" />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: end\">\n            <Demo position=\"end\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: end-top\">\n            <Demo position=\"end-top\" />\n        </Example.Item>\n\n        <Example.Item title=\"position: end-bottom\">\n            <Demo position=\"end-bottom\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "components-tooltip--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: inverted\">\n            <Demo color=\"inverted\" position=\"bottom\" />\n        </Example.Item>\n        <Example.Item title=\"color: dark\">\n            <Demo color=\"dark\" position=\"bottom\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "defaultActive",
+					"id": "components-tooltip--default-active",
+					"name": "uncontrolled",
 					"snippet": "const defaultActive = () => <Tooltip text=\"Content\" onOpen={fn()} onClose={fn()}>\n    {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n</Tooltip>;"
 				},
 				{
-					"name": "edgeCases",
+					"id": "components-tooltip--edge-cases",
+					"name": "test: edge cases",
 					"snippet": "const edgeCases = () => (\n    <Example>\n        <Example.Item title=\"responsive visibility\">\n            <DemoResponsive text=\"Responsive\" />\n        </Example.Item>\n\n        <Example.Item title=\"without text\">\n            <Tooltip>{() => <Button>Button</Button>}</Tooltip>\n        </Example.Item>\n\n        <Example.Item title=\"tooltip with popover\">\n            <Tooltip text=\"Tooltip\" position=\"top\">\n                {(attributes) => (\n                    <Popover position=\"bottom\">\n                        <Popover.Trigger>\n                            {(popoverAttributes) => (\n                                <Button attributes={{ ...attributes, ...popoverAttributes }}>Action</Button>\n                            )}\n                        </Popover.Trigger>\n                        <Popover.Content>Popover</Popover.Content>\n                    </Popover>\n                )}\n            </Tooltip>\n        </Example.Item>\n\n        <Example.Item title=\"nested popovers inside a tooltip\">\n            <View direction=\"row\" gap={2}>\n                <Tooltip position=\"top\" text=\"Hello\">\n                    {(tooltipAttributes) => (\n                        <Popover position=\"bottom\" width=\"300px\">\n                            <Popover.Trigger>\n                                {(attributes) => (\n                                    <Button attributes={{ ...tooltipAttributes, ...attributes }}>\n                                        Tooltip with popover\n                                    </Button>\n                                )}\n                            </Popover.Trigger>\n                            <Popover.Content>\n                                <View gap={2} align=\"center\" direction=\"row\" justify=\"space-between\">\n                                    Popover content\n                                    <Popover position=\"bottom\" width=\"300px\">\n                                        <Popover.Trigger>\n                                            {(attributes) => <Button attributes={attributes}>Open</Button>}\n                                        </Popover.Trigger>\n                                        <Popover.Content>\n                                            <Popover.Dismissible align=\"center\" closeAriaLabel=\"Close\">\n                                                Another popover content\n                                            </Popover.Dismissible>\n                                        </Popover.Content>\n                                    </Popover>\n                                </View>\n                            </Popover.Content>\n                        </Popover>\n                    )}\n                </Tooltip>\n                <Tooltip position=\"top\" text=\"Hello\">\n                    {(tooltipAttributes) => <Button attributes={tooltipAttributes}>Just a tooltip</Button>}\n                </Tooltip>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Button, Example, Popover, Tooltip, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Tooltip/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Tooltip",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Tooltip/Tooltip.tsx",
-				"actualName": "Tooltip",
+				"methods": [],
+				"props": {
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the flyout content interactivity",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"contentAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the content element",
+						"name": "contentAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"contentClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the content element",
+						"name": "contentClassName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "(attributes: TriggerAttributes) => ReactNode" }
+					},
+					"text": {
+						"defaultValue": null,
+						"description": "Text content for the tooltip",
+						"name": "text",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"color": {
+						"defaultValue": { "value": "\"inverted\"" },
+						"description": "Color of the tooltip",
+						"name": "color",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Tooltip/Tooltip.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"dark\" | \"inverted\"",
+							"value": [{ "value": "\"dark\"" }, { "value": "\"inverted\"" }]
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2186,51 +11720,191 @@
 			"path": "./src/components/Accordion/tests/Accordion.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-accordion--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Accordion defaultActive>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--icon-size",
 					"name": "iconSize",
 					"snippet": "const iconSize = () => (\n    <Accordion iconSize={6}>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--icon-position",
 					"name": "iconPosition",
 					"snippet": "const iconPosition = () => (\n    <Accordion iconPosition=\"start\">\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <View paddingTop={2}>\n                <Placeholder />\n            </View>\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Accordion defaultActive gap={4}>\n        <Accordion.Trigger>\n            <Placeholder>Trigger</Placeholder>\n        </Accordion.Trigger>\n        <Accordion.Content>\n            <Placeholder />\n        </Accordion.Content>\n    </Accordion>\n);"
 				},
 				{
+					"id": "utility-components-accordion--on-toggle",
 					"name": "onToggle",
 					"snippet": "const onToggle = () => <Accordion onToggle={fn()}>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
+					"id": "utility-components-accordion--active",
 					"name": "active",
 					"snippet": "const active = () => <Accordion onToggle={fn()} active>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
+					"id": "utility-components-accordion--default-active",
 					"name": "defaultActive",
 					"snippet": "const defaultActive = () => <Accordion onToggle={fn()} defaultActive>\n    <Accordion.Trigger>\n        <Placeholder>Trigger</Placeholder>\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
-					"name": "renderProps",
+					"id": "utility-components-accordion--render-props",
+					"name": "children: render props",
 					"snippet": "const renderProps = () => <Accordion onToggle={fn()}>\n    <Accordion.Trigger>\n        {(attributes, { active }) => (\n            <Button attributes={{ ...attributes, \"data-active\": active }}>Trigger</Button>\n        )}\n    </Accordion.Trigger>\n    <Accordion.Content>\n        <View paddingTop={2}>\n            <Placeholder />\n        </View>\n    </Accordion.Content>\n</Accordion>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-accordion--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Accordion className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Accordion.Trigger>\n                <Placeholder>Trigger</Placeholder>\n            </Accordion.Trigger>\n            <Accordion.Content>\n                <View paddingTop={2}>\n                    <Placeholder />\n                </View>\n            </Accordion.Content>\n        </Accordion>\n    </div>\n);"
 				}
 			],
 			"import": "import { Accordion, Button, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Accordion/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Accordion",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Accordion/Accordion.tsx",
-				"actualName": "Accordion",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"iconSize": {
+						"defaultValue": null,
+						"description": "Expand / collapse icon size in units",
+						"name": "iconSize",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"iconPosition": {
+						"defaultValue": null,
+						"description": "Position of the expand / collapse icon",
+						"name": "iconPosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"start\" | \"end\"",
+							"value": [{ "value": "\"start\"" }, { "value": "\"end\"" }]
+						}
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between the trigger and the content",
+						"name": "gap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the trigger and the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onToggle": {
+						"defaultValue": null,
+						"description": "Callback when the accordion is expanded or collapsed",
+						"name": "onToggle",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((active: boolean) => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control whether the accordion is expanded or collapsed, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control whether the accordion is expanded or collapsed by default, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Accordion/Accordion.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Accordion"
 			}
 		},
 		"utility-components-actionable": {
@@ -2239,54 +11913,456 @@
 			"path": "./src/components/Actionable/tests/Actionable.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "utility-components-actionable--base",
+					"name": "href, onClick",
 					"snippet": "const base = () => <Example>\n    <Example.Item title=\"span\">\n        <Actionable>Span</Actionable>\n    </Example.Item>\n    <Example.Item title=\"onClick\">\n        <Actionable onClick={fn()}>Button</Actionable>\n    </Example.Item>\n    <Example.Item title=\"href\">\n        <Actionable href=\"https://reshaped.so\" attributes={{ target: \"_blank\" }}>Link\n                            </Actionable>\n    </Example.Item>\n    <Example.Item title=\"attributes.href\">\n        <Actionable attributes={{ href: \"https://reshaped.so\" }}>Link with attributes</Actionable>\n    </Example.Item>\n    <Example.Item title=\"href, onClick\">\n        <Actionable\n            onClick={(e) => {\n                e.preventDefault();\n                args.handleSecondClick(e);\n            }}\n            href=\"https://reshaped.so\">Link with onClick\n                            </Actionable>\n    </Example.Item>\n</Example>;"
 				},
 				{
+					"id": "utility-components-actionable--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled, button\">\n            <Actionable disabled onClick={() => {}}>\n                Button\n            </Actionable>\n        </Example.Item>\n        <Example.Item title=\"disabled, link\">\n            <Actionable disabled href=\"https://reshaped.so\">\n                Link\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--full-width",
 					"name": "fullWidth",
 					"snippet": "const fullWidth = () => (\n    <Example>\n        <Example.Item title=\"fullWidth\">\n            <Actionable fullWidth href=\"https://reshaped.so\">\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--inset-focus",
 					"name": "insetFocus",
 					"snippet": "const insetFocus = () => (\n    <Example>\n        <Example.Item title=\"insetFocus\">\n            <Actionable insetFocus onClick={() => {}}>\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--disable-focus-ring",
 					"name": "disableFocusRing",
 					"snippet": "const disableFocusRing = () => (\n    <Example>\n        <Example.Item title=\"disableFocusRing\">\n            <Actionable disableFocusRing onClick={() => {}}>\n                Actionable\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--border-radius",
 					"name": "borderRadius",
 					"snippet": "const borderRadius = () => (\n    <Example>\n        <Example.Item title=\"borderRadius: inherit\">\n            <Actionable borderRadius=\"inherit\" onClick={() => {}}>\n                <View borderRadius=\"large\">Actionable</View>\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--type",
 					"name": "type",
 					"snippet": "const type = (args) => (\n    <Example>\n        <Example.Item title=\"type: submit\">\n            <form\n                onSubmit={(e) => {\n                    e.preventDefault();\n                    args.handleSubmit();\n                }}\n            >\n                <Actionable onClick={() => {}} type=\"submit\">\n                    Submit\n                </Actionable>\n            </form>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "as",
+					"id": "utility-components-actionable--as",
+					"name": "as, render",
 					"snippet": "const as = () => (\n    <Example>\n        <Example.Item title=\"as: span\">\n            <Actionable onClick={() => {}} as=\"span\">\n                Trigger\n            </Actionable>\n        </Example.Item>\n        <Example.Item title=\"render, disabled\">\n            <Actionable disabled onClick={() => {}} render={(props) => <section {...props} />}>\n                Trigger\n            </Actionable>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-actionable--stop-propagation",
 					"name": "stopPropagation",
 					"snippet": "const stopPropagation = () => <div onClick={fn()}>\n    <Actionable stopPropagation onClick={() => {}}>Trigger\n                    </Actionable>\n</div>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-actionable--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Actionable className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Trigger\n        </Actionable>\n    </div>\n);"
 				}
 			],
 			"import": "import { Actionable, Example, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Actionable/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Actionable",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Actionable/Actionable.tsx",
-				"actualName": "Actionable",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"render": {
+						"defaultValue": null,
+						"description": "Render a custom root element, useful for integrating with routers",
+						"name": "render",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Attributes & { ref: AttributesRef; className: string; onClick: (e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void; onKeyDown: (e: KeyboardEvent<HTMLElement>) => void; \"aria-disabled\"?: boolean; children: ReactNode; }) => ReactNode)"
+						}
+					},
+					"onClick": {
+						"defaultValue": null,
+						"description": "Callback when clicked, renders it as a button tag if href is not provided",
+						"name": "onClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "((e: MouseEvent<HTMLElement, MouseEvent> | KeyboardEvent<HTMLElement>) => void)"
+						}
+					},
+					"href": {
+						"defaultValue": null,
+						"description": "URL, renders it as an anchor tag",
+						"name": "href",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"type": {
+						"defaultValue": null,
+						"description": "Type attribute, renders it as a button tag",
+						"name": "type",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"button\" | \"submit\" | \"reset\"",
+							"value": [
+								{ "value": "\"button\"" },
+								{ "value": "\"submit\"" },
+								{ "value": "\"reset\"" }
+							]
+						}
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable from user interaction",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"touchHitbox": {
+						"defaultValue": null,
+						"description": "Enable a minimum required touch hitbox",
+						"name": "touchHitbox",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fullWidth": {
+						"defaultValue": null,
+						"description": "Take up the full width of its parent",
+						"name": "fullWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"insetFocus": {
+						"defaultValue": null,
+						"description": "Enable a focus ring inside the element bounds",
+						"name": "insetFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableFocusRing": {
+						"defaultValue": null,
+						"description": "Don't show a focus ring on focus, can be used when it is within a container with a focus ring",
+						"name": "disableFocusRing",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Apply the focus ring to the child and rely on its border radius",
+						"name": "borderRadius",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"inherit\"", "value": [{ "value": "\"inherit\"" }] }
+					},
+					"stopPropagation": {
+						"defaultValue": null,
+						"description": "Prevent the event from bubbling up to the parent",
+						"name": "stopPropagation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Actionable/Actionable.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2296,30 +12372,149 @@
 			"path": "./src/components/Container/tests/Container.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-container--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example>\n        <Example.Item title=\"padding: default\">\n            <Container>\n                <Placeholder />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"padding: 0\">\n            <Container padding={0}>\n                <Placeholder />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "utility-components-container--size",
+					"name": "width, height, maxHeight",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"width: 200px, height: 200px\">\n            <Container width=\"200px\" height=\"200px\">\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width: 200px, height: 200px, maxHeight: 100px\">\n            <Container width=\"200px\" height=\"200px\" maxHeight=\"100px\">\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width, height: [s] 100px, [m+] 200px\">\n            <Container width={{ s: \"100px\", m: \"200px\" }} height={{ s: \"100px\", m: \"200px\" }}>\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n        <Example.Item title=\"width, height: [s] 100px, [m+] 200px, maxHeight: [s] 50px, [m+]: 100px\">\n            <Container\n                width={{ s: \"100px\", m: \"200px\" }}\n                height={{ s: \"100px\", m: \"200px\" }}\n                maxHeight={{ s: \"50px\", m: \"100px\" }}\n            >\n                <Placeholder h=\"100%\" />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "flex",
+					"id": "utility-components-container--flex",
+					"name": "align, justify",
 					"snippet": "const flex = () => (\n    <Example>\n        <Example.Item title=\"align: center, justify: center\">\n            <Container align=\"center\" justify=\"center\" height=\"200px\">\n                <Placeholder />\n            </Container>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-container--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Container className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            <Placeholder />\n        </Container>\n    </div>\n);"
 				}
 			],
 			"import": "import { Container, Example, Placeholder } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Container/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Container",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Container/Container.tsx",
-				"actualName": "Container",
+				"methods": [],
+				"props": {
+					"align": {
+						"defaultValue": null,
+						"description": "Flex align-items for the content",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Flex justify-content for the content",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier\nComponent height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" },
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height style, literal string value or a base unit token number multiplier\nComponent max height, literal css value or unit token multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" },
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Component inline padding",
+						"name": "padding",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Component width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Container/Container.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2329,34 +12524,157 @@
 			"path": "./src/components/Dismissible/tests/Dismissible.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-dismissible--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: default\">\n            <Dismissible closeAriaLabel=\"Close banner\" onClose={() => {}}>\n                <Placeholder />\n            </Dismissible>\n        </Example.Item>\n        <Example.Item title=\"variant: media\">\n            <View width=\"300px\">\n                <Dismissible variant=\"media\" closeAriaLabel=\"Close banner\" onClose={() => {}}>\n                    <View aspectRatio={16 / 9}>\n                        <Image\n                            height=\"100%\"\n                            src=\"https://images.unsplash.com/photo-1607030529528-ca6923e27f77?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1867&q=80)\"\n                        />\n                    </View>\n                </Dismissible>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-dismissible--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: center\">\n            <Dismissible align=\"center\" closeAriaLabel=\"Close\" onClose={() => {}}>\n                <Placeholder />\n            </Dismissible>\n        </Example.Item>\n\n        <Example.Item title=\"align: center, variant: media\">\n            <Dismissible align=\"center\" closeAriaLabel=\"Close\" variant=\"media\" onClose={() => {}}>\n                <View aspectRatio={16 / 9}>\n                    <Image\n                        height=\"100%\"\n                        src=\"https://images.unsplash.com/photo-1607030529528-ca6923e27f77?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1867&q=80)\"\n                    />\n                </View>\n            </Dismissible>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-dismissible--hide-close-button",
 					"name": "hideCloseButton",
 					"snippet": "const hideCloseButton = () => (\n    <Example>\n        <Example.Item title=\"hide close button\">\n            <div id=\"root\">\n                <Dismissible hideCloseButton>\n                    <Placeholder />\n                </Dismissible>\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "closeAriaLabel",
+					"id": "utility-components-dismissible--close-aria-label",
+					"name": "onClose, closeAriaLabel",
 					"snippet": "const closeAriaLabel = () => <Dismissible closeAriaLabel=\"Close\" onClose={fn()}>\n    <Placeholder />\n</Dismissible>;"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-dismissible--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Dismissible\n            closeAriaLabel=\"Close\"\n            onClose={() => {}}\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n        >\n            <Placeholder />\n        </Dismissible>\n    </div>\n);"
 				}
 			],
 			"import": "import { Dismissible, Example, Image, Placeholder, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Dismissible/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Dismissible",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Dismissible/Dismissible.tsx",
-				"actualName": "Dismissible",
+				"methods": [],
+				"props": {
+					"hideCloseButton": {
+						"defaultValue": null,
+						"description": "Hide the close button\nShow the close button",
+						"name": "hideCloseButton",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"closeAriaLabel": {
+						"defaultValue": null,
+						"description": "aria-label attribute for the close button",
+						"name": "closeAriaLabel",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"variant": {
+						"defaultValue": null,
+						"description": "Component render variant",
+						"name": "variant",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"media\"", "value": [{ "value": "\"media\"" }] }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Close button alignment",
+						"name": "align",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"top\" | \"center\"",
+							"value": [{ "value": "\"top\"" }, { "value": "\"center\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is dismissed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Dismissible/Dismissible.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2366,135 +12684,577 @@
 			"path": "./src/components/Flyout/tests/Flyout.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-flyout--position",
 					"name": "position",
 					"snippet": "const position = () => {\n    return (\n        <View gap={4} padding={50} align=\"center\" justify=\"center\" height=\"100vh\" width=\"120%\">\n            <View gap={4} direction=\"row\">\n                <Demo position=\"top-start\" defaultActive />\n                <Demo position=\"top\" />\n                <Demo position=\"top-end\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"end-top\" />\n                <Demo position=\"end\" />\n                <Demo position=\"end-bottom\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"start-top\" />\n                <Demo position=\"start\" />\n                <Demo position=\"start-bottom\" />\n            </View>\n\n            <View gap={4} direction=\"row\">\n                <Demo position=\"bottom-start\" />\n                <Demo position=\"bottom\" />\n                <Demo position=\"bottom-end\" />\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "defaultActive",
+					"id": "utility-components-flyout--default-active",
+					"name": "defaultActive, uncontrolled",
 					"snippet": "const defaultActive = () => <Flyout onOpen={fn()} onClose={fn()} defaultActive>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "active",
+					"id": "utility-components-flyout--active",
+					"name": "active, controlled",
 					"snippet": "const active = () => <Flyout onOpen={fn()} onClose={fn()} active>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "activeFalse",
+					"id": "utility-components-flyout--active-false",
+					"name": "active: false, controlled",
 					"snippet": "const activeFalse = () => <Flyout onOpen={fn()} onClose={fn()} active={false}>\n    <Flyout.Trigger>\n        {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n    </Flyout.Trigger>\n    <Flyout.Content>\n        <Content />\n    </Flyout.Content>\n</Flyout>;"
 				},
 				{
-					"name": "modes",
+					"id": "utility-components-flyout--modes",
+					"name": "triggerType, trapFocusMode",
 					"snippet": "const modes = () => {\n    return (\n        <Example>\n            <Example.Item title=\"triggerType: click\">\n                <View direction=\"row\" gap={4}>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"dialog\" text=\"dialog\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"action-menu\" text=\"action-menu\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"action-bar\" text=\"action-bar\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"content-menu\" text=\"content-menu\">\n                        {modeContent}\n                    </Demo>\n                    <Demo position=\"bottom-start\" trapFocusMode={false} text=\"false\">\n                        {modeContent}\n                    </Demo>\n                </View>\n            </Example.Item>\n\n            <Example.Item title=\"triggerType: hover\">\n                <View direction=\"row\" gap={4}>\n                    <Demo position=\"bottom-start\" trapFocusMode=\"dialog\" triggerType=\"hover\" text=\"dialog\">\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"action-menu\"\n                        triggerType=\"hover\"\n                        text=\"action-menu\"\n                    >\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"action-bar\"\n                        triggerType=\"hover\"\n                        text=\"action-bar\"\n                    >\n                        {modeContent}\n                    </Demo>\n                    <Demo\n                        position=\"bottom-start\"\n                        trapFocusMode=\"content-menu\"\n                        triggerType=\"hover\"\n                        text=\"content-menu\"\n                    >\n                        {modeContent}\n                    </Demo>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "positionFallbacks",
+					"id": "utility-components-flyout--position-fallbacks",
+					"name": "fallbackPositions",
 					"snippet": "const positionFallbacks = () => {\n    return (\n        <Example>\n            <Example.Item title=\"position: top, default fallbacks\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" />\n                </View>\n            </Example.Item>\n            <Example.Item title=\"position: top, fallbackPositions: [start]\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" fallbackPositions={[\"start\"]} contentHeight={200} defaultActive />\n                </View>\n            </Example.Item>\n            <Example.Item title=\"position: top, fallbackPositions: false\">\n                <View justify=\"center\" align=\"center\">\n                    <Demo position=\"top\" fallbackPositions={false} contentHeight={400} />\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--fallback-adjust-layout",
 					"name": "fallbackAdjustLayout",
 					"snippet": "const fallbackAdjustLayout = () => {\n    return (\n        <Demo\n            contentHeight={false}\n            position=\"bottom-start\"\n            width=\"200px\"\n            fallbackAdjustLayout\n            defaultActive\n        >\n            <div style={{ height: \"600px\" }}>Content</div>\n        </Demo>\n    );\n};"
 				},
 				{
-					"name": "fallbackAdjustLayoutShift",
+					"id": "utility-components-flyout--fallback-adjust-layout-shift",
+					"name": "fallbackAdjustLayout, shift",
 					"snippet": "const fallbackAdjustLayoutShift = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={10}>\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    attributes={{ ref: containerRef }}\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls containerRef={containerRef} />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <FallbackAdjustLayoutControls />\n            <div style={{ height: \"100vh\", width: \"250%\" }} />\n        </View>\n    );\n};"
 				},
 				{
-					"name": "fallbackAdjustLayoutSize",
+					"id": "utility-components-flyout--fallback-adjust-layout-size",
+					"name": "fallbackAdjustLayout, size",
 					"snippet": "const fallbackAdjustLayoutSize = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={10}>\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls large />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <View height=\"95vh\" width=\"100%\" align=\"center\" justify=\"center\">\n                <View\n                    backgroundColor=\"neutral-faded\"\n                    borderRadius=\"medium\"\n                    height=\"1000px\"\n                    width=\"600px\"\n                    attributes={{ ref: containerRef }}\n                    padding={4}\n                    paddingBlock={15}\n                    overflow=\"auto\"\n                >\n                    <FallbackAdjustLayoutControls containerRef={containerRef} large />\n                    <View height=\"150%\" width=\"150%\" attributes={{ style: { pointerEvents: \"none\" } }} />\n                </View>\n            </View>\n\n            <FallbackAdjustLayoutControls large />\n            <div style={{ height: \"100vh\", width: \"250%\" }} />\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--origin-coordinates",
 					"name": "originCoordinates",
 					"snippet": "const originCoordinates = () => {\n    return (\n        <View gap={4} direction=\"row\">\n            <Demo position=\"bottom-start\" originCoordinates={{ x: 150, y: 150 }} defaultActive />\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--width",
 					"name": "width",
 					"snippet": "const width = () => (\n    <Example>\n        <Example.Item title=\"width: 300px\">\n            <Demo width=\"300px\" position=\"bottom\" />\n        </Example.Item>\n\n        <Example.Item title=\"width: trigger\">\n            <Demo width=\"trigger\" contentWidth={false} defaultActive />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-flyout--content-gap",
 					"name": "contentGap",
 					"snippet": "const contentGap = () => <Demo contentGap={10} defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--content-shift",
 					"name": "contentShift",
 					"snippet": "const contentShift = () => <Demo contentShift={10} defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-content-hover",
 					"name": "disableContentHover",
 					"snippet": "const disableContentHover = () => <Demo triggerType=\"hover\" disableContentHover />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-close-on-outside-click",
 					"name": "disableCloseOnOutsideClick",
 					"snippet": "const disableCloseOnOutsideClick = () => <Demo disableCloseOnOutsideClick />;"
 				},
 				{
+					"id": "utility-components-flyout--disable-hide-animation",
 					"name": "disableHideAnimation",
 					"snippet": "const disableHideAnimation = () => <Demo disableHideAnimation defaultActive />;"
 				},
 				{
+					"id": "utility-components-flyout--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Flyout disabled>\n        <Flyout.Trigger>\n            {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n        </Flyout.Trigger>\n        <Flyout.Content>\n            <Content />\n        </Flyout.Content>\n    </Flyout>\n);"
 				},
 				{
+					"id": "utility-components-flyout--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const portalRef = React.useRef<HTMLDivElement>(null);\n    const portalRef2 = React.useRef<HTMLDivElement>(null);\n    const portalRef3 = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={4} direction=\"row\">\n            <View\n                grow\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef, \"data-testid\": \"container\" }}\n                justify=\"end\"\n                align=\"start\"\n                padding={4}\n            >\n                <Demo containerRef={portalRef} position=\"bottom-start\" defaultActive />\n            </View>\n            <View\n                grow\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef2 }}\n                justify=\"start\"\n                align=\"end\"\n                padding={4}\n            >\n                <Demo containerRef={portalRef2} position=\"top-end\" />\n            </View>\n            <View\n                width={50}\n                backgroundColor=\"neutral-faded\"\n                borderRadius=\"small\"\n                height={80}\n                attributes={{ ref: portalRef3 }}\n                padding={4}\n                overflow=\"auto\"\n            >\n                <View height={120} width=\"120%\" justify=\"center\" align=\"center\">\n                    <Demo containerRef={portalRef3} position=\"bottom-end\" />\n                </View>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--initial-focus-ref",
 					"name": "initialFocusRef",
 					"snippet": "const initialFocusRef = () => {\n    const initialFocusRef = React.useRef<HTMLInputElement>(null);\n\n    return (\n        <Demo initialFocusRef={initialFocusRef}>\n            <View gap={4}>\n                <Button onClick={() => {}}>Action 1</Button>\n                <TextField name=\"foo\" inputAttributes={{ ref: initialFocusRef }} />\n            </View>\n        </Demo>\n    );\n};"
 				},
 				{
+					"id": "utility-components-flyout--instance-ref",
 					"name": "instanceRef",
 					"snippet": "const instanceRef = () => {\n    const flyoutRef = React.useRef<FlyoutInstance>(null);\n\n    return (\n        <View direction=\"row\" gap={4}>\n            <Demo\n                instanceRef={flyoutRef}\n                disableCloseOnOutsideClick\n                onOpen={fn()}\n                onClose={fn()} />\n            <Button onClick={() => flyoutRef.current?.open()}>Open</Button>\n            <Button onClick={() => flyoutRef.current?.close()}>Close</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "contentAttributes",
+					"id": "utility-components-flyout--content-attributes",
+					"name": "content: className, attributes",
 					"snippet": "const contentAttributes = () => {\n    return (\n        <Flyout position=\"bottom\" defaultActive>\n            <Flyout.Trigger>\n                {(attributes) => <Button attributes={attributes}>Trigger</Button>}\n            </Flyout.Trigger>\n            <Flyout.Content attributes={{ \"data-testid\": \"test-id\" }} className=\"test-classname\">\n                <Content />\n            </Flyout.Content>\n        </Flyout>\n    );\n};"
 				},
 				{
-					"name": "testShadowDom",
+					"id": "utility-components-flyout--test-shadow-dom",
+					"name": "test: shadow dom",
 					"snippet": "const testShadowDom = () => <custom-element-flyout />;"
 				},
 				{
-					"name": "testInsideFixed",
+					"id": "utility-components-flyout--test-inside-fixed",
+					"name": "test: inside position fixed",
 					"snippet": "const testInsideFixed = () => (\n    <React.Fragment>\n        <View\n            position=\"fixed\"\n            insetBottom={2}\n            insetStart={2}\n            insetEnd={2}\n            backgroundColor=\"elevation-overlay\"\n            borderColor=\"neutral-faded\"\n            borderRadius=\"small\"\n            padding={4}\n            zIndex={10}\n            attributes={{ \"data-testid\": \"container\" }}\n            height={20}\n        >\n            <Demo defaultActive position=\"top-start\" />\n        </View>\n        <View paddingTop={18} gap={4}>\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n        </View>\n    </React.Fragment>\n);"
 				},
 				{
-					"name": "testInsideSticky",
+					"id": "utility-components-flyout--test-inside-sticky",
+					"name": "test: inside position sticky",
 					"snippet": "const testInsideSticky = () => (\n    <React.Fragment>\n        <View\n            position=\"sticky\"\n            insetTop={4}\n            insetStart={0}\n            insetEnd={0}\n            backgroundColor=\"elevation-overlay\"\n            borderColor=\"neutral-faded\"\n            borderRadius=\"small\"\n            padding={4}\n            zIndex={10}\n            attributes={{ \"data-testid\": \"container\" }}\n        >\n            <Demo defaultActive />\n        </View>\n        <View gap={4} paddingTop={2}>\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n            <View height={200} backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n        </View>\n    </React.Fragment>\n);"
 				},
 				{
-					"name": "testInsideScrollable",
+					"id": "utility-components-flyout--test-inside-scrollable",
+					"name": "test: inside scrollable",
 					"snippet": "const testInsideScrollable = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View padding={20}>\n            <View height={30} overflow=\"auto\" backgroundColor=\"neutral-faded\" borderRadius=\"small\">\n                <View height={50} attributes={{ ref: containerRef }} padding={20} paddingBottom={30}>\n                    <Demo position=\"bottom\" />\n                </View>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testInsideModal",
+					"id": "utility-components-flyout--test-inside-modal",
+					"name": "test: inside modal",
 					"snippet": "const testInsideModal = () => {\n    return (\n        <Modal active position=\"end\">\n            <View gap={4} align=\"start\">\n                <Modal.Title>Title</Modal.Title>\n                <Demo position=\"bottom-start\" />\n                <View height={300} width={25} backgroundColor=\"neutral-faded\" />\n                <Demo position=\"start\" />\n                <View height={300} width={25} backgroundColor=\"neutral-faded\" />\n                <Demo position=\"bottom-start\" />\n            </View>\n        </Modal>\n    );\n};"
 				},
 				{
-					"name": "testDynamicBounds",
+					"id": "utility-components-flyout--test-dynamic-bounds",
+					"name": "test: auto position update",
 					"snippet": "const testDynamicBounds = () => {\n    const [left, setLeft] = React.useState(50);\n    const [top, setTop] = React.useState(50);\n    const [size, setSize] = React.useState<\"medium\" | \"large\">(\"medium\");\n    const flyoutRef = React.useRef<FlyoutInstance>(null);\n\n    React.useEffect(() => {\n        flyoutRef.current?.updatePosition();\n    }, [left, top]);\n\n    return (\n        <View gap={4}>\n            <View direction=\"row\" gap={2}>\n                <Button onClick={() => setLeft((prev) => prev - 10)}>Left</Button>\n                <Button onClick={() => setLeft((prev) => prev + 10)}>Right</Button>\n                <Button onClick={() => setTop((prev) => prev - 10)}>Up</Button>\n                <Button onClick={() => setTop((prev) => prev + 10)}>Down</Button>\n                <Button\n                    onClick={() => {\n                        setLeft(50);\n                        setTop(50);\n                    }}\n                >\n                    Center\n                </Button>\n                <Button onClick={() => setSize(\"large\")}>Large button</Button>\n                <Button onClick={() => setSize(\"medium\")}>Small button</Button>\n            </View>\n            <View height={100}>\n                <Flyout\n                    position=\"bottom\"\n                    instanceRef={flyoutRef}\n                    disableCloseOnOutsideClick\n                    defaultActive\n                >\n                    <Flyout.Trigger>\n                        {(attributes) => (\n                            <div style={{ position: \"absolute\", left: `${left}%`, top: `${top}%` }}>\n                                <Button color=\"primary\" attributes={attributes} size={size}>\n                                    Open\n                                </Button>\n                            </div>\n                        )}\n                    </Flyout.Trigger>\n                    <Flyout.Content>\n                        <Content />\n                    </Flyout.Content>\n                </Flyout>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testScopedTheming",
+					"id": "utility-components-flyout--test-scoped-theming",
+					"name": "test: content uses scope theme",
 					"snippet": "const testScopedTheming = () => (\n    <View gap={3} align=\"start\">\n        <Button color=\"primary\">Slate button</Button>\n        <Theme name=\"reshaped\">\n            <Flyout triggerType=\"click\" active position=\"bottom-start\">\n                <Flyout.Trigger>\n                    {(attributes) => (\n                        <Button color=\"primary\" attributes={attributes}>\n                            Reshaped button\n                        </Button>\n                    )}\n                </Flyout.Trigger>\n                <Flyout.Content>\n                    <Content>\n                        <View gap={1}>\n                            <View.Item>Portal content, rendered in body</View.Item>\n                            <Button color=\"primary\">Reshaped button</Button>\n                        </View>\n                    </Content>\n                </Flyout.Content>\n            </Flyout>\n        </Theme>\n    </View>\n);"
 				},
 				{
-					"name": "testWithoutFocusable",
+					"id": "utility-components-flyout--test-without-focusable",
+					"name": "test: without focusable content",
 					"snippet": "const testWithoutFocusable = () => <Demo position=\"bottom-start\" />;"
 				},
 				{
-					"name": "testChangeSize",
+					"id": "utility-components-flyout--test-change-size",
+					"name": "test: size updates",
 					"snippet": "const testChangeSize = () => {\n    const [position, setPosition] = React.useState<FlyoutProps[\"position\"]>(\"bottom-start\");\n    const [updatedHeight, setUpdatedHeight] = React.useState(false);\n\n    return (\n        <>\n            <View direction=\"row\" gap={4} align=\"center\">\n                <Select\n                    name=\"position\"\n                    options={[\n                        \"bottom-start\",\n                        \"bottom\",\n                        \"bottom-end\",\n                        \"top-start\",\n                        \"top\",\n                        \"top-end\",\n                        \"start-top\",\n                        \"start\",\n                        \"start-bottom\",\n                        \"end-top\",\n                        \"end\",\n                        \"end-bottom\",\n                    ].map((p) => ({ label: p, value: p }))}\n                    onChange={(args) => setPosition(args.value as FlyoutProps[\"position\"])}\n                    value={position}\n                />\n                <Switch name=\"height\" onChange={(args) => setUpdatedHeight(args.checked)}>\n                    Change height\n                </Switch>\n            </View>\n            <div\n                style={{\n                    position: \"fixed\",\n                    top: \"50%\",\n                    left: \"50%\",\n                    transform: \"translate(-50%, -50%)\",\n                }}\n            >\n                <Demo position={position} disableCloseOnOutsideClick active contentHeight={false}>\n                    <View\n                        backgroundColor=\"neutral-faded\"\n                        borderRadius=\"small\"\n                        height={updatedHeight ? 50 : 25}\n                        attributes={{ style: { transition: \"0.2s ease-in-out\" } }}\n                    />\n                </Demo>\n            </div>\n        </>\n    );\n};"
 				}
 			],
 			"import": "import {\n    Button,\n    Example,\n    Flyout,\n    Modal,\n    Reshaped,\n    Select,\n    Switch,\n    TextField,\n    Theme,\n    View,\n} from \"reshaped\";\nimport React from \"react\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Flyout/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Flyout",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Flyout/Flyout.tsx",
-				"actualName": "Flyout",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"id": {
+						"defaultValue": null,
+						"description": "Unique id for the flyout content and trigger",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"triggerType": {
+						"defaultValue": null,
+						"description": "Event used for displaying the content",
+						"name": "triggerType",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hover\" | \"click\" | \"focus\"",
+							"value": [
+								{ "value": "\"hover\"" },
+								{ "value": "\"click\"" },
+								{ "value": "\"focus\"" }
+							]
+						}
+					},
+					"groupTimeouts": {
+						"defaultValue": null,
+						"description": "Removes the content display delay if another flyout is already active",
+						"name": "groupTimeouts",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Content position relative to the trigger element",
+						"name": "position",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Position",
+							"value": [
+								{ "value": "\"top\"" },
+								{ "value": "\"top-end\"" },
+								{ "value": "\"top-start\"" },
+								{ "value": "\"bottom\"" },
+								{ "value": "\"bottom-start\"" },
+								{ "value": "\"bottom-end\"" },
+								{ "value": "\"start\"" },
+								{ "value": "\"end\"" },
+								{ "value": "\"start-top\"" },
+								{ "value": "\"start-bottom\"" },
+								{ "value": "\"end-top\"" },
+								{ "value": "\"end-bottom\"" }
+							]
+						}
+					},
+					"forcePosition": {
+						"defaultValue": null,
+						"description": "@deprecated Use fallbackPosition={false} instead, will be removed in v4",
+						"name": "forcePosition",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackPositions": {
+						"defaultValue": null,
+						"description": "Fallback positions for the content when it doesn't fit into the viewport or container",
+						"name": "fallbackPositions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | Position[]" }
+					},
+					"fallbackAdjustLayout": {
+						"defaultValue": null,
+						"description": "Adjust the content size and shift its position to fit into the container when none of the fallback positions work",
+						"name": "fallbackAdjustLayout",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"fallbackMinWidth": {
+						"defaultValue": null,
+						"description": "Minimum width for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinWidth",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"fallbackMinHeight": {
+						"defaultValue": null,
+						"description": "Minimum height for the content when fallbackAdjustLayout is true",
+						"name": "fallbackMinHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"trapFocusMode": {
+						"defaultValue": null,
+						"description": "Change component trap focus keyboard behavior and shortcuts",
+						"name": "trapFocusMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "false | TrapMode" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Disable the flyout content interactivity",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableHideAnimation": {
+						"defaultValue": null,
+						"description": "Disable the flyout content hide animation",
+						"name": "disableHideAnimation",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableContentHover": {
+						"defaultValue": null,
+						"description": "Ignore the content hover events and hide it if the triggerType is hover",
+						"name": "disableContentHover",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disableCloseOnOutsideClick": {
+						"defaultValue": null,
+						"description": "Disable the flyout content close on outside click",
+						"name": "disableCloseOnOutsideClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"autoFocus": {
+						"defaultValue": { "value": "true" },
+						"description": "Automatically focus the first focusable element in the content, when false the content container will be focused instead",
+						"name": "autoFocus",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"originCoordinates": {
+						"defaultValue": null,
+						"description": "Origin coordinates for the content when there is no trigger element",
+						"name": "originCoordinates",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Coordinates" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the content is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the content is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason?: CloseReason; }) => void)" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Content width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"contentGap": {
+						"defaultValue": null,
+						"description": "Gap between the content and the trigger element",
+						"name": "contentGap",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentShift": {
+						"defaultValue": null,
+						"description": "Shift the content on the secondary axis, relative to its original position",
+						"name": "contentShift",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"contentClassName": {
+						"defaultValue": null,
+						"description": "Additional classname for the content element",
+						"name": "contentClassName",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"contentAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the content element",
+						"name": "contentAttributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					},
+					"instanceRef": {
+						"defaultValue": null,
+						"description": "Ref accessor for the flyout methods",
+						"name": "instanceRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Ref<Instance>" }
+					},
+					"containerRef": {
+						"defaultValue": { "value": "document.body" },
+						"description": "Container to render the content in using a portal, position is calculated based on the container bounds",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"initialFocusRef": {
+						"defaultValue": null,
+						"description": "Element to focus when the content is opened",
+						"name": "initialFocusRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the content visibility, enables controlled mode",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"defaultActive": {
+						"defaultValue": null,
+						"description": "Control the content default visibility, enables uncontrolled mode",
+						"name": "defaultActive",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							},
+							{
+								"fileName": "reshaped/src/components/Flyout/Flyout.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "Flyout"
 			}
 		},
 		"utility-components-formcontrol": {
@@ -2503,43 +13263,147 @@
 			"path": "./src/components/FormControl/tests/FormControl.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-formcontrol--status",
 					"name": "status",
 					"snippet": "const status = () => (\n    <Example>\n        <Example.Item title=\"status: default\">\n            <FormControl>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"status: error\">\n            <FormControl hasError>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n                <FormControl.Error>Error</FormControl.Error>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: medium\">\n            <FormControl size=\"medium\">\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n\n        <Example.Item title=\"size: large\">\n            <FormControl size=\"large\">\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" size=\"large\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => (\n    <Example>\n        <Example.Item title=\"disabled\">\n            <FormControl disabled>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--required",
 					"name": "required",
 					"snippet": "const required = () => (\n    <Example>\n        <Example.Item title=\"required\">\n            <FormControl required>\n                <FormControl.Label>Label</FormControl.Label>\n                <TextField name=\"name\" />\n                <FormControl.Helper>Caption</FormControl.Helper>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "composition",
+					"id": "utility-components-formcontrol--composition",
+					"name": "test: composition",
 					"snippet": "const composition = () => (\n    <Example>\n        <Example.Item title=\"horizontal\">\n            <FormControl>\n                <View direction=\"row\" gap={10} align=\"center\">\n                    <View width=\"100px\">\n                        <FormControl.Label>Label</FormControl.Label>\n                    </View>\n                    <View.Item grow>\n                        <TextField name=\"name\" placeholder=\"Enter value\" />\n                    </View.Item>\n                </View>\n            </FormControl>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-formcontrol--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <FormControl id=\"test-id\" hasError>\n        <FormControl.Label>Label</FormControl.Label>\n        <TextField name=\"name\" />\n        <FormControl.Helper>Caption</FormControl.Helper>\n        <FormControl.Error>Error</FormControl.Error>\n    </FormControl>\n);"
 				},
 				{
+					"id": "utility-components-formcontrol--group",
 					"name": "group",
 					"snippet": "const group = () => (\n    <FormControl group>\n        <FormControl.Label>Label</FormControl.Label>\n        <RadioGroup name=\"name\">\n            <View gap={2}>\n                <Radio value=\"1\">One</Radio>\n                <Radio value=\"2\">Two</Radio>\n            </View>\n        </RadioGroup>\n    </FormControl>\n);"
 				}
 			],
 			"import": "import { Example, FormControl, Radio, RadioGroup, TextField, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/FormControl/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "FormControl",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/FormControl/FormControl.tsx",
-				"actualName": "FormControl",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Component size, to be used together with the other form component sizes",
+						"name": "size",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"large\" | \"medium\"",
+							"value": [{ "value": "\"large\"" }, { "value": "\"medium\"" }]
+						}
+					},
+					"hasError": {
+						"defaultValue": null,
+						"description": "Change component to show an error state and display FormControl.Error",
+						"name": "hasError",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"required": {
+						"defaultValue": null,
+						"description": "Change component to show a required indicator",
+						"name": "required",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"disabled": {
+						"defaultValue": null,
+						"description": "Apply disabled styles",
+						"name": "disabled",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"group": {
+						"defaultValue": null,
+						"description": "Apply semantic html markup when used for displaying multiple form fields together with a single label",
+						"name": "group",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"id": {
+						"defaultValue": null,
+						"description": "Custom id for the form control",
+						"name": "id",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/FormControl/FormControl.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "string" }
+					}
+				},
+				"exportName": "FormControl"
 			}
 		},
 		"utility-components-grid": {
@@ -2548,43 +13412,421 @@
 			"path": "./src/components/Grid/tests/Grid.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "utility-components-grid--base",
+					"name": "gap, columnGap, rowGap, align, justify, maxWidth, width, height",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"gap: 2\">\n            <Grid gap={2} columns={2}>\n                {[1, 2].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"columnGap: 2, rowGap: 4\">\n            <Grid columnGap={2} rowGap={4} columns={2}>\n                {[1, 2, 3, 4].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"align: center\">\n            <Grid gap={2} columns={2} align=\"center\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={8}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"justify: center\">\n            <Grid gap={2} columns=\"200px 200px\" justify=\"center\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"maxWidth: 400px\">\n            <Grid gap={2} columns=\"200px 200px\" maxWidth=\"400px\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"width: 400px, height: 200px\">\n            <Grid gap={2} columns={2} width=\"400px\" height=\"200px\">\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    1\n                </View>\n                <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4}>\n                    2\n                </View>\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "layout",
+					"id": "utility-components-grid--layout",
+					"name": "rows, columns",
 					"snippet": "const layout = () => (\n    <Example>\n        <Example.Item title=\"simple: 2 rows, 3 columns\">\n            <Grid gap={4} columns={3} rows={2}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"columns template, 1fr 2fr 1fr\">\n            <Grid gap={4} columns=\"1fr 2fr 1fr\" rows={2}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"rows template, 1fr 2fr\">\n            <Grid gap={4} columns={3} rows=\"1fr 2fr\">\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"responsive\">\n            <Grid gap={4} columns={{ s: 3, m: \"1fr 2fr 1fr\" }} rows={{ s: 2, m: \"1fr 2fr\" }}>\n                {[1, 2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemLayout",
+					"id": "utility-components-grid--item-layout",
+					"name": "colStart, colEnd, rowStart, rowEnd",
 					"snippet": "const itemLayout = () => (\n    <Example>\n        <Example.Item title=\"column, start 1, end 3\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item colStart={1} colEnd={3}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"column, start 1, span 2\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item colStart={1} colSpan={2}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"row, start 1, end 3\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowEnd={3}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"row, start 1, span 2\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowSpan={2}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n\n        <Example.Item title=\"responsive\">\n            <Grid gap={4} columns={3} rows={2}>\n                <Grid.Item rowStart={1} rowSpan={{ s: 1, m: 2 }} colStart={1} colSpan={{ s: 1, m: 2 }}>\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                        1\n                    </View>\n                </Grid.Item>\n                {[2, 3, 4, 5].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-grid--areas",
 					"name": "areas",
 					"snippet": "const areas = () => (\n    <Example>\n        <Example.Item title=\"simple: 2 rows, 3 columns\">\n            <Grid gap={4} rows={2} areas={[\"a .\", \"a b\"]}>\n                {[\"a\", \"b\"].map((area) => (\n                    <Grid.Item area={area} key={area}>\n                        <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} height=\"100%\">\n                            {area}\n                        </View>\n                    </Grid.Item>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "auto",
+					"id": "utility-components-grid--auto",
+					"name": "autoFlow, autoColumns, autoRows",
 					"snippet": "const auto = () => (\n    <Example>\n        <Example.Item title=\"auto flow: column\">\n            <Grid gap={4} autoFlow=\"column\" rows={2} columns={2}>\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"auto rows\">\n            <Grid gap={4} autoRows=\"100px\" columns={2}>\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n        <Example.Item title=\"auto columns\">\n            <Grid gap={4} autoColumns=\"100px\" autoFlow=\"column\">\n                {[1, 2, 3].map((i) => (\n                    <View backgroundColor=\"neutral-faded\" borderRadius=\"medium\" padding={4} key={i}>\n                        {i}\n                    </View>\n                ))}\n            </Grid>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-grid--as",
 					"name": "as",
 					"snippet": "const as = () => (\n    <Grid as=\"ul\">\n        <Grid.Item as=\"li\">Content</Grid.Item>\n    </Grid>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-grid--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Grid className=\"test-class\" attributes={{ id: \"test-id\" }}>\n            <Grid.Item className=\"test-item-class\" attributes={{ id: \"test-item-id\" }}>\n                Content\n            </Grid.Item>\n        </Grid>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Grid, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Grid/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Grid",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Grid/Grid.tsx",
-				"actualName": "Grid",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between grid items",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"columnGap": {
+						"defaultValue": null,
+						"description": "Horizontal gap between grid items",
+						"name": "columnGap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"rowGap": {
+						"defaultValue": null,
+						"description": "Vertical gap between grid items",
+						"name": "rowGap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Align grid items vertically",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Justify grid items horizontally",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"rows": {
+						"defaultValue": null,
+						"description": "Grid template rows",
+						"name": "rows",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<number | \"inherit\" | \"none\" | \"auto\" | (string & {}) | \"-moz-initial\" | \"initial\" | \"revert\" | \"revert-layer\" | \"unset\" | \"max-content\" | \"min-content\" | \"subgrid\">"
+						}
+					},
+					"columns": {
+						"defaultValue": null,
+						"description": "Grid template columns",
+						"name": "columns",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "Responsive<number | \"inherit\" | \"none\" | \"auto\" | (string & {}) | \"-moz-initial\" | \"initial\" | \"revert\" | \"revert-layer\" | \"unset\" | \"max-content\" | \"min-content\" | \"subgrid\">"
+						}
+					},
+					"areas": {
+						"defaultValue": null,
+						"description": "Grid areas for template syntax",
+						"name": "areas",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string[]>" }
+					},
+					"autoFlow": {
+						"defaultValue": null,
+						"description": "Grid auto flow",
+						"name": "autoFlow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoFlow>" }
+					},
+					"autoColumns": {
+						"defaultValue": null,
+						"description": "Grid auto columns",
+						"name": "autoColumns",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoColumns<0 | (string & {})>>" }
+					},
+					"autoRows": {
+						"defaultValue": null,
+						"description": "Grid auto rows",
+						"name": "autoRows",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<GridAutoRows<0 | (string & {})>>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Maximum width of the grid container, literal css value or unit token multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width of the grid container, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height of the grid container, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Custom root element html tag",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Grid/Grid.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					}
+				},
+				"exportName": "Grid"
 			}
 		},
 		"utility-components-hidden": {
@@ -2593,22 +13835,261 @@
 			"path": "./src/components/Hidden/tests/Hidden.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-hidden--visibility",
 					"name": "visibility",
 					"snippet": "const visibility = () => (\n    <Example>\n        <Example.Item title=\"hide: always\">\n            <Hidden hide={true}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on s\">\n            <Hidden hide={{ s: false, m: true }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on l/xl\">\n            <Hidden hide={{ s: true, l: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on m/l/xl\">\n            <Hidden hide={{ s: true, m: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on m\">\n            <Hidden hide={{ s: true, m: false, l: true }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"shown on s/xl\">\n            <Hidden hide={{ s: false, m: true, xl: false }}>Content</Hidden>\n        </Example.Item>\n        <Example.Item title=\"hide: always, visibility\">\n            <Hidden hide visibility>\n                Content\n            </Hidden>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-hidden--as",
 					"name": "as",
 					"snippet": "const as = () => <Hidden as=\"span\">Content</Hidden>;"
 				}
 			],
 			"import": "import { Example, Hidden } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Hidden/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Hidden",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Hidden/Hidden.tsx",
-				"actualName": "Hidden",
+				"methods": [],
+				"props": {
+					"hide": {
+						"defaultValue": null,
+						"description": "Pick at which viewport sizes to hide the children",
+						"name": "hide",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"visibility": {
+						"defaultValue": null,
+						"description": "Use visibility hidden instead of display none",
+						"name": "visibility",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Custom root element html tag",
+						"name": "as",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Hidden/Hidden.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2618,22 +14099,39 @@
 			"path": "./src/components/HiddenVisually/tests/HiddenVisually.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-hiddenvisually--visibility",
 					"name": "visibility",
 					"snippet": "const visibility = () => (\n    <Example>\n        <Example.Item title=\"pronounced by screen readers\">\n            <HiddenVisually>Screen-reader only</HiddenVisually>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-hiddenvisually--children",
 					"name": "children",
 					"snippet": "const children = () => <HiddenVisually>Content</HiddenVisually>;"
 				}
 			],
 			"import": "import { Example, HiddenVisually } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/HiddenVisually/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "HiddenVisually",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/HiddenVisually/HiddenVisually.tsx",
-				"actualName": "HiddenVisually",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/HiddenVisually/HiddenVisually.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2643,34 +14141,115 @@
 			"path": "./src/components/Icon/tests/Icon.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-icon--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"size: 4\">\n            <Icon svg={IconZap} size={4} />\n        </Example.Item>\n        <Example.Item title=\"size: 8\">\n            <Icon svg={IconZap} size={8} />\n        </Example.Item>\n        <Example.Item title=\"size: 100%\">\n            <View width={25} height={25}>\n                <Icon svg={IconZap} size=\"100%\" />\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive size\", \"[s] 5\", \"[m]: 10\"]}>\n            <Icon svg={IconZap} size={{ s: 5, m: 10 }} />\n        </Example.Item>\n        <Example.Item title=\"size: inherit from font\">\n            <Text variant=\"title-6\">\n                <View direction=\"row\" align=\"center\" gap={2}>\n                    <Icon svg={IconZap} />\n                    <View.Item>Reshaped</View.Item>\n                </View>\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-icon--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: neutral\">\n            <Icon svg={IconZap} color=\"neutral\" />\n        </Example.Item>\n        <Example.Item title=\"color: neutral-faded\">\n            <Icon svg={IconZap} color=\"neutral-faded\" />\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <Icon svg={IconZap} color=\"primary\" />\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Icon svg={IconZap} color=\"critical\" />\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Icon svg={IconZap} color=\"positive\" />\n        </Example.Item>\n        <Example.Item title=\"color: disabled\">\n            <Icon svg={IconZap} color=\"disabled\" />\n        </Example.Item>\n        <Example.Item title=\"color: inherit\">\n            <div style={{ color: \"tomato\" }}>\n                <Icon svg={IconZap} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "autoWidth",
+					"id": "utility-components-icon--auto-width",
+					"name": "autoWidth, blank",
 					"snippet": "const autoWidth = () => (\n    <Example>\n        <Example.Item title=\"square boundaries\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={IconMic} size={10} />\n            </div>\n        </Example.Item>\n        <Example.Item title=\"auto width boundaries\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={IconMic} size={10} autoWidth />\n            </div>\n        </Example.Item>\n        <Example.Item title=\"blank\">\n            <div style={{ background: \"var(--rs-color-background-neutral)\", display: \"inline-block\" }}>\n                <Icon svg={null} size={10} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-icon--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Icon svg={IconZap} className=\"test-classname\" attributes={{ id: \"test-id\" }} />\n    </div>\n);"
 				},
 				{
-					"name": "render",
+					"id": "utility-components-icon--render",
+					"name": "test: hidden from sr",
 					"snippet": "const render = () => (\n    <div data-testid=\"root\">\n        <Icon svg={IconZap} />\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Icon, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Icon/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Icon",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Icon/Icon.tsx",
-				"actualName": "Icon",
+				"methods": [],
+				"props": {
+					"svg": {
+						"defaultValue": null,
+						"description": "Icon svg component or node",
+						"name": "svg",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": true,
+						"type": {
+							"name": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentType<{}> | null"
+						}
+					},
+					"size": {
+						"defaultValue": null,
+						"description": "Icon size, literal css value or unit token multiplier",
+						"name": "size",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Icon color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"warning\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"autoWidth": {
+						"defaultValue": null,
+						"description": "Use the width of the svg asset instead of providing a square bounding box",
+						"name": "autoWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Icon/Icon.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"span\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2680,54 +14259,230 @@
 			"path": "./src/components/Image/tests/Image.stories.tsx",
 			"stories": [
 				{
-					"name": "src",
+					"id": "utility-components-image--src",
+					"name": "src, alt",
 					"snippet": "const src = () => (\n    <Example>\n        <Example.Item title=\"src, alt\">\n            <Image src={imgUrl} alt=\"Image alt\" />\n        </Example.Item>\n\n        <Example.Item title=\"src\">\n            <Image src={imgUrl} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "size",
+					"id": "utility-components-image--size",
+					"name": "width, height, maxWidth, aspectRatio",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"width: 200px\">\n            <Image src={imgUrl} width=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"height: 200px\">\n            <Image src={imgUrl} height=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"maxWidth: 200px\">\n            <Image src={imgUrl} maxWidth=\"200px\" />\n        </Example.Item>\n        <Example.Item title=\"aspectRatio: 1/1\">\n            <Image src={imgUrl} aspectRatio={1 / 1} width=\"300px\" />\n        </Example.Item>\n        <Example.Item title={[\"responsive width\", \"[s] 200px\", \"[m+] 300px\"]}>\n            <Image src={imgUrl} width={{ s: \"200px\", m: \"300px\" }} />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "radius",
+					"id": "utility-components-image--radius",
+					"name": "borderRadius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius: small\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"small\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"radius: medium\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"medium\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"radius: large\">\n            <View width=\"300px\">\n                <Image src={imgUrl} borderRadius=\"large\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--display-mode",
 					"name": "displayMode",
 					"snippet": "const displayMode = () => (\n    <Example>\n        <Example.Item title=\"mode: cover\">\n            <Image src={imgUrl} height=\"200px\" width=\"100%\" displayMode=\"cover\" />\n        </Example.Item>\n        <Example.Item title=\"mode: contain\">\n            <Image src={imgUrl} height=\"200px\" width=\"100%\" displayMode=\"contain\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--on-load",
 					"name": "onLoad",
 					"snippet": "const onLoad = () => <Image src={imgUrl} alt=\"photo\" onLoad={fn()} />;"
 				},
 				{
+					"id": "utility-components-image--on-error",
 					"name": "onError",
 					"snippet": "const onError = () => <Image src=\"/invalid.png\" alt=\"photo\" onError={fn()} />;"
 				},
 				{
+					"id": "utility-components-image--fallback",
 					"name": "fallback",
 					"snippet": "const fallback = () => (\n    <Example>\n        <Example.Item title=\"fallback, background, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"fallback, image, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback={imgUrl} />\n                </View>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"fallback, icon, on error\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image src=\"error\" fallback={<Icon svg={IconZap} size={10} />} />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"fallback, icon, no url\">\n            <View width=\"300px\">\n                <View aspectRatio={16 / 9}>\n                    <Image fallback={<Icon svg={IconZap} size={10} />} />\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-image--render-image",
 					"name": "renderImage",
 					"snippet": "const renderImage = () => (\n    <Example>\n        <Example.Item title=\"renderImage\">\n            <Image\n                src={imgUrl}\n                alt=\"Amsterdam canal\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image\" />}\n            />\n        </Example.Item>\n        <Example.Item title=\"renderImage, fallback\">\n            <Image\n                src=\"error\"\n                fallback={imgUrl}\n                alt=\"Amsterdam canal 2\"\n                renderImage={(attributes) => <img {...attributes} id=\"test-image-fallback\" />}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "imageAttributes",
+					"id": "utility-components-image--image-attributes",
+					"name": "className, attributes,imageAttributes",
 					"snippet": "const imageAttributes = () => (\n    <div data-testid=\"root\">\n        <Image\n            src={imgUrl}\n            alt=\"photo\"\n            className=\"test-classname\"\n            attributes={{ id: \"test-id\" }}\n            imageAttributes={{ \"data-testid\": \"test-img-id\" }}\n        />\n    </div>\n);"
 				},
 				{
-					"name": "ratio",
+					"id": "utility-components-image--ratio",
+					"name": "test: aspectRatio",
 					"snippet": "const ratio = () => (\n    <Example>\n        <Example.Item title=\"ratio: 16/9\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"ratio: 16/9, displayMode: contain\">\n            <View aspectRatio={16 / 9}>\n                <Image src={imgUrl} displayMode=\"contain\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				}
 			],
 			"import": "import { Example, Icon, Image, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Image/Image.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Image",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Image/Image.tsx",
-				"actualName": "Image",
+				"methods": [],
+				"props": {
+					"src": {
+						"defaultValue": null,
+						"description": "Image URL",
+						"name": "src",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"alt": {
+						"defaultValue": null,
+						"description": "Image alt text",
+						"name": "alt",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "string" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Image width, literal css value or unit token multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Image height, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Image max width, literal css value or unit token multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"aspectRatio": {
+						"defaultValue": null,
+						"description": "Image aspect ratio, width / height",
+						"name": "aspectRatio",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Image border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"small\" | \"large\" | \"medium\"",
+							"value": [
+								{ "value": "\"small\"" },
+								{ "value": "\"large\"" },
+								{ "value": "\"medium\"" }
+							]
+						}
+					},
+					"displayMode": {
+						"defaultValue": null,
+						"description": "Image display mode for controlling how it fits into the provided boundaries",
+						"name": "displayMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"cover\" | \"contain\"",
+							"value": [{ "value": "\"cover\"" }, { "value": "\"contain\"" }]
+						}
+					},
+					"onLoad": {
+						"defaultValue": null,
+						"description": "Image on load event",
+						"name": "onLoad",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: SyntheticEvent<Element, Event>) => void)" }
+					},
+					"onError": {
+						"defaultValue": null,
+						"description": "Image on error event",
+						"name": "onError",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "((e: SyntheticEvent<Element, Event>) => void)" }
+					},
+					"fallback": {
+						"defaultValue": null,
+						"description": "Image fallback content if the image fails to load or was not provided",
+						"name": "fallback",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"renderImage": {
+						"defaultValue": null,
+						"description": "Image render function, can be used for integrating with Image component in 3rd party frameworks",
+						"name": "renderImage",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((attributes: Omit<Attributes<\"img\">, \"src\" | \"alt\"> & { src: string; alt: string; }) => ReactNode)"
+						}
+					},
+					"imageAttributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the image element",
+						"name": "imageAttributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"img\">" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Image/Image.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "(Attributes<\"div\"> & Attributes<\"img\">)" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2737,46 +14492,229 @@
 			"path": "./src/components/Overlay/tests/Overlay.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-overlay--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate}>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--transparent",
 					"name": "transparent",
 					"snippet": "const transparent = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate} transparent>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--blurred",
 					"name": "blurred",
 					"snippet": "const blurred = () => {\n    const overlayToggle = useToggle(false);\n\n    return (\n        <Example>\n            <Example.Item title=\"base\">\n                <Button onClick={overlayToggle.activate}>Open overlay</Button>\n                <Overlay active={overlayToggle.active} onClose={overlayToggle.deactivate} blurred>\n                    Overlay content\n                </Overlay>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "renderProps",
+					"id": "utility-components-overlay--render-props",
+					"name": "children, render props",
 					"snippet": "const renderProps = () => (\n    <Overlay active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        {(args) => (args.active ? \"Opened\" : \"Closed\")}\n    </Overlay>\n);"
 				},
 				{
-					"name": "handlers",
+					"id": "utility-components-overlay--handlers",
+					"name": "onOpen, onClose, onAfterOpen, onAfterClose",
 					"snippet": "const handlers = () => {\n    const overlayToggle = useToggle();\n\n    return (\n        <>\n            <Button onClick={() => overlayToggle.toggle()}>Open overlay</Button>\n            <Overlay\n                active={overlayToggle.active}\n                onClose={(closeArgs) => {\n                    overlayToggle.deactivate();\n                    args.handleClose(closeArgs);\n                }}\n                onOpen={fn()}\n                onAfterOpen={fn()}\n                onAfterClose={fn()}>Content\n                                </Overlay>\n        </>\n    );\n};"
 				},
 				{
+					"id": "utility-components-overlay--disable-close-on-click",
 					"name": "disableCloseOnClick",
 					"snippet": "const disableCloseOnClick = (args) => (\n    <Overlay\n        active\n        disableCloseOnClick\n        onClose={(closeArgs) => {\n            args.handleClose(closeArgs);\n        }}\n    >\n        Content\n    </Overlay>\n);"
 				},
 				{
+					"id": "utility-components-overlay--container-ref",
 					"name": "containerRef",
 					"snippet": "const containerRef = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <>\n            <div ref={containerRef} data-testid=\"test-id\" style={{ height: 200 }} />\n            <Overlay active containerRef={containerRef}>\n                Content\n            </Overlay>\n        </>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-overlay--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <Overlay active className=\"test-classname\" attributes={{ \"data-testid\": \"test-id\" }}>\n        Content\n    </Overlay>\n);"
 				}
 			],
 			"import": "import { Button, Example, Overlay } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Overlay/index.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Overlay",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Overlay/Overlay.tsx",
-				"actualName": "Overlay",
+				"methods": [],
+				"props": {
+					"transparent": {
+						"defaultValue": null,
+						"description": "Make the overlay transparent",
+						"name": "transparent",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "number | boolean" }
+					},
+					"blurred": {
+						"defaultValue": null,
+						"description": "Make the overlay blurred",
+						"name": "blurred",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Control the overflow of the component content",
+						"name": "overflow",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"auto\"",
+							"value": [{ "value": "\"hidden\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children, render function receives the state of the component as an argument",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode | ((props: { active: boolean; }) => ReactNode)" }
+					},
+					"active": {
+						"defaultValue": null,
+						"description": "Control the visibility of the component",
+						"name": "active",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"onClose": {
+						"defaultValue": null,
+						"description": "Callback when the component is closed",
+						"name": "onClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: { reason: CloseReason; }) => void)" }
+					},
+					"onAfterClose": {
+						"defaultValue": null,
+						"description": "Callback after the component close transition is complete",
+						"name": "onAfterClose",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onOpen": {
+						"defaultValue": null,
+						"description": "Callback when the component is opened",
+						"name": "onOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"onAfterOpen": {
+						"defaultValue": null,
+						"description": "Callback after the component open transition is complete",
+						"name": "onAfterOpen",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "(() => void)" }
+					},
+					"disableCloseOnClick": {
+						"defaultValue": null,
+						"description": "Disable closing the component on outside click",
+						"name": "disableCloseOnClick",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"containerRef": {
+						"defaultValue": null,
+						"description": "Element to render the component in",
+						"name": "containerRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | null>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Overlay/Overlay.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2786,42 +14724,213 @@
 			"path": "./src/components/Reshaped/tests/Reshaped.stories.tsx",
 			"stories": [
 				{
-					"name": "rtl",
+					"id": "utility-components-reshaped--rtl",
+					"name": "defaultRTL",
 					"snippet": "const rtl = () => (\n    <Reshaped defaultRTL theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				},
 				{
-					"name": "controlledMode",
+					"id": "utility-components-reshaped--controlled-mode",
+					"name": "colorMode, controlled",
 					"snippet": "const controlledMode = () => {\n    const [mode, setMode] = useState<G.ColorMode>(\"dark\");\n\n    return (\n        <Reshaped theme=\"reshaped\" colorMode={mode}>\n            <Button\n                onClick={() => {\n                    setMode(mode === \"dark\" ? \"light\" : \"dark\");\n                }}\n            >\n                Toggle color mode\n            </Button>\n        </Reshaped>\n    );\n};"
 				},
 				{
-					"name": "lightMode",
+					"id": "utility-components-reshaped--light-mode",
+					"name": "defaultColorMode=light",
 					"snippet": "const lightMode = () => <Reshaped theme=\"reshaped\">Hello</Reshaped>;"
 				},
 				{
-					"name": "darkMode",
+					"id": "utility-components-reshaped--dark-mode",
+					"name": "defaultColorMode=dark",
 					"snippet": "const darkMode = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				},
 				{
+					"id": "utility-components-reshaped--scoped",
 					"name": "scoped",
 					"snippet": "const scoped = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\" scoped>\n        Hello\n    </Reshaped>\n);"
 				},
 				{
-					"name": "testScoped",
+					"id": "utility-components-reshaped--test-scoped",
+					"name": "test: scoped switch",
 					"snippet": "const testScoped = () => (\n    <Reshaped theme=\"reshaped\">\n        <Reshaped theme=\"slate\" scoped>\n            <ScopedComponent />\n        </Reshaped>\n    </Reshaped>\n);"
 				},
 				{
-					"name": "keyboardMode",
+					"id": "utility-components-reshaped--keyboard-mode",
+					"name": "test: keyboard mode",
 					"snippet": "const keyboardMode = () => (\n    <Reshaped theme=\"reshaped\" defaultColorMode=\"dark\">\n        Hello\n    </Reshaped>\n);"
 				}
 			],
 			"import": "import { Button, Reshaped } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Reshaped/Reshaped.tsx",
 				"description": "",
-				"methods": [],
 				"displayName": "Reshaped",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Reshaped/Reshaped.tsx",
-				"actualName": "Reshaped",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"theme": {
+						"defaultValue": null,
+						"description": "Theme of the application, enables controlled mode",
+						"name": "theme",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NonNullable<Theme>" }
+					},
+					"defaultTheme": {
+						"defaultValue": null,
+						"description": "Default theme of the application, enables uncontrolled mode",
+						"name": "defaultTheme",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "NonNullable<Theme>" }
+					},
+					"defaultRTL": {
+						"defaultValue": null,
+						"description": "Default content direction of the application",
+						"name": "defaultRTL",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode of the application, enables controlled mode",
+						"name": "colorMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode",
+							"value": [{ "value": "\"light\"" }, { "value": "\"dark\"" }]
+						}
+					},
+					"defaultColorMode": {
+						"defaultValue": null,
+						"description": "Default color mode of the application, enables uncontrolled mode",
+						"name": "defaultColorMode",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode",
+							"value": [{ "value": "\"light\"" }, { "value": "\"dark\"" }]
+						}
+					},
+					"defaultViewport": {
+						"defaultValue": null,
+						"description": "Default viewport size of the application",
+						"name": "defaultViewport",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "Viewport",
+							"value": [
+								{ "value": "\"s\"" },
+								{ "value": "\"m\"" },
+								{ "value": "\"l\"" },
+								{ "value": "\"xl\"" }
+							]
+						}
+					},
+					"toastOptions": {
+						"defaultValue": null,
+						"description": "Global options for the ToastProvider",
+						"name": "toastOptions",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "Partial<Record<Position, { width?: string; expanded?: boolean; }>> | undefined"
+						}
+					},
+					"scoped": {
+						"defaultValue": null,
+						"description": "Enable scoped mode for applications not using Reshaped provider at the application root",
+						"name": "scoped",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/Reshaped/Reshaped.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2831,42 +14940,150 @@
 			"path": "./src/components/ScrollArea/tests/ScrollArea.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-scrollarea--base",
 					"name": "base",
 					"snippet": "const base = () => (\n    <Example>\n        <Example.Item title=\"vertical scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"horizontal scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\" height=\"100px\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"horizontal and vertical scroll\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-scrollarea--scrollbar-display",
 					"name": "scrollbarDisplay",
 					"snippet": "const scrollbarDisplay = () => (\n    <Example>\n        <Example.Item title=\"scrollbarDisplay: hover\">\n            <ScrollArea height=\"100px\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"scrollbarDisplay: hidden\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"hidden\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"scrollbarDisplay: visible\">\n            <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n                <View backgroundColor=\"elevation-base\" padding={4} width=\"150%\">\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "height",
+					"id": "utility-components-scrollarea--height",
+					"name": "height, maxHeight",
 					"snippet": "const height = () => (\n    <Example>\n        <Example.Item title=\"height: 80px\">\n            <ScrollArea height=\"80px\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"responsive height: s 80px, m: 120px\">\n            <ScrollArea height={{ s: \"80px\", m: \"120px\" }}>\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"maxHeight: 80px\">\n            <ScrollArea maxHeight=\"80px\">\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n\n        <Example.Item title=\"responsive max height: s 80px, m: 200px\">\n            <ScrollArea maxHeight={{ s: \"80px\", m: \"200px\" }}>\n                <View backgroundColor=\"elevation-base\" padding={4}>\n                    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                    has been the industry's standard dummy text ever since the 1500s, when an unknown\n                    printer took a galley of type and scrambled it to make a type specimen book. It has\n                    survived not only five centuries, but also the leap into electronic typesetting,\n                    remaining essentially unchanged. It was popularised in the 1960s with the release of\n                    Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                    publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                </View>\n            </ScrollArea>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "onScroll",
+					"id": "utility-components-scrollarea--on-scroll",
+					"name": "ref, onScroll",
 					"snippet": "const onScroll = () => {\n    const ref = React.useRef<HTMLDivElement>(null);\n\n    return (\n        <View gap={4}>\n            <View.Item>\n                <Button onClick={() => ref.current?.scrollBy({ top: 50, left: 50 })}>Scroll</Button>\n            </View.Item>\n            <ScrollArea height=\"100px\" ref={ref} scrollbarDisplay=\"visible\" onScroll={fn()}>\n                <View backgroundColor=\"neutral-faded\" padding={4} width=\"1000px\" height=\"200px\">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum\n                                            has been the industry's standard dummy text ever since the 1500s, when an unknown\n                                            printer took a galley of type and scrambled it to make a type specimen book. It has\n                                            survived not only five centuries, but also the leap into electronic typesetting,\n                                            remaining essentially unchanged. It was popularised in the 1960s with the release of\n                                            Letraset sheets containing Lorem Ipsum passages, and more recently with desktop\n                                            publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n                                        </View>\n            </ScrollArea>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-scrollarea--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <ScrollArea className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </ScrollArea>\n    </div>\n);"
 				},
 				{
-					"name": "testNested",
+					"id": "utility-components-scrollarea--test-nested",
+					"name": "test: nested",
 					"snippet": "const testNested = () => (\n    <ScrollArea height=\"100px\" scrollbarDisplay=\"visible\">\n        <View padding={4} paddingInline={16}>\n            <ScrollArea height=\"200px\" scrollbarDisplay=\"visible\">\n                {Array(20)\n                    .fill(\"\")\n                    .map((_, index) => {\n                        return <div key={index}>Item {index + 1}</div>;\n                    })}\n            </ScrollArea>\n        </View>\n    </ScrollArea>\n);"
 				},
 				{
-					"name": "testDynamicHeight",
+					"id": "utility-components-scrollarea--test-dynamic-height",
+					"name": "test: dynamic height change",
 					"snippet": "const testDynamicHeight = () => {\n    const [count, setCount] = React.useState(10);\n\n    return (\n        <View gap={4}>\n            <View.Item>\n                <Button onClick={() => setCount((prev) => prev + 10)}>Add more items</Button>\n            </View.Item>\n\n            <ScrollArea height=\"200px\" scrollbarDisplay=\"visible\">\n                <View gap={2}>\n                    {new Array(count).fill(\"\").map((_, i) => (\n                        <View.Item key={i}>Item {i + 1}</View.Item>\n                    ))}\n                </View>\n            </ScrollArea>\n        </View>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Example, ScrollArea, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/ScrollArea/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "ScrollArea",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/ScrollArea/ScrollArea.tsx",
-				"actualName": "ScrollArea",
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting content",
+						"name": "children",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": true,
+						"type": { "name": "ReactNode" }
+					},
+					"scrollbarDisplay": {
+						"defaultValue": null,
+						"description": "Scrollbar visibility behavior based on the user interaction",
+						"name": "scrollbarDisplay",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"hover\" | \"visible\"",
+							"value": [
+								{ "value": "\"hidden\"" },
+								{ "value": "\"hover\"" },
+								{ "value": "\"visible\"" }
+							]
+						}
+					},
+					"onScroll": {
+						"defaultValue": null,
+						"description": "Callback when the scroll area is scrolled",
+						"name": "onScroll",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "((args: Coordinates) => void)" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height of the scroll area, literal css value or unit token multiplier",
+						"name": "height",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height of the scroll area, literal css value or unit token multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/ScrollArea/ScrollArea.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "Attributes<\"div\">" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2876,54 +15093,387 @@
 			"path": "./src/components/Text/tests/Text.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-text--variant",
 					"name": "variant",
 					"snippet": "const variant = () => (\n    <Example>\n        <Example.Item title=\"variant: title-1\">\n            <Text variant=\"title-1\">Title 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-2\">\n            <Text variant=\"title-2\">Title 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-3\">\n            <Text variant=\"title-3\">Title 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-4\">\n            <Text variant=\"title-4\">Title 4</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-5\">\n            <Text variant=\"title-5\">Title 5</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: title-6\">\n            <Text variant=\"title-6\">Title 6</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-1\">\n            <Text variant=\"featured-1\">Featured 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-2\">\n            <Text variant=\"featured-2\">Featured 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: featured-3\">\n            <Text variant=\"featured-3\">Featured 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-1\">\n            <Text variant=\"body-1\">Body 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-2\">\n            <Text variant=\"body-2\">Body 2</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: body-3\">\n            <Text variant=\"body-3\">Body 3</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: caption-1\">\n            <Text variant=\"caption-1\">Caption 1</Text>\n        </Example.Item>\n        <Example.Item title=\"variant: caption-2\">\n            <Text variant=\"caption-2\">Caption 2</Text>\n        </Example.Item>\n        <Example.Item title={[\"responsive variant\", \"[s] body-3\", \"[m+] title-4\"]}>\n            <Text variant={{ s: \"body-3\", m: \"title-4\" }}>Responsive</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--weight",
 					"name": "weight",
 					"snippet": "const weight = () => (\n    <Example>\n        <Example.Item title=\"weight: regular\">\n            <Text weight=\"regular\">Regular</Text>\n        </Example.Item>\n        <Example.Item title=\"weight: medium\">\n            <Text weight=\"medium\">Medium</Text>\n        </Example.Item>\n        <Example.Item title=\"weight: bold\">\n            <Text weight=\"bold\">Bold</Text>\n        </Example.Item>\n        <Example.Item title={[\"responsive\", \"[s] weight: regular\", \"[m+] bold\"]}>\n            <Text weight={{ s: \"regular\", m: \"bold\" }}>Responsive</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--color",
 					"name": "color",
 					"snippet": "const color = () => (\n    <Example>\n        <Example.Item title=\"color: inherit\">\n            <Text>Neutral</Text>\n        </Example.Item>\n        <Example.Item title=\"color: neutral-faded\">\n            <Text color=\"neutral-faded\">Faded</Text>\n        </Example.Item>\n        <Example.Item title=\"color: positive\">\n            <Text color=\"positive\">Positive</Text>\n        </Example.Item>\n        <Example.Item title=\"color: warning\">\n            <Text color=\"warning\">Warning</Text>\n        </Example.Item>\n        <Example.Item title=\"color: critical\">\n            <Text color=\"critical\">Critical</Text>\n        </Example.Item>\n        <Example.Item title=\"color: primary\">\n            <Text color=\"primary\">Primary</Text>\n        </Example.Item>\n        <Example.Item title=\"color: disabled\">\n            <Text color=\"disabled\" attributes={{ \"aria-disabled\": true }}>\n                Disabled\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--decoration",
 					"name": "decoration",
 					"snippet": "const decoration = () => (\n    <Example>\n        <Example.Item title=\"decoration: line-through\">\n            <Text decoration=\"line-through\">Line through</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--wrap",
 					"name": "wrap",
 					"snippet": "const wrap = () => (\n    <Example>\n        <Example.Item title=\"wrap: balance\">\n            <Text wrap=\"balance\" variant=\"title-3\">\n                The design system you want to build\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "mono",
+					"id": "utility-components-text--mono",
+					"name": "monospace",
 					"snippet": "const mono = () => (\n    <Example>\n        <Example.Item title=\"monospace\">\n            <Text monospace>Content</Text>\n        </Example.Item>\n        <Example.Item title=\"monospace, variant, weight\">\n            <Text monospace variant=\"title-1\" weight=\"regular\">\n                Content\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--max-lines",
 					"name": "maxLines",
 					"snippet": "const maxLines = () => (\n    <Example>\n        <Example.Item title=\"maxLines: 2\">\n            <Text maxLines={2}>\n                There are many variations of passages of Lorem Ipsum available, but the majority have\n                suffered alteration in some form, by injected humour, or randomised words which don't look\n                even slightly believable. If you are going to use a passage of Lorem Ipsum, you need to be\n                sure there isn't anything embarrassing hidden in the middle of text. All the Lorem Ipsum\n                generators on the Internet tend to repeat predefined chunks as necessary, making this the\n                first true generator on the Internet. It uses a dictionary of over 200 Latin words,\n                combined with a handful of model sentence structures, to generate Lorem Ipsum which looks\n                reasonable. The generated Lorem Ipsum is therefore always free from repetition, injected\n                humour, or non-characteristic words etc.\n            </Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-text--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: start\">\n            <Text align=\"start\">Text content</Text>\n        </Example.Item>\n        <Example.Item title=\"align: center\">\n            <Text align=\"center\">Text content</Text>\n        </Example.Item>\n        <Example.Item title=\"align: end\">\n            <Text align=\"end\">Text content</Text>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive alignment\", \"[s]: center\", \"[m+] start\"]}>\n            <Text align={{ s: \"center\", m: \"start\" }}>Text content</Text>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "asProp",
+					"id": "utility-components-text--as-prop",
+					"name": "as",
 					"snippet": "const asProp = () => (\n    <>\n        <Text as=\"h1\">Content</Text>\n        <Text variant=\"title-3\">Content</Text>\n        <Text variant={{ s: \"title-3\", m: \"title-4\" }}>Content</Text>\n    </>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-text--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <Text className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </Text>\n    </div>\n);"
 				}
 			],
 			"import": "import { Example, Text } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Text/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Text",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Text/Text.tsx",
-				"actualName": "Text",
+				"methods": [],
+				"props": {
+					"variant": {
+						"defaultValue": null,
+						"description": "Text render variant",
+						"name": "variant",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Variant>" }
+					},
+					"weight": {
+						"defaultValue": null,
+						"description": "Text font weight",
+						"name": "weight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"medium\" | \"bold\" | \"regular\">" }
+					},
+					"monospace": {
+						"defaultValue": null,
+						"description": "Render monospace font",
+						"name": "monospace",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"color": {
+						"defaultValue": null,
+						"description": "Text color, based on the color tokens",
+						"name": "color",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"warning\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"warning\"" }
+							]
+						}
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Text alignment",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<\"center\" | \"start\" | \"end\">" }
+					},
+					"wrap": {
+						"defaultValue": null,
+						"description": "CSS wrapping style",
+						"name": "wrap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "enum", "raw": "\"balance\"", "value": [{ "value": "\"balance\"" }] }
+					},
+					"decoration": {
+						"defaultValue": null,
+						"description": "CSS text decoration style",
+						"name": "decoration",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"line-through\"",
+							"value": [{ "value": "\"line-through\"" }]
+						}
+					},
+					"maxLines": {
+						"defaultValue": null,
+						"description": "Maximum number of lines to render, used for text truncation",
+						"name": "maxLines",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different html tag",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Text/Text.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2933,46 +15483,114 @@
 			"path": "./src/components/Theme/tests/Theme.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-theme--scoped",
 					"name": "scoped",
 					"snippet": "const scoped = () => (\n    <Example>\n        <Example.Item title=\"scoped, single\">\n            <Theme name=\"reshaped\">\n                <Card attributes={{ \"data-testid\": \"test-id\" }}>\n                    <Button color=\"primary\">Action</Button>\n                </Card>\n            </Theme>\n        </Example.Item>\n\n        <Example.Item title=\"scoped, multiple\">\n            <Theme name={[\"reshaped\", \"figma\"]}>\n                <Card attributes={{ \"data-testid\": \"test-id-multi\" }}>\n                    <View direction=\"row\" gap={4}>\n                        <Button color=\"primary\">Action</Button>\n\n                        <Popover>\n                            <Popover.Trigger>\n                                {(attributes) => <Button attributes={attributes}>Popover</Button>}\n                            </Popover.Trigger>\n                            <Popover.Content>Content</Popover.Content>\n                        </Popover>\n                    </View>\n                </Card>\n            </Theme>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-theme--light",
 					"name": "light",
 					"snippet": "const light = () => (\n    <Theme name=\"reshaped\" colorMode=\"light\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--dark",
 					"name": "dark",
 					"snippet": "const dark = () => (\n    <Theme name=\"reshaped\" colorMode=\"dark\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--inherited",
 					"name": "inherited",
 					"snippet": "const inherited = () => (\n    <Theme name=\"reshaped\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--inverted",
 					"name": "inverted",
 					"snippet": "const inverted = () => (\n    <Theme name=\"reshaped\" colorMode=\"inverted\">\n        <Card attributes={{ \"data-testid\": \"test-id\" }}>Content</Card>\n    </Theme>\n);"
 				},
 				{
+					"id": "utility-components-theme--controlled",
 					"name": "controlled",
 					"snippet": "const controlled = () => {\n    const Internal = () => {\n        const { setTheme, theme } = useTheme();\n\n        return (\n            <Button color=\"primary\" onClick={() => setTheme(\"slate\")}>\n                Switch to slate\n            </Button>\n        );\n    };\n\n    return (\n        <div data-testid=\"root\">\n            <Theme name=\"reshaped\">\n                <Internal />\n            </Theme>\n        </div>\n    );\n};"
 				},
 				{
+					"id": "utility-components-theme--uncontrolled",
 					"name": "uncontrolled",
 					"snippet": "const uncontrolled = () => {\n    const Internal = () => {\n        const { setTheme } = useTheme();\n\n        return (\n            <Button color=\"primary\" onClick={() => setTheme(\"slate\")}>\n                Switch to slate\n            </Button>\n        );\n    };\n\n    return (\n        <div data-testid=\"root\">\n            <Theme defaultName=\"reshaped\">\n                <Internal />\n            </Theme>\n        </div>\n    );\n};"
 				},
 				{
-					"name": "disabledTransition",
+					"id": "utility-components-theme--disabled-transition",
+					"name": "disabled transitions",
 					"snippet": "const disabledTransition = () => {\n    const { invertColorMode } = useTheme();\n\n    return (\n        <Example>\n            <Example.Item title=\"should have no transitions while switching color mode\">\n                <View gap={3}>\n                    <Button onClick={invertColorMode}>Invert mode</Button>\n\n                    <MenuItem selected>Test transition</MenuItem>\n\n                    <Card>Default card</Card>\n\n                    <Theme colorMode=\"inverted\">\n                        <Card>Inverted card</Card>\n                    </Theme>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
 			"import": "import { Button, Card, Example, MenuItem, Popover, Theme, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Theme/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Theme",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Theme/Theme.tsx",
-				"actualName": "Theme",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the theme to use, enables controlled mode",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"defaultName": {
+						"defaultValue": null,
+						"description": "Default name of the theme to use, enables uncontrolled mode",
+						"name": "defaultName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode to use",
+						"name": "colorMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode | \"inverted\"",
+							"value": [
+								{ "value": "\"light\"" },
+								{ "value": "\"dark\"" },
+								{ "value": "\"inverted\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -2982,147 +15600,880 @@
 			"path": "./src/components/View/tests/View.stories.tsx",
 			"stories": [
 				{
+					"id": "utility-components-view--padding",
 					"name": "padding",
 					"snippet": "const padding = () => (\n    <Example title=\"Border is used to highlight the padding value\">\n        <Example.Item title=\"padding: 4\">\n            <View padding={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: 6\">\n            <View padding={6} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: 0\">\n            <View padding={0} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"padding: vertical 2, horizontal 4\">\n            <View paddingInline={4} paddingBlock={2} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingTop: 4\">\n            <View paddingTop={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingBottom: 4\">\n            <View paddingBottom={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingStart: 4\">\n            <View paddingStart={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"paddingEnd: 4\">\n            <View paddingEnd={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive padding:\",\n                \"[s] vertical 2, horizontal 4\",\n                \"[m+] vertical 4, horizontal 8\",\n            ]}\n        >\n            <View paddingInline={{ s: 4, m: 8 }} paddingBlock={{ s: 2, m: 4 }} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"responsive padding:\", \"[s] top 2, bottom 4\", \"[m+] top 4, bottom 0, start: 8\"]}\n        >\n            <View\n                paddingTop={{ s: 2, m: 4 }}\n                paddingBottom={{ s: 4, m: 0 }}\n                paddingStart={{ s: 0, m: 8 }}\n                borderColor=\"neutral\"\n            >\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"nested padding, child view should have no horizontal padding\">\n            <View paddingStart={4} borderColor=\"neutral\">\n                <View borderColor=\"primary\" paddingBlock={4}>\n                    <Placeholder />\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--direction",
 					"name": "direction",
 					"snippet": "const direction = () => (\n    <Example title=\"Item 1 is another component, Item 2 is View.Item, Item 3 is text\">\n        <Example.Item title=\"direction: column as default\">\n            <View gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <View gap={3} direction=\"column\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column-reverse\">\n            <View gap={3} direction=\"column-reverse\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row\">\n            <View gap={3} direction=\"row\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row-reverse\">\n            <View gap={3} direction=\"row-reverse\">\n                <Placeholder>Item 1</Placeholder>\n                <View.Item>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                Text item 3\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\"responsive direction\", \"[s] column-reverse\", \"[m] row-reverse\", \"[l+] row\"]}\n        >\n            <View direction={{ s: \"column-reverse\", m: \"row-reverse\", l: \"row\" }} gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--gap",
 					"name": "gap",
 					"snippet": "const gap = () => (\n    <Example>\n        <Example.Item title=\"gap: 4, direction: row\">\n            <View direction=\"row\" gap={4} divided>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n                <Placeholder>Item 3</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 0, direction: row\">\n            <View direction=\"row\" gap={0}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap, direction: row\", \"[s] 4\", \"[m+] 8\"]}>\n            <View direction=\"row\" gap={{ s: 4, m: 8 }}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 4, direction: column\">\n            <View gap={4}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"gap: 0, direction: column\">\n            <View gap={0}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive gap, direction: column\", \"[s] 4\", \"[m+] 8\"]}>\n            <View gap={{ s: 4, m: 8 }}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--divided",
 					"name": "divided",
 					"snippet": "const divided = () => (\n    <Example>\n        <Example.Item title=\"direction: row\">\n            <View divided direction=\"row\" gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column\">\n            <View divided gap={3}>\n                <Placeholder>Item 1</Placeholder>\n                <Placeholder>Item 2</Placeholder>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive divided\", \"[s] direction: row\", \"[m+] direction: column\"]}>\n            <View divided direction={{ s: \"row\", m: \"column\" }} gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row, columns\">\n            <View divided gap={3} direction=\"row\">\n                <View.Item columns={2}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={8}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={2}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"with React.Fragment\">\n            <View direction=\"row\" gap={4} divided>\n                <Placeholder>Item 1</Placeholder>\n                <>\n                    <Placeholder>Item 2</Placeholder>\n                    <Placeholder>Item 3</Placeholder>\n                </>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--bleed",
 					"name": "bleed",
 					"snippet": "const bleed = () => (\n    <Example title=\"Removes side borders and border radius when applied\">\n        <Example.Item title=\"bleed: 4\">\n            <View bleed={4} padding={4} borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive bleed\", \"[s] 4\", \"[m+] 0\"]}>\n            <View bleed={{ s: 4, m: 0 }} padding={4} borderRadius=\"small\" borderColor=\"neutral\">\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--wrap",
 					"name": "wrap",
 					"snippet": "const wrap = () => (\n    <Example>\n        <Example.Item title=\"wrap: false\">\n            <View direction=\"row\" wrap={false} gap={3}>\n                <Placeholder w={600} h={100} />\n                <Placeholder w={600} h={100} />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--align",
 					"name": "align",
 					"snippet": "const align = () => (\n    <Example>\n        <Example.Item title=\"align: start, direction: row\">\n            <View align=\"start\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: center, direction: row\">\n            <View align=\"center\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: end, direction: row\">\n            <View align=\"end\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder h={100} />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"align: stretch, direction: row\",\n                \"2nd item is stretched based on the 1st item height\",\n            ]}\n        >\n            <View align=\"stretch\" direction=\"row\" gap={3}>\n                <Placeholder h={100} />\n                <Placeholder h=\"auto\" />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: baseline, direction: row\">\n            <View align=\"baseline\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Text variant=\"title-6\">Content</Text>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"align: start, direction: column\">\n            <View align=\"start\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: center, direction: column\">\n            <View align=\"center\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"align: end, direction: row\">\n            <View align=\"end\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder w={100} />\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"align: stretch, direction: column\",\n                \"1st item uses its own width, 2nd item is stretched to full width\",\n            ]}\n        >\n            <View align=\"stretch\" direction=\"column\" gap={3}>\n                <Placeholder w={100} />\n                <Placeholder w=\"auto\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--justify",
 					"name": "justify",
 					"snippet": "const justify = () => (\n    <Example>\n        <Example.Item title=\"justify: start, direction: row\">\n            <View justify=\"start\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: center, direction: row\">\n            <View justify=\"center\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: end, direction: row\">\n            <View justify=\"end\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: space-between, direction: row\">\n            <View justify=\"space-between\" direction=\"row\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"justify: start, direction: column, height: 200px\">\n            <View height=\"200px\" justify=\"start\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: center, direction: column, height: 200px\">\n            <View height=\"200px\" justify=\"center\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: end, direction: column, height: 200px\">\n            <View justify=\"end\" height=\"200px\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"justify: space-between, direction: column, height: 200px\">\n            <View justify=\"space-between\" height=\"200px\" direction=\"column\" gap={3}>\n                <Placeholder />\n                <Placeholder />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--text-align",
 					"name": "textAlign",
 					"snippet": "const textAlign = () => (\n    <Example>\n        <Example.Item title=\"textAlign: start\">\n            <View textAlign=\"start\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: center\">\n            <View textAlign=\"center\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: end\">\n            <View textAlign=\"end\">Content</View>\n        </Example.Item>\n\n        <Example.Item title=\"textAlign: [s] start, [m+] end\">\n            <View textAlign={{ s: \"start\", m: \"end\" }}>Content</View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--size",
 					"name": "size",
 					"snippet": "const size = () => (\n    <Example>\n        <Example.Item title=\"height: 100px, width: 100px\">\n            <View backgroundColor=\"neutral-faded\" height=\"100px\" width=\"100px\" />\n        </Example.Item>\n        <Example.Item title=\"height: 25, width: 25\">\n            <View backgroundColor=\"neutral-faded\" height={25} width={25} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive height and width\",\n                \"[s] height: 25, width: 25\",\n                \"[m+] height: 200px, width: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                height={{ s: 25, m: \"200px\" }}\n                width={{ s: 25, m: \"200px\" }}\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "ratio",
+					"id": "utility-components-view--ratio",
+					"name": "aspectRatio",
 					"snippet": "const ratio = () => (\n    <Example>\n        <Example.Item title=\"ratio: 16 / 9\">\n            <View backgroundColor=\"neutral-faded\" aspectRatio={16 / 9} width=\"200px\" />\n        </Example.Item>\n        <Example.Item title={[\"responsive ratio\", \"[s] 1/1\", \"[m+] 16/9\"]}>\n            <View backgroundColor=\"neutral-faded\" aspectRatio={{ s: 1, m: 16 / 9 }} width=\"200px\" />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "maxSize",
+					"id": "utility-components-view--max-size",
+					"name": "width, height, maxWidth, maxHeight",
 					"snippet": "const maxSize = () => (\n    <Example>\n        <Example.Item title=\"maxHeight: 150px, maxWidth: 150px, height: 300px\">\n            <View backgroundColor=\"neutral-faded\" maxHeight=\"150px\" maxWidth=\"150px\" height=\"300px\" />\n        </Example.Item>\n        <Example.Item title=\"maxHeight: 25, maxWidth: 25, height: 50\">\n            <View backgroundColor=\"neutral-faded\" maxHeight={25} maxWidth={25} height={50} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive maxHeight and maxWidth, height: 300\",\n                \"[s] maxHeight: 25, maxWidth: 25\",\n                \"[m+] maxHeight: 200px, maxWidth: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                maxHeight={{ s: 25, m: \"200px\" }}\n                maxWidth={{ s: 25, m: \"200px\" }}\n                height=\"300px\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "minSize",
+					"id": "utility-components-view--min-size",
+					"name": "width, height, minWidth, minHeight",
 					"snippet": "const minSize = () => (\n    <Example>\n        <Example.Item title=\"minHeight: 150px, minWidth: 150px, height: 50px, width: 50px\">\n            <View\n                backgroundColor=\"neutral-faded\"\n                minHeight=\"150px\"\n                minWidth=\"150px\"\n                height=\"50px\"\n                width=\"50px\"\n            />\n        </Example.Item>\n        <Example.Item title=\"minHeight: 25, minWidth: 25, height: 5, width: 5\">\n            <View backgroundColor=\"neutral-faded\" minHeight={25} minWidth={25} height={5} width={5} />\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive minHeight and minWidth, height: 50px, width: 50px\",\n                \"[s] minHeight: 25, minWidth: 25\",\n                \"[m+] minHeight: 200px, minWidth: 200px\",\n            ]}\n        >\n            <View\n                backgroundColor=\"neutral-faded\"\n                minHeight={{ s: 25, m: \"200px\" }}\n                minWidth={{ s: 25, m: \"200px\" }}\n                height=\"50px\"\n                width=\"50px\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "background",
+					"id": "utility-components-view--background",
+					"name": "backgroundColor",
 					"snippet": "const background = () => (\n    <Example title=\"border is used to highlight the backround value when it's similar to the page background, text color changes based on the background\">\n        <Example.Item title=\"bg: page\">\n            <View backgroundColor=\"page\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: page-faded\">\n            <View backgroundColor=\"page-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: disabled\">\n            <View backgroundColor=\"disabled\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: disabled-faded\">\n            <View backgroundColor=\"disabled-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-base\">\n            <View backgroundColor=\"elevation-base\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-raised\">\n            <View backgroundColor=\"elevation-raised\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: elevation-overlay\">\n            <View backgroundColor=\"elevation-overlay\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: neutral\">\n            <View backgroundColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: neutral-faded\">\n            <View backgroundColor=\"neutral-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: primary\">\n            <View backgroundColor=\"primary\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: primary-faded\">\n            <View backgroundColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: critical\">\n            <View backgroundColor=\"critical\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: critical-faded\">\n            <View backgroundColor=\"critical-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: warning\">\n            <View backgroundColor=\"warning\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: warning-faded\">\n            <View backgroundColor=\"warning-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: positive\">\n            <View backgroundColor=\"positive\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n        <Example.Item title=\"bg: positive-faded\">\n            <View backgroundColor=\"positive-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--border-color",
 					"name": "borderColor",
 					"snippet": "const borderColor = () => (\n    <Example>\n        <Example.Item title=\"border: neutral\">\n            <View borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: neutral-faded\">\n            <View borderColor=\"neutral-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: primary\">\n            <View borderColor=\"primary\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: primary-faded\">\n            <View borderColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: critical\">\n            <View borderColor=\"critical\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: critical-faded\">\n            <View borderColor=\"critical-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: warning\">\n            <View borderColor=\"warning\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: warning-faded\">\n            <View borderColor=\"warning-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: positive\">\n            <View borderColor=\"positive\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: positive-faded\">\n            <View borderColor=\"positive-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"border: transparent, background: primary-faded\">\n            <View borderColor=\"transparent\" backgroundColor=\"primary-faded\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive\", \"[s] primary\", \"[m+] neutral\"]}>\n            <View borderColor={{ s: \"primary\", m: \"neutral\" }} padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--border",
 					"name": "border",
 					"snippet": "const border = () => (\n    <Example>\n        <Example.Item title=\"border: true\">\n            <View border borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderTop: true\">\n            <View borderTop borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderBottom: true\">\n            <View borderBottom borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderStart: true\">\n            <View borderStart borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderEnd: true\">\n            <View borderEnd borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderInline: true\">\n            <View borderInline borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderBlock: true\">\n            <View borderBlock borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"borderTop: true, borderStart: true, \">\n            <View borderColor=\"neutral\" borderTop borderStart padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"responsive\",\n                \"[s] borderTop: true, borderStart: true\",\n                \"[m+] borderBottom: true, borderEnd: true\",\n            ]}\n        >\n            <View\n                borderColor=\"neutral\"\n                borderTop={{ s: true, m: false }}\n                borderStart={{ s: true, m: false }}\n                borderBottom={{ s: false, m: true }}\n                borderEnd={{ s: false, m: true }}\n                padding={4}\n            >\n                Content\n            </View>\n        </Example.Item>\n\n        <div style={{ height: 100 }} />\n    </Example>\n);"
 				},
 				{
-					"name": "radius",
+					"id": "utility-components-view--radius",
+					"name": "borderRadius",
 					"snippet": "const radius = () => (\n    <Example>\n        <Example.Item title=\"radius: small\">\n            <View borderRadius=\"small\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: medium\">\n            <View borderRadius=\"medium\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: large\">\n            <View borderRadius=\"large\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"radius: circular\">\n            <View borderRadius=\"circular\" borderColor=\"neutral\" padding={4}>\n                Content\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--shadow",
 					"name": "shadow",
 					"snippet": "const shadow = () => (\n    <Example>\n        <Example.Item title=\"shadow: raised, radius: medium\">\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                shadow=\"raised\"\n                borderRadius=\"medium\"\n                backgroundColor=\"elevation-raised\"\n            />\n        </Example.Item>\n        <Example.Item title=\"shadow: overlay, radius: medium\">\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                shadow=\"overlay\"\n                borderRadius=\"medium\"\n                backgroundColor=\"elevation-overlay\"\n            />\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--overflow",
 					"name": "overflow",
 					"snippet": "const overflow = () => (\n    <Example>\n        <Example.Item\n            title={[\"overflow: hidden, radius: medium\", \"child background should have radius\"]}\n        >\n            <View height=\"100px\" width=\"100px\" shadow=\"raised\" borderRadius=\"medium\" overflow=\"hidden\">\n                <View backgroundColor=\"primary\" height=\"100%\" width=\"100%\" />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "positioning",
+					"id": "utility-components-view--positioning",
+					"name": "position",
 					"snippet": "const positioning = () => (\n    <Example>\n        <Example.Item title=\"position: relative + absolute\">\n            <View borderColor=\"neutral\" position=\"relative\">\n                <Placeholder />\n                <View\n                    position=\"absolute\"\n                    insetTop={0}\n                    insetEnd={0}\n                    backgroundColor=\"critical\"\n                    zIndex={5}\n                    height={10}\n                    width={10}\n                />\n                <View\n                    position=\"absolute\"\n                    insetTop={0}\n                    insetEnd={0}\n                    backgroundColor=\"primary\"\n                    height={15}\n                    width={15}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"position: sticky\">\n            <div style={{ overflow: \"auto\", height: 100 }} tabIndex={0}>\n                <View position=\"sticky\" borderColor=\"primary\" insetTop={0}>\n                    Content\n                </View>\n                <Placeholder h={1000} />\n            </div>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive\", \"[s] position: absolute\", \"[m+]: position: relative\"]}>\n            <div style={{ overflow: \"auto\", height: 100, position: \"relative\" }} tabIndex={0}>\n                <View position={{ s: \"absolute\", m: \"relative\" }} borderColor=\"primary\" insetTop={0}>\n                    Content\n                </View>\n                <Placeholder h={1000} />\n            </div>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--inset",
 					"name": "inset",
 					"snippet": "const inset = () => (\n    <Example>\n        <Example.Item title=\"inset: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" inset={4} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetTop: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" insetTop={4} height={10} width={10} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetStart: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetStart={4}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetEnd: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View backgroundColor=\"neutral\" position=\"absolute\" insetEnd={4} height={10} width={10} />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"insetBottom: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetBottom={4}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"responsive, [s] insetBottom: 4 [m+] insetEnd: 4\">\n            <View backgroundColor=\"neutral-faded\" width={25} height={25}>\n                <View\n                    backgroundColor=\"neutral\"\n                    position=\"absolute\"\n                    insetBottom={{ s: 4, m: \"auto\" }}\n                    insetEnd={{ s: \"auto\", m: 4 }}\n                    height={10}\n                    width={10}\n                />\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
+					"id": "utility-components-view--animated",
 					"name": "animated",
 					"snippet": "const animated = () => {\n    const [background, setBackground] = React.useState<ViewProps[\"backgroundColor\"]>(\"neutral\");\n\n    return (\n        <View gap={3} align=\"start\">\n            <Button\n                onClick={() => setBackground((prev) => (prev === \"neutral\" ? \"primary\" : \"neutral\"))}\n            >\n                Change background\n            </Button>\n            <View\n                height=\"100px\"\n                width=\"100px\"\n                backgroundColor={background}\n                align=\"center\"\n                justify=\"center\"\n                animated\n            >\n                Content\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "itemGapBefore",
+					"id": "utility-components-view--item-gap-before",
+					"name": "item, gapBefore",
 					"snippet": "const itemGapBefore = () => (\n    <Example>\n        <Example.Item title={[\"gap: 4, 3rd item gapBefore: 10, direction: row\", \"increased gap\"]}>\n            <View direction=\"row\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={10}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 4, direction: row\", \"reduced gap\"]}>\n            <View direction=\"row\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={4}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 0, direction: row\", \"removed gap\"]}>\n            <View direction=\"row\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={0}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"gap: 4, direction: row, 2nd item gap: auto\">\n            <View direction=\"row\" gap={4}>\n                <Placeholder w={200} />\n                <View.Item gapBefore=\"auto\">\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"gap: 4, 3rd item gapBefore: 10, direction: column\", \"increased gap\"]}>\n            <View direction=\"column\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={10}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 4, direction: column\", \"reduced gap\"]}>\n            <View direction=\"column\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={4}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"gap: 10, 3rd item gapBefore: 0, direction: column\", \"removed gap\"]}>\n            <View direction=\"column\" gap={10}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={0}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"gap: 4, direction: column, height: 200px, 2nd item gap: auto\">\n            <View height=\"200px\" gap={4}>\n                <Placeholder />\n                <View.Item gapBefore=\"auto\">\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"responsive item gap\",\n                \"gap: 4, direction: row\",\n                \"[s] 3rd item gapBefore: 10\",\n                \"[m+] 3rd item gapBefore: 0\",\n            ]}\n        >\n            <View direction=\"row\" gap={4}>\n                <Placeholder />\n                <Placeholder />\n                <View.Item gapBefore={{ s: 10, m: 0 }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemGrow",
+					"id": "utility-components-view--item-grow",
+					"name": "item, grow",
 					"snippet": "const itemGrow = () => (\n    <Example>\n        <Example.Item title=\"direction: row, 2nd item grow\">\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View.Item grow>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: column, height: 200px, 2nd item grow\">\n            <View direction=\"column\" gap={3} height=\"200px\">\n                <Placeholder />\n                <View.Item grow>\n                    <Placeholder h=\"100%\" />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"direction: row, 2nd item grow, applied to View\">\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View grow>\n                    <Placeholder />\n                </View>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive item grow, direction: row\",\n                \"[s] 2nd item grow\",\n                \"[m+] 2nd item doesn't grow\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Placeholder w={200} />\n                <View.Item grow={{ s: true, m: false }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive item grow, direction: column, height: 200px\",\n                \"[s] 2nd item grow\",\n                \"[m+] 2nd item doesn't grow\",\n            ]}\n        >\n            <View direction=\"column\" gap={3} height=\"200px\">\n                <Placeholder />\n                <View.Item grow={{ s: true, m: false }}>\n                    <Placeholder h=\"100%\" />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemColumns",
+					"id": "utility-components-view--item-columns",
+					"name": "item, columns",
 					"snippet": "const itemColumns = () => (\n    <Example>\n        <Example.Item title=\"columns 6, 6, gap: 0\">\n            <View direction=\"row\">\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 3, 9, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={3}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, 9, gap: 4\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title={[\"responsive columns\", \"[s] columns 6, 6, 12, gap: 4\", \"[m+]: 4, 4, 4\"]}>\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={{ s: 6, m: 4 }}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 6, m: 4 }}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 12, m: 4 }}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item title=\"columns 6, 6, 9, gap: 4, 2nd item gapBefore: 20\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={6}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={6} gapBefore={20}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={9}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "itemOrder",
+					"id": "utility-components-view--item-order",
+					"name": "item, order",
 					"snippet": "const itemOrder = () => (\n    <Example>\n        <Example.Item title=\"order: 1 3 2\">\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={4}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={4} order={1}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={4}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title={[\"responsive order\", \"[s] 1 2 3\", \"[m+] 1 3 2\"]}>\n            <View direction=\"row\" gap={4}>\n                <View.Item columns={4}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item columns={4} order={{ s: 0, m: 1 }}>\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={4}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"responsive order\",\n                \"[s]: 1 3 2, 2 is full width on second row\",\n                \"[m+]: 1 2 3, 2 has grow in the center of the first row\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <View.Item columns={{ s: 6, m: \"auto\" }}>\n                    <Placeholder>Item 1</Placeholder>\n                </View.Item>\n                <View.Item\n                    grow={{ s: false, m: true }}\n                    order={{ s: 1, m: 0 }}\n                    columns={{ s: 12, m: \"auto\" }}\n                >\n                    <Placeholder>Item 2</Placeholder>\n                </View.Item>\n                <View.Item columns={{ s: 6, m: \"auto\" }}>\n                    <Placeholder>Item 3</Placeholder>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "hiddenItem",
+					"id": "utility-components-view--hidden-item",
+					"name": "composition, Hidden item",
 					"snippet": "const hiddenItem = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"[s] 2nd item: visible, grow, 3rd item: !grow\",\n                \"[m+] 2nd item: hidden, 2nd item divider: hidden, 3rd item: grow\",\n            ]}\n        >\n            <View direction=\"row\" divided gap={3}>\n                <Placeholder />\n                <Hidden hide={{ s: false, m: true }}>\n                    <View.Item grow key=\"3\">\n                        <Placeholder />\n                    </View.Item>\n                </Hidden>\n                <View.Item grow={{ s: false, m: true }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n\n        <Example.Item\n            title={[\n                \"[s] 2nd item: visible, grow, 3rd item: !grow\",\n                \"[m+] 2nd item: hidden, 2nd item: grow doesn't push 3rd item, 3rd item: grow\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <Placeholder />\n                <Hidden hide={{ s: false, m: true }}>\n                    <View.Item grow>\n                        <Placeholder />\n                    </View.Item>\n                </Hidden>\n                <View.Item grow={{ s: false, m: true }}>\n                    <Placeholder />\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "keys",
+					"id": "utility-components-view--keys",
+					"name": "item, key",
 					"snippet": "const keys = () => {\n    const toggle = useToggle();\n\n    return (\n        <View gap={2}>\n            <Button onClick={() => toggle.toggle()}>Toggle</Button>\n            <View.Item>Item 1</View.Item>\n            {toggle.active && <KeyItem>Item 2</KeyItem>}\n            <KeyItem>Item 3</KeyItem>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "nestedGaps",
+					"id": "utility-components-view--nested-gaps",
+					"name": "composition, nested gap",
 					"snippet": "const nestedGaps = () => (\n    <Example>\n        <Example.Item\n            title={[\n                \"direction: column, gap: 10\",\n                \"Child 1: direction: column, gap: 2\",\n                \"Child 2: direction column, gap: 6\",\n                \"Child 3: gapBefore: 0\",\n                \"Child 3 view: direction: row, gap: 2\",\n            ]}\n        >\n            <View gap={10}>\n                <View gap={2}>\n                    <Placeholder>Child 1</Placeholder>\n                    <Placeholder>Child 1</Placeholder>\n                </View>\n\n                <View gap={6}>\n                    <Placeholder>Child 2</Placeholder>\n                    <Placeholder>Child 2</Placeholder>\n                </View>\n\n                <View.Item gapBefore={0}>\n                    <View direction=\"row\" gap={2}>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                        <Placeholder>Child 3, very long text</Placeholder>\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "testComposition",
+					"id": "utility-components-view--test-composition",
+					"name": "composition, edge cases",
 					"snippet": "const testComposition = () => (\n    <Example>\n        <Example.Item>\n            <View direction=\"row\" align=\"center\" gap={4} padding={4}>\n                <View width=\"80px\" height=\"60px\" backgroundColor=\"neutral-faded\" borderRadius=\"small\" />\n\n                <View direction=\"row\" align=\"center\" gap={1} grow>\n                    <View.Item shrink>\n                        <Text>Text (like Jeff's Puzzles)</Text>\n                    </View.Item>\n\n                    <View minWidth=\"auto\" grow>\n                        <Button size=\"small\" color=\"neutral\" icon={IconPlus} />\n                    </View>\n                </View>\n\n                <Button color=\"primary\" rounded>\n                    Button\n                </Button>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"View.Item, MenuItem, Aspect ratio\",\n                \"ratio should increase height on viewport change\",\n            ]}\n        >\n            <View direction=\"row\" gap={3}>\n                <View.Item>\n                    <Placeholder />\n                </View.Item>\n                <MenuItem selected roundedCorners>\n                    Menu\n                </MenuItem>\n                <View.Item grow>\n                    <View aspectRatio={16 / 9}>\n                        <Placeholder h=\"100%\" />\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"Scrollable tabs inside View.Item with grow\">\n            <View direction=\"row\" align=\"center\" gap={3}>\n                <Placeholder />\n                <View.Item grow>\n                    <View padding={0} align=\"center\">\n                        <Tabs variant=\"pills\">\n                            <Tabs.List>\n                                <Tabs.Item value=\"1\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"2\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"3\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"4\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"5\">Very long item</Tabs.Item>\n                                <Tabs.Item value=\"6\">Very long item</Tabs.Item>\n                            </Tabs.List>\n                            {[1, 2, 3, 5, 6].map((i) => (\n                                <Tabs.Panel key={i} value={i.toString()} />\n                            ))}\n                        </Tabs>\n                    </View>\n                </View.Item>\n                <Placeholder />\n            </View>\n        </Example.Item>\n        <Example.Item title=\"2nd item has grow, Avatar stays circle\">\n            <View direction=\"row\" gap={3}>\n                <Avatar initials=\"DB\" />\n                <View.Item grow>\n                    Veggies sunt bona vobis, proinde vos postulo esse magis grape pea sprouts horseradish\n                    courgette maize spinach prairie turnip jícama coriander quandong gourd broccoli seakale\n                    gumbo. Parsley corn lentil zucchini radicchio maize burdock avocado sea lettuce.\n                    Garbanzo tigernut earthnut pea fennel.\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item\n            title={[\n                \"item gapBefore from parent doesn't affect the child view\",\n                \"columns should take full width\",\n            ]}\n        >\n            <View>\n                <View.Item gapBefore={20}>\n                    <View direction=\"row\" gap={4}>\n                        <View.Item columns={6}>\n                            <Placeholder />\n                        </View.Item>\n                        <View.Item columns={6}>\n                            <Placeholder />\n                        </View.Item>\n                    </View>\n                </View.Item>\n            </View>\n        </Example.Item>\n        <Example.Item title=\"View becomes flexbox if there is a child with grow\">\n            <View height=\"300px\" borderColor=\"neutral-faded\">\n                <View height=\"50px\" />\n                <View grow backgroundColor=\"neutral-faded\" padding={4}>\n                    Grow\n                </View>\n            </View>\n        </Example.Item>\n    </Example>\n);"
 				},
 				{
-					"name": "asProp",
+					"id": "utility-components-view--as-prop",
+					"name": "as",
 					"snippet": "const asProp = () => (\n    <View as=\"ul\">\n        <View.Item as=\"li\">Content</View.Item>\n    </View>\n);"
 				},
 				{
-					"name": "className",
+					"id": "utility-components-view--class-name",
+					"name": "className, attributes",
 					"snippet": "const className = () => (\n    <div data-testid=\"root\">\n        <View className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </View>\n    </div>\n);"
 				},
 				{
-					"name": "itemClassName",
+					"id": "utility-components-view--item-class-name",
+					"name": "item className, attributes",
 					"snippet": "const itemClassName = () => (\n    <div data-testid=\"root\">\n        <View.Item className=\"test-classname\" attributes={{ id: \"test-id\" }}>\n            Content\n        </View.Item>\n    </div>\n);"
 				}
 			],
 			"import": "import { Avatar, Button, Example, Hidden, MenuItem, Placeholder, Tabs, Text, View } from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/View/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "View",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/View/View.tsx",
-				"actualName": "View",
-				"exportName": "default"
+				"methods": [],
+				"props": {
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting the content",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					},
+					"as": {
+						"defaultValue": null,
+						"description": "Render as a different element",
+						"name": "as",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "keyof IntrinsicElements",
+							"value": [
+								{ "value": "\"symbol\"" },
+								{ "value": "\"object\"" },
+								{ "value": "\"div\"" },
+								{ "value": "\"s\"" },
+								{ "value": "\"button\"" },
+								{ "value": "\"a\"" },
+								{ "value": "\"form\"" },
+								{ "value": "\"slot\"" },
+								{ "value": "\"style\"" },
+								{ "value": "\"title\"" },
+								{ "value": "\"abbr\"" },
+								{ "value": "\"address\"" },
+								{ "value": "\"area\"" },
+								{ "value": "\"article\"" },
+								{ "value": "\"aside\"" },
+								{ "value": "\"audio\"" },
+								{ "value": "\"b\"" },
+								{ "value": "\"base\"" },
+								{ "value": "\"bdi\"" },
+								{ "value": "\"bdo\"" },
+								{ "value": "\"big\"" },
+								{ "value": "\"blockquote\"" },
+								{ "value": "\"body\"" },
+								{ "value": "\"br\"" },
+								{ "value": "\"canvas\"" },
+								{ "value": "\"caption\"" },
+								{ "value": "\"center\"" },
+								{ "value": "\"cite\"" },
+								{ "value": "\"code\"" },
+								{ "value": "\"col\"" },
+								{ "value": "\"colgroup\"" },
+								{ "value": "\"data\"" },
+								{ "value": "\"datalist\"" },
+								{ "value": "\"dd\"" },
+								{ "value": "\"del\"" },
+								{ "value": "\"details\"" },
+								{ "value": "\"dfn\"" },
+								{ "value": "\"dialog\"" },
+								{ "value": "\"dl\"" },
+								{ "value": "\"dt\"" },
+								{ "value": "\"em\"" },
+								{ "value": "\"embed\"" },
+								{ "value": "\"fieldset\"" },
+								{ "value": "\"figcaption\"" },
+								{ "value": "\"figure\"" },
+								{ "value": "\"footer\"" },
+								{ "value": "\"h1\"" },
+								{ "value": "\"h2\"" },
+								{ "value": "\"h3\"" },
+								{ "value": "\"h4\"" },
+								{ "value": "\"h5\"" },
+								{ "value": "\"h6\"" },
+								{ "value": "\"head\"" },
+								{ "value": "\"header\"" },
+								{ "value": "\"hgroup\"" },
+								{ "value": "\"hr\"" },
+								{ "value": "\"html\"" },
+								{ "value": "\"i\"" },
+								{ "value": "\"iframe\"" },
+								{ "value": "\"img\"" },
+								{ "value": "\"input\"" },
+								{ "value": "\"ins\"" },
+								{ "value": "\"kbd\"" },
+								{ "value": "\"keygen\"" },
+								{ "value": "\"label\"" },
+								{ "value": "\"legend\"" },
+								{ "value": "\"li\"" },
+								{ "value": "\"link\"" },
+								{ "value": "\"main\"" },
+								{ "value": "\"map\"" },
+								{ "value": "\"mark\"" },
+								{ "value": "\"menu\"" },
+								{ "value": "\"menuitem\"" },
+								{ "value": "\"meta\"" },
+								{ "value": "\"meter\"" },
+								{ "value": "\"nav\"" },
+								{ "value": "\"noindex\"" },
+								{ "value": "\"noscript\"" },
+								{ "value": "\"ol\"" },
+								{ "value": "\"optgroup\"" },
+								{ "value": "\"option\"" },
+								{ "value": "\"output\"" },
+								{ "value": "\"p\"" },
+								{ "value": "\"param\"" },
+								{ "value": "\"picture\"" },
+								{ "value": "\"pre\"" },
+								{ "value": "\"progress\"" },
+								{ "value": "\"q\"" },
+								{ "value": "\"rp\"" },
+								{ "value": "\"rt\"" },
+								{ "value": "\"ruby\"" },
+								{ "value": "\"samp\"" },
+								{ "value": "\"search\"" },
+								{ "value": "\"script\"" },
+								{ "value": "\"section\"" },
+								{ "value": "\"select\"" },
+								{ "value": "\"small\"" },
+								{ "value": "\"source\"" },
+								{ "value": "\"span\"" },
+								{ "value": "\"strong\"" },
+								{ "value": "\"sub\"" },
+								{ "value": "\"summary\"" },
+								{ "value": "\"sup\"" },
+								{ "value": "\"table\"" },
+								{ "value": "\"template\"" },
+								{ "value": "\"tbody\"" },
+								{ "value": "\"td\"" },
+								{ "value": "\"textarea\"" },
+								{ "value": "\"tfoot\"" },
+								{ "value": "\"th\"" },
+								{ "value": "\"thead\"" },
+								{ "value": "\"time\"" },
+								{ "value": "\"tr\"" },
+								{ "value": "\"track\"" },
+								{ "value": "\"u\"" },
+								{ "value": "\"ul\"" },
+								{ "value": "\"var\"" },
+								{ "value": "\"video\"" },
+								{ "value": "\"wbr\"" },
+								{ "value": "\"webview\"" },
+								{ "value": "\"svg\"" },
+								{ "value": "\"animate\"" },
+								{ "value": "\"animateMotion\"" },
+								{ "value": "\"animateTransform\"" },
+								{ "value": "\"circle\"" },
+								{ "value": "\"clipPath\"" },
+								{ "value": "\"defs\"" },
+								{ "value": "\"desc\"" },
+								{ "value": "\"ellipse\"" },
+								{ "value": "\"feBlend\"" },
+								{ "value": "\"feColorMatrix\"" },
+								{ "value": "\"feComponentTransfer\"" },
+								{ "value": "\"feComposite\"" },
+								{ "value": "\"feConvolveMatrix\"" },
+								{ "value": "\"feDiffuseLighting\"" },
+								{ "value": "\"feDisplacementMap\"" },
+								{ "value": "\"feDistantLight\"" },
+								{ "value": "\"feDropShadow\"" },
+								{ "value": "\"feFlood\"" },
+								{ "value": "\"feFuncA\"" },
+								{ "value": "\"feFuncB\"" },
+								{ "value": "\"feFuncG\"" },
+								{ "value": "\"feFuncR\"" },
+								{ "value": "\"feGaussianBlur\"" },
+								{ "value": "\"feImage\"" },
+								{ "value": "\"feMerge\"" },
+								{ "value": "\"feMergeNode\"" },
+								{ "value": "\"feMorphology\"" },
+								{ "value": "\"feOffset\"" },
+								{ "value": "\"fePointLight\"" },
+								{ "value": "\"feSpecularLighting\"" },
+								{ "value": "\"feSpotLight\"" },
+								{ "value": "\"feTile\"" },
+								{ "value": "\"feTurbulence\"" },
+								{ "value": "\"filter\"" },
+								{ "value": "\"foreignObject\"" },
+								{ "value": "\"g\"" },
+								{ "value": "\"image\"" },
+								{ "value": "\"line\"" },
+								{ "value": "\"linearGradient\"" },
+								{ "value": "\"marker\"" },
+								{ "value": "\"mask\"" },
+								{ "value": "\"metadata\"" },
+								{ "value": "\"mpath\"" },
+								{ "value": "\"path\"" },
+								{ "value": "\"pattern\"" },
+								{ "value": "\"polygon\"" },
+								{ "value": "\"polyline\"" },
+								{ "value": "\"radialGradient\"" },
+								{ "value": "\"rect\"" },
+								{ "value": "\"set\"" },
+								{ "value": "\"stop\"" },
+								{ "value": "\"switch\"" },
+								{ "value": "\"text\"" },
+								{ "value": "\"textPath\"" },
+								{ "value": "\"tspan\"" },
+								{ "value": "\"use\"" },
+								{ "value": "\"view\"" }
+							]
+						}
+					},
+					"divided": {
+						"defaultValue": null,
+						"description": "Render a divider between each child",
+						"name": "divided",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"direction": {
+						"defaultValue": null,
+						"description": "Flex direction for the content",
+						"name": "direction",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Direction>" }
+					},
+					"gap": {
+						"defaultValue": null,
+						"description": "Gap between children, base unit token number multiplier",
+						"name": "gap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"wrap": {
+						"defaultValue": null,
+						"description": "Flex wrap for the content",
+						"name": "wrap",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"align": {
+						"defaultValue": null,
+						"description": "Flex align-items for the content",
+						"name": "align",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Align>" }
+					},
+					"justify": {
+						"defaultValue": null,
+						"description": "Flex justify-content for the content",
+						"name": "justify",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Justify>" }
+					},
+					"height": {
+						"defaultValue": null,
+						"description": "Height style, literal string value or a base unit token number multiplier",
+						"name": "height",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"width": {
+						"defaultValue": null,
+						"description": "Width style, literal string value or a base unit token number multiplier",
+						"name": "width",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"aspectRatio": {
+						"defaultValue": null,
+						"description": "Aspect ratio style, represented as width / height",
+						"name": "aspectRatio",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"maxHeight": {
+						"defaultValue": null,
+						"description": "Maximum height style, literal string value or a base unit token number multiplier",
+						"name": "maxHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"maxWidth": {
+						"defaultValue": null,
+						"description": "Maximum width style, literal string value or a base unit token number multiplier",
+						"name": "maxWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"minHeight": {
+						"defaultValue": null,
+						"description": "Minimum height style, literal string value or a base unit token number multiplier",
+						"name": "minHeight",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"minWidth": {
+						"defaultValue": null,
+						"description": "Minimum width style, literal string value or a base unit token number multiplier",
+						"name": "minWidth",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<string | number>" }
+					},
+					"padding": {
+						"defaultValue": null,
+						"description": "Padding style for all sides, base unit token number multiplier",
+						"name": "padding",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingTop": {
+						"defaultValue": null,
+						"description": "Padding top, base unit token number multiplier",
+						"name": "paddingTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingBottom": {
+						"defaultValue": null,
+						"description": "Padding bottom, base unit token number multiplier",
+						"name": "paddingBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingStart": {
+						"defaultValue": null,
+						"description": "Padding inline start, base unit token number multiplier",
+						"name": "paddingStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingEnd": {
+						"defaultValue": null,
+						"description": "Padding inline end, base unit token number multiplier",
+						"name": "paddingEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingInline": {
+						"defaultValue": null,
+						"description": "Padding inline, base unit token number multiplier",
+						"name": "paddingInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"paddingBlock": {
+						"defaultValue": null,
+						"description": "Padding block, base unit token number multiplier",
+						"name": "paddingBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"bleed": {
+						"defaultValue": null,
+						"description": "Apply negative margin and remove side borders, base unit token number multiplier",
+						"name": "bleed",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<number>" }
+					},
+					"textAlign": {
+						"defaultValue": null,
+						"description": "Text align for the content",
+						"name": "textAlign",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<TextAlign>" }
+					},
+					"backgroundColor": {
+						"defaultValue": null,
+						"description": "Background color, based on the color tokens",
+						"name": "backgroundColor",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"disabled\" | \"primary\" | \"critical\" | \"positive\" | \"neutral\" | \"neutral-faded\" | \"critical-faded\" | \"warning\" | \"warning-faded\" | \"positive-faded\" | \"primary-faded\" | \"elevation-base\" | \"elevation-raised\" | \"elevation-overlay\" | \"page\" | \"page-faded\" | \"disabled-faded\" | \"brand\" | \"white\" | \"black\"",
+							"value": [
+								{ "value": "\"disabled\"" },
+								{ "value": "\"primary\"" },
+								{ "value": "\"critical\"" },
+								{ "value": "\"positive\"" },
+								{ "value": "\"neutral\"" },
+								{ "value": "\"neutral-faded\"" },
+								{ "value": "\"critical-faded\"" },
+								{ "value": "\"warning\"" },
+								{ "value": "\"warning-faded\"" },
+								{ "value": "\"positive-faded\"" },
+								{ "value": "\"primary-faded\"" },
+								{ "value": "\"elevation-base\"" },
+								{ "value": "\"elevation-raised\"" },
+								{ "value": "\"elevation-overlay\"" },
+								{ "value": "\"page\"" },
+								{ "value": "\"page-faded\"" },
+								{ "value": "\"disabled-faded\"" },
+								{ "value": "\"brand\"" },
+								{ "value": "\"white\"" },
+								{ "value": "\"black\"" }
+							]
+						}
+					},
+					"borderColor": {
+						"defaultValue": null,
+						"description": "Border color, based on the color tokens",
+						"name": "borderColor",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<BorderColor>" }
+					},
+					"border": {
+						"defaultValue": null,
+						"description": "Add border to all sides",
+						"name": "border",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderTop": {
+						"defaultValue": null,
+						"description": "Add border to the top side",
+						"name": "borderTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderBottom": {
+						"defaultValue": null,
+						"description": "Add border to the bottom side",
+						"name": "borderBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderStart": {
+						"defaultValue": null,
+						"description": "Add border to the inline start side",
+						"name": "borderStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderEnd": {
+						"defaultValue": null,
+						"description": "Add border to the inline end side",
+						"name": "borderEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderInline": {
+						"defaultValue": null,
+						"description": "Add border to the inline direction",
+						"name": "borderInline",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderBlock": {
+						"defaultValue": null,
+						"description": "Add border to the block direction",
+						"name": "borderBlock",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"borderRadius": {
+						"defaultValue": null,
+						"description": "Border radius, based on the radius tokens",
+						"name": "borderRadius",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Radius>" }
+					},
+					"position": {
+						"defaultValue": null,
+						"description": "Position style",
+						"name": "position",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Position>" }
+					},
+					"inset": {
+						"defaultValue": null,
+						"description": "Inset style, base unit token number multiplier when used as a number",
+						"name": "inset",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetStart": {
+						"defaultValue": null,
+						"description": "Inset start, base unit token number multiplier when used as a number",
+						"name": "insetStart",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetEnd": {
+						"defaultValue": null,
+						"description": "Inset end, base unit token number multiplier when used as a number",
+						"name": "insetEnd",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetTop": {
+						"defaultValue": null,
+						"description": "Inset top, base unit token number multiplier when used as a number",
+						"name": "insetTop",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"insetBottom": {
+						"defaultValue": null,
+						"description": "Inset bottom, base unit token number multiplier when used as a number",
+						"name": "insetBottom",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<Inset>" }
+					},
+					"zIndex": {
+						"defaultValue": null,
+						"description": "z-index style",
+						"name": "zIndex",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "number" }
+					},
+					"shadow": {
+						"defaultValue": null,
+						"description": "Shadow style, based on the shadow tokens",
+						"name": "shadow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"raised\" | \"overlay\"",
+							"value": [{ "value": "\"raised\"" }, { "value": "\"overlay\"" }]
+						}
+					},
+					"overflow": {
+						"defaultValue": null,
+						"description": "Overflow style",
+						"name": "overflow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "\"hidden\" | \"auto\"",
+							"value": [{ "value": "\"hidden\"" }, { "value": "\"auto\"" }]
+						}
+					},
+					"animated": {
+						"defaultValue": null,
+						"description": "Add transition for the properties",
+						"name": "animated",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"attributes": {
+						"defaultValue": null,
+						"description": "Additional attributes for the root element",
+						"name": "attributes",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & object & { style?: StyleAttribute; }) | ((DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> | DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> | SVGProps<SVGSymbolElement> | DetailedHTMLProps<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> | DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement> | DetailedHTMLProps<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement> | DetailedHTMLProps<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement> | DetailedHTMLProps<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement> | DetailedHTMLProps<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement> | DetailedHTMLProps<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement> | DetailedHTMLProps<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement> | DetailedHTMLProps<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement> | DetailedHTMLProps<HTMLAttributes<HTMLBRElement>, HTMLBRElement> | DetailedHTMLProps<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement> | DetailedHTMLProps<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement> | DetailedHTMLProps<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement> | DetailedHTMLProps<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement> | DetailedHTMLProps<DelHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement> | DetailedHTMLProps<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> | DetailedHTMLProps<HTMLAttributes<HTMLDListElement>, HTMLDListElement> | DetailedHTMLProps<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement> | DetailedHTMLProps<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement> | DetailedHTMLProps<HTMLAttributes<HTMLHeadElement>, HTMLHeadElement> | DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement> | DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> | DetailedHTMLProps<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement> | DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> | DetailedHTMLProps<InsHTMLAttributes<HTMLModElement>, HTMLModElement> | DetailedHTMLProps<KeygenHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement> | DetailedHTMLProps<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement> | DetailedHTMLProps<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> | DetailedHTMLProps<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> | DetailedHTMLProps<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement> | DetailedHTMLProps<MenuHTMLAttributes<HTMLElement>, HTMLElement> | DetailedHTMLProps<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement> | DetailedHTMLProps<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement> | DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement> | DetailedHTMLProps<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement> | DetailedHTMLProps<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement> | DetailedHTMLProps<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement> | DetailedHTMLProps<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement> | DetailedHTMLProps<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement> | DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement> | DetailedHTMLProps<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement> | DetailedHTMLProps<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement> | DetailedHTMLProps<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement> | DetailedHTMLProps<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement> | DetailedHTMLProps<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement> | DetailedHTMLProps<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> | DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> | DetailedHTMLProps<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> | DetailedHTMLProps<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement> | DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> | DetailedHTMLProps<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement> | DetailedHTMLProps<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement> | DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> | DetailedHTMLProps<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement> | DetailedHTMLProps<HTMLAttributes<HTMLUListElement>, HTMLUListElement> | DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> | DetailedHTMLProps<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> | SVGProps<SVGSVGElement> | SVGProps<SVGElement> | SVGProps<SVGCircleElement> | SVGProps<SVGClipPathElement> | SVGProps<SVGDefsElement> | SVGProps<SVGDescElement> | SVGProps<SVGEllipseElement> | SVGProps<SVGFEBlendElement> | SVGProps<SVGFEColorMatrixElement> | SVGProps<SVGFEComponentTransferElement> | SVGProps<SVGFECompositeElement> | SVGProps<SVGFEConvolveMatrixElement> | SVGProps<SVGFEDiffuseLightingElement> | SVGProps<SVGFEDisplacementMapElement> | SVGProps<SVGFEDistantLightElement> | SVGProps<SVGFEDropShadowElement> | SVGProps<SVGFEFloodElement> | SVGProps<SVGFEFuncAElement> | SVGProps<SVGFEFuncBElement> | SVGProps<SVGFEFuncGElement> | SVGProps<SVGFEFuncRElement> | SVGProps<SVGFEGaussianBlurElement> | SVGProps<SVGFEImageElement> | SVGProps<SVGFEMergeElement> | SVGProps<SVGFEMergeNodeElement> | SVGProps<SVGFEMorphologyElement> | SVGProps<SVGFEOffsetElement> | SVGProps<SVGFEPointLightElement> | SVGProps<SVGFESpecularLightingElement> | SVGProps<SVGFESpotLightElement> | SVGProps<SVGFETileElement> | SVGProps<SVGFETurbulenceElement> | SVGProps<SVGFilterElement> | SVGProps<SVGForeignObjectElement> | SVGProps<SVGGElement> | SVGProps<SVGImageElement> | SVGLineElementAttributes<SVGLineElement> | SVGProps<SVGLinearGradientElement> | SVGProps<SVGMarkerElement> | SVGProps<SVGMaskElement> | SVGProps<SVGMetadataElement> | SVGProps<SVGPathElement> | SVGProps<SVGPatternElement> | SVGProps<SVGPolygonElement> | SVGProps<SVGPolylineElement> | SVGProps<SVGRadialGradientElement> | SVGProps<SVGRectElement> | SVGProps<SVGSetElement> | SVGProps<SVGStopElement> | SVGProps<SVGSwitchElement> | SVGTextElementAttributes<SVGTextElement> | SVGProps<SVGTextPathElement> | SVGProps<SVGTSpanElement> | SVGProps<SVGUseElement> | SVGProps<SVGViewElement>) & Record<`data-${string}`, string | boolean> & { style?: StyleAttribute; }) | undefined"
+						}
+					},
+					"grow": {
+						"defaultValue": null,
+						"description": "Apply flex-grow, using it on View.Item applies additional styles on the parent View",
+						"name": "grow",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Responsive<boolean>" }
+					},
+					"shrink": {
+						"defaultValue": null,
+						"description": "Apply flex-shrink",
+						"name": "shrink",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/View/View.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "boolean" }
+					}
+				},
+				"exportName": "View"
 			}
 		},
 		"hooks-useelementid": {
@@ -3131,7 +16482,8 @@
 			"path": "./src/hooks/tests/useElementId.stories.tsx",
 			"stories": [
 				{
-					"name": "id",
+					"id": "hooks-useelementid--id",
+					"name": "passed id",
 					"snippet": "const id = () => {\n    return <Component id=\"hey\" />;\n};"
 				}
 			],
@@ -3148,6 +16500,7 @@
 			"path": "./src/hooks/tests/useHandlerRef.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usehandlerref--base",
 					"name": "base",
 					"snippet": "const base = (args) => {\n    const [count, setCount] = React.useState(0);\n\n    // Creating a new handler on each render\n    const handleEffect = () => {\n        args.handleEffect(0);\n    };\n\n    return (\n        <View gap={4}>\n            <Button onClick={() => setCount((prev) => prev + 1)}>Increase count</Button>\n            <Component onEffect={handleEffect} count={count} />\n        </View>\n    );\n};"
 				}
@@ -3165,43 +16518,53 @@
 			"path": "./src/hooks/tests/useHotkeys.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usehotkeys--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const { checkHotkeyState } = useHotkeys({\n        \"shift + b + n\": () => console.log(\"pressed\"),\n        \"c + v\": () => console.log(\"c + v\"),\n        \"Meta + k\": () => console.log(\"meta + k\"),\n        \"Meta + f\": () => console.log(\"meta + f\"),\n        \"Meta + v\": () => console.log(\"meta + v\"),\n        \"Meta + b\": () => console.log(\"meta + b\"),\n        \"control + enter\": () => console.log(\"control + enter\"),\n        \"meta + enter\": () => console.log(\"meta + enter\"),\n        \"mod + enter\": () => console.log(\"mod + enter\"),\n        \"mod + ArrowRight\": () => console.log(\"right\"),\n        \"mod + ArrowUp\": () => console.log(\"top\"),\n        \"shift + ArrowRight\": () => console.log(\"right\"),\n        \"shift + ArrowUp\": () => console.log(\"top\"),\n        \"alt+shift+n\": () => console.log(\"alt+shift+n\"),\n        \"shift+alt+n\": () => console.log(\"shift+alt+n\"),\n        \"alt+shiftLeft+n\": () => console.log(\"alt+shiftLeft+n\"),\n    });\n    const active = checkHotkeyState(\"shift + b + n\");\n    const shiftActive = checkHotkeyState(\"shift\");\n    const bActive = checkHotkeyState(\"b\");\n    const nActive = checkHotkeyState(\"n\");\n\n    return (\n        <View\n            animated\n            gap={2}\n            direction=\"row\"\n            backgroundColor={active ? \"positive-faded\" : undefined}\n            padding={2}\n            borderRadius=\"small\"\n        >\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={shiftActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={shiftActive ? undefined : \"raised\"}\n            >\n                Shift\n            </View>\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={bActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={bActive ? undefined : \"raised\"}\n            >\n                b\n            </View>\n            <View\n                paddingInline={4}\n                paddingBlock={2}\n                borderRadius=\"small\"\n                borderColor=\"neutral-faded\"\n                animated\n                backgroundColor={nActive ? \"neutral-faded\" : \"elevation-raised\"}\n                shadow={nActive ? undefined : \"raised\"}\n            >\n                n\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "singleKey",
+					"id": "hooks-usehotkeys--single-key",
+					"name": "single key",
 					"snippet": "const singleKey = (args) => <Component hotkeys={{ a: args.handleHotkey }} />;"
 				},
 				{
-					"name": "modKey",
+					"id": "hooks-usehotkeys--mod-key",
+					"name": "mod key",
 					"snippet": "const modKey = (args) => <Component hotkeys={{ mod: args.handleHotkey }} />;"
 				},
 				{
-					"name": "modKeyHold",
+					"id": "hooks-usehotkeys--mod-key-hold",
+					"name": "mod key on hold",
 					"snippet": "const modKeyHold = (args) => <Component hotkeys={{ \"Meta + b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyList",
+					"id": "hooks-usehotkeys--key-list",
+					"name": "key list",
 					"snippet": "const keyList = (args) => <Component hotkeys={{ \"a,b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombination",
+					"id": "hooks-usehotkeys--key-combination",
+					"name": "key combination",
 					"snippet": "const keyCombination = (args) => <Component hotkeys={{ \"a+b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationFormat",
+					"id": "hooks-usehotkeys--key-combination-format",
+					"name": "key combination without formatting",
 					"snippet": "const keyCombinationFormat = (args) => <Component hotkeys={{ \"A  + b\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationOrder",
+					"id": "hooks-usehotkeys--key-combination-order",
+					"name": "key combination without order",
 					"snippet": "const keyCombinationOrder = (args) => <Component hotkeys={{ \"b+a\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "keyCombinationMoreThanRequired",
+					"id": "hooks-usehotkeys--key-combination-more-than-required",
+					"name": "key combination, more keys pressed",
 					"snippet": "const keyCombinationMoreThanRequired = (args) => <Component hotkeys={{ \"z + x\": args.handleHotkey }} />;"
 				},
 				{
-					"name": "optionModified",
+					"id": "hooks-usehotkeys--option-modified",
+					"name": "modified with alt/option",
 					"snippet": "const optionModified = (args) => (\n    <Component hotkeys={{ \"alt+n\": args.handleHotkeyModified, \"alt+shift\": args.handleHotkey }} />\n);"
 				}
 			],
@@ -3218,22 +16581,27 @@
 			"path": "./src/hooks/tests/useKeyboardArrowNavigation.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usekeyboardarrownavigation--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "horizontal",
+					"id": "hooks-usekeyboardarrownavigation--horizontal",
+					"name": "orientation: horizontal",
 					"snippet": "const horizontal = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, orientation: \"horizontal\" });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "vertical",
+					"id": "hooks-usekeyboardarrownavigation--vertical",
+					"name": "orientation: vertical",
 					"snippet": "const vertical = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, orientation: \"vertical\" });\n\n    return (\n        <View gap={2} direction=\"column\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-usekeyboardarrownavigation--circular",
 					"name": "circular",
 					"snippet": "const circular = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, circular: true });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-usekeyboardarrownavigation--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => {\n    const ref = useRef<HTMLDivElement>(null);\n\n    useKeyboardArrowNavigation({ ref, disabled: true });\n\n    return (\n        <View gap={2} direction=\"row\" attributes={{ ref }}>\n            <Button onClick={() => {}}>Action 1</Button>\n            <Button onClick={() => {}}>Action 2</Button>\n            <Button onClick={() => {}}>Action 3</Button>\n        </View>\n    );\n};"
 				}
@@ -3249,7 +16617,13 @@
 			"id": "hooks-usekeyboardmode",
 			"name": "useKeyboardMode",
 			"path": "./src/hooks/tests/useKeyboardMode.stories.tsx",
-			"stories": [{ "name": "base", "snippet": "const base = () => <Component />;" }],
+			"stories": [
+				{
+					"id": "hooks-usekeyboardmode--base",
+					"name": "base",
+					"snippet": "const base = () => <Component />;"
+				}
+			],
 			"import": "import { Button, View } from \"reshaped\";",
 			"jsDocTags": {},
 			"error": {
@@ -3263,19 +16637,23 @@
 			"path": "./src/hooks/tests/useOnClickOutside.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-useonclickoutside--base",
 					"name": "base",
 					"snippet": "const base = (args) => {\n    const ref = React.useRef(null);\n    const [target, setTarget] = React.useState<\"inside\" | \"outside\" | null>(null);\n\n    useOnClickOutside([ref], () => {\n        args.handleOutsideClick();\n        setTarget(\"outside\");\n    });\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }} onClick={() => setTarget(\"inside\")}>\n                Trigger\n            </Button>\n            {target && `Clicked ${target}`}\n        </View>\n    );\n};"
 				},
 				{
-					"name": "refs",
+					"id": "hooks-useonclickoutside--refs",
+					"name": "multiple refs",
 					"snippet": "const refs = (args) => {\n    const ref = React.useRef(null);\n    const ref2 = React.useRef(null);\n\n    useOnClickOutside([ref, ref2], () => {\n        args.handleOutsideClick();\n    });\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }}>Trigger</Button>\n            <Button attributes={{ ref: ref2 }}>Trigger 2</Button>\n        </View>\n    );\n};"
 				},
 				{
+					"id": "hooks-useonclickoutside--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = (args) => {\n    const ref = React.useRef(null);\n\n    useOnClickOutside(\n        [ref],\n        () => {\n            args.handleOutsideClick();\n        },\n        {\n            disabled: true,\n        }\n    );\n\n    return (\n        <View gap={4} align=\"start\">\n            <Button attributes={{ ref }}>Trigger</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "deps",
+					"id": "hooks-useonclickoutside--deps",
+					"name": "test: handler uses latest state",
 					"snippet": "const deps = (args) => {\n    const ref = React.useRef(null);\n    const [count, setCount] = React.useState(0);\n\n    useOnClickOutside([ref], () => {\n        args.handleOutsideClick({ count });\n    });\n\n    return (\n        <Button attributes={{ ref }} onClick={() => setCount((prev) => prev + 1)}>\n            Trigger\n        </Button>\n    );\n};"
 				}
 			],
@@ -3290,7 +16668,13 @@
 			"id": "hooks-usertl",
 			"name": "useRTL",
 			"path": "./src/hooks/tests/useRTL.stories.tsx",
-			"stories": [{ "name": "setRTL", "snippet": "const setRTL = () => <Component />;" }],
+			"stories": [
+				{
+					"id": "hooks-usertl--set-rtl",
+					"name": "setRTL",
+					"snippet": "const setRTL = () => <Component />;"
+				}
+			],
 			"import": "",
 			"jsDocTags": {},
 			"error": {
@@ -3304,10 +16688,12 @@
 			"path": "./src/hooks/tests/useResponsiveClientValue.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-useresponsiveclientvalue--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const value = useResponsiveClientValue<ViewProps[\"backgroundColor\"]>({\n        s: \"neutral\",\n        m: \"critical\",\n        l: \"positive\",\n    });\n\n    return <View width={25} height={25} backgroundColor={value} />;\n};"
 				},
 				{
+					"id": "hooks-useresponsiveclientvalue--boolean",
 					"name": "boolean",
 					"snippet": "const boolean = () => {\n    const value = useResponsiveClientValue<boolean>({\n        s: true,\n        l: false,\n    });\n\n    return <div>{value?.toString()}</div>;\n};"
 				}
@@ -3325,19 +16711,23 @@
 			"path": "./src/hooks/tests/useScrollLock.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usescrolllock--base",
 					"name": "base",
 					"snippet": "const base = () => {\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock();\n\n    return (\n        <React.Fragment>\n            <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n            <div style={{ height: \"150vh\" }} />\n        </React.Fragment>\n    );\n};"
 				},
 				{
-					"name": "origin",
+					"id": "hooks-usescrolllock--origin",
+					"name": "originRef",
 					"snippet": "const origin = () => {\n    const originRef = React.useRef<HTMLDivElement>(null);\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock({ originRef });\n\n    return (\n        <View overflow=\"auto\" height={25} attributes={{ ref: originRef, \"data-testid\": \"root\" }}>\n            <View height={50} padding={4} backgroundColor=\"neutral-faded\" borderRadius=\"medium\">\n                <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n            </View>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "container",
+					"id": "hooks-usescrolllock--container",
+					"name": "containerRef",
 					"snippet": "const container = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const { lockScroll, unlockScroll, scrollLocked } = useScrollLock({ containerRef });\n\n    return (\n        <View height={25} attributes={{ ref: containerRef, \"data-testid\": \"root\" }}>\n            <Button onClick={scrollLocked ? unlockScroll : lockScroll}>Toggle</Button>\n        </View>\n    );\n};"
 				},
 				{
-					"name": "testContainerAsync",
+					"id": "hooks-usescrolllock--test-container-async",
+					"name": "test: containerRef locked count",
 					"snippet": "const testContainerAsync = () => {\n    const containerRef = React.useRef<HTMLDivElement>(null);\n    const globalLock = useScrollLock();\n    const scopedLock = useScrollLock({ containerRef });\n\n    return (\n        <Example>\n            <Example.Item title=\"calling regular lock and lock with a container only requires a single unlock to remove overflow\">\n                <View attributes={{ ref: containerRef }} gap={4} direction=\"row\">\n                    <Button\n                        onClick={globalLock.scrollLocked ? globalLock.unlockScroll : globalLock.lockScroll}\n                    >\n                        Toggle\n                    </Button>\n                    <Button\n                        onClick={scopedLock.scrollLocked ? scopedLock.unlockScroll : scopedLock.lockScroll}\n                    >\n                        Toggle\n                    </Button>\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
@@ -3354,14 +16744,17 @@
 			"path": "./src/hooks/tests/useToggle.stories.tsx",
 			"stories": [
 				{
+					"id": "hooks-usetoggle--toggle",
 					"name": "toggle",
 					"snippet": "const toggle = () => {\n    const { toggle, active } = useToggle();\n\n    return (\n        <Button onClick={() => toggle()} attributes={{ \"data-active\": active }}>\n            {active ? \"Deactivate\" : \"Activate\"}\n        </Button>\n    );\n};"
 				},
 				{
+					"id": "hooks-usetoggle--activate",
 					"name": "activate",
 					"snippet": "const activate = () => {\n    const { activate, active } = useToggle();\n\n    return (\n        <React.Fragment>\n            <Button onClick={activate} attributes={{ \"data-active\": active }}>\n                Activate\n            </Button>\n        </React.Fragment>\n    );\n};"
 				},
 				{
+					"id": "hooks-usetoggle--deactivate",
 					"name": "deactivate",
 					"snippet": "const deactivate = () => {\n    const { deactivate, active } = useToggle(true);\n\n    return (\n        <Button onClick={deactivate} attributes={{ \"data-active\": active }}>\n            Deactivate\n        </Button>\n    );\n};"
 				}
@@ -3379,39 +16772,48 @@
 			"path": "./src/utilities/a11y/tests/TrapFocus.stories.tsx",
 			"stories": [
 				{
-					"name": "modeDialog",
+					"id": "utilities-trapfocus--mode-dialog",
+					"name": "mode: dialog",
 					"snippet": "const modeDialog = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, { mode: \"dialog\" });\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\"mode: dialog\", \"tab navigation, always stays inside until released\"]}\n            >\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View.Item>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeActionMenu",
+					"id": "utilities-trapfocus--mode-action-menu",
+					"name": "mode: action-menu",
 					"snippet": "const modeActionMenu = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"action-menu\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: action-menu\",\n                    \"up/down arrow navigation, tab and shift+tab release the focus and follows natural tab order\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeActionBar",
+					"id": "utilities-trapfocus--mode-action-bar",
+					"name": "mode: action-bar",
 					"snippet": "const modeActionBar = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"action-bar\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: action-bar\",\n                    \"left/right arrow navigation, tab and shift+tab release the focus and follows natural tab order\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "modeContentMenu",
+					"id": "utilities-trapfocus--mode-content-menu",
+					"name": "mode: content-menu",
 					"snippet": "const modeContentMenu = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"content-menu\",\n            onRelease: () => {\n                trapToggle.deactivate();\n            },\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item\n                title={[\n                    \"mode: content-menu\",\n                    \"tab navigation, tabbing outside the content will trigger the release\",\n                ]}\n            >\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                        <Button onClick={() => {}}>Next trigger</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utilities-trapfocus--include-trigger",
 					"name": "includeTrigger",
 					"snippet": "const includeTrigger = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n            includeTrigger: true,\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <TrapContent onRelease={trapToggle.deactivate} rootRef={rootRef} />\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
+					"id": "utilities-trapfocus--initial-focus-el",
 					"name": "initialFocusEl",
 					"snippet": "const initialFocusEl = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const initialFocusRef = React.useRef<HTMLButtonElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n            initialFocusEl: initialFocusRef.current,\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View\n                            gap={4}\n                            direction=\"row\"\n                            padding={4}\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            attributes={{ ref: rootRef }}\n                        >\n                            <Button onClick={() => {}}>Action 1</Button>\n                            <Button onClick={() => {}} attributes={{ ref: initialFocusRef }}>\n                                Action 2\n                            </Button>\n                            <Button onClick={() => {}}>Action 3</Button>\n                            <Button onClick={trapToggle.deactivate}>Release</Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "focusableElements",
+					"id": "utilities-trapfocus--focusable-elements",
+					"name": "test: focusable elements",
 					"snippet": "const focusableElements = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current);\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title=\"test with all types of focusable elements\">\n                <View gap={4}>\n                    <View.Item>\n                        <Button onClick={trapToggle.activate}>Activate</Button>\n                    </View.Item>\n\n                    {trapToggle.active && (\n                        <View\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            padding={4}\n                            gap={4}\n                            attributes={{ ref: rootRef }}\n                            align=\"start\"\n                        >\n                            <Link href=\"#\" attributes={{ \"data-testid\": \"test-link\" }}>\n                                Link\n                            </Link>\n\n                            <TextField\n                                name=\"input\"\n                                placeholder=\"Input\"\n                                inputAttributes={{ \"data-testid\": \"test-text-field\" }}\n                            />\n\n                            <TextArea name=\"textarea\" inputAttributes={{ \"data-testid\": \"test-text-area\" }} />\n\n                            <Select\n                                name=\"select\"\n                                options={[\n                                    { label: \"Option 1\", value: \"1\" },\n                                    { label: \"Option 2\", value: \"2\" },\n                                ]}\n                                inputAttributes={{ \"data-testid\": \"test-select\" }}\n                            />\n\n                            <RadioGroup name=\"radio\">\n                                <Radio value=\"1\" inputAttributes={{ \"data-testid\": \"test-radio-1\" }}>\n                                    Option 1\n                                </Radio>\n                                <Radio value=\"2\" inputAttributes={{ \"data-testid\": \"test-radio-2\" }}>\n                                    Option 2\n                                </Radio>\n                            </RadioGroup>\n\n                            <Editor />\n\n                            <div tabIndex={0} role=\"button\" data-testid=\"test-tabindex\">\n                                div with tabIndex\n                            </div>\n\n                            <div style={{ display: \"none\" }}>\n                                <Button onClick={() => {}} attributes={{ \"data-testid\": \"test-hidden-button\" }}>\n                                    Hidden\n                                </Button>\n                            </div>\n\n                            <Button\n                                onClick={() => {}}\n                                attributes={{ tabIndex: -1, \"data-testid\": \"test-button-negative-tabindex\" }}\n                            >\n                                Excluded\n                            </Button>\n\n                            <input type=\"hidden\" data-testid=\"test-input-hidden\" />\n\n                            <Button\n                                onClick={trapToggle.deactivate}\n                                attributes={{ \"data-testid\": \"test-button\" }}\n                            >\n                                Release button\n                            </Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "nested",
+					"id": "utilities-trapfocus--nested",
+					"name": "test: nested",
 					"snippet": "const nested = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const innerRootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n    const innerTrapToggle = useToggle();\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n        });\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    React.useEffect(() => {\n        if (!innerTrapToggle.active) return;\n        if (!innerRootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(innerRootRef.current, {\n            mode: \"dialog\",\n        });\n\n        return () => trapFocus.release();\n    }, [innerTrapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"nested, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View gap={4}>\n                            <View\n                                gap={4}\n                                direction=\"row\"\n                                padding={4}\n                                backgroundColor=\"neutral-faded\"\n                                borderRadius=\"medium\"\n                                attributes={{ ref: rootRef }}\n                            >\n                                <Button onClick={() => {}}>Action</Button>\n                                <Button onClick={innerTrapToggle.activate}>Inner trap focus</Button>\n                                <Button onClick={trapToggle.deactivate}>Release</Button>\n                            </View>\n\n                            {innerTrapToggle.active && (\n                                <View\n                                    gap={4}\n                                    direction=\"row\"\n                                    padding={4}\n                                    backgroundColor=\"neutral-faded\"\n                                    borderRadius=\"medium\"\n                                    attributes={{ ref: innerRootRef }}\n                                >\n                                    <Button onClick={() => {}}>Action</Button>\n                                    <Button onClick={innerTrapToggle.deactivate}>Release</Button>\n                                </View>\n                            )}\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				},
 				{
-					"name": "mutationObserver",
+					"id": "utilities-trapfocus--mutation-observer",
+					"name": "test: mutation observer",
 					"snippet": "const mutationObserver = () => {\n    const rootRef = React.useRef<HTMLDivElement>(null);\n    const trapToggle = useToggle();\n    const [mutated, setMutated] = React.useState(false);\n\n    React.useEffect(() => {\n        if (!trapToggle.active) return;\n        if (!rootRef.current) return;\n\n        const trapFocus = new TrapFocus();\n\n        trapFocus.trap(rootRef.current, {\n            mode: \"dialog\",\n        });\n\n        setTimeout(() => {\n            setMutated(true);\n        }, 50);\n\n        return () => trapFocus.release();\n    }, [trapToggle.active]);\n\n    return (\n        <Example>\n            <Example.Item title={[\"includeTrigger, mode: dialog\"]}>\n                <View gap={4}>\n                    <View gap={4} direction=\"row\">\n                        <Button onClick={trapToggle.activate}>Trap focus</Button>\n                    </View>\n\n                    {trapToggle.active && (\n                        <View\n                            gap={4}\n                            direction=\"row\"\n                            padding={4}\n                            backgroundColor=\"neutral-faded\"\n                            borderRadius=\"medium\"\n                            attributes={{ ref: rootRef }}\n                        >\n                            {!mutated && (\n                                <>\n                                    <Button onClick={() => {}}>Action 1</Button>\n                                    <Button onClick={() => {}}>Action 2</Button>\n                                </>\n                            )}\n                            <Button onClick={() => {}}>Action 3</Button>\n                            <Button onClick={trapToggle.deactivate}>Release</Button>\n                        </View>\n                    )}\n                </View>\n            </Example.Item>\n        </Example>\n    );\n};"
 				}
 			],
@@ -3428,15 +16830,35 @@
 			"path": "./src/components/_private/Portal/tests/Portal.stories.tsx",
 			"stories": [
 				{
-					"name": "base",
+					"id": "internal-portal--base",
+					"name": "Base",
 					"snippet": "const base = () => {\n\tconst ref = React.useRef<HTMLDivElement>(null);\n\tconst [mounted, setMounted] = React.useState(false);\n\n\tReact.useEffect(() => {\n\t\tsetMounted(true);\n\t}, []);\n\n\treturn (\n\t\t<>\n\t\t\t<div style={{ border: \"2px solid #333\", padding: 16 }}>\n\t\t\t\tApp\n\t\t\t\t{mounted && <Portal targetRef={ref}>Ported to green</Portal>}\n\t\t\t</div>\n\t\t\t<div ref={ref} style={{ border: \"2px solid green\", padding: 16 }} />\n\t\t</>\n\t);\n};"
 				}
 			],
 			"import": "import { Portal } from \"reshaped\";",
 			"jsDocTags": {},
-			"error": {
-				"name": "No component definition found",
-				"message": "File: /Users/shilman/projects/design-systems/reshaped/src/components/_private/Portal/index.ts\nError:\nNo suitable component definition found.\nYou can debug your component file in this playground: https://react-docgen.dev/playground\nCode:\nimport Portal, { PortalScope } from \"./Portal\";\n\nconst PortalRoot = Portal as typeof Portal & {\n\tScope: typeof PortalScope;\n};\n\nPortalRoot.Scope = PortalScope;\n\nexport default PortalRoot;\nexport type { Props as PortalProps } from \"./Portal.types\";\n\n\nFile: /Users/shilman/projects/design-systems/reshaped/src/components/_private/Portal/Portal.types.ts\nError:\nNo suitable component definition found.\nYou can debug your component file in this playground: https://react-docgen.dev/playground\nCode:\nimport React from \"react\";\n\nexport type Props = {\n\tchildren?: React.ReactNode;\n\ttargetRef?: React.RefObject<HTMLElement | ShadowRoot | null>;\n};\n\nexport type ScopeProps<T extends HTMLElement> = {\n\tchildren: (ref: React.RefObject<T | null>) => React.ReactNode;\n};\n\nexport type Context = {\n\tscopeRef: React.RefObject<HTMLElement | null>;\n};\n"
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/_private/Portal/index.ts",
+				"description": "",
+				"displayName": "Portal",
+				"methods": [],
+				"props": {
+					"targetRef": {
+						"defaultValue": null,
+						"description": "",
+						"name": "targetRef",
+						"declarations": [
+							{
+								"fileName": "reshaped/src/components/_private/Portal/Portal.types.ts",
+								"name": "TypeLiteral"
+							}
+						],
+						"required": false,
+						"type": { "name": "RefObject<HTMLElement | ShadowRoot | null>" }
+					}
+				},
+				"exportName": "Portal"
 			}
 		},
 		"internal-usedrag": {
@@ -3444,24 +16866,33 @@
 			"name": "useDrag",
 			"path": "./src/hooks/tests/useDrag.stories.tsx",
 			"stories": [
-				{ "name": "base", "snippet": "const base = () => <Example />;" },
 				{
-					"name": "mouseEvents",
+					"id": "internal-usedrag--base",
+					"name": "base",
+					"snippet": "const base = () => <Example />;"
+				},
+				{
+					"id": "internal-usedrag--mouse-events",
+					"name": "onDrag, mouse events",
 					"snippet": "const mouseEvents = () => {\n    return <Demo onDrag={fn()} />;\n};"
 				},
 				{
-					"name": "touchEvents",
+					"id": "internal-usedrag--touch-events",
+					"name": "onDrag, touch events",
 					"snippet": "const touchEvents = () => {\n    return <Demo onDrag={fn()} />;\n};"
 				},
 				{
-					"name": "orientationHorizontal",
+					"id": "internal-usedrag--orientation-horizontal",
+					"name": "orientation horizontal",
 					"snippet": "const orientationHorizontal = () => {\n    return <Demo onDrag={fn()} orientation=\"horizontal\" />;\n};"
 				},
 				{
-					"name": "orientationVertical",
+					"id": "internal-usedrag--orientation-vertical",
+					"name": "orientation vertical",
 					"snippet": "const orientationVertical = () => {\n    return <Demo onDrag={fn()} orientation=\"vertical\" />;\n};"
 				},
 				{
+					"id": "internal-usedrag--disabled",
 					"name": "disabled",
 					"snippet": "const disabled = () => {\n    return <Demo onDrag={fn()} disabled />;\n};"
 				}
@@ -3479,7 +16910,8 @@
 			"path": "./src/tests/ShadowDOM.stories.tsx",
 			"stories": [
 				{
-					"name": "behavior",
+					"id": "internal-shadowdom--behavior",
+					"name": "Behavior",
 					"snippet": "const behavior = () => (\n\t<Example>\n\t\t<Example.Item title=\"base\">\n\t\t\t<Component />\n\t\t</Example.Item>\n\t</Example>\n);"
 				}
 			],
@@ -3496,30 +16928,94 @@
 			"path": "./src/tests/themes.stories.tsx",
 			"stories": [
 				{
-					"name": "test",
+					"id": "internal-themes--test",
+					"name": "Test",
 					"snippet": "const test = () => {\n\tconst { colorMode } = useTheme();\n\tconst [activeColor, setColor] = useState(colors[0]);\n\tconst [theme, setTheme] = useState(\"\");\n\tconst [algo, setAlgo] = useState<\"wcag\" | \"apca\">(\"wcag\");\n\n\tuseLayoutEffect(() => {\n\t\tsetTheme(\n\t\t\tgetThemeCSS(\n\t\t\t\t\"test\",\n\t\t\t\t{\n\t\t\t\t\tcolor: generateThemeColors({\n\t\t\t\t\t\tprimary: activeColor === colors[0] ? undefined : activeColor,\n\t\t\t\t\t}),\n\t\t\t\t},\n\t\t\t\t{\n\t\t\t\t\tcolorContrastAlgorithm: algo,\n\t\t\t\t}\n\t\t\t)\n\t\t);\n\t}, [activeColor, algo]);\n\n\treturn (\n\t\t<>\n\t\t\t<style>{theme}</style>\n\t\t\t<Theme name=\"test\">\n\t\t\t\t<View gap={4}>\n\t\t\t\t\t<View direction=\"row\" align=\"center\" gap={4}>\n\t\t\t\t\t\t{colors.map((color) => {\n\t\t\t\t\t\t\tconst hex = colorMode === \"dark\" && color === \"#000000\" ? \"#ffffff\" : color;\n\n\t\t\t\t\t\t\treturn (\n\t\t\t\t\t\t\t\t<Actionable key={color} onClick={() => setColor(color)} borderRadius=\"inherit\">\n\t\t\t\t\t\t\t\t\t<View\n\t\t\t\t\t\t\t\t\t\twidth={5}\n\t\t\t\t\t\t\t\t\t\theight={5}\n\t\t\t\t\t\t\t\t\t\tborderRadius=\"circular\"\n\t\t\t\t\t\t\t\t\t\tattributes={{\n\t\t\t\t\t\t\t\t\t\t\tstyle: {\n\t\t\t\t\t\t\t\t\t\t\t\ttransition: `box-shadow var(--rs-duration-fast) var(--rs-easing-standard)`,\n\t\t\t\t\t\t\t\t\t\t\t\tbackground: hex,\n\t\t\t\t\t\t\t\t\t\t\t\tboxShadow:\n\t\t\t\t\t\t\t\t\t\t\t\t\tcolor === activeColor\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t? `0 0 0 3px var(--rs-color-background-elevation-base), 0 0 0 5px ${hex}`\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t: undefined,\n\t\t\t\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t\t\t\t}}\n\t\t\t\t\t\t\t\t\t/>\n\t\t\t\t\t\t\t\t</Actionable>\n\t\t\t\t\t\t\t);\n\t\t\t\t\t\t})}\n\t\t\t\t\t\t<View.Item gapBefore=\"auto\">\n\t\t\t\t\t\t\t<Switch name=\"algo\" onChange={(args) => setAlgo(args.checked ? \"apca\" : \"wcag\")}>\n\t\t\t\t\t\t\t\tUse APCA\n\t\t\t\t\t\t\t</Switch>\n\t\t\t\t\t\t</View.Item>\n\t\t\t\t\t</View>\n\n\t\t\t\t\t<ThemePlayground />\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</>\n\t);\n};"
 				},
 				{
-					"name": "base",
+					"id": "internal-themes--base",
+					"name": "Base",
 					"snippet": "const base = () => (\n\t<Example>\n\t\t<Example.Item title=\"custom runtime theme\">\n\t\t\t<style>{css}</style>\n\t\t\t<Theme name=\"green\">\n\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"on colors generation\">\n\t\t\t<style>{css2}</style>\n\t\t\t<Theme name=\"peach\">\n\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t</Example>\n);"
 				},
 				{
-					"name": "generation",
+					"id": "internal-themes--generation",
+					"name": "Generation",
 					"snippet": "const generation = () => (\n\t<div>\n\t\t<style>{cssGenerated}</style>\n\t\t<Theme name=\"generated\">{componentExamples}</Theme>\n\t</div>\n);"
 				},
 				{
-					"name": "onColors",
+					"id": "internal-themes--on-colors",
+					"name": "On Colors",
 					"snippet": "const onColors = () => (\n\t<Example>\n\t\t<Example.Item title=\"custom on color values\">\n\t\t\t<style>{onColorsCss}</style>\n\t\t\t<Theme name=\"on-color\">\n\t\t\t\t<View gap={2} direction=\"row\">\n\t\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t\t\t<Button color=\"critical\">Critical button</Button>\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t\t<Example.Item title=\"custom on color values, apca\">\n\t\t\t<style>{onColorsCssApca}</style>\n\t\t\t<Theme name=\"on-color-apca\">\n\t\t\t\t<View gap={2} direction=\"row\">\n\t\t\t\t\t<Button color=\"primary\">Primary button</Button>\n\t\t\t\t\t<Button color=\"critical\">Critical button</Button>\n\t\t\t\t</View>\n\t\t\t</Theme>\n\t\t</Example.Item>\n\t</Example>\n);"
 				}
 			],
 			"import": "import {\n    Actionable,\n    Alert,\n    Avatar,\n    Badge,\n    Button,\n    Card,\n    DropdownMenu,\n    Example,\n    Link,\n    Switch,\n    Text,\n    TextField,\n    Theme,\n    ThemePlayground,\n    View,\n} from \"reshaped\";",
 			"jsDocTags": {},
-			"reactDocgen": {
+			"reactDocgenTypescript": {
+				"tags": {},
+				"filePath": "/Users/jeppe/dev/temp/reshaped/src/components/Theme/index.ts",
 				"description": "",
-				"methods": [],
 				"displayName": "Theme",
-				"definedInFile": "/Users/shilman/projects/design-systems/reshaped/src/components/Theme/Theme.tsx",
-				"actualName": "Theme",
+				"methods": [],
+				"props": {
+					"name": {
+						"defaultValue": null,
+						"description": "Name of the theme to use, enables controlled mode",
+						"name": "name",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"defaultName": {
+						"defaultValue": null,
+						"description": "Default name of the theme to use, enables uncontrolled mode",
+						"name": "defaultName",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "Theme" }
+					},
+					"colorMode": {
+						"defaultValue": null,
+						"description": "Color mode to use",
+						"name": "colorMode",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": {
+							"name": "enum",
+							"raw": "ColorMode | \"inverted\"",
+							"value": [
+								{ "value": "\"light\"" },
+								{ "value": "\"dark\"" },
+								{ "value": "\"inverted\"" }
+							]
+						}
+					},
+					"className": {
+						"defaultValue": null,
+						"description": "Additional classname for the root element",
+						"name": "className",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ClassName" }
+					},
+					"children": {
+						"defaultValue": null,
+						"description": "Node for inserting children",
+						"name": "children",
+						"declarations": [
+							{ "fileName": "reshaped/src/components/Theme/Theme.types.ts", "name": "TypeLiteral" }
+						],
+						"required": false,
+						"type": { "name": "ReactNode" }
+					}
+				},
 				"exportName": "default"
 			}
 		},
@@ -3529,7 +17025,8 @@
 			"path": "./src/Sandbox.stories.tsx",
 			"stories": [
 				{
-					"name": "preview",
+					"id": "sandbox--preview",
+					"name": "Preview",
 					"snippet": "const preview = () => {\n\treturn (\n\t\t<Preview>\n\t\t\t<Component />\n\t\t</Preview>\n\t);\n};"
 				}
 			],
@@ -3540,5 +17037,6 @@
 				"message": "We could not detect the component from your story file. Specify meta.component.\n   7 | import MenuItem from \"components/MenuItem\";\n   8 |\n>  9 | export default {\n     | ^\n  10 | \ttitle: \"Sandbox\",\n  11 | \tchromatic: { disableSnapshot: true },\n  12 | };\n\n./src/Sandbox.stories.tsx:\nimport View from \"components/View\";\nimport Image from \"components/Image\";\nimport React from \"react\";\nimport Select from \"components/Select\";\nimport useToggle from \"hooks/useToggle\";\nimport Modal from \"components/Modal\";\nimport MenuItem from \"components/MenuItem\";\n\nexport default {\n\ttitle: \"Sandbox\",\n\tchromatic: { disableSnapshot: true },\n};\n\nconst Preview: React.FC<{ children: React.ReactNode }> = (props) => {\n\treturn (\n\t\t<View padding={20} gap={6}>\n\t\t\t<View position=\"absolute\" insetTop={0} insetStart={0}>\n\t\t\t\t<Image src=\"./logo.svg\" />\n\t\t\t</View>\n\n\t\t\t{props.children}\n\t\t</View>\n\t);\n};\n\nexport const preview = () => {\n\treturn (\n\t\t<Preview>\n\t\t\t<Component />\n\t\t</Preview>\n\t);\n};\n\nconst Component = () => {\n\tconst toggle = useToggle();\n\tconst [value, setValue] = React.useState(\"Dog\");\n\n\tconst handleClick = () => {\n\t\ttoggle.toggle();\n\t};\n\n\treturn (\n\t\t<>\n\t\t\t<Select name=\"animal\" placeholder=\"Select an animal\" onClick={handleClick}>\n\t\t\t\t{value}\n\t\t\t</Select>\n\t\t\t<Modal active={toggle.active} onClose={toggle.deactivate} position=\"bottom\" padding={2}>\n\t\t\t\t<MenuItem\n\t\t\t\t\troundedCorners\n\t\t\t\t\tonClick={() => {\n\t\t\t\t\t\tsetValue(\"Dog\");\n\t\t\t\t\t\ttoggle.deactivate();\n\t\t\t\t\t}}\n\t\t\t\t\tattributes={{\n\t\t\t\t\t\trole: \"option\",\n\t\t\t\t\t}}\n\t\t\t\t>\n\t\t\t\t\tDog\n\t\t\t\t</MenuItem>\n\t\t\t\t<MenuItem\n\t\t\t\t\troundedCorners\n\t\t\t\t\tattributes={{\n\t\t\t\t\t\trole: \"option\",\n\t\t\t\t\t}}\n\t\t\t\t\tonClick={() => {\n\t\t\t\t\t\tsetValue(\"Turtle\");\n\t\t\t\t\t\ttoggle.deactivate();\n\t\t\t\t\t}}\n\t\t\t\t>\n\t\t\t\t\tTurtle\n\t\t\t\t</MenuItem>\n\t\t\t</Modal>\n\t\t</>\n\t);\n};\n"
 			}
 		}
-	}
+	},
+	"meta": { "docgen": "react-docgen-typescript", "durationMs": 2919 }
 }


### PR DESCRIPTION
## Summary
Move the reshaped eval component manifest updates into a dedicated stacked PR so they do not bloat the server-instructions PR.

## Changes
- update component manifests for reshaped eval tasks
- keep scope limited to manifest files only

## Files
- eval/tasks/000-flight-booking-simple-reshaped/manifests/components.json
- eval/tasks/110-flight-booking-reshaped/manifests/components.json
- eval/tasks/901-create-component-atom-reshaped/manifests/components.json
- eval/tasks/902-create-component-composite-reshaped/manifests/components.json
- eval/tasks/903-create-component-async-fetch-reshaped/manifests/components.json
- eval/tasks/904-create-component-async-module-reshaped/manifests/components.json
- eval/tasks/905-existing-component-write-story-reshaped/manifests/components.json
- eval/tasks/906-existing-component-edit-story-reshaped/manifests/components.json
- eval/tasks/907-existing-component-change-component-reshaped/manifests/components.json