### PR TITLE
Add root Storybook plugin marketplaces

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+	"name": "storybook",
+	"interface": {
+		"displayName": "Storybook"
+	},
+	"plugins": [
+		{
+			"name": "storybook",
+			"source": {
+				"source": "local",
+				"path": "./packages/codex-plugin/plugins/storybook"
+			},
+			"policy": {
+				"installation": "AVAILABLE",
+				"authentication": "ON_INSTALL"
+			},
+			"category": "Coding"
+		}
+	]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,33 @@
+{
+	"name": "storybook",
+	"owner": {
+		"name": "Storybook"
+	},
+	"metadata": {
+		"description": "Storybook plugins for Claude Code."
+	},
+	"plugins": [
+		{
+			"name": "storybook",
+			"description": "Build, preview, and test UI components with Storybook.",
+			"source": "./packages/claude-plugin",
+			"author": {
+				"name": "Storybook",
+				"url": "https://storybook.js.org/"
+			},
+			"homepage": "https://storybook.js.org/docs/ai/mcp/overview",
+			"repository": "https://github.com/storybookjs/mcp",
+			"license": "MIT",
+			"keywords": [
+				"storybook",
+				"mcp",
+				"components",
+				"stories",
+				"design-systems",
+				"testing",
+				"preview"
+			],
+			"category": "development"
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,48 @@ Each package has its own README with user-facing documentation. This document is
 
 ## 🚀 Quick Start
 
+### Testing the Claude and Codex plugins from GitHub
+
+External testers can install the plugin marketplace directly from this repository's
+`main` branch. No local clone is required.
+
+#### Codex
+
+```bash
+codex plugin marketplace add storybookjs/mcp --ref main
+codex plugin add storybook@storybook
+```
+
+Verify the marketplace and plugin:
+
+```bash
+codex plugin marketplace list
+codex plugin list --marketplace storybook
+```
+
+#### Claude Code
+
+```bash
+claude plugin marketplace add storybookjs/mcp@main --scope user
+claude plugin install storybook@storybook --scope user
+```
+
+Verify the plugin and MCP server:
+
+```bash
+claude plugin list --json
+claude mcp list
+```
+
+`claude mcp list` should show `plugin:storybook:storybook` using the
+`@storybook/mcp-proxy` preview URL from `pkg.pr.new`.
+
+The repository intentionally keeps marketplace catalogs in two places. The root
+catalogs support GitHub installs from `storybookjs/mcp`; the package-local
+catalogs support local package development scripts. They should stay identical
+except for the relative plugin source path, and the package validation checks
+that they do.
+
 ### Prerequisites
 
 - **Node.js 24+** - The project requires Node.js 24 or higher (see `.nvmrc`)

--- a/packages/claude-plugin/README.md
+++ b/packages/claude-plugin/README.md
@@ -4,6 +4,26 @@ Build, preview, and test UI components from Claude.
 
 This package installs Storybook-specific skills and configures Claude to start `@storybook/mcp-proxy`.
 
+## Testing from GitHub
+
+Install the Storybook marketplace directly from this repository's `main` branch:
+
+```sh
+claude plugin marketplace add storybookjs/mcp@main --scope user
+claude plugin install storybook@storybook --scope user
+```
+
+Verify the installed plugin:
+
+```sh
+claude plugin list --json
+claude mcp list
+```
+
+The output should include `storybook@storybook` with `"enabled": true`, and
+`claude mcp list` should show `plugin:storybook:storybook` using the
+`@storybook/mcp-proxy` preview URL from `pkg.pr.new`.
+
 ## Local development
 
 This package includes a local Claude marketplace descriptor at `.claude-plugin/marketplace.json`. It points at this same directory so you can register, install, and update the plugin the same way users will once it ships through the official marketplace.
@@ -99,11 +119,15 @@ To test in Claude Desktop, restart Claude Desktop after installing or updating t
 
 ## Distribution
 
-This package is private during development. The local marketplace in `.claude-plugin/marketplace.json` is for testing only; the plugin will eventually ship through the official Claude plugin marketplace.
+This package is private during development. The repository root includes
+`.claude-plugin/marketplace.json` so testers can install from GitHub with
+`claude plugin marketplace add storybookjs/mcp@main`. The local marketplace in
+this package is for package-local development and validation. The plugin will
+eventually ship through the official Claude plugin marketplace.
 
 The plugin directory must include these files:
 
-- `.claude-plugin/marketplace.json` (local testing only)
+- `.claude-plugin/marketplace.json` (package-local testing only)
 - `.claude-plugin/plugin.json`
 - `.mcp.json`
 - `skills/**`

--- a/packages/claude-plugin/plugin.test.ts
+++ b/packages/claude-plugin/plugin.test.ts
@@ -1,10 +1,19 @@
+import { readFileSync } from 'node:fs';
 import { dirname } from 'node:path';
+import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { x } from 'tinyexec';
 import { describe, expect, it } from 'vitest';
 
 const packageRoot = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(packageRoot, '../..');
+
+type ClaudeMarketplaceJson = {
+	plugins?: Array<{
+		source?: string;
+	}>;
+};
 
 async function isClaudeCliAvailable() {
 	try {
@@ -17,18 +26,47 @@ async function isClaudeCliAvailable() {
 
 const hasClaudeCli = await isClaudeCliAvailable();
 
+function readMarketplace(path: string) {
+	return JSON.parse(readFileSync(path, 'utf8')) as ClaudeMarketplaceJson;
+}
+
+function normalizeMarketplace(marketplace: ClaudeMarketplaceJson) {
+	return {
+		...marketplace,
+		plugins: marketplace.plugins?.map((plugin) => ({
+			...plugin,
+			source: '<plugin-root>',
+		})),
+	};
+}
+
 describe('Storybook Claude plugin CLI validation', () => {
+	it('keeps root and package-local marketplaces in sync', () => {
+		const packageMarketplace = readMarketplace(
+			resolve(packageRoot, '.claude-plugin/marketplace.json'),
+		);
+		const rootMarketplace = readMarketplace(resolve(repoRoot, '.claude-plugin/marketplace.json'));
+
+		expect(packageMarketplace.plugins?.[0]?.source).toBe('./');
+		expect(rootMarketplace.plugins?.[0]?.source).toBe('./packages/claude-plugin');
+		expect(normalizeMarketplace(rootMarketplace)).toEqual(normalizeMarketplace(packageMarketplace));
+	});
+
 	it.skipIf(!hasClaudeCli)(
 		'passes claude plugin validate for marketplace and plugin manifests',
 		async () => {
-			const marketplace = await x('claude', ['plugin', 'validate', '.'], {
+			const packageMarketplace = await x('claude', ['plugin', 'validate', '.'], {
 				nodeOptions: { cwd: packageRoot },
+			});
+			const rootMarketplace = await x('claude', ['plugin', 'validate', '.'], {
+				nodeOptions: { cwd: repoRoot },
 			});
 			const plugin = await x('claude', ['plugin', 'validate', '.claude-plugin/plugin.json'], {
 				nodeOptions: { cwd: packageRoot },
 			});
 
-			expect(marketplace.exitCode).toBe(0);
+			expect(packageMarketplace.exitCode).toBe(0);
+			expect(rootMarketplace.exitCode).toBe(0);
 			expect(plugin.exitCode).toBe(0);
 		},
 	);

--- a/packages/codex-plugin/README.md
+++ b/packages/codex-plugin/README.md
@@ -2,7 +2,25 @@
 
 Private workspace package for the Storybook Codex plugin. It bundles Storybook setup, init, and upgrade skills with MCP configuration for UI component workflows.
 
-This package is intentionally shaped like a Codex plugin while living under `packages/` so it can be tested from this repository and later submitted to the official Codex marketplace. Codex does not install plugins from npm directly; it discovers plugin folders through a marketplace catalog. For local development, this package includes `.agents/plugins/marketplace.json`, which points at `plugins/storybook/`.
+This package is intentionally shaped like a Codex plugin while living under `packages/` so it can be tested from this repository and later submitted to the official Codex marketplace. Codex does not install plugins from npm directly; it discovers plugin folders through a marketplace catalog. The repository root contains the GitHub-installable marketplace, and this package includes `.agents/plugins/marketplace.json` for package-local development.
+
+## Testing from GitHub
+
+Install the Storybook marketplace directly from this repository's `main` branch:
+
+```sh
+codex plugin marketplace add storybookjs/mcp --ref main
+codex plugin add storybook@storybook
+```
+
+Verify the marketplace and plugin:
+
+```sh
+codex plugin marketplace list
+codex plugin list --marketplace storybook
+```
+
+The plugin should appear as `storybook@storybook` with status `installed, enabled`.
 
 ## Package layout
 
@@ -20,7 +38,7 @@ This matches the layout Codex expects for bundled marketplaces such as `openai-b
 
 ## Local Testing
 
-Codex exposes marketplace lifecycle commands in the CLI. Installing the plugin itself happens in the Codex app after the marketplace is registered.
+Codex exposes marketplace lifecycle and plugin install commands in the CLI.
 
 Run package scripts from the repository root with `pnpm --filter @storybook/codex-plugin run <script>`, or from this package directory with `pnpm run <script>`.
 
@@ -63,19 +81,20 @@ Then reinstall the Storybook plugin in the Codex app and restart Codex. Codex ca
 
 The plugin points at the latest `@storybook/mcp-proxy` preview from pkg.pr.new.
 
-To test from a Git branch while the plugin still lives under `packages/`, sparse-checkout this package directory:
+To test from a Git branch, install the repository-level marketplace and pin the
+branch:
 
 ```sh
-codex plugin marketplace add storybookjs/mcp --ref <branch> --sparse packages/codex-plugin
+codex plugin marketplace add storybookjs/mcp --ref <branch>
+codex plugin add storybook@storybook
 ```
 
 In the Codex **Add marketplace** UI, use the same values:
 
-| Field        | Value                                                               |
-| ------------ | ------------------------------------------------------------------- |
-| Source       | `storybookjs/mcp`                                                   |
-| Git ref      | your branch name, for example `kasper/create-claude-plugin-package` |
-| Sparse paths | `packages/codex-plugin`                                             |
+| Field   | Value                                                               |
+| ------- | ------------------------------------------------------------------- |
+| Source  | `storybookjs/mcp`                                                   |
+| Git ref | your branch name, for example `kasper/create-claude-plugin-package` |
 
 Do **not** use `plugins/codex` — that path does not exist in this repository.
 
@@ -90,11 +109,11 @@ After installing the plugin, Codex loads it from its plugin cache. If changes do
 ## Scripts
 
 - `validate:marketplace`: Validate layout and run a clean `CODEX_HOME` marketplace add smoke test.
-- `marketplace:add`: Add this package directory as a Codex marketplace.
+- `marketplace:add`: Add this package directory as a local Codex marketplace.
 - `marketplace:remove`: Remove the configured `storybook` Codex marketplace.
 - `remove`: Remove the marketplace, delete `[plugins."storybook@storybook"]` from `~/.codex/config.toml`, and delete `~/.codex/plugins/cache/storybook`.
 
-Codex does not expose CLI commands for plugin install or update. Use the Codex app plugin picker to install after `marketplace:add`. Use `remove` for a full uninstall without manual config edits.
+Use `remove` for a full uninstall without manual config edits.
 
 ## MCP Runtime
 

--- a/packages/codex-plugin/scripts/validate-marketplace.ts
+++ b/packages/codex-plugin/scripts/validate-marketplace.ts
@@ -1,3 +1,4 @@
+import { deepStrictEqual } from 'node:assert/strict';
 import { existsSync } from 'node:fs';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -7,6 +8,8 @@ import { x } from 'tinyexec';
 
 const marketplaceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const marketplacePath = resolve(marketplaceRoot, '.agents/plugins/marketplace.json');
+const repoRoot = resolve(marketplaceRoot, '../..');
+const rootMarketplacePath = resolve(repoRoot, '.agents/plugins/marketplace.json');
 
 type MarketplaceJson = {
 	name: string;
@@ -23,48 +26,92 @@ function assert(condition: unknown, message: string): asserts condition {
 	}
 }
 
-const marketplace = JSON.parse(await readFile(marketplacePath, 'utf8')) as MarketplaceJson;
-assert(marketplace.name === 'storybook', 'marketplace name must be storybook');
-assert(
-	marketplace.interface?.displayName === 'Storybook',
-	'marketplace displayName must be Storybook',
-);
-
-const entry = marketplace.plugins?.[0];
-assert(entry?.name === 'storybook', 'plugin entry name must be storybook');
-
-const pluginPath = entry?.source?.path;
-assert(
-	typeof pluginPath === 'string' && pluginPath.startsWith('./'),
-	'plugin path must start with ./',
-);
-
-const pluginRoot = resolve(marketplaceRoot, pluginPath);
-assert(
-	existsSync(resolve(pluginRoot, '.codex-plugin/plugin.json')),
-	`missing plugin manifest at ${pluginRoot}/.codex-plugin/plugin.json`,
-);
-assert(
-	existsSync(resolve(pluginRoot, '.mcp.json')),
-	`missing MCP config at ${pluginRoot}/.mcp.json`,
-);
-
-const codexHome = await mkdtemp(resolve(tmpdir(), 'codex-marketplace-'));
-try {
-	const result = await x('codex', ['plugin', 'marketplace', 'add', marketplaceRoot], {
-		nodeOptions: { env: { ...process.env, CODEX_HOME: codexHome } },
-		throwOnError: true,
-	});
-
-	assert(result.stdout.includes('Added marketplace `storybook`'), result.stdout);
-
-	const config = await readFile(resolve(codexHome, 'config.toml'), 'utf8');
-	assert(config.includes('[marketplaces.storybook]'), 'config.toml missing storybook marketplace');
-	assert(config.includes(marketplaceRoot), 'config.toml source must point at marketplace root');
-
-	console.log('Codex marketplace validation passed.');
-	console.log(`  marketplace root: ${marketplaceRoot}`);
-	console.log(`  plugin root: ${pluginRoot}`);
-} finally {
-	await rm(codexHome, { recursive: true, force: true });
+function normalizeMarketplace(marketplace: MarketplaceJson): MarketplaceJson {
+	return {
+		...marketplace,
+		plugins: marketplace.plugins?.map((plugin) => ({
+			...plugin,
+			source: plugin.source ? { ...plugin.source, path: '<plugin-root>' } : plugin.source,
+		})),
+	};
 }
+
+async function readMarketplace(path: string): Promise<MarketplaceJson> {
+	return JSON.parse(await readFile(path, 'utf8')) as MarketplaceJson;
+}
+
+function validateMarketplaceShape(
+	marketplace: MarketplaceJson,
+	marketplaceRoot: string,
+	expectedPluginPath: string,
+): string {
+	assert(marketplace.name === 'storybook', 'marketplace name must be storybook');
+	assert(
+		marketplace.interface?.displayName === 'Storybook',
+		'marketplace displayName must be Storybook',
+	);
+
+	const entry = marketplace.plugins?.[0];
+	assert(entry?.name === 'storybook', 'plugin entry name must be storybook');
+
+	const pluginPath = entry?.source?.path;
+	assert(pluginPath === expectedPluginPath, `plugin path must be ${expectedPluginPath}`);
+
+	const pluginRoot = resolve(marketplaceRoot, pluginPath);
+	assert(
+		existsSync(resolve(pluginRoot, '.codex-plugin/plugin.json')),
+		`missing plugin manifest at ${pluginRoot}/.codex-plugin/plugin.json`,
+	);
+	assert(
+		existsSync(resolve(pluginRoot, '.mcp.json')),
+		`missing MCP config at ${pluginRoot}/.mcp.json`,
+	);
+
+	return pluginRoot;
+}
+
+async function validateCodexMarketplaceAdd(marketplaceRoot: string): Promise<void> {
+	const codexHome = await mkdtemp(resolve(tmpdir(), 'codex-marketplace-'));
+	try {
+		const result = await x('codex', ['plugin', 'marketplace', 'add', marketplaceRoot], {
+			nodeOptions: { env: { ...process.env, CODEX_HOME: codexHome } },
+			throwOnError: true,
+		});
+
+		assert(result.stdout.includes('Added marketplace `storybook`'), result.stdout);
+
+		const config = await readFile(resolve(codexHome, 'config.toml'), 'utf8');
+		assert(
+			config.includes('[marketplaces.storybook]'),
+			'config.toml missing storybook marketplace',
+		);
+		assert(config.includes(marketplaceRoot), 'config.toml source must point at marketplace root');
+	} finally {
+		await rm(codexHome, { recursive: true, force: true });
+	}
+}
+
+const packageMarketplace = await readMarketplace(marketplacePath);
+const rootMarketplace = await readMarketplace(rootMarketplacePath);
+
+const packagePluginRoot = validateMarketplaceShape(
+	packageMarketplace,
+	marketplaceRoot,
+	'./plugins/storybook',
+);
+const rootPluginRoot = validateMarketplaceShape(
+	rootMarketplace,
+	repoRoot,
+	'./packages/codex-plugin/plugins/storybook',
+);
+
+deepStrictEqual(normalizeMarketplace(rootMarketplace), normalizeMarketplace(packageMarketplace));
+
+await validateCodexMarketplaceAdd(marketplaceRoot);
+await validateCodexMarketplaceAdd(repoRoot);
+
+console.log('Codex marketplace validation passed.');
+console.log(`  package marketplace root: ${marketplaceRoot}`);
+console.log(`  package plugin root: ${packagePluginRoot}`);
+console.log(`  root marketplace root: ${repoRoot}`);
+console.log(`  root plugin root: ${rootPluginRoot}`);


### PR DESCRIPTION
## Summary

- Add root-level Codex and Claude marketplace catalogs so testers can install the Storybook plugins directly from `storybookjs/mcp` without cloning.
- Document the official GitHub branch install commands in the root README and package READMEs.
- Replace the stale Codex sparse-checkout instructions with the repository-level marketplace flow.
- Add validation so root and package-local marketplace catalogs stay identical except for the required relative plugin source path.

## Verification

- `corepack pnpm format:check`
- `corepack pnpm lint`
- `corepack pnpm --filter @storybook/codex-plugin validate:marketplace`
- `claude plugin validate . && claude plugin validate packages/claude-plugin/.claude-plugin/plugin.json`
- `corepack pnpm vitest run --project=@storybook/claude-code-plugin --project=@storybook/codex-plugin`
- Temp Codex config: `codex plugin marketplace add storybookjs/mcp --ref kasper/root-marketplace-docs` then `codex plugin add storybook@storybook`
- Temp Claude config: `claude plugin marketplace add storybookjs/mcp@kasper/root-marketplace-docs --scope user` then `claude plugin install storybook@storybook --scope user` and `claude mcp list`

## Notes

No changeset: this enables GitHub marketplace testing and updates docs, but does not publish an npm package.