### PR TITLE
fix(ade): add prefer-online flag to npx invocation

### DIFF
--- a/packages/claude-plugin/.mcp.json
+++ b/packages/claude-plugin/.mcp.json
@@ -2,7 +2,7 @@
 	"mcpServers": {
 		"storybook": {
 			"command": "npx",
-			"args": ["-y", "https://pkg.pr.new/storybookjs/mcp/@storybook/mcp-proxy@main", "--prefer-online"]
+			"args": ["-y", "--prefer-online", "https://pkg.pr.new/storybookjs/mcp/@storybook/mcp-proxy@main"]
 		}
 	}
 }

--- a/packages/claude-plugin/.mcp.json
+++ b/packages/claude-plugin/.mcp.json
@@ -2,7 +2,11 @@
 	"mcpServers": {
 		"storybook": {
 			"command": "npx",
-			"args": ["-y", "--prefer-online", "https://pkg.pr.new/storybookjs/mcp/@storybook/mcp-proxy@main"]
+			"args": [
+				"-y",
+				"--prefer-online",
+				"https://pkg.pr.new/storybookjs/mcp/@storybook/mcp-proxy@main"
+			]
 		}
 	}
 }

--- a/packages/claude-plugin/.mcp.json
+++ b/packages/claude-plugin/.mcp.json
@@ -2,7 +2,7 @@
 	"mcpServers": {
 		"storybook": {
 			"command": "npx",
-			"args": ["-y", "https://pkg.pr.new/storybookjs/mcp/@storybook/mcp-proxy@main"]
+			"args": ["-y", "https://pkg.pr.new/storybookjs/mcp/@storybook/mcp-proxy@main", "--prefer-online"]
 		}
 	}
 }

--- a/packages/claude-plugin/README.md
+++ b/packages/claude-plugin/README.md
@@ -114,7 +114,7 @@ The plugin directory must include these files:
 The plugin's `.mcp.json` starts the latest `@storybook/mcp-proxy` preview from pkg.pr.new:
 
 ```sh
-npx -y https://pkg.pr.new/storybookjs/mcp/@storybook/mcp-proxy@main
+npx -y --prefer-online https://pkg.pr.new/storybookjs/mcp/@storybook/mcp-proxy@main
 ```
 
 The `@main` ref tracks the latest preview build from the `main` branch.

--- a/packages/codex-plugin/README.md
+++ b/packages/codex-plugin/README.md
@@ -101,7 +101,7 @@ Codex does not expose CLI commands for plugin install or update. Use the Codex a
 The plugin's `plugins/storybook/.mcp.json` configures Codex to run the latest `@storybook/mcp-proxy` preview from pkg.pr.new:
 
 ```sh
-npx -y https://pkg.pr.new/storybookjs/mcp/@storybook/mcp-proxy@main
+npx -y --prefer-online https://pkg.pr.new/storybookjs/mcp/@storybook/mcp-proxy@main
 ```
 
 The `@main` ref tracks the latest preview build from the `main` branch.

--- a/packages/codex-plugin/plugins/storybook/.mcp.json
+++ b/packages/codex-plugin/plugins/storybook/.mcp.json
@@ -1,6 +1,6 @@
 {
 	"storybook": {
 		"command": "npx",
-		"args": ["-y", "https://pkg.pr.new/storybookjs/mcp/@storybook/mcp-proxy@main", "--prefer-online"]
+		"args": ["-y", "--prefer-online", "https://pkg.pr.new/storybookjs/mcp/@storybook/mcp-proxy@main"]
 	}
 }

--- a/packages/codex-plugin/plugins/storybook/.mcp.json
+++ b/packages/codex-plugin/plugins/storybook/.mcp.json
@@ -1,6 +1,10 @@
 {
 	"storybook": {
 		"command": "npx",
-		"args": ["-y", "--prefer-online", "https://pkg.pr.new/storybookjs/mcp/@storybook/mcp-proxy@main"]
+		"args": [
+			"-y",
+			"--prefer-online",
+			"https://pkg.pr.new/storybookjs/mcp/@storybook/mcp-proxy@main"
+		]
 	}
 }

--- a/packages/codex-plugin/plugins/storybook/.mcp.json
+++ b/packages/codex-plugin/plugins/storybook/.mcp.json
@@ -1,6 +1,6 @@
 {
 	"storybook": {
 		"command": "npx",
-		"args": ["-y", "https://pkg.pr.new/storybookjs/mcp/@storybook/mcp-proxy@main"]
+		"args": ["-y", "https://pkg.pr.new/storybookjs/mcp/@storybook/mcp-proxy@main", "--prefer-online"]
 	}
 }


### PR DESCRIPTION
add `--prefer-online` so `npx` would always fetch the last meta data for `@storybook/mcp-proxy` and update the local package/cache if neecessary.