### PR TITLE
feat(mcp-proxy): add instructions when no storybook is installed

### DIFF
--- a/packages/mcp-proxy/src/tools/intercepts.test.ts
+++ b/packages/mcp-proxy/src/tools/intercepts.test.ts
@@ -4,6 +4,7 @@ import { getInterceptMarkdown, intercept, META_INTERCEPT_REASON } from './interc
 describe('intercepts', () => {
 	it.each([
 		['no-instance', 'Storybook is not running'],
+		['storybook-not-installed', 'storybook-init'],
 		['addon-missing', '@storybook/addon-mcp'],
 		['mcp-starting', 'starting up'],
 		['mcp-error', 'reported an error'],

--- a/packages/mcp-proxy/src/tools/intercepts.ts
+++ b/packages/mcp-proxy/src/tools/intercepts.ts
@@ -25,6 +25,16 @@ npx storybook add @storybook/addon-mcp
 \`\`\`
 to install the MCP addon. After the upgrade, call the \`clear-storybook-version-cache\` tool with the same \`cwd\` so the proxy re-detects the new version. Restart Storybook, then retry the tool call.`;
 
+const STORYBOOK_NOT_INSTALLED = `No Storybook is running at this cwd, and Storybook does not appear to be installed here (\`storybook\` could not be resolved from this project).
+
+Ask the user whether they want to add Storybook. If they agree, invoke the \`storybook-init\` skill to set it up, then install the MCP addon:
+\`\`\`
+npx storybook add @storybook/addon-mcp
+\`\`\`
+Start Storybook, then retry the tool call.
+
+If you believe Storybook is in fact installed (e.g. a monorepo where \`storybook\` resolves from a different location), start \`storybook dev\` from this exact cwd and retry — a running instance is always proxied regardless of this check.`;
+
 const ADDON_MISSING = `Storybook is running but does not expose an MCP server. The \`@storybook/addon-mcp\` addon is missing.
 
 Install it:
@@ -55,6 +65,8 @@ export function getInterceptMarkdown(
 			return records && records.length > 0
 				? buildNoInstanceWithCandidates(records)
 				: NO_INSTANCE_EMPTY;
+		case 'storybook-not-installed':
+			return STORYBOOK_NOT_INSTALLED;
 		case 'addon-missing':
 			return ADDON_MISSING;
 		case 'mcp-starting':

--- a/packages/mcp-proxy/src/tools/proxy-tool.test.ts
+++ b/packages/mcp-proxy/src/tools/proxy-tool.test.ts
@@ -204,6 +204,30 @@ describe('registerProxyTool / list-all-documentation', () => {
 		expect(firstText(response.result)).toContain('storybook-upgrade');
 	});
 
+	it('returns the storybook-not-installed intercept when Storybook is unresolvable and nothing is running at the cwd', async () => {
+		vi.mocked(checkStorybookVersion).mockReturnValue({ status: 'not-installed' });
+		vi.mocked(readRegistry).mockResolvedValue([]);
+		const server = await buildServer();
+		const response = await callTool(server, { cwd: '/projects/foo' });
+		expect(response.result.isError).toBe(true);
+		expect(response.result._meta).toEqual({ [META_INTERCEPT_REASON]: 'storybook-not-installed' });
+		expect(firstText(response.result)).toContain('storybook-init');
+	});
+
+	it('still proxies to a running instance even when the version check reports not-installed (avoids monorepo false negatives)', async () => {
+		vi.mocked(checkStorybookVersion).mockReturnValue({ status: 'not-installed' });
+		vi.mocked(proxyToolCall).mockResolvedValue({
+			content: [{ type: 'text', text: 'COMPONENTS' }],
+		});
+		const server = await buildServer();
+		const response = await callTool(server, { cwd: '/projects/foo', withStoryIds: true });
+		expect(proxyToolCall).toHaveBeenCalledWith(record, {
+			name: 'list-all-documentation',
+			arguments: { withStoryIds: true },
+		});
+		expect(firstText(response.result)).toBe('COMPONENTS');
+	});
+
 	it('proxies the call and prepends a multi-instance warning when 2+ ready instances share the cwd', async () => {
 		const a: StorybookInstanceRecordV1 = {
 			...record,

--- a/packages/mcp-proxy/src/tools/proxy-tool.ts
+++ b/packages/mcp-proxy/src/tools/proxy-tool.ts
@@ -98,6 +98,9 @@ export function registerProxyTool<Schema extends v.ObjectEntries>(
 			const resolution = resolveInstance(records, cwd);
 
 			if (resolution.kind === 'intercept') {
+				if (resolution.reason === 'no-instance' && versionStatus.status === 'not-installed') {
+					return intercept('storybook-not-installed');
+				}
 				return intercept(resolution.reason, { records: resolution.records });
 			}
 

--- a/packages/mcp-proxy/src/tools/proxy-tool.ts
+++ b/packages/mcp-proxy/src/tools/proxy-tool.ts
@@ -98,7 +98,11 @@ export function registerProxyTool<Schema extends v.ObjectEntries>(
 			const resolution = resolveInstance(records, cwd);
 
 			if (resolution.kind === 'intercept') {
-				if (resolution.reason === 'no-instance' && versionStatus.status === 'not-installed') {
+				if (
+					resolution.reason === 'no-instance' &&
+					versionStatus.status === 'not-installed' &&
+					(resolution.records?.length ?? 0) === 0
+				) {
 					return intercept('storybook-not-installed');
 				}
 				return intercept(resolution.reason, { records: resolution.records });

--- a/packages/mcp-proxy/src/types/index.ts
+++ b/packages/mcp-proxy/src/types/index.ts
@@ -5,6 +5,7 @@ export { McpStatusV1Schema, StorybookInstanceRecordV1Schema } from './record/v1.
 
 export type InterceptReason =
 	| 'no-instance'
+	| 'storybook-not-installed'
 	| 'addon-missing'
 	| 'mcp-starting'
 	| 'mcp-error'


### PR DESCRIPTION
Return instructions when storybook is not installed in a project that agent is trying to target