### PR TITLE
feat(mcp): duplicate server instruction into tool

### DIFF
--- a/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
+++ b/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
@@ -100,10 +100,23 @@ describe('MCP Endpoint E2E Tests', () => {
 
 			expect(response.result).toHaveProperty('tools');
 			// Dev, docs, and test tools should be present
-			expect(response.result.tools).toHaveLength(8);
+			expect(response.result.tools).toHaveLength(9);
 
 			expect(response.result.tools).toMatchInlineSnapshot(`
 				[
+				  {
+				    "description": "Get the recommended Storybook workflow: which Storybook MCP tools to call, when, and in what order.
+
+				Call this tool at the start of a session, or before doing any work that touches UI components or Storybook, to learn the workflows this server expects you to follow (developing UI, running story tests, looking up component documentation — depending on which toolsets are enabled).
+
+				This returns the high-level workflow (which tools to call when), not story-writing guidance — the workflow itself directs you to other tools such as get-storybook-story-instructions for that.",
+				    "inputSchema": {
+				      "properties": {},
+				      "type": "object",
+				    },
+				    "name": "get-storybook-workflow",
+				    "title": "Storybook Workflow",
+				  },
 				  {
 				    "_meta": {
 				      "ui": {
@@ -1015,6 +1028,7 @@ describe('MCP Endpoint E2E Tests', () => {
 
 			expect(toolNames).toMatchInlineSnapshot(`
 				[
+				  "get-storybook-workflow",
 				  "preview-stories",
 				  "get-storybook-story-instructions",
 				  "get-changed-stories",
@@ -1038,6 +1052,7 @@ describe('MCP Endpoint E2E Tests', () => {
 
 			expect(toolNames).toMatchInlineSnapshot(`
 				[
+				  "get-storybook-workflow",
 				  "list-all-documentation",
 				  "get-documentation",
 				  "get-documentation-for-story",

--- a/packages/addon-mcp/src/instructions/get-live-server-instructions.ts
+++ b/packages/addon-mcp/src/instructions/get-live-server-instructions.ts
@@ -1,0 +1,24 @@
+import type { McpServer } from 'tmcp';
+import type { AddonContext } from '../types.ts';
+import type { ToolAvailability } from '../utils/get-tool-availability.ts';
+import { buildServerInstructions } from './build-server-instructions.ts';
+
+/**
+ * Computes the server's workflow instructions for the live request, combining the
+ * per-request toolset state (from the addon context) with the startup-time tool
+ * availability. Shared by the `instructions` field on `initialize` and the
+ * `get-storybook-workflow` tool so the two access paths can't drift.
+ */
+export function getLiveServerInstructions(
+	server: McpServer<any, AddonContext>,
+	availability: ToolAvailability,
+): string {
+	return buildServerInstructions({
+		devEnabled: server?.ctx.custom?.toolsets?.dev ?? true,
+		testEnabled: (server?.ctx.custom?.toolsets?.test ?? true) && availability.testSupported,
+		docsEnabled: (server?.ctx.custom?.toolsets?.docs ?? true) && availability.docsEnabled,
+		changeDetectionEnabled: availability.changeDetectionEnabled,
+		moduleGraphSupported: availability.moduleGraphSupported,
+		reviewEnabled: availability.reviewEnabled,
+	});
+}

--- a/packages/addon-mcp/src/mcp-handler.ts
+++ b/packages/addon-mcp/src/mcp-handler.ts
@@ -23,7 +23,8 @@ import { getToolAvailability } from './utils/get-tool-availability.ts';
 import { addRunStoryTestsTool } from './tools/run-story-tests.ts';
 import { estimateTokens } from './utils/estimate-tokens.ts';
 import type { CompositionAuth } from './auth/index.ts';
-import { buildServerInstructions } from './instructions/build-server-instructions.ts';
+import { getLiveServerInstructions } from './instructions/get-live-server-instructions.ts';
+import { addGetStorybookWorkflowTool } from './tools/get-storybook-workflow.ts';
 import { DEFAULT_MCP_ENDPOINT } from './constants.ts';
 
 let transport: HttpTransport<AddonContext> | undefined;
@@ -50,14 +51,7 @@ const initializeMCPServer = async (options: Options, multiSource?: boolean) => {
 	const serverOptions = {
 		adapter: new ValibotJsonSchemaAdapter(),
 		get instructions() {
-			return buildServerInstructions({
-				devEnabled: server?.ctx.custom?.toolsets?.dev ?? true,
-				testEnabled: (server?.ctx.custom?.toolsets?.test ?? true) && availability.testSupported,
-				docsEnabled: (server?.ctx.custom?.toolsets?.docs ?? true) && availability.docsEnabled,
-				changeDetectionEnabled: availability.changeDetectionEnabled,
-				moduleGraphSupported: availability.moduleGraphSupported,
-				reviewEnabled: availability.reviewEnabled,
-			});
+			return getLiveServerInstructions(server, availability);
 		},
 		capabilities: {
 			tools: { listChanged: true },
@@ -79,6 +73,10 @@ const initializeMCPServer = async (options: Options, multiSource?: boolean) => {
 			await collectTelemetry({ event: 'session:initialized', server });
 		});
 	}
+
+	// Available regardless of toolset configuration — exposes the same workflow
+	// instructions as the `initialize` result for clients that ignore that field.
+	await addGetStorybookWorkflowTool(server, availability);
 
 	// Register dev addon tools
 	await addPreviewStoriesTool(server);

--- a/packages/addon-mcp/src/template.html
+++ b/packages/addon-mcp/src/template.html
@@ -199,6 +199,16 @@
 
 				<div class="toolset">
 					<div class="toolset-header">
+						<span>always available</span>
+						<span class="toolset-status enabled">enabled</span>
+					</div>
+					<ul class="toolset-tools">
+						<li><code>get-storybook-workflow</code></li>
+					</ul>
+				</div>
+
+				<div class="toolset">
+					<div class="toolset-header">
 						<span>dev</span>
 						<span class="toolset-status {{DEV_STATUS}}">{{DEV_STATUS}}</span>
 					</div>

--- a/packages/addon-mcp/src/tools/get-storybook-workflow.test.ts
+++ b/packages/addon-mcp/src/tools/get-storybook-workflow.test.ts
@@ -137,7 +137,13 @@ describe('getStorybookWorkflowTool', () => {
 	});
 
 	it('should explain why no workflows are available when everything is disabled', async () => {
-		await setupServer({ ...fullAvailability, testSupported: false, docsEnabled: false });
+		// feature flag on but no manifests found → docsEnabled is false
+		await setupServer({
+			...fullAvailability,
+			testSupported: false,
+			docsEnabled: false,
+			docsHasManifests: false,
+		});
 
 		const text = await callTool({ toolsets: { dev: false, docs: true, test: true } });
 
@@ -145,6 +151,21 @@ describe('getStorybookWorkflowTool', () => {
 		expect(text).toContain('the `dev` toolset is disabled');
 		expect(text).toContain('`@storybook/addon-vitest` is not installed');
 		expect(text).toContain('no component manifest is available');
+	});
+
+	it('should explain when the component manifest feature flag is off', async () => {
+		await setupServer({
+			...fullAvailability,
+			testSupported: false,
+			docsEnabled: false,
+			docsHasManifests: false,
+			docsFeatureEnabled: false,
+		});
+
+		const text = await callTool({ toolsets: { dev: false, docs: true, test: true } });
+
+		expect(text).toContain('the component manifest feature is not enabled');
+		expect(text).not.toContain('no component manifest is available');
 	});
 
 	it('should explain disabled toolsets in the empty case', async () => {

--- a/packages/addon-mcp/src/tools/get-storybook-workflow.test.ts
+++ b/packages/addon-mcp/src/tools/get-storybook-workflow.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { McpServer } from 'tmcp';
+import { ValibotJsonSchemaAdapter } from '@tmcp/adapter-valibot';
+import { addGetStorybookWorkflowTool } from './get-storybook-workflow.ts';
+import type { AddonContext } from '../types.ts';
+import type { ToolAvailability } from '../utils/get-tool-availability.ts';
+import { GET_STORYBOOK_WORKFLOW_TOOL_NAME } from './tool-names.ts';
+
+const fullAvailability: ToolAvailability = {
+	moduleGraphSupported: true,
+	changeDetectionEnabled: true,
+	reviewEnabled: true,
+	docsEnabled: true,
+	docsHasManifests: true,
+	docsFeatureEnabled: true,
+	testSupported: true,
+	a11yEnabled: false,
+};
+
+describe('getStorybookWorkflowTool', () => {
+	let server: McpServer<any, AddonContext>;
+
+	async function setupServer(availability: ToolAvailability) {
+		server = new McpServer(
+			{
+				name: 'test-server',
+				version: '1.0.0',
+				description: 'Test server for get-storybook-workflow tool',
+			},
+			{
+				adapter: new ValibotJsonSchemaAdapter(),
+				capabilities: {
+					tools: { listChanged: true },
+				},
+			},
+		).withContext<AddonContext>();
+
+		await server.receive(
+			{
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'initialize',
+				params: {
+					protocolVersion: '2025-06-18',
+					capabilities: {},
+					clientInfo: { name: 'test', version: '1.0.0' },
+				},
+			},
+			{
+				sessionId: 'test-session',
+			},
+		);
+
+		await addGetStorybookWorkflowTool(server, availability);
+	}
+
+	async function callTool(context: Partial<AddonContext>) {
+		const response = await server.receive(
+			{
+				jsonrpc: '2.0' as const,
+				id: 2,
+				method: 'tools/call',
+				params: {
+					name: GET_STORYBOOK_WORKFLOW_TOOL_NAME,
+					arguments: {},
+				},
+			},
+			{
+				sessionId: 'test-session',
+				custom: {
+					origin: 'http://localhost:6006',
+					disableTelemetry: true,
+					...context,
+				} as AddonContext,
+			},
+		);
+		return response.result?.content[0].text as string;
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should be listed regardless of toolset configuration', async () => {
+		await setupServer(fullAvailability);
+
+		const response = await server.receive(
+			{
+				jsonrpc: '2.0' as const,
+				id: 3,
+				method: 'tools/list',
+				params: {},
+			},
+			{
+				sessionId: 'test-session',
+				custom: {
+					origin: 'http://localhost:6006',
+					disableTelemetry: true,
+					toolsets: { dev: false, docs: false, test: false },
+				} as AddonContext,
+			},
+		);
+
+		const tools = response.result?.tools ?? [];
+		const tool = tools.find((t: any) => t.name === GET_STORYBOOK_WORKFLOW_TOOL_NAME);
+		expect(tool).toBeDefined();
+		expect(tool.description).toContain('Storybook MCP tools to call');
+	});
+
+	it('should return all workflow sections when everything is enabled', async () => {
+		await setupServer(fullAvailability);
+
+		const text = await callTool({ toolsets: { dev: true, docs: true, test: true } });
+
+		expect(text).toContain('Follow these workflows when working with UI and/or Storybook.');
+		expect(text).toContain('get-changed-stories');
+		expect(text).toContain('preview-stories');
+		expect(text).toContain('run-story-tests');
+	});
+
+	it('should omit sections for disabled toolsets', async () => {
+		await setupServer(fullAvailability);
+
+		const text = await callTool({ toolsets: { dev: true, docs: false, test: false } });
+
+		expect(text).toContain('preview-stories');
+		expect(text).not.toContain('run-story-tests');
+	});
+
+	it('should omit the test section when addon-vitest is unavailable', async () => {
+		await setupServer({ ...fullAvailability, testSupported: false });
+
+		const text = await callTool({ toolsets: { dev: true, docs: true, test: true } });
+
+		expect(text).toContain('preview-stories');
+		expect(text).not.toContain('run-story-tests');
+	});
+
+	it('should explain why no workflows are available when everything is disabled', async () => {
+		await setupServer({ ...fullAvailability, testSupported: false, docsEnabled: false });
+
+		const text = await callTool({ toolsets: { dev: false, docs: true, test: true } });
+
+		expect(text).toContain('No Storybook workflows are currently available');
+		expect(text).toContain('the `dev` toolset is disabled');
+		expect(text).toContain('`@storybook/addon-vitest` is not installed');
+		expect(text).toContain('no component manifest is available');
+	});
+
+	it('should explain disabled toolsets in the empty case', async () => {
+		await setupServer(fullAvailability);
+
+		const text = await callTool({ toolsets: { dev: false, docs: false, test: false } });
+
+		expect(text).toContain('No Storybook workflows are currently available');
+		expect(text).toContain('the `dev` toolset is disabled');
+		expect(text).toContain('the `test` toolset is disabled');
+		expect(text).toContain('the `docs` toolset is disabled');
+	});
+
+	it('should collect telemetry when enabled', async () => {
+		const { telemetry } = await import('storybook/internal/telemetry');
+
+		await setupServer(fullAvailability);
+		await callTool({
+			disableTelemetry: false,
+			toolsets: { dev: true, docs: true, test: true },
+		});
+
+		expect(telemetry).toHaveBeenCalledWith(
+			'addon-mcp',
+			expect.objectContaining({
+				event: 'tool:getStorybookWorkflow',
+				mcpSessionId: 'test-session',
+			}),
+		);
+	});
+});

--- a/packages/addon-mcp/src/tools/get-storybook-workflow.ts
+++ b/packages/addon-mcp/src/tools/get-storybook-workflow.ts
@@ -72,7 +72,11 @@ function buildNoWorkflowsMessage(
 	if (!(toolsets?.docs ?? true)) {
 		reasons.push('the `docs` toolset is disabled');
 	} else if (!availability.docsEnabled) {
-		reasons.push('no component manifest is available (disables the `docs` workflow)');
+		reasons.push(
+			availability.docsFeatureEnabled
+				? 'no component manifest is available (disables the `docs` workflow)'
+				: 'the component manifest feature is not enabled (disables the `docs` workflow)',
+		);
 	}
 
 	return `No Storybook workflows are currently available because ${reasons.join(', and ')}. Enable the relevant toolsets or features to get workflow instructions.`;

--- a/packages/addon-mcp/src/tools/get-storybook-workflow.ts
+++ b/packages/addon-mcp/src/tools/get-storybook-workflow.ts
@@ -1,0 +1,79 @@
+import type { McpServer } from 'tmcp';
+import type { AddonContext } from '../types.ts';
+import type { ToolAvailability } from '../utils/get-tool-availability.ts';
+import { collectTelemetry } from '../telemetry.ts';
+import { errorToMCPContent } from '../utils/errors.ts';
+import { getLiveServerInstructions } from '../instructions/get-live-server-instructions.ts';
+import { GET_STORYBOOK_WORKFLOW_TOOL_NAME } from './tool-names.ts';
+
+export async function addGetStorybookWorkflowTool(
+	server: McpServer<any, AddonContext>,
+	availability: ToolAvailability,
+) {
+	server.tool(
+		{
+			name: GET_STORYBOOK_WORKFLOW_TOOL_NAME,
+			title: 'Storybook Workflow',
+			description: `Get the recommended Storybook workflow: which Storybook MCP tools to call, when, and in what order.
+
+Call this tool at the start of a session, or before doing any work that touches UI components or Storybook, to learn the workflows this server expects you to follow (developing UI, running story tests, looking up component documentation — depending on which toolsets are enabled).
+
+This returns the high-level workflow (which tools to call when), not story-writing guidance — the workflow itself directs you to other tools such as get-storybook-story-instructions for that.`,
+		},
+		async () => {
+			try {
+				const { disableTelemetry } = server.ctx.custom ?? {};
+
+				if (!disableTelemetry) {
+					await collectTelemetry({
+						event: 'tool:getStorybookWorkflow',
+						server,
+					});
+				}
+
+				const instructions = getLiveServerInstructions(server, availability);
+
+				if (!instructions) {
+					return {
+						content: [
+							{
+								type: 'text' as const,
+								text: buildNoWorkflowsMessage(server, availability),
+							},
+						],
+					};
+				}
+
+				return {
+					content: [{ type: 'text' as const, text: instructions }],
+				};
+			} catch (error) {
+				return errorToMCPContent(error);
+			}
+		},
+	);
+}
+
+function buildNoWorkflowsMessage(
+	server: McpServer<any, AddonContext>,
+	availability: ToolAvailability,
+): string {
+	const toolsets = server.ctx.custom?.toolsets;
+	const reasons: string[] = [];
+
+	if (!(toolsets?.dev ?? true)) {
+		reasons.push('the `dev` toolset is disabled');
+	}
+	if (!(toolsets?.test ?? true)) {
+		reasons.push('the `test` toolset is disabled');
+	} else if (!availability.testSupported) {
+		reasons.push('`@storybook/addon-vitest` is not installed (disables the `test` workflow)');
+	}
+	if (!(toolsets?.docs ?? true)) {
+		reasons.push('the `docs` toolset is disabled');
+	} else if (!availability.docsEnabled) {
+		reasons.push('no component manifest is available (disables the `docs` workflow)');
+	}
+
+	return `No Storybook workflows are currently available because ${reasons.join(', and ')}. Enable the relevant toolsets or features to get workflow instructions.`;
+}

--- a/packages/addon-mcp/src/tools/tool-names.ts
+++ b/packages/addon-mcp/src/tools/tool-names.ts
@@ -8,3 +8,4 @@ export const GET_STORIES_BY_COMPONENT_TOOL_NAME = 'get-stories-by-component';
 export const GET_UI_BUILDING_INSTRUCTIONS_TOOL_NAME = 'get-storybook-story-instructions';
 export const RUN_STORY_TESTS_TOOL_NAME = 'run-story-tests';
 export const DISPLAY_REVIEW_TOOL_NAME = 'display-review';
+export const GET_STORYBOOK_WORKFLOW_TOOL_NAME = 'get-storybook-workflow';


### PR DESCRIPTION
Since we moved to CLI commands, Agents are not able to discover dev isntructions through CLI. Thus only get partial instructions (`get-storybook-story-insteructions`), causing it to not follow the full workflow with display review at the end of component changes 

This PR duplicates the server instructions into tools so the CLI ai -è-help can discover it and list it as a command to Agents 