### PR TITLE
Fix tool call crash

### DIFF
--- a/packages/addon-mcp/src/tools/get-stories-by-component.ts
+++ b/packages/addon-mcp/src/tools/get-stories-by-component.ts
@@ -29,7 +29,7 @@ Story files (\`*.stories.*\`) are accepted too: they appear at distance 0 as sel
 		),
 	),
 	maxDistance: v.pipe(
-		v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))),
+		v.optional(v.pipe(v.number(), v.minValue(1), v.integer())),
 		v.description(
 			`Ceiling on the import depth to include in results. Must be a positive integer.
 - 1: only stories that directly import the component.

--- a/packages/mcp-proxy/src/types/record/v1.ts
+++ b/packages/mcp-proxy/src/types/record/v1.ts
@@ -11,10 +11,10 @@ export type McpStatusV1 = v.InferOutput<typeof McpStatusV1Schema>;
 export const StorybookInstanceRecordV1Schema = v.object({
 	schemaVersion: v.literal(1),
 	instanceId: v.string(),
-	pid: v.pipe(v.number(), v.integer(), v.minValue(1)),
+	pid: v.pipe(v.number(), v.minValue(1), v.integer()),
 	cwd: v.string(),
 	url: v.string(),
-	port: v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(65535)),
+	port: v.pipe(v.number(), v.minValue(1), v.maxValue(65535), v.integer()),
 	storybookVersion: v.optional(v.string()),
 	startedAt: v.optional(v.string()),
 	updatedAt: v.optional(v.string()),


### PR DESCRIPTION
### Summary
tools/list throws and returns zero tools to any MCP client whenever the get-stories-by-component tool is registered. The culprit is the action ordering in a valibot pipe: v.pipe(v.number(), v.integer(), v.minValue(1)). This PR reorders the bound actions to run before integer(), which produces valid JSON Schema and stops the crash.

### The bug
```
An unexpected error occurred while executing "tools/list" JSON-RPC method:
Error: The "min_value" action is not supported on type "integer".
    at handleError (.../@valibot/to-json-schema/dist/index.js:35:18)
    at convertAction (.../@valibot/to-json-schema/dist/index.js:211:44)
    ...
    at async Promise.all (index 3)
```
@valibot/to-json-schema (v1.3.0, pulled in transitively via @tmcp/adapter-valibot) converts pipe actions in order, mutating the JSON-Schema type as it goes:
```
v.number() → type: "number"
v.integer() → type: "integer"
v.minValue(1) → rejected, because this version only allows min_value/max_value on type: "number", not "integer"
```

The converter is invoked with the default errorMode, which throws. Because tmcp converts all tool schemas together under Promise.all, this single failure rejects the entire tools/list response, so the client registers no tools at all. initialize is unaffected (it converts no schemas), which is why the server's instructions still load while the tool list comes back empty — a confusing symptom that masks the real cause.

### The fix
Move the value-bound actions ahead of integer() so the bound is applied while the type is still number:
```diff
- v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))),
+ v.optional(v.pipe(v.number(), v.minValue(1), v.integer())),
```

Same treatment for the matching schemas in mcp-proxy (latent — not currently in the failing path, fixed for consistency):
```diff
- pid:  v.pipe(v.number(), v.integer(), v.minValue(1)),
- port: v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(65535)),
+ pid:  v.pipe(v.number(), v.minValue(1), v.integer()),
+ port: v.pipe(v.number(), v.minValue(1), v.maxValue(65535), v.integer()),
```

integer() stays last so both bounds are processed while the type is number.

This is purely a schema-conversion ordering change. Valibot enforces every action in a pipe regardless of order, so the accepted input set is identical at runtime.