### PR TITLE
feat(mcp-proxy): add optionnal port arg to proxy calls

### DIFF
--- a/packages/mcp-proxy/src/tools/intercepts.test.ts
+++ b/packages/mcp-proxy/src/tools/intercepts.test.ts
@@ -53,6 +53,24 @@ describe('intercepts', () => {
 		expect(md).not.toContain('storybook-setup-claude-launch');
 	});
 
+	it('port-mismatch names the requested port and lists the running ports at the cwd', () => {
+		const records = [
+			{
+				schemaVersion: 1 as const,
+				instanceId: 'a',
+				pid: 1,
+				cwd: '/a',
+				url: 'http://localhost:6006',
+				port: 6006,
+				mcp: { status: 'ready' as const, endpoint: 'http://localhost:6006/mcp' },
+			},
+		];
+		const md = getInterceptMarkdown('port-mismatch', { records, port: 9999 });
+		expect(md).toContain('not on port `9999`');
+		expect(md).toContain('port `6006`');
+		expect(md).toContain('http://localhost:6006');
+	});
+
 	it('intercept() returns a tool result with isError and namespaced reason metadata', () => {
 		const result = intercept('no-instance');
 		expect(result.isError).toBe(true);

--- a/packages/mcp-proxy/src/tools/intercepts.ts
+++ b/packages/mcp-proxy/src/tools/intercepts.ts
@@ -16,6 +16,12 @@ const buildNoInstanceWithCandidates = (records: StorybookInstanceRecordV1[]) =>
 Running Storybooks:
 ${records.map((r) => `- \`${r.cwd}\` (${r.url})`).join('\n')}`;
 
+const buildPortMismatch = (port: number | undefined, records: StorybookInstanceRecordV1[]) =>
+	`Storybook is running at this cwd, but not on port \`${port ?? 'unknown'}\`. Retry with one of the running ports below, or omit \`port\` to route by cwd alone.
+
+Running Storybooks at this cwd:
+${records.map((r) => `- port \`${r.port}\` (${r.url}, mcp: \`${r.mcp.status}\`)`).join('\n')}`;
+
 const buildStorybookTooOld = (version: string) =>
 	`The Storybook installed at this cwd is version \`${version}\`, but this plugin requires \`${STORYBOOK_MIN_VERSION}\` or newer.
 
@@ -53,18 +59,21 @@ const INVALID_CWD = `\`cwd\` must be an absolute path matching the cwd from whic
 export type InterceptExtras = {
 	records?: StorybookInstanceRecordV1[];
 	version?: string;
+	port?: number;
 };
 
 export function getInterceptMarkdown(
 	reason: InterceptReason,
 	extras: InterceptExtras = {},
 ): string {
-	const { records, version } = extras;
+	const { records, version, port } = extras;
 	switch (reason) {
 		case 'no-instance':
 			return records && records.length > 0
 				? buildNoInstanceWithCandidates(records)
 				: NO_INSTANCE_EMPTY;
+		case 'port-mismatch':
+			return buildPortMismatch(port, records ?? []);
 		case 'storybook-not-installed':
 			return STORYBOOK_NOT_INSTALLED;
 		case 'addon-missing':

--- a/packages/mcp-proxy/src/tools/proxy-tool.test.ts
+++ b/packages/mcp-proxy/src/tools/proxy-tool.test.ts
@@ -306,9 +306,7 @@ describe('registerProxyTool / list-all-documentation', () => {
 		const response = await listTools(server);
 		// `clear-storybook-version-cache` is a local control op, not a proxied call,
 		// so it has no routing port — only the proxied tools carry `port`.
-		const proxied = response.result.tools.filter(
-			(t) => t.name !== 'clear-storybook-version-cache',
-		);
+		const proxied = response.result.tools.filter((t) => t.name !== 'clear-storybook-version-cache');
 		for (const tool of proxied) {
 			const props = Object.keys(tool.inputSchema.properties ?? {});
 			expect(props, `tool ${tool.name} should expose port`).toContain('port');

--- a/packages/mcp-proxy/src/tools/proxy-tool.test.ts
+++ b/packages/mcp-proxy/src/tools/proxy-tool.test.ts
@@ -301,6 +301,66 @@ describe('registerProxyTool / list-all-documentation', () => {
 		expect(only.text).not.toContain('Multiple Storybook instances');
 	});
 
+	it('exposes port as an optional (not required) field on every proxied tool (but not the local control tool)', async () => {
+		const server = await buildServer();
+		const response = await listTools(server);
+		// `clear-storybook-version-cache` is a local control op, not a proxied call,
+		// so it has no routing port — only the proxied tools carry `port`.
+		const proxied = response.result.tools.filter(
+			(t) => t.name !== 'clear-storybook-version-cache',
+		);
+		for (const tool of proxied) {
+			const props = Object.keys(tool.inputSchema.properties ?? {});
+			expect(props, `tool ${tool.name} should expose port`).toContain('port');
+			const required = tool.inputSchema.required ?? [];
+			expect(required, `tool ${tool.name} should NOT require port`).not.toContain('port');
+		}
+	});
+
+	it('routes to the instance matching both cwd and port, and does not forward port downstream', async () => {
+		const a: StorybookInstanceRecordV1 = {
+			...record,
+			instanceId: 'inst-a',
+			pid: 100,
+			port: 6006,
+			url: 'http://localhost:6006',
+			mcp: { status: 'ready', endpoint: 'http://localhost:6006/mcp' },
+		};
+		const b: StorybookInstanceRecordV1 = {
+			...record,
+			instanceId: 'inst-b',
+			pid: 200,
+			port: 6007,
+			url: 'http://localhost:6007',
+			mcp: { status: 'ready', endpoint: 'http://localhost:6007/mcp' },
+		};
+		vi.mocked(readRegistry).mockResolvedValue([a, b]);
+		vi.mocked(proxyToolCall).mockResolvedValue({ content: [{ type: 'text', text: 'B' }] });
+
+		const server = await buildServer();
+		const response = await callTool(server, {
+			cwd: '/projects/foo',
+			port: 6007,
+			withStoryIds: true,
+		});
+
+		// Selected the port-6007 instance, and `port` was stripped from upstream args.
+		expect(proxyToolCall).toHaveBeenCalledWith(b, {
+			name: 'list-all-documentation',
+			arguments: { withStoryIds: true },
+		});
+		expect(firstText(response.result)).toBe('B');
+	});
+
+	it('returns the port-mismatch intercept when the cwd matches but no instance is on that port', async () => {
+		const server = await buildServer();
+		const response = await callTool(server, { cwd: '/projects/foo', port: 9999 });
+		expect(response.result.isError).toBe(true);
+		expect(response.result._meta).toEqual({ [META_INTERCEPT_REASON]: 'port-mismatch' });
+		expect(firstText(response.result)).toContain('not on port `9999`');
+		expect(firstText(response.result)).toContain('port `6006`');
+	});
+
 	it('surfaces a friendly error when proxyToolCall throws', async () => {
 		vi.mocked(proxyToolCall).mockRejectedValue(new Error('connection refused'));
 		const server = await buildServer();

--- a/packages/mcp-proxy/src/tools/proxy-tool.ts
+++ b/packages/mcp-proxy/src/tools/proxy-tool.ts
@@ -44,6 +44,17 @@ const CwdField = {
 			'Absolute path of the Storybook project this call targets. Required — must exactly match the cwd from which `storybook dev` was started.',
 		),
 	),
+	port: v.optional(
+		v.pipe(
+			v.number(),
+			v.integer(),
+			v.minValue(1),
+			v.maxValue(65535),
+			v.description(
+				'Optional. The port the target Storybook is running on. Supply it to address one specific instance when several share the same `cwd`, or when an ADE (e.g. Claude Desktop) launched Storybook on a port it knows. When set, the instance must match BOTH `cwd` and this port; omit it to route by `cwd` alone.',
+			),
+		),
+	),
 };
 
 type ProxyToolDefinition<Schema extends v.ObjectEntries> = {
@@ -79,8 +90,10 @@ export function registerProxyTool<Schema extends v.ObjectEntries>(
 		// union (`text` / `image` / `audio` / `resource` / `resource_link`). We forward
 		// it as-is; tmcp's generic CallToolResult type narrows to a strict union, so we
 		// cast at the boundary rather than carry the union through every internal type.
-		async (input: Record<string, unknown> & { cwd: string }): Promise<ProxyToolCallResult> => {
-			const { cwd, ...upstreamArgs } = input;
+		async (
+			input: Record<string, unknown> & { cwd: string; port?: number },
+		): Promise<ProxyToolCallResult> => {
+			const { cwd, port, ...upstreamArgs } = input;
 
 			if (!path.isAbsolute(cwd)) {
 				return intercept('invalid-cwd');
@@ -95,7 +108,7 @@ export function registerProxyTool<Schema extends v.ObjectEntries>(
 			// read the registry and resolve the target instance based on the input cwd;
 			// compatibility has already been validated by the Storybook version check above
 			const records = await readRegistry(registryDir);
-			const resolution = resolveInstance(records, cwd);
+			const resolution = resolveInstance(records, cwd, port);
 
 			if (resolution.kind === 'intercept') {
 				if (
@@ -105,7 +118,7 @@ export function registerProxyTool<Schema extends v.ObjectEntries>(
 				) {
 					return intercept('storybook-not-installed');
 				}
-				return intercept(resolution.reason, { records: resolution.records });
+				return intercept(resolution.reason, { records: resolution.records, port });
 			}
 
 			try {

--- a/packages/mcp-proxy/src/types/index.ts
+++ b/packages/mcp-proxy/src/types/index.ts
@@ -5,6 +5,7 @@ export { McpStatusV1Schema, StorybookInstanceRecordV1Schema } from './record/v1.
 
 export type InterceptReason =
 	| 'no-instance'
+	| 'port-mismatch'
 	| 'storybook-not-installed'
 	| 'addon-missing'
 	| 'mcp-starting'

--- a/packages/mcp-proxy/src/utils/resolve-instance.test.ts
+++ b/packages/mcp-proxy/src/utils/resolve-instance.test.ts
@@ -121,4 +121,47 @@ describe('resolveInstance', () => {
 		const result = resolveInstance([r], '/p');
 		expect(result).toEqual({ kind: 'intercept', reason: 'mcp-error', matches: [r] });
 	});
+
+	it('selects the instance matching BOTH cwd and port when a port is supplied', () => {
+		const a = record('/Users/x/projects/foo', 'ready', { pid: 100, port: 6006 });
+		const b = record('/Users/x/projects/foo', 'ready', { pid: 200, port: 6007 });
+		const result = resolveInstance([a, b], '/Users/x/projects/foo', 6007);
+		expect(result.kind).toBe('instance');
+		if (result.kind === 'instance') {
+			expect(result.record).toBe(b);
+			expect(result.matches).toEqual([b]);
+		}
+	});
+
+	it('ignores port when it is not supplied (routes by cwd alone)', () => {
+		const a = record('/Users/x/projects/foo', 'ready', { pid: 100, port: 6006 });
+		const b = record('/Users/x/projects/foo', 'ready', { pid: 200, port: 6007 });
+		const result = resolveInstance([a, b], '/Users/x/projects/foo');
+		expect(result.kind).toBe('instance');
+		if (result.kind === 'instance') {
+			expect(result.record).toBe(a);
+			expect(result.matches).toEqual([a, b]);
+		}
+	});
+
+	it('returns port-mismatch with the cwd instances as candidates when cwd matches but no instance is on the port', () => {
+		const a = record('/Users/x/projects/foo', 'ready', { pid: 100, port: 6006 });
+		const b = record('/Users/x/projects/foo', 'ready', { pid: 200, port: 6007 });
+		const result = resolveInstance([a, b], '/Users/x/projects/foo', 9999);
+		expect(result.kind).toBe('intercept');
+		if (result.kind === 'intercept') {
+			expect(result.reason).toBe('port-mismatch');
+			expect(result.records).toEqual([a, b]);
+			expect(result.matches).toEqual([]);
+		}
+	});
+
+	it('returns no-instance (not port-mismatch) when the cwd itself does not match', () => {
+		const a = record('/Users/x/projects/foo', 'ready', { port: 6006 });
+		const result = resolveInstance([a], '/Users/x/projects/bar', 6006);
+		expect(result.kind).toBe('intercept');
+		if (result.kind === 'intercept') {
+			expect(result.reason).toBe('no-instance');
+		}
+	});
 });

--- a/packages/mcp-proxy/src/utils/resolve-instance.ts
+++ b/packages/mcp-proxy/src/utils/resolve-instance.ts
@@ -45,8 +45,7 @@ export function resolveInstance(
 ): ResolveResult {
 	const normalisedTarget = resolve(targetCwd);
 	const cwdMatches = records.filter((r) => resolve(r.cwd) === normalisedTarget);
-	const matches =
-		targetPort == null ? cwdMatches : cwdMatches.filter((r) => r.port === targetPort);
+	const matches = targetPort == null ? cwdMatches : cwdMatches.filter((r) => r.port === targetPort);
 
 	if (matches.length === 0) {
 		// cwd matched, but no instance there is on the requested port: a distinct,

--- a/packages/mcp-proxy/src/utils/resolve-instance.ts
+++ b/packages/mcp-proxy/src/utils/resolve-instance.ts
@@ -19,6 +19,13 @@ export type ResolveResult =
  * normalisation. Per milestone 2 of storybookjs/storybook#34826: matching is
  * exact-normalized, with no longest-prefix or fallback behaviour.
  *
+ * When `targetPort` is supplied (e.g. an ADE that launched Storybook on a
+ * known port and wants to address that exact instance), it further constrains
+ * the cwd matches: an instance must match BOTH cwd and port. If the cwd matches
+ * but no instance there is on `targetPort`, a `port-mismatch` intercept is
+ * returned with the cwd's instances as candidates so callers can surface the
+ * running ports.
+ *
  * If at least one record matches, dispatch based on the selected instance's
  * `mcp.status`:
  *   - ready          → proxy
@@ -34,11 +41,24 @@ export type ResolveResult =
 export function resolveInstance(
 	records: StorybookInstanceRecordV1[],
 	targetCwd: string,
+	targetPort?: number,
 ): ResolveResult {
 	const normalisedTarget = resolve(targetCwd);
-	const matches = records.filter((r) => resolve(r.cwd) === normalisedTarget);
+	const cwdMatches = records.filter((r) => resolve(r.cwd) === normalisedTarget);
+	const matches =
+		targetPort == null ? cwdMatches : cwdMatches.filter((r) => r.port === targetPort);
 
 	if (matches.length === 0) {
+		// cwd matched, but no instance there is on the requested port: a distinct,
+		// more actionable failure than "nothing is running here".
+		if (targetPort != null && cwdMatches.length > 0) {
+			return {
+				kind: 'intercept',
+				reason: 'port-mismatch',
+				records: cwdMatches,
+				matches: [],
+			};
+		}
 		return {
 			kind: 'intercept',
 			reason: 'no-instance',


### PR DESCRIPTION
PR adds optionnal port argument to proxy calls because mcp-proxy allows multiple running sb instances for a cwd. 

This makes 1 required arg for MCP-proxy to know which sb instance to target when proxying. 

IF prot is prodvided:
 - cwd is still required, check if port is correctly linked to a running sb instance to the provided CWD
   - yes: proxy the call
   - no: return an error
 - port is not supplied: keep the old behavior and proxy to the first instance found.
   - if multiple instance found, we still return the information in the response