### PR TITLE
refactor: make readRegistry more maintenable and warn about read regitry errors

### DIFF
--- a/packages/mcp-proxy/src/index.test.ts
+++ b/packages/mcp-proxy/src/index.test.ts
@@ -7,7 +7,7 @@ import { readRegistry } from './utils/registry.ts';
 import type { ProxyToolCallResult, StorybookInstanceRecordV1 } from './types/index.ts';
 
 vi.mock('./utils/registry.ts', () => ({
-	readRegistry: vi.fn().mockResolvedValue({ records: [], anomalies: [] }),
+	readRegistry: vi.fn().mockResolvedValue({ records: [], errors: [] }),
 	DEFAULT_REGISTRY_DIR: '/tmp/mcp-proxy-test-default-registry',
 }));
 

--- a/packages/mcp-proxy/src/index.test.ts
+++ b/packages/mcp-proxy/src/index.test.ts
@@ -7,7 +7,7 @@ import { readRegistry } from './utils/registry.ts';
 import type { ProxyToolCallResult, StorybookInstanceRecordV1 } from './types/index.ts';
 
 vi.mock('./utils/registry.ts', () => ({
-	readRegistry: vi.fn().mockResolvedValue([]),
+	readRegistry: vi.fn().mockResolvedValue({ records: [], anomalies: [] }),
 	DEFAULT_REGISTRY_DIR: '/tmp/mcp-proxy-test-default-registry',
 }));
 
