### PR TITLE
fix(mcp): support externalized-docgen component manifest format

### DIFF
--- a/.changeset/support-externalized-docgen-manifest.md
+++ b/.changeset/support-externalized-docgen-manifest.md
@@ -1,0 +1,5 @@
+---
+"@storybook/mcp": patch
+---
+
+Support the externalized-docgen component manifest format. Newer Storybooks emit a `components.json` whose entries are lightweight stubs carrying a `docgen.$ref` pointer instead of inline `path`/docgen data, with the full component data served from a referenced file. `get-documentation` and `get-documentation-for-story` now resolve that reference (through the same auth-aware manifest provider) before formatting, so composition/multi-source documentation works against Storybooks using the new format. `path` and the top-level manifest `v` field are now optional to accommodate stubs and referenced docgen files.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -71,7 +71,7 @@ jobs:
             coverage/lcov.info
 
       - name: Upload test results to Codecov
-        uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
+        uses: codecov/test-results-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v1.1.1
         if: always()
         with:
           use_oidc: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -63,7 +63,7 @@ jobs:
         run: pnpm turbo run test:ci
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v5.5.1
         with:
           use_oidc: true
           fail_ci_if_error: true
@@ -71,7 +71,7 @@ jobs:
             coverage/lcov.info
 
       - name: Upload test results to Codecov
-        uses: codecov/test-results-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v1.1.1
+        uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
         if: always()
         with:
           use_oidc: true

--- a/packages/mcp/src/tools/get-documentation-for-story.ts
+++ b/packages/mcp/src/tools/get-documentation-for-story.ts
@@ -2,7 +2,7 @@ import * as v from 'valibot';
 import type { McpServer } from 'tmcp';
 import type { StorybookContext } from '../types.ts';
 import { StorybookIdField } from '../types.ts';
-import { errorToMCPContent, getManifests } from '../utils/get-manifest.ts';
+import { errorToMCPContent, getManifests, resolveComponentDocgen } from '../utils/get-manifest.ts';
 import { formatStoryDocumentation } from '../utils/manifest-formatter/markdown.ts';
 import { LIST_TOOL_NAME } from './list-all-documentation.ts';
 
@@ -71,7 +71,7 @@ export async function addGetStoryDocumentationTool(
 
 				const manifest = await getManifests(ctx?.request, ctx?.manifestProvider, source);
 
-				const component = manifest.componentManifest?.components[componentId];
+				let component = manifest.componentManifest?.components[componentId];
 
 				if (!component) {
 					return {
@@ -83,6 +83,16 @@ export async function addGetStoryDocumentationTool(
 						],
 						isError: true,
 					};
+				}
+
+				// Externalized-docgen manifests carry only a stub here; fetch the full data.
+				if (component.docgen?.$ref) {
+					component = await resolveComponentDocgen(
+						component,
+						ctx?.request,
+						ctx?.manifestProvider,
+						source,
+					);
 				}
 
 				const story = component.stories?.find((s) => s.name === storyName);

--- a/packages/mcp/src/tools/get-documentation.ts
+++ b/packages/mcp/src/tools/get-documentation.ts
@@ -2,7 +2,7 @@ import * as v from 'valibot';
 import type { McpServer } from 'tmcp';
 import type { ComponentManifest, Doc, StorybookContext } from '../types.ts';
 import { StorybookIdField } from '../types.ts';
-import { getManifests, errorToMCPContent } from '../utils/get-manifest.ts';
+import { getManifests, errorToMCPContent, resolveComponentDocgen } from '../utils/get-manifest.ts';
 import { LIST_TOOL_NAME } from './list-all-documentation.ts';
 import {
 	formatComponentManifest,
@@ -82,7 +82,7 @@ Example: id="button" returns Primary, Secondary, Large stories with code like <B
 					source,
 				);
 
-				const component = componentManifest.components[id];
+				let component = componentManifest.components[id];
 				const docsEntry = docsManifest?.docs[id];
 
 				if (!component && !docsEntry) {
@@ -101,6 +101,15 @@ Example: id="button" returns Primary, Secondary, Large stories with code like <B
 						],
 						isError: true,
 					};
