### PR TITLE
feat: allow disabling SB installation step at user level

### DIFF
--- a/packages/claude-plugin/skills/stories/SKILL.md
+++ b/packages/claude-plugin/skills/stories/SKILL.md
@@ -51,16 +51,26 @@ working around it. Treat any shortcut as a failure of this workflow.
 Installing and configuring Storybook is invasive, so it is the **user's choice**.
 Never set it up on your own initiative as a side effect of a component change.
 
-Before asking the user anything, check whether they have already declined:
+Before asking the user anything, check whether they have already declined. An
+opt-out can be saved at two scopes:
 
-1. **Read the saved decision** at `.claude/storybook-optout.json` (project-local).
-   If it exists with `{ "storybookOptOut": true }`, the user has ALREADY refused
-   Storybook for this project. Do NOT ask again — silently skip all story work,
-   finish the component change (if any), and move on.
-2. **If there is no opt-out file**, briefly tell the user the project has no
-   Storybook and ask whether they want to set it up (and write stories) for it.
-3. **If the user declines**, persist that choice so future invocations don't
-   re-ask: write `.claude/storybook-optout.json` with:
+- **User-level** (all projects): `~/.claude/storybook-optout.json`
+- **Project-level** (this project only): `.claude/storybook-optout.json`
+
+1. **Read the saved decision.** Check the user-level file first, then the
+   project-level file. If either exists with `{ "storybookOptOut": true }`, the
+   user has ALREADY refused Storybook at that scope. Do NOT ask again — silently
+   skip all story work, finish the component change (if any), and move on.
+2. **If there is no opt-out file at either scope**, briefly tell the user the
+   project has no Storybook and ask whether they want to set it up (and write
+   stories). Offer three choices:
+   - **Yes** — set it up for this project.
+   - **No, not for this project** — decline at the project level.
+   - **No, and don't ask me again in any project** — decline at the user level.
+3. **If the user declines**, persist that choice at the scope they chose so
+   future invocations don't re-ask. For a project-level decline, write
+   `.claude/storybook-optout.json`; for a user-level decline, write
+   `~/.claude/storybook-optout.json`. In both cases the contents are:
 
    ```json
    {
@@ -75,12 +85,13 @@ Before asking the user anything, check whether they have already declined:
 
 4. **If the user opts in**, set Storybook up via the setup skills
    (`storybook-init` / `storybook-setup`), then resume this workflow from
-   Step 1. If an opt-out file existed from a previous "no", delete it.
+   Step 1. If an opt-out file existed at either scope from a previous "no",
+   delete it.
 
 **Gate:** Do NOT install Storybook, scaffold `.storybook/`, add Storybook
 dependencies, or invoke the setup skills unless the user has explicitly opted in
-this time. A saved opt-out MUST be respected on every later invocation without
-re-prompting.
+this time. A saved opt-out at either scope MUST be respected on every later
+invocation without re-prompting.
 
 ## Step 1 — Open the preview browser up front
 

--- a/packages/claude-plugin/skills/stories/SKILL.md
+++ b/packages/claude-plugin/skills/stories/SKILL.md
@@ -51,46 +51,39 @@ working around it. Treat any shortcut as a failure of this workflow.
 Installing and configuring Storybook is invasive, so it is the **user's choice**.
 Never set it up on your own initiative as a side effect of a component change.
 
-Before asking the user anything, check whether they have already declined. An
-opt-out can be saved at two scopes:
+Before asking the user anything, check whether they have already declined. A
+decline can apply at two scopes:
 
-- **User-level** (all projects): `~/.claude/storybook-optout.json`
-- **Project-level** (this project only): `.claude/storybook-optout.json`
+- **User-level** — the user never wants Storybook set up in any project.
+- **Project-level** — the user only declined for this project.
 
-1. **Read the saved decision.** Check the user-level file first, then the
-   project-level file. If either exists with `{ "storybookOptOut": true }`, the
-   user has ALREADY refused Storybook at that scope. Do NOT ask again — silently
-   skip all story work, finish the component change (if any), and move on.
-2. **If there is no opt-out file at either scope**, briefly tell the user the
-   project has no Storybook and ask whether they want to set it up (and write
-   stories). Offer three choices:
+1. **Look for a previously recorded decline.** If you find one that applies here
+   (at either scope), the user has ALREADY refused Storybook. Do NOT ask again —
+   silently skip all story work, finish the component change (if any), and move
+   on.
+2. **If there is no recorded decline**, briefly tell the user the project has no
+   Storybook and ask whether they want to set it up (and write stories). Offer
+   three choices:
    - **Yes** — set it up for this project.
    - **No, not for this project** — decline at the project level.
    - **No, and don't ask me again in any project** — decline at the user level.
-3. **If the user declines**, persist that choice at the scope they chose so
-   future invocations don't re-ask. For a project-level decline, write
-   `.claude/storybook-optout.json`; for a user-level decline, write
-   `~/.claude/storybook-optout.json`. In both cases the contents are:
-
-   ```json
-   {
-   	"storybookOptOut": true,
-   	"reason": "<short paraphrase of what the user said>"
-   }
-   ```
-
-   Then finish the component change (if any) without any story work. If the
-   user explicitly asked for story work, STOP and report that Storybook is
-   required for it.
+3. **If the user declines**, remember that decision durably so future
+   invocations don't re-ask, recording the scope they chose (this project vs.
+   all projects) and a short paraphrase of their reason. Choose an appropriate
+   place and format yourself — but do NOT commit it to the project's version
+   control; if the only durable option lives inside the repo, keep it out of
+   commits (e.g. via `.gitignore`). Then finish the component change (if any)
+   without any story work. If the user explicitly asked for story work, STOP and
+   report that Storybook is required for it.
 
 4. **If the user opts in**, set Storybook up via the setup skills
    (`storybook-init` / `storybook-setup`), then resume this workflow from
-   Step 1. If an opt-out file existed at either scope from a previous "no",
-   delete it.
+   Step 1. If you recorded a decline at either scope from a previous "no", clear
+   it.
 
 **Gate:** Do NOT install Storybook, scaffold `.storybook/`, add Storybook
 dependencies, or invoke the setup skills unless the user has explicitly opted in
-this time. A saved opt-out at either scope MUST be respected on every later
+this time. A recorded decline at either scope MUST be respected on every later
 invocation without re-prompting.
 
 ## Step 1 — Open the preview browser up front

--- a/packages/codex-plugin/plugins/storybook/skills/stories/SKILL.md
+++ b/packages/codex-plugin/plugins/storybook/skills/stories/SKILL.md
@@ -39,16 +39,26 @@ working around it. Treat any shortcut as a failure of this workflow.
 Installing and configuring Storybook is invasive, so it is the **user's choice**.
 Never set it up on your own initiative as a side effect of a component change.
 
-Before asking the user anything, check whether they have already declined:
+Before asking the user anything, check whether they have already declined. An
+opt-out can be saved at two scopes:
 
-1. **Read the saved decision** at `.codex/storybook-optout.json` (project-local).
-   If it exists with `{ "storybookOptOut": true }`, the user has ALREADY refused
-   Storybook for this project. Do NOT ask again — silently skip all story work,
-   finish the component change (if any), and move on.
-2. **If there is no opt-out file**, briefly tell the user the project has no
-   Storybook and ask whether they want to set it up (and write stories) for it.
-3. **If the user declines**, persist that choice so future invocations don't
-   re-ask: write `.codex/storybook-optout.json` with:
+- **User-level** (all projects): `~/.codex/storybook-optout.json`
+- **Project-level** (this project only): `.codex/storybook-optout.json`
+
+1. **Read the saved decision.** Check the user-level file first, then the
+   project-level file. If either exists with `{ "storybookOptOut": true }`, the
+   user has ALREADY refused Storybook at that scope. Do NOT ask again — silently
+   skip all story work, finish the component change (if any), and move on.
+2. **If there is no opt-out file at either scope**, briefly tell the user the
+   project has no Storybook and ask whether they want to set it up (and write
+   stories). Offer three choices:
+   - **Yes** — set it up for this project.
+   - **No, not for this project** — decline at the project level.
+   - **No, and don't ask me again in any project** — decline at the user level.
+3. **If the user declines**, persist that choice at the scope they chose so
+   future invocations don't re-ask. For a project-level decline, write
+   `.codex/storybook-optout.json`; for a user-level decline, write
+   `~/.codex/storybook-optout.json`. In both cases the contents are:
 
    ```json
    {
@@ -63,12 +73,13 @@ Before asking the user anything, check whether they have already declined:
 
 4. **If the user opts in**, set Storybook up via the setup skills
    (`init` / `setup`), then resume this workflow from
-   Step 1. If an opt-out file existed from a previous "no", delete it.
+   Step 1. If an opt-out file existed at either scope from a previous "no",
+   delete it.
 
 **Gate:** Do NOT install Storybook, scaffold `.storybook/`, add Storybook
 dependencies, or invoke the setup skills unless the user has explicitly opted in
-this time. A saved opt-out MUST be respected on every later invocation without
-re-prompting.
+this time. A saved opt-out at either scope MUST be respected on every later
+invocation without re-prompting.
 
 ## Step 1 — Guarantee a running preview browser
 

--- a/packages/codex-plugin/plugins/storybook/skills/stories/SKILL.md
+++ b/packages/codex-plugin/plugins/storybook/skills/stories/SKILL.md
@@ -39,46 +39,39 @@ working around it. Treat any shortcut as a failure of this workflow.
 Installing and configuring Storybook is invasive, so it is the **user's choice**.
 Never set it up on your own initiative as a side effect of a component change.
 
-Before asking the user anything, check whether they have already declined. An
-opt-out can be saved at two scopes:
+Before asking the user anything, check whether they have already declined. A
+decline can apply at two scopes:
 
-- **User-level** (all projects): `~/.codex/storybook-optout.json`
-- **Project-level** (this project only): `.codex/storybook-optout.json`
+- **User-level** — the user never wants Storybook set up in any project.
+- **Project-level** — the user only declined for this project.
 
-1. **Read the saved decision.** Check the user-level file first, then the
-   project-level file. If either exists with `{ "storybookOptOut": true }`, the
-   user has ALREADY refused Storybook at that scope. Do NOT ask again — silently
-   skip all story work, finish the component change (if any), and move on.
-2. **If there is no opt-out file at either scope**, briefly tell the user the
-   project has no Storybook and ask whether they want to set it up (and write
-   stories). Offer three choices:
+1. **Look for a previously recorded decline.** If you find one that applies here
+   (at either scope), the user has ALREADY refused Storybook. Do NOT ask again —
+   silently skip all story work, finish the component change (if any), and move
+   on.
+2. **If there is no recorded decline**, briefly tell the user the project has no
+   Storybook and ask whether they want to set it up (and write stories). Offer
+   three choices:
    - **Yes** — set it up for this project.
    - **No, not for this project** — decline at the project level.
    - **No, and don't ask me again in any project** — decline at the user level.
-3. **If the user declines**, persist that choice at the scope they chose so
-   future invocations don't re-ask. For a project-level decline, write
-   `.codex/storybook-optout.json`; for a user-level decline, write
-   `~/.codex/storybook-optout.json`. In both cases the contents are:
-
-   ```json
-   {
-   	"storybookOptOut": true,
-   	"reason": "<short paraphrase of what the user said>"
-   }
-   ```
-
-   Then finish the component change (if any) without any story work. If the
-   user explicitly asked for story work, STOP and report that Storybook is
-   required for it.
+3. **If the user declines**, remember that decision durably so future
+   invocations don't re-ask, recording the scope they chose (this project vs.
+   all projects) and a short paraphrase of their reason. Choose an appropriate
+   place and format yourself — but do NOT commit it to the project's version
+   control; if the only durable option lives inside the repo, keep it out of
+   commits (e.g. via `.gitignore`). Then finish the component change (if any)
+   without any story work. If the user explicitly asked for story work, STOP and
+   report that Storybook is required for it.
 
 4. **If the user opts in**, set Storybook up via the setup skills
    (`init` / `setup`), then resume this workflow from
-   Step 1. If an opt-out file existed at either scope from a previous "no",
-   delete it.
+   Step 1. If you recorded a decline at either scope from a previous "no", clear
+   it.
 
 **Gate:** Do NOT install Storybook, scaffold `.storybook/`, add Storybook
 dependencies, or invoke the setup skills unless the user has explicitly opted in
-this time. A saved opt-out at either scope MUST be respected on every later
+this time. A recorded decline at either scope MUST be respected on every later
 invocation without re-prompting.
 
 ## Step 1 — Guarantee a running preview browser


### PR DESCRIPTION
Can be annoying to have Agents always as users if they want to install SB in a project. This allows to disable at user level so they never get prompted again