@@ -102,7 +102,7 @@ describe('createMcpProxyServer', () => {
 
 	afterEach(() => {
 		vi.mocked(readRegistry).mockReset();
-		vi.mocked(readRegistry).mockResolvedValue([]);
+		vi.mocked(readRegistry).mockResolvedValue({ records: [], errors: [] });
 	});
 
 	it('responds to initialize with server metadata and instructions', async () => {
@@ -158,7 +158,10 @@ describe('createMcpProxyServer', () => {
 			port: 6006,
 			mcp: { status: 'ready', endpoint: addon.endpoint },
 		};
-		vi.mocked(readRegistry).mockResolvedValue([record]);
+		vi.mocked(readRegistry).mockResolvedValue({
+			records: [record],
+			errors: [],
+		});
 
 		const server = await createMcpProxyServer();
 

--- a/packages/mcp-proxy/src/tools/proxy-tool.test.ts
+++ b/packages/mcp-proxy/src/tools/proxy-tool.test.ts
@@ -37,7 +37,7 @@ beforeEach(() => {
 	vi.mocked(readRegistry).mockReset();
 	vi.mocked(proxyToolCall).mockReset();
 	vi.mocked(checkStorybookVersion).mockReset();
-	vi.mocked(readRegistry).mockResolvedValue([record]);
+	vi.mocked(readRegistry).mockResolvedValue({ records: [record], errors: [] });
 	vi.mocked(proxyToolCall).mockResolvedValue({
 		content: [{ type: 'text', text: 'upstream result' }],
 	});
@@ -117,7 +117,7 @@ describe('registerProxyTool / list-all-documentation', () => {
 	});
 
 	it('returns the no-instance intercept (empty) when the registry is empty', async () => {
-		vi.mocked(readRegistry).mockResolvedValue([]);
+		vi.mocked(readRegistry).mockResolvedValue({ records: [], errors: [] });
 		const server = await buildServer();
 		const response = await callTool(server, { cwd: '/projects/foo' });
 		expect(response.result.isError).toBe(true);
@@ -148,7 +148,10 @@ describe('registerProxyTool / list-all-documentation', () => {
 	});
 
 	it('dispatches mcp.status=starting to the mcp-starting intercept', async () => {
-		vi.mocked(readRegistry).mockResolvedValue([{ ...record, mcp: { status: 'starting' } }]);
+		vi.mocked(readRegistry).mockResolvedValue({
+			records: [{ ...record, mcp: { status: 'starting' } }],
+			errors: [],
+		});
 		const server = await buildServer();
 		const response = await callTool(server, { cwd: '/projects/foo' });
 		expect(response.result.isError).toBe(true);
@@ -156,7 +159,10 @@ describe('registerProxyTool / list-all-documentation', () => {
 	});
 
 	it('dispatches mcp.status=not-installed to the addon-missing intercept', async () => {
-		vi.mocked(readRegistry).mockResolvedValue([{ ...record, mcp: { status: 'not-installed' } }]);
+		vi.mocked(readRegistry).mockResolvedValue({
+			records: [{ ...record, mcp: { status: 'not-installed' } }],
+			errors: [],
+		});
 		const server = await buildServer();
 		const response = await callTool(server, { cwd: '/projects/foo' });
 		expect(response.result.isError).toBe(true);
@@ -164,9 +170,10 @@ describe('registerProxyTool / list-all-documentation', () => {
 	});
 
 	it('dispatches mcp.status=error to the mcp-error intercept', async () => {
-		vi.mocked(readRegistry).mockResolvedValue([
-			{ ...record, mcp: { status: 'error', endpoint: 'http://localhost:6006/mcp' } },
-		]);
+		vi.mocked(readRegistry).mockResolvedValue({
+			records: [{ ...record, mcp: { status: 'error', endpoint: 'http://localhost:6006/mcp' } }],
+			errors: [],
+		});
 		const server = await buildServer();
 		const response = await callTool(server, { cwd: '/projects/foo' });
 		expect(response.result.isError).toBe(true);
@@ -192,6 +199,136 @@ describe('registerProxyTool / list-all-documentation', () => {
 		expect(response.result._meta).toEqual({ [META_INTERCEPT_REASON]: 'storybook-too-old' });
 		expect(firstText(response.result)).toContain('9.0.5');
 		expect(firstText(response.result)).toContain('storybook-upgrade');
+	});
+
+	it('prepends a schema-upgrade warning when anomalies at the target cwd exist, but still proxies the call', async () => {
+		vi.mocked(readRegistry).mockResolvedValue({
+			records: [record],
+			errors: [
+				{ kind: 'unsupported-schema', cwd: '/projects/foo', schemaVersion: 2 },
+				{ kind: 'unsupported-schema', cwd: '/projects/foo', schemaVersion: 3 },
+			],
+		});
+		vi.mocked(proxyToolCall).mockResolvedValue({
+			content: [{ type: 'text', text: 'PRIMARY' }],
+		});
+
+		const server = await buildServer();
+		const response = await callTool(server, { cwd: '/projects/foo' });
+
+		const items = response.result.content ?? [];
+		expect(items).toHaveLength(2);
+		const warning = items[0];
+		const primary = items[1];
+		if (!warning || warning.type !== 'text') throw new Error('expected warning text');
+		if (!primary || primary.type !== 'text') throw new Error('expected primary text');
+		expect(warning.text).toContain('@storybook/mcp-proxy');
+		expect(warning.text).toContain('/projects/foo');
+		expect(warning.text).toContain('`v2`');
+		expect(warning.text).toContain('`v3`');
+		expect(primary.text).toBe('PRIMARY');
+		expect(response.result.isError).toBeFalsy();
+	});
+
+	it('still prepends the schema-upgrade warning on top of an intercept response when anomalies match the target cwd', async () => {
+		vi.mocked(readRegistry).mockResolvedValue({
+			records: [],
+			errors: [{ kind: 'unsupported-schema', cwd: '/projects/foo', schemaVersion: 2 }],
+		});
+		const server = await buildServer();
+		const response = await callTool(server, { cwd: '/projects/foo' });
+
+		expect(response.result.isError).toBe(true);
+		expect(response.result._meta).toEqual({ [META_INTERCEPT_REASON]: 'no-instance' });
+		const items = response.result.content ?? [];
+		const first = items[0];
+		if (!first || first.type !== 'text') throw new Error('expected warning text');
+		expect(first.text).toContain('@storybook/mcp-proxy');
+		expect(first.text).toContain('`v2`');
+	});
+
+	it('prepends the warning for unparseable anomalies tied to the target cwd', async () => {
+		vi.mocked(readRegistry).mockResolvedValue({
+			records: [record],
+			errors: [
+				{ kind: 'unparseable', cwd: '/projects/foo' },
+				{ kind: 'unparseable', cwd: '/projects/foo' },
+			],
+		});
+		vi.mocked(proxyToolCall).mockResolvedValue({
+			content: [{ type: 'text', text: 'PRIMARY' }],
+		});
+		const server = await buildServer();
+		const response = await callTool(server, { cwd: '/projects/foo' });
+
+		const items = response.result.content ?? [];
+		expect(items).toHaveLength(2);
+		const warning = items[0];
+		if (!warning || warning.type !== 'text') throw new Error('expected warning text');
+		expect(warning.text).toContain('@storybook/mcp-proxy');
+		expect(warning.text).toContain('2 record files');
+		expect(warning.text).not.toContain('schema version');
+	});
+
+	it('combines both anomaly kinds in one warning when both fire at the target cwd', async () => {
+		vi.mocked(readRegistry).mockResolvedValue({
+			records: [record],
+			errors: [
+				{ kind: 'unsupported-schema', cwd: '/projects/foo', schemaVersion: 2 },
+				{ kind: 'unparseable', cwd: '/projects/foo' },
+			],
+		});
+		vi.mocked(proxyToolCall).mockResolvedValue({
+			content: [{ type: 'text', text: 'PRIMARY' }],
+		});
+		const server = await buildServer();
+		const response = await callTool(server, { cwd: '/projects/foo' });
+
+		const items = response.result.content ?? [];
+		expect(items).toHaveLength(2);
+		const warning = items[0];
+		if (!warning || warning.type !== 'text') throw new Error('expected warning text');
+		expect(warning.text).toContain('@storybook/mcp-proxy');
+		expect(warning.text).toContain('`v2`');
+		expect(warning.text).toContain('1 record file');
+		expect(warning.text).toContain(' and ');
+	});
+
+	it('does NOT emit a warning when registry anomalies all belong to other cwds', async () => {
+		vi.mocked(readRegistry).mockResolvedValue({
+			records: [record],
+			errors: [
+				{ kind: 'unsupported-schema', cwd: '/projects/bar', schemaVersion: 2 },
+				{ kind: 'unparseable', cwd: '/projects/baz' },
+			],
+		});
+		vi.mocked(proxyToolCall).mockResolvedValue({
+			content: [{ type: 'text', text: 'PRIMARY' }],
+		});
+		const server = await buildServer();
+		const response = await callTool(server, { cwd: '/projects/foo' });
+
+		const items = response.result.content ?? [];
+		expect(items).toHaveLength(1);
+		expect(firstText(response.result)).toBe('PRIMARY');
+	});
+
+	it('matches anomalies whose cwd is non-normalized (trailing slash / dot segments)', async () => {
+		vi.mocked(readRegistry).mockResolvedValue({
+			records: [record],
+			errors: [{ kind: 'unsupported-schema', cwd: '/projects/foo/./', schemaVersion: 2 }],
+		});
+		vi.mocked(proxyToolCall).mockResolvedValue({
+			content: [{ type: 'text', text: 'PRIMARY' }],
+		});
+		const server = await buildServer();
+		const response = await callTool(server, { cwd: '/projects/foo' });
+
+		const items = response.result.content ?? [];
+		expect(items).toHaveLength(2);
+		const warning = items[0];
+		if (!warning || warning.type !== 'text') throw new Error('expected warning text');
+		expect(warning.text).toContain('`v2`');
 	});
 
 	it('surfaces a friendly error when proxyToolCall throws', async () => {

--- a/packages/mcp-proxy/src/tools/proxy-tool.ts
+++ b/packages/mcp-proxy/src/tools/proxy-tool.ts
@@ -114,10 +114,7 @@ function anomaliesAtCwd(anomalies: RegistryError[], targetCwd: string): Registry
 	});
 }
 
-function formatIncompatibleRegistryWarning(
-	targetCwd: string,
-	anomalies: RegistryError[],
-): string {
+function formatIncompatibleRegistryWarning(targetCwd: string, anomalies: RegistryError[]): string {
 	const unsupportedVersions = [
 		...new Set(
 			anomalies

--- a/packages/mcp-proxy/src/tools/proxy-tool.ts
+++ b/packages/mcp-proxy/src/tools/proxy-tool.ts
@@ -25,15 +25,10 @@ ${lines.join('\n')}
 > If results look unexpected, ask the user whether they want to stop the other instance(s).`;
 }
 
-function prependMultiInstanceWarning(
-	result: ProxyToolCallResult,
-	chosen: StorybookInstanceRecordV1,
-	siblings: StorybookInstanceRecordV1[],
-): ProxyToolCallResult {
-	const warning = formatMultiInstanceWarning(chosen, siblings);
+function prependWarning(result: ProxyToolCallResult, text: string): ProxyToolCallResult {
 	return {
 		...result,
-		content: [{ type: 'text', text: warning }, ...(result.content ?? [])],
+		content: [{ type: 'text', text }, ...(result.content ?? [])],
 	};
 }
 
@@ -101,7 +96,7 @@ export function registerProxyTool<Schema extends v.ObjectEntries>(
 
 			const withWarning = (result: ProxyToolCallResult): ProxyToolCallResult =>
 				localAnomalies.length > 0
-					? prependIncompatibleRegistryWarning(result, cwd, localAnomalies)
+					? prependWarning(result, formatIncompatibleRegistryWarning(cwd, localAnomalies))
 					: result;
 
 			if (resolution.kind === 'intercept') {
@@ -123,7 +118,7 @@ export function registerProxyTool<Schema extends v.ObjectEntries>(
 				const siblings = resolution.matches.filter((r) => r !== resolution.record);
 				const withSiblings =
 					siblings.length > 0
-						? prependMultiInstanceWarning(result, resolution.record, siblings)
+						? prependWarning(result, formatMultiInstanceWarning(resolution.record, siblings))
 						: result;
 				return withWarning(withSiblings);
 			} catch (error) {
@@ -178,18 +173,4 @@ function formatIncompatibleRegistryWarning(targetCwd: string, anomalies: Registr
 		parts.push(`${unparseableCount} ${plural} this proxy could not parse`);
 	}
 	return `> Note: The Storybook instance registry has record(s) at \`${targetCwd}\` that this MCP proxy cannot interpret: ${parts.join(' and ')}. The user's Storybook at that cwd is likely newer than the proxy or writing a format the proxy does not yet recognise. Upgrade \`@storybook/mcp-proxy\` you are running. The current call was handled using only the records this proxy could parse.`;
-}
-
-function prependIncompatibleRegistryWarning(
-	result: ProxyToolCallResult,
-	targetCwd: string,
-	anomalies: RegistryError[],
-): ProxyToolCallResult {
-	return {
-		...result,
-		content: [
-			{ type: 'text', text: formatIncompatibleRegistryWarning(targetCwd, anomalies) },
-			...(result.content ?? []),
-		],
-	};
 }

--- a/packages/mcp-proxy/src/tools/proxy-tool.ts
+++ b/packages/mcp-proxy/src/tools/proxy-tool.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import type { McpServer } from 'tmcp';
 import * as v from 'valibot';
-import { readRegistry } from '../utils/registry.ts';
+import { readRegistry, type RegistryError } from '../utils/registry.ts';
 import { proxyToolCall } from '../utils/proxy-client.ts';
 import { resolveInstance } from '../utils/resolve-instance.ts';
 import { checkStorybookVersion } from '../utils/version-check.ts';
@@ -65,20 +65,29 @@ export function registerProxyTool<Schema extends v.ObjectEntries>(
 
 			// read the registry and resolve the target instance based on the input cwd;
 			// compatibility has already been validated by the Storybook version check above
-			const records = await readRegistry(registryDir);
+			const { records, errors } = await readRegistry(registryDir);
 			const resolution = resolveInstance(records, cwd);
 
+			const localAnomalies = anomaliesAtCwd(errors, cwd);
+
+			const withWarning = (result: ProxyToolCallResult): ProxyToolCallResult =>
+				localAnomalies.length > 0
+					? prependIncompatibleRegistryWarning(result, cwd, localAnomalies)
+					: result;
+
 			if (resolution.kind === 'intercept') {
-				return intercept(resolution.reason, { records: resolution.records });
+				return withWarning(intercept(resolution.reason, { records: resolution.records }));
 			}
 
 			try {
-				return await proxyToolCall(resolution.record, {
-					name: tool.name,
-					arguments: upstreamArgs,
-				});
+				return withWarning(
+					await proxyToolCall(resolution.record, {
+						name: tool.name,
+						arguments: upstreamArgs,
+					}),
+				);
 			} catch (error) {
-				return {
+				return withWarning({
 					content: [
 						{
 							type: 'text',
@@ -88,8 +97,62 @@ export function registerProxyTool<Schema extends v.ObjectEntries>(
 						},
 					],
 					isError: true,
-				};
+				});
 			}
 		},
 	);
+}
+
+function anomaliesAtCwd(anomalies: RegistryError[], targetCwd: string): RegistryError[] {
+	const normalized = path.resolve(targetCwd);
+	return anomalies.filter((a) => {
+		try {
+			return path.resolve(a.cwd) === normalized;
+		} catch {
+			return false;
+		}
+	});
+}
+
+function formatIncompatibleRegistryWarning(
+	targetCwd: string,
+	anomalies: RegistryError[],
+): string {
+	const unsupportedVersions = [
+		...new Set(
+			anomalies
+				.filter(
+					(a): a is Extract<RegistryError, { kind: 'unsupported-schema' }> =>
+						a.kind === 'unsupported-schema',
+				)
+				.map((a) => a.schemaVersion),
+		),
+	].sort((a, b) => a - b);
+	const unparseableCount = anomalies.filter((a) => a.kind === 'unparseable').length;
+
+	const parts: string[] = [];
+	if (unsupportedVersions.length > 0) {
+		const list = unsupportedVersions.map((n) => `\`v${n}\``).join(', ');
+		const plural = unsupportedVersions.length === 1 ? 'schema version' : 'schema versions';
+		parts.push(`${plural} ${list} (newer than this proxy supports)`);
+	}
+	if (unparseableCount > 0) {
+		const plural = unparseableCount === 1 ? 'record file' : 'record files';
+		parts.push(`${unparseableCount} ${plural} this proxy could not parse`);
+	}
+	return `> Note: The Storybook instance registry has record(s) at \`${targetCwd}\` that this MCP proxy cannot interpret: ${parts.join(' and ')}. The user's Storybook at that cwd is likely newer than the proxy or writing a format the proxy does not yet recognise. Tell the user to upgrade \`@storybook/mcp-proxy\` so the proxy can recognise that Storybook instance. The current call was handled using only the records this proxy could parse.`;
+}
+
+function prependIncompatibleRegistryWarning(
+	result: ProxyToolCallResult,
+	targetCwd: string,
+	anomalies: RegistryError[],
+): ProxyToolCallResult {
+	return {
+		...result,
+		content: [
+			{ type: 'text', text: formatIncompatibleRegistryWarning(targetCwd, anomalies) },
+			...(result.content ?? []),
+		],
+	};
 }

--- a/packages/mcp-proxy/src/tools/proxy-tool.ts
+++ b/packages/mcp-proxy/src/tools/proxy-tool.ts
@@ -140,7 +140,7 @@ function formatIncompatibleRegistryWarning(
 		const plural = unparseableCount === 1 ? 'record file' : 'record files';
 		parts.push(`${unparseableCount} ${plural} this proxy could not parse`);
 	}
-	return `> Note: The Storybook instance registry has record(s) at \`${targetCwd}\` that this MCP proxy cannot interpret: ${parts.join(' and ')}. The user's Storybook at that cwd is likely newer than the proxy or writing a format the proxy does not yet recognise. Tell the user to upgrade \`@storybook/mcp-proxy\` so the proxy can recognise that Storybook instance. The current call was handled using only the records this proxy could parse.`;
+	return `> Note: The Storybook instance registry has record(s) at \`${targetCwd}\` that this MCP proxy cannot interpret: ${parts.join(' and ')}. The user's Storybook at that cwd is likely newer than the proxy or writing a format the proxy does not yet recognise. Upgrade \`@storybook/mcp-proxy\` you are running. The current call was handled using only the records this proxy could parse.`;
 }
 
 function prependIncompatibleRegistryWarning(

--- a/packages/mcp-proxy/src/utils/registry.test.ts
+++ b/packages/mcp-proxy/src/utils/registry.test.ts
@@ -15,17 +15,17 @@ describe('readRegistry', () => {
 		await fs.rm(dir, { recursive: true, force: true });
 	});
 
-	it('returns [] when the registry dir does not exist', async () => {
+	it('returns an empty result when the registry dir does not exist', async () => {
 		const result = await readRegistry(join(dir, 'does-not-exist'));
-		expect(result).toEqual([]);
+		expect(result).toEqual({ records: [], errors: [] });
 	});
 
-	it('returns [] when the registry dir is empty', async () => {
+	it('returns an empty result when the registry dir is empty', async () => {
 		const result = await readRegistry(dir);
-		expect(result).toEqual([]);
+		expect(result).toEqual({ records: [], errors: [] });
 	});
 
-	it('parses valid records and filters dead PIDs and bad schema versions', async () => {
+	it('parses valid v1 records and silently drops dead pids + buggy v1 records that fail validation', async () => {
 		const alive = {
 			schemaVersion: 1,
 			instanceId: 'alive-uuid',
@@ -47,7 +47,7 @@ describe('readRegistry', () => {
 			port: 6007,
 			mcp: { status: 'ready', endpoint: 'http://localhost:6007/mcp' },
 		};
-		const unknownStatus = {
+		const buggyV1 = {
 			schemaVersion: 1,
 			instanceId: 'bad-uuid',
 			pid: process.pid,
@@ -59,33 +59,77 @@ describe('readRegistry', () => {
 
 		await fs.writeFile(join(dir, 'alive.json'), JSON.stringify(alive));
 		await fs.writeFile(join(dir, 'dead.json'), JSON.stringify(dead));
-		await fs.writeFile(join(dir, 'bad-status.json'), JSON.stringify(unknownStatus));
-		await fs.writeFile(join(dir, 'malformed.json'), '{ not json');
-		await fs.writeFile(join(dir, 'wrong-shape.json'), JSON.stringify({ foo: 'bar' }));
+		await fs.writeFile(join(dir, 'buggy-v1.json'), JSON.stringify(buggyV1));
 		await fs.writeFile(join(dir, 'ignored.txt'), 'should be ignored');
 
 		const result = await readRegistry(dir);
-		expect(result).toEqual([alive]);
+		expect(result).toEqual({ records: [alive], errors: [] });
 	});
 
-	it('filters records with non-positive PIDs (process-group sentinels)', async () => {
-		const base = {
+	it('emits per-cwd errors for future-version records with an extractable cwd, gated on liveness', async () => {
+		const v1Alive = {
 			schemaVersion: 1,
-			cwd: '/tmp/x',
+			instanceId: 'v1',
+			pid: process.pid,
+			cwd: '/tmp/v1',
 			url: 'http://localhost:6006',
 			port: 6006,
 			mcp: { status: 'ready', endpoint: 'http://localhost:6006/mcp' },
 		};
+		const v2AliveA = { schemaVersion: 2, pid: process.pid, cwd: '/tmp/a' };
+		const v2AliveB = { schemaVersion: 2, pid: process.pid, cwd: '/tmp/b' };
+		const v3Alive = { schemaVersion: 3, pid: process.pid, cwd: '/tmp/a' };
+		const v2Dead = { schemaVersion: 2, pid: 2147483646, cwd: '/tmp/a' };
+		const v2NoCwd = { schemaVersion: 2, pid: process.pid };
+
+		await fs.writeFile(join(dir, 'v1.json'), JSON.stringify(v1Alive));
+		await fs.writeFile(join(dir, 'v2-a.json'), JSON.stringify(v2AliveA));
+		await fs.writeFile(join(dir, 'v2-b.json'), JSON.stringify(v2AliveB));
+		await fs.writeFile(join(dir, 'v3-a.json'), JSON.stringify(v3Alive));
+		await fs.writeFile(join(dir, 'v2-dead.json'), JSON.stringify(v2Dead));
+		await fs.writeFile(join(dir, 'v2-no-cwd.json'), JSON.stringify(v2NoCwd));
+
+		const result = await readRegistry(dir);
+		expect(result.records).toEqual([v1Alive]);
+		expect(result.errors).toStrictEqual([
+				{ kind: 'unsupported-schema', cwd: '/tmp/a', schemaVersion: 2 },
+				{ kind: 'unsupported-schema', cwd: '/tmp/b', schemaVersion: 2 },
+				{ kind: 'unsupported-schema', cwd: '/tmp/a', schemaVersion: 3 },
+			]
+		);
+		expect(result.errors).toHaveLength(3);
+	});
+
+	it('emits per-cwd unparseable errors for JSON records with a cwd but no usable schemaVersion', async () => {
+		await fs.writeFile(join(dir, 'no-version.json'), JSON.stringify({ cwd: '/tmp/a', foo: 'bar' }));
 		await fs.writeFile(
-			join(dir, 'zero.json'),
-			JSON.stringify({ ...base, instanceId: 'zero', pid: 0 }),
+			join(dir, 'string-version.json'),
+			JSON.stringify({ cwd: '/tmp/b', schemaVersion: '1' }),
 		);
 		await fs.writeFile(
-			join(dir, 'negative.json'),
-			JSON.stringify({ ...base, instanceId: 'neg', pid: -1 }),
+			join(dir, 'negative-version.json'),
+			JSON.stringify({ cwd: '/tmp/c', schemaVersion: -1 }),
 		);
 
 		const result = await readRegistry(dir);
-		expect(result).toEqual([]);
+		expect(result.records).toEqual([]);
+		expect(result.errors).toEqual(
+			expect.arrayContaining([
+				{ kind: 'unparseable', cwd: '/tmp/a' },
+				{ kind: 'unparseable', cwd: '/tmp/b' },
+				{ kind: 'unparseable', cwd: '/tmp/c' },
+			]),
+		);
+		expect(result.errors).toHaveLength(3);
+	});
+
+	it('silently drops errors that cannot be tied to a cwd', async () => {
+		await fs.writeFile(join(dir, 'bad-json.json'), '{ not json');
+		await fs.writeFile(join(dir, 'array.json'), JSON.stringify([1, 2, 3]));
+		await fs.writeFile(join(dir, 'no-cwd.json'), JSON.stringify({ foo: 'bar' }));
+		await fs.writeFile(join(dir, 'v2-no-cwd.json'), JSON.stringify({ schemaVersion: 2 }));
+
+		const result = await readRegistry(dir);
+		expect(result).toEqual({ records: [], errors: [] });
 	});
 });

--- a/packages/mcp-proxy/src/utils/registry.test.ts
+++ b/packages/mcp-proxy/src/utils/registry.test.ts
@@ -92,11 +92,10 @@ describe('readRegistry', () => {
 		const result = await readRegistry(dir);
 		expect(result.records).toEqual([v1Alive]);
 		expect(result.errors).toStrictEqual([
-				{ kind: 'unsupported-schema', cwd: '/tmp/a', schemaVersion: 2 },
-				{ kind: 'unsupported-schema', cwd: '/tmp/b', schemaVersion: 2 },
-				{ kind: 'unsupported-schema', cwd: '/tmp/a', schemaVersion: 3 },
-			]
-		);
+			{ kind: 'unsupported-schema', cwd: '/tmp/a', schemaVersion: 2 },
+			{ kind: 'unsupported-schema', cwd: '/tmp/b', schemaVersion: 2 },
+			{ kind: 'unsupported-schema', cwd: '/tmp/a', schemaVersion: 3 },
+		]);
 		expect(result.errors).toHaveLength(3);
 	});
 

--- a/packages/mcp-proxy/src/utils/registry.ts
+++ b/packages/mcp-proxy/src/utils/registry.ts
@@ -68,6 +68,7 @@ export async function readRegistry(
 	const outcomes = await Promise.all(
 		entries
 			.filter((name) => name.endsWith('.json'))
+			.sort((a, b) => a.localeCompare(b))
 			.map((name) => classify(join(registryDir, name))),
 	);
 
@@ -128,6 +129,13 @@ async function classify(filePath: string): Promise<FileOutcome> {
 			return { kind: 'drop' };
 		}
 		return { kind: 'error', error: { kind: 'unsupported-schema', cwd, schemaVersion } };
+	}
+
+	if (typeof obj.pid === 'number' && !isProcessAlive(obj.pid)) {
+		clearRegistry(filePath).catch(() => {
+			/* ignore cleanup errors */
+		});
+		return { kind: 'drop' };
 	}
 
 	return { kind: 'error', error: { kind: 'unparseable', cwd } };

--- a/packages/mcp-proxy/src/utils/registry.ts
+++ b/packages/mcp-proxy/src/utils/registry.ts
@@ -47,9 +47,10 @@ type FileOutcome =
  *
  * Returns alive v1 records plus a list of per-record anomalies the proxy
  * could not interpret but could tie to a `cwd`: either records with a
- * schema version newer than the proxy supports, or records the proxy could
- * not parse at all. Each anomaly carries its `cwd` so the caller can decide
- * whether the warning applies to the cwd the agent is targeting.
+ * schema version newer than the proxy supports, or other JSON objects with
+ * a usable `cwd` that still could not be interpreted as a supported record.
+ * Each anomaly carries its `cwd` so the caller can decide whether the
+ * warning applies to the cwd the agent is targeting.
  */
 export async function readRegistry(
 	registryDir: string = DEFAULT_REGISTRY_DIR,

--- a/packages/mcp-proxy/src/utils/registry.ts
+++ b/packages/mcp-proxy/src/utils/registry.ts
@@ -15,48 +15,116 @@ export const DEFAULT_REGISTRY_DIR = join(homedir(), '.storybook', 'instances');
 const SOFT_REGISTRY_ERRORS = new Set(['ENOENT', 'EACCES', 'EPERM', 'ENOTDIR']);
 
 /**
+ * A registry file the proxy could not turn into a usable v1 record but that
+ * we *can* tie to a specific `cwd`. The proxy-tool layer compares each
+ * anomaly's `cwd` against the cwd of the tool call and only warns the agent
+ * when the anomaly affects the project the agent is actually working in.
+ *
+ * Records the proxy cannot tie to a cwd (bad JSON, JSON without a `cwd`
+ * field, etc.) are silently dropped — they can't be scoped to a project, so
+ * surfacing them globally would just be noise.
+ */
+export type RegistryError =
+	| { kind: 'unsupported-schema'; cwd: string; schemaVersion: number }
+	| { kind: 'unparseable'; cwd: string };
+
+export type ReadRegistryResult = {
+	records: StorybookInstanceRecordV1[];
+	errors: RegistryError[];
+};
+
+/**
+ * Per-file result. `drop` covers everything we discard without telling the
+ * agent: read failures, dead processes, and records we can't tie to a `cwd`.
+ */
+type FileOutcome =
+	| { kind: 'record'; record: StorybookInstanceRecordV1 }
+	| { kind: 'error'; error: RegistryError }
+	| { kind: 'drop' };
+
+/**
  * Read all Storybook instance records from `registryDir`.
  *
- * Each file is expected to be a single JSON object matching
- * {@link StorybookInstanceRecordV1}. Records whose PID is no longer alive are
- * filtered out (stale removal per milestone 2). Malformed files are skipped
- * silently — the proxy should degrade to "no instance" rather than fail loudly.
+ * Returns alive v1 records plus a list of per-record anomalies the proxy
+ * could not interpret but could tie to a `cwd`: either records with a
+ * schema version newer than the proxy supports, or records the proxy could
+ * not parse at all. Each anomaly carries its `cwd` so the caller can decide
+ * whether the warning applies to the cwd the agent is targeting.
  */
 export async function readRegistry(
 	registryDir: string = DEFAULT_REGISTRY_DIR,
-): Promise<StorybookInstanceRecordV1[]> {
+): Promise<ReadRegistryResult> {
 	let entries: string[];
 	try {
 		entries = await fs.readdir(registryDir);
 	} catch (error) {
 		if (SOFT_REGISTRY_ERRORS.has((error as NodeJS.ErrnoException).code ?? '')) {
-			return [];
+			return { records: [], errors: [] };
 		}
 		throw error;
 	}
 
-	const records = await Promise.all(
+	const outcomes = await Promise.all(
 		entries
 			.filter((name) => name.endsWith('.json'))
-			.map(async (name) => {
-				try {
-					const raw = await fs.readFile(join(registryDir, name), 'utf-8');
-					const parsed = v.safeParse(StorybookInstanceRecordV1Schema, JSON.parse(raw));
-					if (!parsed.success) return null;
-					if (!isProcessAlive(parsed.output.pid)) {
-						clearRegistry(join(registryDir, name)).catch(() => {
-							/* ignore cleanup errors */
-						});
-						return null;
-					}
-					return parsed.output;
-				} catch {
-					return null;
-				}
-			}),
+			.map((name) => classify(join(registryDir, name))),
 	);
 
-	return records.filter((r): r is StorybookInstanceRecordV1 => r !== null);
+	const records: StorybookInstanceRecordV1[] = [];
+	const anomalies: RegistryError[] = [];
+	for (const outcome of outcomes) {
+		if (outcome.kind === 'record') records.push(outcome.record);
+		else if (outcome.kind === 'error') anomalies.push(outcome.error);
+	}
+
+	return { records, errors: anomalies };
+}
+
+async function classify(filePath: string): Promise<FileOutcome> {
+	let raw: string;
+	try {
+		raw = await fs.readFile(filePath, 'utf-8');
+	} catch {
+		return { kind: 'drop' };
+	}
+
+	let json: unknown;
+	try {
+		json = JSON.parse(raw);
+	} catch {
+		return { kind: 'drop' };
+	}
+	if (typeof json !== 'object' || json === null) return { kind: 'drop' };
+
+	const obj = json as { schemaVersion?: unknown; cwd?: unknown; pid?: unknown; };
+	const cwd = typeof obj.cwd === 'string' && obj.cwd.length ? obj.cwd : null;
+	const schemaVersion = obj.schemaVersion;
+
+	if (schemaVersion === 1) {
+		const parsed = v.safeParse(StorybookInstanceRecordV1Schema, json);
+		// A v1 record that fails strict validation is almost certainly a buggy
+		// writer (Storybook should bump the version when the shape changes), so
+		// drop it rather than nag the agent about a proxy upgrade it can't fix.
+		if (!parsed.success) return { kind: 'drop' };
+		if (!isProcessAlive(parsed.output.pid)) {
+			clearRegistry(filePath).catch(() => {
+				/* ignore cleanup errors */
+			});
+			return { kind: 'drop' };
+		}
+		return { kind: 'record', record: parsed.output };
+	}
+
+	// Beyond v1 we can't parse the record, so we can only warn when it's tied
+	// to a cwd the agent might be targeting; otherwise drop it as noise.
+	if (cwd === null) return { kind: 'drop' };
+
+	if (typeof schemaVersion === 'number' && Number.isInteger(schemaVersion) && schemaVersion > 1) {
+		if (typeof obj.pid === 'number' && !isProcessAlive(obj.pid)) return { kind: 'drop' };
+		return { kind: 'error', error: { kind: 'unsupported-schema', cwd, schemaVersion } };
+	}
+
+	return { kind: 'error', error: { kind: 'unparseable', cwd } };
 }
 
 /**

--- a/packages/mcp-proxy/src/utils/registry.ts
+++ b/packages/mcp-proxy/src/utils/registry.ts
@@ -97,7 +97,7 @@ async function classify(filePath: string): Promise<FileOutcome> {
 	}
 	if (typeof json !== 'object' || json === null) return { kind: 'drop' };
 
-	const obj = json as { schemaVersion?: unknown; cwd?: unknown; pid?: unknown; };
+	const obj = json as { schemaVersion?: unknown; cwd?: unknown; pid?: unknown };
 	const cwd = typeof obj.cwd === 'string' && obj.cwd.length ? obj.cwd : null;
 	const schemaVersion = obj.schemaVersion;
 

--- a/packages/mcp-proxy/src/utils/registry.ts
+++ b/packages/mcp-proxy/src/utils/registry.ts
@@ -121,7 +121,12 @@ async function classify(filePath: string): Promise<FileOutcome> {
 	if (cwd === null) return { kind: 'drop' };
 
 	if (typeof schemaVersion === 'number' && Number.isInteger(schemaVersion) && schemaVersion > 1) {
-		if (typeof obj.pid === 'number' && !isProcessAlive(obj.pid)) return { kind: 'drop' };
+		if (typeof obj.pid === 'number' && !isProcessAlive(obj.pid)) {
+			clearRegistry(filePath).catch(() => {
+				/* ignore cleanup errors */
+			});
+			return { kind: 'drop' };
+		}
 		return { kind: 'error', error: { kind: 'unsupported-schema', cwd, schemaVersion } };
 	}
 


### PR DESCRIPTION
https://github.com/storybookjs/storybook/issues/34826

This PR makes readRegistry more maintenable by changing the return type to an object with additionnal infromation. 

This PR also change the behavior of readRegistry by returning every errors (like unparseable jsons, unsupported schema etc...) to log them and instruct agent to update mcp-proxy