+				}
+
+				if (component?.docgen?.$ref) {
+					component = await resolveComponentDocgen(
+						component,
+						ctx?.request,
+						ctx?.manifestProvider,
+						source,
+					);
 				}
 
 				const documentation = component ?? docsEntry!;

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -128,9 +128,23 @@ export type Doc = v.InferOutput<typeof Doc>;
  */
 export type ComponentDocWithExportName = ComponentDoc & { exportName: string };
 
+/**
+ * A JSON Reference to externalized component data, e.g.
+ * `"../services/core/docgen/button.json#/components/button"`. Used by the
+ * externalized-docgen manifest format, where the top-level component manifest
+ * only carries lightweight stubs and the full data lives in a referenced file.
+ * The path is resolved relative to the component manifest's location.
+ */
+export const DocgenRef = v.object({
+	$ref: v.string(),
+});
+export type DocgenRef = v.InferOutput<typeof DocgenRef>;
+
 const BaseComponentProperties = v.object({
 	...BaseManifest.entries,
-	path: v.string(),
+	// Optional: stub entries in the externalized-docgen manifest format omit `path`
+	// (it lives in the referenced docgen file alongside the rest of the component data).
+	path: v.optional(v.string()),
 	summary: v.optional(v.string()),
 	import: v.optional(v.string()),
 	reactDocgen: v.optional(v.any()),
@@ -150,11 +164,16 @@ export const ComponentManifest = v.object({
 	stories: v.optional(v.array(Story)),
 	subcomponents: v.optional(v.record(v.string(), SubcomponentManifest)),
 	docs: v.optional(v.record(v.string(), Doc)),
+	// Present on stub entries in the externalized-docgen manifest format. When set,
+	// the full component data must be resolved from the referenced file.
+	docgen: v.optional(DocgenRef),
 });
 export type ComponentManifest = v.InferOutput<typeof ComponentManifest>;
 
 export const ComponentManifestMap = v.object({
-	v: v.number(),
+	// Optional: externalized docgen files (referenced via `docgen.$ref`) are shaped
+	// like a component manifest map but omit the top-level version field.
+	v: v.optional(v.number()),
 	components: v.record(v.string(), ComponentManifest),
 });
 export type ComponentManifestMap = v.InferOutput<typeof ComponentManifestMap>;

--- a/packages/mcp/src/utils/get-manifest.test.ts
+++ b/packages/mcp/src/utils/get-manifest.test.ts
@@ -604,9 +604,7 @@ Invalid key: Expected "components" but received undefined]`);
 
 describe('parseDocgenRef', () => {
 	it('resolves a `../`-prefixed ref relative to the component manifest location', () => {
-		expect(
-			parseDocgenRef('../services/core/docgen/button.json#/components/button'),
-		).toEqual({
+		expect(parseDocgenRef('../services/core/docgen/button.json#/components/button')).toEqual({
 			path: './services/core/docgen/button.json',
 			pointer: ['components', 'button'],
 		});

--- a/packages/mcp/src/utils/get-manifest.test.ts
+++ b/packages/mcp/src/utils/get-manifest.test.ts
@@ -3,8 +3,11 @@ import {
 	getManifests,
 	getMultiSourceManifests,
 	ManifestGetError,
+	parseDocgenRef,
+	resolveComponentDocgen,
 	RequiresOwnMcpError,
 } from './get-manifest.ts';
+import type { ComponentManifest } from '../types.ts';
 import type { ComponentManifestMap, DocsManifestMap, Source } from '../types.ts';
 
 global.fetch = vi.fn();
@@ -192,8 +195,8 @@ describe('getManifest', () => {
 				},
 				text: vi.fn().mockResolvedValue(
 					JSON.stringify({
-						// Missing required 'v' field
-						components: {},
+						// Missing required 'components' field
+						v: 1,
 					}),
 				),
 			});
@@ -201,7 +204,7 @@ describe('getManifest', () => {
 			const request = createMockRequest('https://example.com/mcp');
 			await expect(getManifests(request)).rejects
 				.toThrowErrorMatchingInlineSnapshot(`[ManifestGetError: Failed to parse component manifest:
-Invalid key: Expected "v" but received undefined]`);
+Invalid key: Expected "components" but received undefined]`);
 		});
 
 		it('should throw ManifestGetError when components object is empty', async () => {
@@ -596,5 +599,81 @@ Invalid key: Expected "v" but received undefined]`);
 				remoteSource,
 			);
 		});
+	});
+});
+
+describe('parseDocgenRef', () => {
+	it('resolves a `../`-prefixed ref relative to the component manifest location', () => {
+		expect(
+			parseDocgenRef('../services/core/docgen/button.json#/components/button'),
+		).toEqual({
+			path: './services/core/docgen/button.json',
+			pointer: ['components', 'button'],
+		});
+	});
+
+	it('resolves a sibling ref within the manifests directory', () => {
+		expect(parseDocgenRef('./button.json#/components/button')).toEqual({
+			path: './manifests/button.json',
+			pointer: ['components', 'button'],
+		});
+	});
+
+	it('decodes JSON-pointer escape sequences', () => {
+		expect(parseDocgenRef('../x.json#/a~1b/c~0d')).toEqual({
+			path: './x.json',
+			pointer: ['a/b', 'c~d'],
+		});
+	});
+});
+
+describe('resolveComponentDocgen', () => {
+	const stub: ComponentManifest = {
+		id: 'button',
+		name: 'Button',
+		description: 'A button',
+		docgen: { $ref: '../services/core/docgen/button.json#/components/button' },
+	};
+
+	it('returns the component unchanged when it has no docgen $ref', async () => {
+		const plain: ComponentManifest = { id: 'button', name: 'Button', path: 'src/Button.tsx' };
+		const provider = vi.fn();
+		await expect(resolveComponentDocgen(plain, undefined, provider)).resolves.toBe(plain);
+		expect(provider).not.toHaveBeenCalled();
+	});
+
+	it('fetches the referenced file and merges the resolved entry over the stub', async () => {
+		const provider = vi.fn().mockResolvedValue(
+			JSON.stringify({
+				components: {
+					button: {
+						id: 'button',
+						name: 'Button',
+						path: 'src/Button.tsx',
+						stories: [{ name: 'Primary', snippet: '<Button />' }],
+					},
+				},
+			}),
+		);
+
+		const resolved = await resolveComponentDocgen(stub, undefined, provider);
+
+		// Provider is asked for the resolved (relative) path of the referenced file.
+		expect(provider).toHaveBeenCalledWith(
+			undefined,
+			'./services/core/docgen/button.json',
+			undefined,
+		);
+		expect(resolved.path).toBe('src/Button.tsx');
+		expect(resolved.stories).toEqual([{ name: 'Primary', snippet: '<Button />' }]);
+		// Stub identity fields are retained.
+		expect(resolved.id).toBe('button');
+	});
+
+	it('throws when the JSON pointer does not resolve', async () => {
+		const provider = vi.fn().mockResolvedValue(JSON.stringify({ components: {} }));
+		await expect(resolveComponentDocgen(stub, undefined, provider)).rejects.toThrow(
+			ManifestGetError,
+		);
 	});
 });

--- a/packages/mcp/src/utils/get-manifest.ts
+++ b/packages/mcp/src/utils/get-manifest.ts
@@ -213,7 +213,10 @@ export function parseDocgenRef(ref: string): { path: string; pointer: string[] }
 	// Directory of the component manifest (e.g. "manifests/"), used as the base for
 	// resolving the (possibly `../`-prefixed) relative file path.
 	const manifestDir = COMPONENT_MANIFEST_PATH.replace(/^\.\//, '').replace(/[^/]+$/, '');
-	const resolved = new URL(filePath, `https://localhost/${manifestDir}`).pathname.replace(/^\//, '');
+	const resolved = new URL(filePath, `https://localhost/${manifestDir}`).pathname.replace(
+		/^\//,
+		'',
+	);
 
 	const pointer = hash
 		.split('/')

--- a/packages/mcp/src/utils/get-manifest.ts
+++ b/packages/mcp/src/utils/get-manifest.ts
@@ -1,4 +1,5 @@
 import {
+	ComponentManifest,
 	ComponentManifestMap,
 	DocsManifestMap,
 	type AllManifests,
@@ -9,6 +10,12 @@ import * as v from 'valibot';
 import { formatRequiresOwnMcpNotice, getSourceMcpEndpoint } from './requires-own-mcp.ts';
 
 type SourceWithUrl = Source & { url: string };
+
+type ManifestProvider = (
+	request: Request | undefined,
+	path: string,
+	source?: Source,
+) => Promise<string>;
 
 /**
  * The paths to the manifest files relative to the Storybook build
@@ -189,6 +196,85 @@ export async function getManifests(
 	});
 
 	return { componentManifest, docsManifest };
+}
+
+/**
+ * Resolves a docgen `$ref` into the provider path of the referenced file and the
+ * JSON-pointer segments into it.
+ *
+ * The `$ref` file path is relative to the component manifest's location, e.g.
+ * `"../services/core/docgen/button.json#/components/button"` from
+ * `./manifests/components.json` resolves to `./services/core/docgen/button.json`
+ * with pointer `["components", "button"]`.
+ */
+export function parseDocgenRef(ref: string): { path: string; pointer: string[] } {
+	const [filePath = '', hash = ''] = ref.split('#');
+
+	// Directory of the component manifest (e.g. "manifests/"), used as the base for
+	// resolving the (possibly `../`-prefixed) relative file path.
+	const manifestDir = COMPONENT_MANIFEST_PATH.replace(/^\.\//, '').replace(/[^/]+$/, '');
+	const resolved = new URL(filePath, `https://localhost/${manifestDir}`).pathname.replace(/^\//, '');
+
+	const pointer = hash
+		.split('/')
+		.filter(Boolean)
+		.map((segment) => segment.replace(/~1/g, '/').replace(/~0/g, '~'));
+
+	return { path: `./${resolved}`, pointer };
+}
+
+/**
+ * Resolves a stub component (externalized-docgen manifest format) into a full
+ * component manifest by fetching the referenced docgen file and reading the
+ * pointed-to entry. Components without a `docgen.$ref` are returned unchanged.
+ */
+export async function resolveComponentDocgen(
+	component: ComponentManifest,
+	request?: Request,
+	manifestProvider?: ManifestProvider,
+	source?: Source,
+): Promise<ComponentManifest> {
+	const ref = component.docgen?.$ref;
+	if (!ref) {
+		return component;
+	}
+
+	const { path, pointer } = parseDocgenRef(ref);
+	const provider = manifestProvider ?? defaultManifestProvider;
+	const jsonString = await provider(request, path, source);
+
+	let target: unknown;
+	try {
+		target = JSON.parse(jsonString);
+	} catch (error) {
+		throw new ManifestGetError(
+			`Failed to parse externalized docgen referenced by "${ref}"`,
+			path,
+			error instanceof Error ? error : undefined,
+		);
+	}
+
+	for (const key of pointer) {
+		if (target && typeof target === 'object' && key in (target as Record<string, unknown>)) {
+			target = (target as Record<string, unknown>)[key];
+		} else {
+			throw new ManifestGetError(
+				`Docgen reference "${ref}" could not be resolved: missing "${key}".`,
+				path,
+			);
+		}
+	}
+
+	const resolved = parseManifest({
+		jsonString: JSON.stringify(target),
+		schema: ComponentManifest,
+		name: 'component docgen',
+		url: path,
+	});
+
+	// Stub fields (id/name/description) are authoritative for identity; the resolved
+	// entry supplies path/stories/docgen data.
+	return { ...component, ...resolved };
 }
 
 /**


### PR DESCRIPTION
Newer Storybooks emit a components.json of lightweight stubs that carry a `docgen.$ref` pointer (with full component data in a referenced file) instead of inline path/docgen data. Resolve that reference in get-documentation and get-documentation-for-story before formatting, and make `path` and the top-level manifest `v` field optional. Restores multi-source/composition docs against Storybooks using the new manifest format.