### PR TITLE
feat(mcp-proxy): rework instance conflict into warning

### DIFF
--- a/packages/mcp-proxy/src/tools/intercepts.test.ts
+++ b/packages/mcp-proxy/src/tools/intercepts.test.ts
@@ -45,34 +45,6 @@ describe('intercepts', () => {
 		expect(md).toContain('http://localhost:6006');
 	});
 
-	it('multiple-matches lists conflicting pids', () => {
-		const md = getInterceptMarkdown('multiple-matches', {
-			records: [
-				{
-					schemaVersion: 1,
-					instanceId: 'a',
-					pid: 111,
-					cwd: '/same',
-					url: 'http://localhost:6006',
-					port: 6006,
-					mcp: { status: 'ready', endpoint: 'http://localhost:6006/mcp' },
-				},
-				{
-					schemaVersion: 1,
-					instanceId: 'b',
-					pid: 222,
-					cwd: '/same',
-					url: 'http://localhost:6007',
-					port: 6007,
-					mcp: { status: 'ready', endpoint: 'http://localhost:6007/mcp' },
-				},
-			],
-		});
-		expect(md).toContain('111');
-		expect(md).toContain('222');
-		expect(md).toContain('/same');
-	});
-
 	it('intercept() returns a tool result with isError and namespaced reason metadata', () => {
 		const result = intercept('no-instance');
 		expect(result.isError).toBe(true);

--- a/packages/mcp-proxy/src/tools/intercepts.ts
+++ b/packages/mcp-proxy/src/tools/intercepts.ts
@@ -40,12 +40,6 @@ const MCP_ERROR = `Storybook is running but its MCP server reported an error. In
 
 const INVALID_CWD = `\`cwd\` must be an absolute path matching the cwd from which \`storybook dev\` was started. Resolve the path on the client side (e.g. with \`path.resolve\`) and retry the tool call.`;
 
-const buildMultipleMatches = (records: StorybookInstanceRecordV1[]) =>
-	`Multiple Storybook processes are registered at the same cwd. Stop all but one and retry.
-
-Conflicting instances:
-${records.map((r) => `- pid \`${r.pid}\` at \`${r.cwd}\` (${r.url})`).join('\n')}`;
-
 export type InterceptExtras = {
 	records?: StorybookInstanceRecordV1[];
 	version?: string;
@@ -67,8 +61,6 @@ export function getInterceptMarkdown(
 			return MCP_STARTING;
 		case 'mcp-error':
 			return MCP_ERROR;
-		case 'multiple-matches':
-			return buildMultipleMatches(records ?? []);
 		case 'invalid-cwd':
 			return INVALID_CWD;
 		case 'storybook-too-old':

--- a/packages/mcp-proxy/src/tools/proxy-tool.test.ts
+++ b/packages/mcp-proxy/src/tools/proxy-tool.test.ts
@@ -194,6 +194,77 @@ describe('registerProxyTool / list-all-documentation', () => {
 		expect(firstText(response.result)).toContain('storybook-upgrade');
 	});
 
+	it('proxies the call and prepends a multi-instance warning when 2+ ready instances share the cwd', async () => {
+		const a: StorybookInstanceRecordV1 = {
+			...record,
+			instanceId: 'inst-a',
+			pid: 200,
+			port: 6006,
+			url: 'http://localhost:6006',
+			mcp: { status: 'ready', endpoint: 'http://localhost:6006/mcp' },
+		};
+		const b: StorybookInstanceRecordV1 = {
+			...record,
+			instanceId: 'inst-b',
+			pid: 100,
+			port: 6007,
+			url: 'http://localhost:6007',
+			mcp: { status: 'ready', endpoint: 'http://localhost:6007/mcp' },
+		};
+		vi.mocked(readRegistry).mockResolvedValue([a, b]);
+		vi.mocked(proxyToolCall).mockResolvedValue({
+			content: [{ type: 'text', text: 'PRIMARY' }],
+		});
+
+		const server = await buildServer();
+		const response = await callTool(server, { cwd: '/projects/foo' });
+
+		// Lowest pid (b) is chosen.
+		expect(proxyToolCall).toHaveBeenCalledWith(b, expect.anything());
+
+		const items = response.result.content ?? [];
+		expect(items).toHaveLength(2);
+		const warning = items[0];
+		const primary = items[1];
+		if (!warning || warning.type !== 'text') throw new Error('expected warning text');
+		if (!primary || primary.type !== 'text') throw new Error('expected primary text');
+		expect(warning.text).toContain('Multiple Storybook instances');
+		expect(warning.text).toContain('pid `100`');
+		expect(warning.text).toContain('pid `200`');
+		expect(warning.text).toContain('(proxied)');
+		expect(primary.text).toBe('PRIMARY');
+		expect(response.result.isError).toBeFalsy();
+
+		expect(response.result.content).toMatchInlineSnapshot(`
+			[
+			  {
+			    "text": "> Note: Multiple Storybook instances are running at this cwd. This call was proxied to pid \`100\`.
+			>
+			> Instances at \`/projects/foo\`:
+			> - pid \`100\` at http://localhost:6007 (mcp: \`ready\`) (proxied)
+			> - pid \`200\` at http://localhost:6006 (mcp: \`ready\`)
+			>
+			> No action required from you. If the user wants only one Storybook running, they can stop the unwanted process(es) by pid.",
+			    "type": "text",
+			  },
+			  {
+			    "text": "PRIMARY",
+			    "type": "text",
+			  },
+			]
+		`)
+	});
+
+	it('does not inject the multi-instance warning when only one record matches the cwd', async () => {
+		const server = await buildServer();
+		const response = await callTool(server, { cwd: '/projects/foo' });
+		const items = response.result.content ?? [];
+		expect(items).toHaveLength(1);
+		const only = items[0];
+		if (!only || only.type !== 'text') throw new Error('expected text content');
+		expect(only.text).not.toContain('Multiple Storybook instances');
+	});
+
 	it('surfaces a friendly error when proxyToolCall throws', async () => {
 		vi.mocked(proxyToolCall).mockRejectedValue(new Error('connection refused'));
 		const server = await buildServer();

--- a/packages/mcp-proxy/src/tools/proxy-tool.test.ts
+++ b/packages/mcp-proxy/src/tools/proxy-tool.test.ts
@@ -252,7 +252,7 @@ describe('registerProxyTool / list-all-documentation', () => {
 			    "type": "text",
 			  },
 			]
-		`)
+		`);
 	});
 
 	it('does not inject the multi-instance warning when only one record matches the cwd', async () => {

--- a/packages/mcp-proxy/src/tools/proxy-tool.test.ts
+++ b/packages/mcp-proxy/src/tools/proxy-tool.test.ts
@@ -239,13 +239,13 @@ describe('registerProxyTool / list-all-documentation', () => {
 		expect(response.result.content).toMatchInlineSnapshot(`
 			[
 			  {
-			    "text": "> Note: Multiple Storybook instances are running at this cwd. This call was proxied to pid \`100\`.
+			    "text": "> Warning: Multiple Storybook instances are running at this cwd. This call was proxied to pid \`100\`.
 			>
 			> Instances at \`/projects/foo\`:
 			> - pid \`100\` at http://localhost:6007 (mcp: \`ready\`) (proxied)
 			> - pid \`200\` at http://localhost:6006 (mcp: \`ready\`)
 			>
-			> No action required from you. If the user wants only one Storybook running, they can stop the unwanted process(es) by pid.",
+			> If results look unexpected, ask the user whether they want to stop the other instance(s).",
 			    "type": "text",
 			  },
 			  {
@@ -254,7 +254,6 @@ describe('registerProxyTool / list-all-documentation', () => {
 			  },
 			]
 		`);
-	});
 
 	it('does not inject the multi-instance warning when only one record matches the cwd', async () => {
 		const server = await buildServer();

--- a/packages/mcp-proxy/src/tools/proxy-tool.test.ts
+++ b/packages/mcp-proxy/src/tools/proxy-tool.test.ts
@@ -254,6 +254,7 @@ describe('registerProxyTool / list-all-documentation', () => {
 			  },
 			]
 		`);
+	});
 
 	it('does not inject the multi-instance warning when only one record matches the cwd', async () => {
 		const server = await buildServer();

--- a/packages/mcp-proxy/src/tools/proxy-tool.ts
+++ b/packages/mcp-proxy/src/tools/proxy-tool.ts
@@ -6,7 +6,36 @@ import { proxyToolCall } from '../utils/proxy-client.ts';
 import { resolveInstance } from '../utils/resolve-instance.ts';
 import { checkStorybookVersion } from '../utils/version-check.ts';
 import { intercept } from './intercepts.ts';
-import type { ProxyToolCallResult } from '../types/index.ts';
+import type { ProxyToolCallResult, StorybookInstanceRecordV1 } from '../types/index.ts';
+
+function formatMultiInstanceWarning(
+	chosen: StorybookInstanceRecordV1,
+	siblings: StorybookInstanceRecordV1[],
+): string {
+	const all = [chosen, ...siblings];
+	const lines = all.map((r) => {
+		const marker = r === chosen ? ' (proxied)' : '';
+		return `> - pid \`${r.pid}\` at ${r.url} (mcp: \`${r.mcp.status}\`)${marker}`;
+	});
+	return `> Note: Multiple Storybook instances are running at this cwd. This call was proxied to pid \`${chosen.pid}\`.
+>
+> Instances at \`${chosen.cwd}\`:
+${lines.join('\n')}
+>
+> No action required from you. If the user wants only one Storybook running, they can stop the unwanted process(es) by pid.`;
+}
+
+function prependMultiInstanceWarning(
+	result: ProxyToolCallResult,
+	chosen: StorybookInstanceRecordV1,
+	siblings: StorybookInstanceRecordV1[],
+): ProxyToolCallResult {
+	const warning = formatMultiInstanceWarning(chosen, siblings);
+	return {
+		...result,
+		content: [{ type: 'text', text: warning }, ...(result.content ?? [])],
+	};
+}
 
 const CwdField = {
 	cwd: v.pipe(
@@ -73,10 +102,14 @@ export function registerProxyTool<Schema extends v.ObjectEntries>(
 			}
 
 			try {
-				return await proxyToolCall(resolution.record, {
+				const result = await proxyToolCall(resolution.record, {
 					name: tool.name,
 					arguments: upstreamArgs,
 				});
+				if (resolution.siblings && resolution.siblings.length > 0) {
+					return prependMultiInstanceWarning(result, resolution.record, resolution.siblings);
+				}
+				return result;
 			} catch (error) {
 				return {
 					content: [

--- a/packages/mcp-proxy/src/tools/proxy-tool.ts
+++ b/packages/mcp-proxy/src/tools/proxy-tool.ts
@@ -17,12 +17,12 @@ function formatMultiInstanceWarning(
 		const marker = r === chosen ? ' (proxied)' : '';
 		return `> - pid \`${r.pid}\` at ${r.url} (mcp: \`${r.mcp.status}\`)${marker}`;
 	});
-	return `> Note: Multiple Storybook instances are running at this cwd. This call was proxied to pid \`${chosen.pid}\`.
+	return `> Warning: Multiple Storybook instances are running at this cwd. This call was proxied to pid \`${chosen.pid}\`.
 >
 > Instances at \`${chosen.cwd}\`:
 ${lines.join('\n')}
 >
-> No action required from you. If the user wants only one Storybook running, they can stop the unwanted process(es) by pid.`;
+> If results look unexpected, ask the user whether they want to stop the other instance(s).`;
 }
 
 function prependMultiInstanceWarning(

--- a/packages/mcp-proxy/src/tools/proxy-tool.ts
+++ b/packages/mcp-proxy/src/tools/proxy-tool.ts
@@ -106,8 +106,9 @@ export function registerProxyTool<Schema extends v.ObjectEntries>(
 					name: tool.name,
 					arguments: upstreamArgs,
 				});
-				if (resolution.siblings && resolution.siblings.length > 0) {
-					return prependMultiInstanceWarning(result, resolution.record, resolution.siblings);
+				const siblings = resolution.matches.filter((r) => r !== resolution.record);
+				if (siblings.length > 0) {
+					return prependMultiInstanceWarning(result, resolution.record, siblings);
 				}
 				return result;
 			} catch (error) {

--- a/packages/mcp-proxy/src/types/index.ts
+++ b/packages/mcp-proxy/src/types/index.ts
@@ -8,7 +8,6 @@ export type InterceptReason =
 	| 'addon-missing'
 	| 'mcp-starting'
 	| 'mcp-error'
-	| 'multiple-matches'
 	| 'invalid-cwd'
 	| 'storybook-too-old';
 

--- a/packages/mcp-proxy/src/utils/resolve-instance.test.ts
+++ b/packages/mcp-proxy/src/utils/resolve-instance.test.ts
@@ -31,7 +31,7 @@ function record(
 describe('resolveInstance', () => {
 	it('returns no-instance with empty candidates when registry is empty', () => {
 		const result = resolveInstance([], '/Users/x/projects/foo');
-		expect(result).toEqual({ kind: 'intercept', reason: 'no-instance', records: [] });
+		expect(result).toEqual({ kind: 'intercept', reason: 'no-instance', records: [], matches: [] });
 	});
 
 	it('returns no-instance with candidates when no record cwd matches', () => {
@@ -48,13 +48,13 @@ describe('resolveInstance', () => {
 	it('matches a record by exact normalized cwd', () => {
 		const r = record('/Users/x/projects/foo');
 		const result = resolveInstance([r], '/Users/x/projects/foo');
-		expect(result).toEqual({ kind: 'instance', record: r });
+		expect(result).toEqual({ kind: 'instance', record: r, matches: [r] });
 	});
 
 	it('normalizes trailing slashes and dot segments before matching', () => {
 		const r = record('/Users/x/projects/foo');
 		const result = resolveInstance([r], '/Users/x/projects/foo/./');
-		expect(result).toEqual({ kind: 'instance', record: r });
+		expect(result).toEqual({ kind: 'instance', record: r, matches: [r] });
 	});
 
 	it('does NOT match a child path of a record cwd (exact only)', () => {
@@ -75,14 +75,14 @@ describe('resolveInstance', () => {
 		}
 	});
 
-	it('returns the lowest-pid ready instance plus siblings when 2+ records share the same exact cwd', () => {
+	it('returns the lowest-pid ready instance plus all matches when 2+ records share the same exact cwd', () => {
 		const a = record('/Users/x/projects/foo', 'ready', { pid: 200 });
 		const b = record('/Users/x/projects/foo', 'ready', { pid: 100 });
 		const result = resolveInstance([a, b], '/Users/x/projects/foo');
 		expect(result.kind).toBe('instance');
 		if (result.kind === 'instance') {
 			expect(result.record).toBe(b);
-			expect(result.siblings).toEqual([a]);
+			expect(result.matches).toEqual([b, a]);
 		}
 	});
 
@@ -93,7 +93,7 @@ describe('resolveInstance', () => {
 		expect(result.kind).toBe('instance');
 		if (result.kind === 'instance') {
 			expect(result.record).toBe(ready);
-			expect(result.siblings).toEqual([starting]);
+			expect(result.matches).toEqual([starting, ready]);
 		}
 	});
 
@@ -101,24 +101,24 @@ describe('resolveInstance', () => {
 		const a = record('/Users/x/projects/foo', 'starting', { pid: 200 });
 		const b = record('/Users/x/projects/foo', 'error', { pid: 100 });
 		const result = resolveInstance([a, b], '/Users/x/projects/foo');
-		expect(result).toEqual({ kind: 'intercept', reason: 'mcp-error' });
+		expect(result).toEqual({ kind: 'intercept', reason: 'mcp-error', matches: [b, a] });
 	});
 
 	it('dispatches mcp.status=starting as mcp-starting intercept', () => {
 		const r = record('/p', 'starting');
 		const result = resolveInstance([r], '/p');
-		expect(result).toEqual({ kind: 'intercept', reason: 'mcp-starting' });
+		expect(result).toEqual({ kind: 'intercept', reason: 'mcp-starting', matches: [r] });
 	});
 
 	it('dispatches mcp.status=not-installed as addon-missing intercept', () => {
 		const r = record('/p', 'not-installed');
 		const result = resolveInstance([r], '/p');
-		expect(result).toEqual({ kind: 'intercept', reason: 'addon-missing' });
+		expect(result).toEqual({ kind: 'intercept', reason: 'addon-missing', matches: [r] });
 	});
 
 	it('dispatches mcp.status=error as mcp-error intercept', () => {
 		const r = record('/p', 'error');
 		const result = resolveInstance([r], '/p');
-		expect(result).toEqual({ kind: 'intercept', reason: 'mcp-error' });
+		expect(result).toEqual({ kind: 'intercept', reason: 'mcp-error', matches: [r] });
 	});
 });

--- a/packages/mcp-proxy/src/utils/resolve-instance.test.ts
+++ b/packages/mcp-proxy/src/utils/resolve-instance.test.ts
@@ -75,15 +75,33 @@ describe('resolveInstance', () => {
 		}
 	});
 
-	it('returns multiple-matches when 2+ records share the same exact cwd', () => {
-		const a = record('/Users/x/projects/foo');
-		const b = record('/Users/x/projects/foo');
+	it('returns the lowest-pid ready instance plus siblings when 2+ records share the same exact cwd', () => {
+		const a = record('/Users/x/projects/foo', 'ready', { pid: 200 });
+		const b = record('/Users/x/projects/foo', 'ready', { pid: 100 });
 		const result = resolveInstance([a, b], '/Users/x/projects/foo');
-		expect(result.kind).toBe('intercept');
-		if (result.kind === 'intercept') {
-			expect(result.reason).toBe('multiple-matches');
-			expect(result.records).toEqual([a, b]);
+		expect(result.kind).toBe('instance');
+		if (result.kind === 'instance') {
+			expect(result.record).toBe(b);
+			expect(result.siblings).toEqual([a]);
 		}
+	});
+
+	it('prefers a ready record over non-ready ones when multiple records share the cwd', () => {
+		const starting = record('/Users/x/projects/foo', 'starting', { pid: 100 });
+		const ready = record('/Users/x/projects/foo', 'ready', { pid: 200 });
+		const result = resolveInstance([starting, ready], '/Users/x/projects/foo');
+		expect(result.kind).toBe('instance');
+		if (result.kind === 'instance') {
+			expect(result.record).toBe(ready);
+			expect(result.siblings).toEqual([starting]);
+		}
+	});
+
+	it('falls back to dispatching the lowest-pid status when no record at the cwd is ready', () => {
+		const a = record('/Users/x/projects/foo', 'starting', { pid: 200 });
+		const b = record('/Users/x/projects/foo', 'error', { pid: 100 });
+		const result = resolveInstance([a, b], '/Users/x/projects/foo');
+		expect(result).toEqual({ kind: 'intercept', reason: 'mcp-error' });
 	});
 
 	it('dispatches mcp.status=starting as mcp-starting intercept', () => {

--- a/packages/mcp-proxy/src/utils/resolve-instance.ts
+++ b/packages/mcp-proxy/src/utils/resolve-instance.ts
@@ -42,7 +42,11 @@ export function resolveInstance(
 
 	switch (chosen.mcp.status) {
 		case 'ready':
-			return { kind: 'instance', record: chosen, siblings };
+			return {
+				kind: 'instance',
+				record: chosen,
+				...(siblings ? { siblings } : {}),
+			};
 		case 'starting':
 			return { kind: 'intercept', reason: 'mcp-starting' };
 		case 'not-installed':

--- a/packages/mcp-proxy/src/utils/resolve-instance.ts
+++ b/packages/mcp-proxy/src/utils/resolve-instance.ts
@@ -5,16 +5,22 @@ export type ResolveResult =
 	| {
 			kind: 'instance';
 			record: StorybookInstanceRecordV1;
-			siblings?: StorybookInstanceRecordV1[];
+			matches: StorybookInstanceRecordV1[];
 	  }
-	| { kind: 'intercept'; reason: InterceptReason; records?: StorybookInstanceRecordV1[] };
+	| {
+			kind: 'intercept';
+			reason: InterceptReason;
+			records?: StorybookInstanceRecordV1[];
+			matches: StorybookInstanceRecordV1[];
+	  };
 
 /**
  * Pick the Storybook instance whose cwd exactly matches `targetCwd` after
  * normalisation. Per milestone 2 of storybookjs/storybook#34826: matching is
  * exact-normalized, with no longest-prefix or fallback behaviour.
  *
- * If a single record matches, dispatch based on `mcp.status`:
+ * If at least one record matches, dispatch based on the selected instance's
+ * `mcp.status`:
  *   - ready          → proxy
  *   - starting       → mcp-starting intercept
  *   - not-installed  → addon-missing intercept
@@ -22,8 +28,8 @@ export type ResolveResult =
  *
  * Zero matches → no-instance intercept (callers may surface running cwds).
  * 2+ matches at the same cwd → pick a deterministic instance (lowest pid among
- * `ready` records, else lowest pid overall) and surface the others as
- * `siblings` so callers can warn the agent without blocking the call.
+ * `ready` records, else lowest pid overall). All matches are returned (sorted by
+ * pid) as `matches` so callers can warn the agent without blocking the call.
  */
 export function resolveInstance(
 	records: StorybookInstanceRecordV1[],
@@ -33,25 +39,44 @@ export function resolveInstance(
 	const matches = records.filter((r) => resolve(r.cwd) === normalisedTarget);
 
 	if (matches.length === 0) {
-		return { kind: 'intercept', reason: 'no-instance', records };
+		return {
+			kind: 'intercept',
+			reason: 'no-instance',
+			records,
+			matches: [],
+		};
 	}
 
-	const sorted = [...matches].sort((a, b) => a.pid - b.pid);
-	const chosen = sorted.find((r) => r.mcp.status === 'ready') ?? sorted[0]!;
-	const siblings = matches.length > 1 ? sorted.filter((r) => r !== chosen) : undefined;
+	const sortedMatches = [...matches].sort((a, b) => a.pid - b.pid);
+	const selected = sortedMatches.find((r) => r.mcp.status === 'ready') ?? sortedMatches[0]!;
 
-	switch (chosen.mcp.status) {
+	switch (selected.mcp.status) {
 		case 'ready':
 			return {
 				kind: 'instance',
-				record: chosen,
-				...(siblings ? { siblings } : {}),
+				record: selected,
+				matches: sortedMatches,
 			};
+
 		case 'starting':
-			return { kind: 'intercept', reason: 'mcp-starting' };
+			return {
+				kind: 'intercept',
+				reason: 'mcp-starting',
+				matches: sortedMatches,
+			};
+
 		case 'not-installed':
-			return { kind: 'intercept', reason: 'addon-missing' };
+			return {
+				kind: 'intercept',
+				reason: 'addon-missing',
+				matches: sortedMatches,
+			};
+
 		case 'error':
-			return { kind: 'intercept', reason: 'mcp-error' };
+			return {
+				kind: 'intercept',
+				reason: 'mcp-error',
+				matches: sortedMatches,
+			};
 	}
 }

--- a/packages/mcp-proxy/src/utils/resolve-instance.ts
+++ b/packages/mcp-proxy/src/utils/resolve-instance.ts
@@ -2,7 +2,11 @@ import { resolve } from 'node:path';
 import type { InterceptReason, StorybookInstanceRecordV1 } from '../types/index.ts';
 
 export type ResolveResult =
-	| { kind: 'instance'; record: StorybookInstanceRecordV1 }
+	| {
+			kind: 'instance';
+			record: StorybookInstanceRecordV1;
+			siblings?: StorybookInstanceRecordV1[];
+	  }
 	| { kind: 'intercept'; reason: InterceptReason; records?: StorybookInstanceRecordV1[] };
 
 /**
@@ -17,7 +21,9 @@ export type ResolveResult =
  *   - error          → mcp-error intercept
  *
  * Zero matches → no-instance intercept (callers may surface running cwds).
- * Two or more matches at the same cwd → multiple-matches intercept (degenerate).
+ * 2+ matches at the same cwd → pick a deterministic instance (lowest pid among
+ * `ready` records, else lowest pid overall) and surface the others as
+ * `siblings` so callers can warn the agent without blocking the call.
  */
 export function resolveInstance(
 	records: StorybookInstanceRecordV1[],
@@ -29,13 +35,14 @@ export function resolveInstance(
 	if (matches.length === 0) {
 		return { kind: 'intercept', reason: 'no-instance', records };
 	}
-	if (matches.length > 1) {
-		return { kind: 'intercept', reason: 'multiple-matches', records: matches };
-	}
-	const record = matches[0]!;
-	switch (record.mcp.status) {
+
+	const sorted = [...matches].sort((a, b) => a.pid - b.pid);
+	const chosen = sorted.find((r) => r.mcp.status === 'ready') ?? sorted[0]!;
+	const siblings = matches.length > 1 ? sorted.filter((r) => r !== chosen) : undefined;
+
+	switch (chosen.mcp.status) {
 		case 'ready':
-			return { kind: 'instance', record };
+			return { kind: 'instance', record: chosen, siblings };
 		case 'starting':
 			return { kind: 'intercept', reason: 'mcp-starting' };
 		case 'not-installed':


### PR DESCRIPTION
https://github.com/storybookjs/storybook/issues/34826

This PR remove errors when multiple storybooks are running from a same cwd. 

Instead we'll proxy the tool call to the lowest SB PID (which should in theory the first one started) and add warning and list all PID of SB instances of a same cwd in the response. 
We try to avoid giving instructions to agent but hint them that they can ask user if they want to stop them.