### PR TITLE
feat(mcp-proxy): proxy to most recent SB instance

### DIFF
--- a/packages/mcp-proxy/src/tools/proxy-tool.ts
+++ b/packages/mcp-proxy/src/tools/proxy-tool.ts
@@ -51,7 +51,7 @@ const CwdField = {
 			v.minValue(1),
 			v.maxValue(65535),
 			v.description(
-				'Optional. The port the target Storybook is running on. Supply it to address one specific instance when several share the same `cwd`, or when an ADE (e.g. Claude Desktop) launched Storybook on a port it knows. When set, the instance must match BOTH `cwd` and this port; omit it to route by `cwd` alone.',
+				'Optional. The port the target Storybook is running on. Supply it to address one specific instance when several share the same `cwd`, or when an ADE (e.g. Claude Desktop) launched Storybook on a port it knows. When set, the instance must match BOTH `cwd` and this port; omit it to route by `cwd` alone — when several instances share that `cwd`, the most recently started one is used.',
 			),
 		),
 	),

--- a/packages/mcp-proxy/src/utils/resolve-instance.test.ts
+++ b/packages/mcp-proxy/src/utils/resolve-instance.test.ts
@@ -75,7 +75,7 @@ describe('resolveInstance', () => {
 		}
 	});
 
-	it('returns the lowest-pid ready instance plus all matches when 2+ records share the same exact cwd', () => {
+	it('tie-breaks on lowest pid when 2+ records share the cwd and none carry a startedAt', () => {
 		const a = record('/Users/x/projects/foo', 'ready', { pid: 200 });
 		const b = record('/Users/x/projects/foo', 'ready', { pid: 100 });
 		const result = resolveInstance([a, b], '/Users/x/projects/foo');
@@ -83,6 +83,68 @@ describe('resolveInstance', () => {
 		if (result.kind === 'instance') {
 			expect(result.record).toBe(b);
 			expect(result.matches).toEqual([b, a]);
+		}
+	});
+
+	it('picks the most recently started ready instance when 2+ records share the cwd', () => {
+		const older = record('/Users/x/projects/foo', 'ready', {
+			pid: 100,
+			startedAt: '2026-06-09T10:00:00.000Z',
+		});
+		const newer = record('/Users/x/projects/foo', 'ready', {
+			pid: 200,
+			startedAt: '2026-06-09T11:00:00.000Z',
+		});
+		const result = resolveInstance([older, newer], '/Users/x/projects/foo');
+		expect(result.kind).toBe('instance');
+		if (result.kind === 'instance') {
+			expect(result.record).toBe(newer);
+			expect(result.matches).toEqual([newer, older]);
+		}
+	});
+
+	it('treats a record without startedAt as older than one with a startedAt', () => {
+		const noStamp = record('/Users/x/projects/foo', 'ready', { pid: 100 });
+		const stamped = record('/Users/x/projects/foo', 'ready', {
+			pid: 200,
+			startedAt: '2026-06-09T11:00:00.000Z',
+		});
+		const result = resolveInstance([noStamp, stamped], '/Users/x/projects/foo');
+		expect(result.kind).toBe('instance');
+		if (result.kind === 'instance') {
+			expect(result.record).toBe(stamped);
+		}
+	});
+
+	it('prefers a ready record over a more recently started non-ready one', () => {
+		const ready = record('/Users/x/projects/foo', 'ready', {
+			pid: 100,
+			startedAt: '2026-06-09T10:00:00.000Z',
+		});
+		const newerStarting = record('/Users/x/projects/foo', 'starting', {
+			pid: 200,
+			startedAt: '2026-06-09T11:00:00.000Z',
+		});
+		const result = resolveInstance([ready, newerStarting], '/Users/x/projects/foo');
+		expect(result.kind).toBe('instance');
+		if (result.kind === 'instance') {
+			expect(result.record).toBe(ready);
+		}
+	});
+
+	it('dispatches the most recently started instance status when none are ready', () => {
+		const olderError = record('/Users/x/projects/foo', 'error', {
+			pid: 100,
+			startedAt: '2026-06-09T10:00:00.000Z',
+		});
+		const newerStarting = record('/Users/x/projects/foo', 'starting', {
+			pid: 200,
+			startedAt: '2026-06-09T11:00:00.000Z',
+		});
+		const result = resolveInstance([olderError, newerStarting], '/Users/x/projects/foo');
+		expect(result.kind).toBe('intercept');
+		if (result.kind === 'intercept') {
+			expect(result.reason).toBe('mcp-starting');
 		}
 	});
 

--- a/packages/mcp-proxy/src/utils/resolve-instance.ts
+++ b/packages/mcp-proxy/src/utils/resolve-instance.ts
@@ -117,10 +117,7 @@ function startedAtMs(r: StorybookInstanceRecordV1): number {
  * Sort comparator: most recently started first, tie-breaking on lowest pid so
  * ordering stays deterministic when timestamps are equal or missing.
  */
-function byMostRecentlyStarted(
-	a: StorybookInstanceRecordV1,
-	b: StorybookInstanceRecordV1,
-): number {
+function byMostRecentlyStarted(a: StorybookInstanceRecordV1, b: StorybookInstanceRecordV1): number {
 	const ta = startedAtMs(a);
 	const tb = startedAtMs(b);
 	if (ta !== tb) return tb > ta ? 1 : -1;

--- a/packages/mcp-proxy/src/utils/resolve-instance.ts
+++ b/packages/mcp-proxy/src/utils/resolve-instance.ts
@@ -34,9 +34,12 @@ export type ResolveResult =
  *   - error          → mcp-error intercept
  *
  * Zero matches → no-instance intercept (callers may surface running cwds).
- * 2+ matches at the same cwd → pick a deterministic instance (lowest pid among
- * `ready` records, else lowest pid overall). All matches are returned (sorted by
- * pid) as `matches` so callers can warn the agent without blocking the call.
+ * 2+ matches at the same cwd → pick the most recently started instance (latest
+ * `startedAt` among `ready` records, else latest overall), on the assumption
+ * that the freshest instance is the one the agent just started. Records without
+ * a `startedAt` tie-break on lowest pid for determinism. All matches are
+ * returned (most-recent first) as `matches` so callers can warn the agent
+ * without blocking the call.
  */
 export function resolveInstance(
 	records: StorybookInstanceRecordV1[],
@@ -66,7 +69,7 @@ export function resolveInstance(
 		};
 	}
 
-	const sortedMatches = [...matches].sort((a, b) => a.pid - b.pid);
+	const sortedMatches = [...matches].sort(byMostRecentlyStarted);
 	const selected = sortedMatches.find((r) => r.mcp.status === 'ready') ?? sortedMatches[0]!;
 
 	switch (selected.mcp.status) {
@@ -98,4 +101,28 @@ export function resolveInstance(
 				matches: sortedMatches,
 			};
 	}
+}
+
+/**
+ * `startedAt` as epoch millis, or `-Infinity` when absent/unparseable so such
+ * records sort as the oldest (and fall through to the pid tie-break).
+ */
+function startedAtMs(r: StorybookInstanceRecordV1): number {
+	if (!r.startedAt) return Number.NEGATIVE_INFINITY;
+	const t = Date.parse(r.startedAt);
+	return Number.isNaN(t) ? Number.NEGATIVE_INFINITY : t;
+}
+
+/**
+ * Sort comparator: most recently started first, tie-breaking on lowest pid so
+ * ordering stays deterministic when timestamps are equal or missing.
+ */
+function byMostRecentlyStarted(
+	a: StorybookInstanceRecordV1,
+	b: StorybookInstanceRecordV1,
+): number {
+	const ta = startedAtMs(a);
+	const tb = startedAtMs(b);
+	if (ta !== tb) return tb > ta ? 1 : -1;
+	return a.pid - b.pid;
 }


### PR DESCRIPTION
If port is not provided to a proxied tool call, we proxy the call to the most recent sb instance