### PR TITLE
Addon MCP: Expose serverless Storybook AI metadata

### DIFF
--- a/.changeset/serverless-ai-metadata.md
+++ b/.changeset/serverless-ai-metadata.md
@@ -1,0 +1,6 @@
+---
+"@storybook/addon-mcp": minor
+"@storybook/mcp": minor
+---
+
+Expose serverless Storybook AI metadata from addon-mcp presets. The new preset returns MCP-shaped instructions and tool descriptors, plus a local `get-storybook-story-instructions` runner that shares the same builders as the live MCP server.

--- a/packages/addon-mcp/src/auth/get-refs-from-config.ts
+++ b/packages/addon-mcp/src/auth/get-refs-from-config.ts
@@ -13,13 +13,24 @@ export async function getRefsFromConfig(options: Options): Promise<ComposedRef[]
 			return [];
 		}
 
-		return Object.entries(refs as Record<string, { title?: string; url?: string }>)
-			.map(([key, value]) => ({
-				id: key,
-				title: value.title || key,
-				url: value.url,
-			}))
-			.filter((ref): ref is ComposedRef => !!ref.url);
+		return Object.entries(refs as Record<string, unknown>).flatMap(([key, value]) => {
+			if (!value || typeof value !== 'object') {
+				return [];
+			}
+
+			const { title, url } = value as { title?: unknown; url?: unknown };
+			if (typeof url !== 'string' || url.length === 0) {
+				return [];
+			}
+
+			return [
+				{
+					id: key,
+					title: typeof title === 'string' && title.length > 0 ? title : key,
+					url,
+				},
+			];
+		});
 	} catch {
 		return [];
 	}

--- a/packages/addon-mcp/src/auth/get-refs-from-config.ts
+++ b/packages/addon-mcp/src/auth/get-refs-from-config.ts
@@ -1,0 +1,26 @@
+import type { Options } from 'storybook/internal/types';
+import type { ComposedRef } from './composition-auth.ts';
+
+/**
+ * Get composed Storybook refs from Storybook config.
+ * See: https://storybook.js.org/docs/sharing/storybook-composition
+ */
+export async function getRefsFromConfig(options: Options): Promise<ComposedRef[]> {
+	try {
+		const refs = await options.presets.apply('refs', {});
+
+		if (!refs || typeof refs !== 'object') {
+			return [];
+		}
+
+		return Object.entries(refs as Record<string, { title?: string; url?: string }>)
+			.map(([key, value]) => ({
+				id: key,
+				title: value.title || key,
+				url: value.url,
+			}))
+			.filter((ref): ref is ComposedRef => !!ref.url);
+	} catch {
+		return [];
+	}
+}

--- a/packages/addon-mcp/src/auth/resolve-composition-sources.ts
+++ b/packages/addon-mcp/src/auth/resolve-composition-sources.ts
@@ -4,6 +4,8 @@ import * as v from 'valibot';
 import { CompositionAuth, type ComposedRef } from './composition-auth.ts';
 import { getRefsFromConfig } from './get-refs-from-config.ts';
 
+const MANIFEST_PROBE_TIMEOUT_MS = 3_000;
+
 export type ResolvedCompositionSources = {
 	refs: ComposedRef[];
 	compositionAuth: CompositionAuth;
@@ -60,10 +62,17 @@ export async function resolveServerlessCompositionSources(
 }
 
 async function hasServerlessComponentManifestSource(refUrl: string): Promise<boolean> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), MANIFEST_PROBE_TIMEOUT_MS);
+
 	try {
-		const response = await fetch(`${refUrl}/manifests/components.json`, {
-			headers: { Accept: 'application/json' },
-		});
+		const response = await fetch(
+			new URL('manifests/components.json', `${refUrl.replace(/\/$/, '')}/`),
+			{
+				headers: { Accept: 'application/json' },
+				signal: controller.signal,
+			},
+		);
 		if (response.status === 401 && hasOAuthResourceMetadataChallenge(response)) {
 			return true;
 		}
@@ -74,6 +83,8 @@ async function hasServerlessComponentManifestSource(refUrl: string): Promise<boo
 		return v.safeParse(v.pipe(v.string(), v.parseJson(), ComponentManifestMap), text).success;
 	} catch {
 		return false;
+	} finally {
+		clearTimeout(timeout);
 	}
 }
 

--- a/packages/addon-mcp/src/auth/resolve-composition-sources.ts
+++ b/packages/addon-mcp/src/auth/resolve-composition-sources.ts
@@ -1,0 +1,82 @@
+import { ComponentManifestMap, type Source } from '@storybook/mcp';
+import type { Options } from 'storybook/internal/types';
+import * as v from 'valibot';
+import { CompositionAuth, type ComposedRef } from './composition-auth.ts';
+import { getRefsFromConfig } from './get-refs-from-config.ts';
+
+export type ResolvedCompositionSources = {
+	refs: ComposedRef[];
+	compositionAuth: CompositionAuth;
+	sources: Source[] | undefined;
+	multiSource: boolean;
+};
+
+export async function resolveCompositionSources(
+	options: Options,
+): Promise<ResolvedCompositionSources> {
+	const refs = await getRefsFromConfig(options);
+	const compositionAuth = new CompositionAuth();
+
+	if (refs.length === 0) {
+		return { refs, compositionAuth, sources: undefined, multiSource: false };
+	}
+
+	await compositionAuth.initialize(refs);
+	const sources = compositionAuth.buildSources();
+
+	return {
+		refs,
+		compositionAuth,
+		sources,
+		multiSource: sources.some((source) => !!source.url),
+	};
+}
+
+export async function resolveServerlessCompositionSources(
+	options: Options,
+): Promise<Pick<ResolvedCompositionSources, 'refs' | 'sources' | 'multiSource'>> {
+	const refs = await getRefsFromConfig(options);
+	const refsWithManifests = await Promise.all(
+		refs.map(async (ref) =>
+			(await hasServerlessComponentManifestSource(ref.url)) ? ref : undefined,
+		),
+	);
+	const sources: Source[] = [
+		{ id: 'local', title: 'Local' },
+		...refsWithManifests
+			.filter((ref): ref is ComposedRef => !!ref)
+			.map((ref) => ({
+				id: ref.id,
+				title: ref.title,
+				url: ref.url,
+			})),
+	];
+
+	return {
+		refs,
+		sources,
+		multiSource: sources.some((source) => !!source.url),
+	};
+}
+
+async function hasServerlessComponentManifestSource(refUrl: string): Promise<boolean> {
+	try {
+		const response = await fetch(`${refUrl}/manifests/components.json`, {
+			headers: { Accept: 'application/json' },
+		});
+		if (response.status === 401 && hasOAuthResourceMetadataChallenge(response)) {
+			return true;
+		}
+		if (!response.ok) {
+			return false;
+		}
+		const text = await response.text();
+		return v.safeParse(v.pipe(v.string(), v.parseJson(), ComponentManifestMap), text).success;
+	} catch {
+		return false;
+	}
+}
+
+function hasOAuthResourceMetadataChallenge(response: Response): boolean {
+	return /resource_metadata="[^"]+"/.test(response.headers.get('WWW-Authenticate') ?? '');
+}

--- a/packages/addon-mcp/src/mcp-handler.test.ts
+++ b/packages/addon-mcp/src/mcp-handler.test.ts
@@ -521,7 +521,7 @@ describe('mcpServerHandler', () => {
 		expect(toolNames).toContain('get-documentation-for-story');
 	});
 
-	it('registers docs tools for composed refs with manifests when local manifests are unavailable', async () => {
+	it('registers docs tools for composed sources when local manifests are unavailable', async () => {
 		const mockOptions = createMockOptions({
 			port: 6012,
 			presets: {

--- a/packages/addon-mcp/src/mcp-handler.test.ts
+++ b/packages/addon-mcp/src/mcp-handler.test.ts
@@ -245,7 +245,11 @@ describe('mcpServerHandler', () => {
 	}
 
 	// Initializes the server then asks for `tools/list`, returning the registered tool names.
-	async function getRegisteredToolNames(mockOptions: any, port: number): Promise<string[]> {
+	async function getRegisteredToolNames(
+		mockOptions: any,
+		port: number,
+		handlerOptions: { sources?: any[] } = {},
+	): Promise<string[]> {
 		const host = `localhost:${port}`;
 		const addonOptions = { toolsets: { dev: true, docs: true } };
 
@@ -261,6 +265,7 @@ describe('mcpServerHandler', () => {
 			options: mockOptions,
 			addonOptions,
 			compositionAuth: new CompositionAuth(),
+			...handlerOptions,
 		});
 
 		const listReq = createMockIncomingMessage({
@@ -275,6 +280,7 @@ describe('mcpServerHandler', () => {
 			options: mockOptions,
 			addonOptions,
 			compositionAuth: new CompositionAuth(),
+			...handlerOptions,
 		});
 
 		const { body } = getResponseData();
@@ -510,6 +516,30 @@ describe('mcpServerHandler', () => {
 
 		// Verify component manifest tools are included
 		const toolNames = parsedResponse.result.tools.map((t: any) => t.name);
+		expect(toolNames).toContain('list-all-documentation');
+		expect(toolNames).toContain('get-documentation');
+		expect(toolNames).toContain('get-documentation-for-story');
+	});
+
+	it('registers docs tools for composed refs with manifests when local manifests are unavailable', async () => {
+		const mockOptions = createMockOptions({
+			port: 6012,
+			presets: {
+				apply: vi.fn(async (key: string, defaultValue?: any) => {
+					if (key === 'core') return { disableTelemetry: false };
+					if (key === 'features') return { componentsManifest: true };
+					return defaultValue;
+				}),
+			},
+		});
+
+		const toolNames = await getRegisteredToolNames(mockOptions, 6012, {
+			sources: [
+				{ id: 'local', title: 'Local' },
+				{ id: 'remote', title: 'Remote', url: 'https://example.com/storybook' },
+			],
+		});
+
 		expect(toolNames).toContain('list-all-documentation');
 		expect(toolNames).toContain('get-documentation');
 		expect(toolNames).toContain('get-documentation-for-story');

--- a/packages/addon-mcp/src/mcp-handler.ts
+++ b/packages/addon-mcp/src/mcp-handler.ts
@@ -2,17 +2,7 @@ import { McpServer } from 'tmcp';
 import { ValibotJsonSchemaAdapter } from '@tmcp/adapter-valibot';
 import { HttpTransport } from '@tmcp/transport-http';
 import pkgJson from '../package.json' with { type: 'json' };
-import { addPreviewStoriesTool } from './tools/preview-stories.ts';
-import { addGetChangedStoriesTool } from './tools/get-changed-stories.ts';
-import { addGetStoriesByComponentTool } from './tools/get-stories-by-component.ts';
-import { addDisplayReviewTool } from './tools/display-review.ts';
-import { addGetUIBuildingInstructionsTool } from './tools/get-storybook-story-instructions.ts';
-import {
-	addListAllDocumentationTool,
-	addGetDocumentationTool,
-	addGetStoryDocumentationTool,
-	type Source,
-} from '@storybook/mcp';
+import type { Source } from '@storybook/mcp';
 import type { Options } from 'storybook/internal/types';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { buffer } from 'node:stream/consumers';
@@ -20,11 +10,11 @@ import { collectTelemetry } from './telemetry.ts';
 import type { AddonContext, AddonOptionsOutput } from './types.ts';
 import { logger } from 'storybook/internal/node-logger';
 import { getToolAvailability } from './utils/get-tool-availability.ts';
-import { addRunStoryTestsTool } from './tools/run-story-tests.ts';
 import { estimateTokens } from './utils/estimate-tokens.ts';
 import type { CompositionAuth } from './auth/index.ts';
 import { buildServerInstructions } from './instructions/build-server-instructions.ts';
 import { DEFAULT_MCP_ENDPOINT } from './constants.ts';
+import { registerAddonMcpTools } from './tools/tool-registry.ts';
 
 let transport: HttpTransport<AddonContext> | undefined;
 let origin: string | undefined;
@@ -80,34 +70,7 @@ const initializeMCPServer = async (options: Options, multiSource?: boolean) => {
 		});
 	}
 
-	// Register dev addon tools
-	await addPreviewStoriesTool(server);
-	await addGetUIBuildingInstructionsTool(server);
-
-	if (availability.changeDetectionEnabled) {
-		await addGetChangedStoriesTool(server);
-	}
-
-	// get-stories-by-component only needs the module graph, not the status pipeline.
-	if (availability.moduleGraphSupported) {
-		await addGetStoriesByComponentTool(server);
-	}
-
-	if (availability.reviewEnabled) {
-		await addDisplayReviewTool(server);
-	}
-
-	// Register test addon tools
-	await addRunStoryTestsTool(server, { a11yEnabled });
-
-	// Only register the additional tools if the component manifest feature is enabled
-	if (availability.docsEnabled) {
-		logger.info('Experimental components manifest feature detected - registering component tools');
-		const contextAwareEnabled = () => server.ctx.custom?.toolsets?.docs ?? true;
-		await addListAllDocumentationTool(server, contextAwareEnabled);
-		await addGetDocumentationTool(server, contextAwareEnabled, { multiSource });
-		await addGetStoryDocumentationTool(server, contextAwareEnabled, { multiSource });
-	}
+	await registerAddonMcpTools(server, { availability, multiSource });
 
 	transport = new HttpTransport(server, { path: null });
 

--- a/packages/addon-mcp/src/mcp-handler.ts
+++ b/packages/addon-mcp/src/mcp-handler.ts
@@ -9,7 +9,10 @@ import { buffer } from 'node:stream/consumers';
 import { collectTelemetry } from './telemetry.ts';
 import type { AddonContext, AddonOptionsOutput } from './types.ts';
 import { logger } from 'storybook/internal/node-logger';
-import { getToolAvailability } from './utils/get-tool-availability.ts';
+import {
+	getEffectiveToolAvailability,
+	getToolAvailability,
+} from './utils/get-tool-availability.ts';
 import { estimateTokens } from './utils/estimate-tokens.ts';
 import type { CompositionAuth } from './auth/index.ts';
 import { buildServerInstructions } from './instructions/build-server-instructions.ts';
@@ -32,7 +35,8 @@ const initializeMCPServer = async (options: Options, multiSource?: boolean) => {
 	// Shares one source of truth with the browser landing page (see get-tool-availability.ts)
 	// so the registered tools and the page's enabled/disabled badges can't drift. Reuse the
 	// already-resolved `features` so it doesn't re-apply the preset and risk a different snapshot.
-	const availability = await getToolAvailability(options, { features });
+	const rawAvailability = await getToolAvailability(options, { features });
+	const availability = getEffectiveToolAvailability(rawAvailability, { multiSource });
 	a11yEnabled = availability.a11yEnabled;
 
 	let server: McpServer<any, AddonContext>;

--- a/packages/addon-mcp/src/preset.test.ts
+++ b/packages/addon-mcp/src/preset.test.ts
@@ -495,6 +495,54 @@ describe('experimental_devServer', () => {
 		);
 	});
 
+	it('does not show the local manifest debugger link when docs only come from composed refs', async () => {
+		const handlers: Record<string, any> = {};
+		mockApp.get = vi.fn((path: string, handler: any) => {
+			handlers[path] = handler;
+		});
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				text: () => Promise.resolve('{"v":1,"components":{}}'),
+			}),
+		);
+
+		const remoteDocsOptions = {
+			...mockOptions,
+			port: 6006,
+			presets: {
+				apply: vi.fn((key: string) => {
+					if (key === 'refs') {
+						return Promise.resolve({
+							remote: { title: 'Remote', url: 'https://example.com/storybook' },
+						});
+					}
+					if (key === 'features') {
+						return Promise.resolve({ componentsManifest: true });
+					}
+					return Promise.resolve(undefined);
+				}),
+			},
+		} as unknown as Options;
+
+		await (experimental_devServer as any)(mockApp, remoteDocsOptions);
+		const getMcpHandler = handlers['/mcp'];
+		expect(getMcpHandler).toBeDefined();
+
+		const mockRes = {
+			writeHead: vi.fn(),
+			end: vi.fn(),
+		} as any;
+
+		await getMcpHandler({ headers: { accept: 'text/html' } } as any, mockRes);
+
+		const html = mockRes.end.mock.calls[0][0];
+		expect(html).not.toContain('{{MANIFEST_DEBUGGER_LINK}}');
+		expect(html).not.toContain('/manifests/components.html');
+		expect(html).toContain('<span class="toolset-status enabled">enabled</span>');
+	});
+
 	it('should handle POST requests as MCP protocol', async () => {
 		await (experimental_devServer as any)(mockApp, mockOptions);
 

--- a/packages/addon-mcp/src/preset.ts
+++ b/packages/addon-mcp/src/preset.ts
@@ -105,6 +105,7 @@ export const experimental_devServer: PresetPropertyFn<
 	// Same gates the MCP server uses to register these tools, so the page can't
 	// claim a tool is available when it isn't (and vice versa).
 	const multiSource = sources?.some((source) => !!source.url) ?? false;
+	const rawAvailability = await getToolAvailability(options);
 	const {
 		moduleGraphSupported,
 		changeDetectionEnabled,
@@ -114,7 +115,7 @@ export const experimental_devServer: PresetPropertyFn<
 		docsFeatureEnabled,
 		testSupported,
 		a11yEnabled,
-	} = getEffectiveToolAvailability(await getToolAvailability(options), { multiSource });
+	} = getEffectiveToolAvailability(rawAvailability, { multiSource });
 
 	const isDevEnabled = addonOptions.toolsets?.dev ?? true;
 	const isDocsEnabled = docsEnabled && (addonOptions.toolsets?.docs ?? true);
@@ -201,7 +202,7 @@ export const experimental_devServer: PresetPropertyFn<
 			.replace('{{TEST_NOTICE}}', testNotice)
 			.replace(
 				'{{MANIFEST_DEBUGGER_LINK}}',
-				docsEnabled
+				rawAvailability.docsEnabled
 					? '<p>View the <a href="/manifests/components.html">component manifest debugger</a>.</p>'
 					: '',
 			)

--- a/packages/addon-mcp/src/preset.ts
+++ b/packages/addon-mcp/src/preset.ts
@@ -6,17 +6,16 @@ import { getToolAvailability } from './utils/get-tool-availability.ts';
 import htmlTemplate from './template.html';
 import path from 'node:path';
 import {
-	CompositionAuth,
 	STORYBOOK_MCP_PROXY_HEADER,
 	extractBearerToken,
 	isStorybookMcpProxyRequest as hasStorybookMcpProxyHeader,
-	type ComposedRef,
 	type ManifestProvider,
 } from './auth/index.ts';
+import { resolveCompositionSources } from './auth/resolve-composition-sources.ts';
 import { logger } from 'storybook/internal/node-logger';
-import type { Source } from '@storybook/mcp';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { DEFAULT_MCP_ENDPOINT } from './constants.ts';
+import { buildStorybookAiMetadata, type StorybookAiMetadata } from './storybook-ai-metadata.ts';
 
 const STORYBOOK_MCP_PROXY_HEADER_KEY = STORYBOOK_MCP_PROXY_HEADER.toLowerCase();
 
@@ -41,24 +40,16 @@ export const experimental_devServer: PresetPropertyFn<
 	const origin = `http://localhost:${options.port}`;
 	const endpoint = addonOptions.endpoint ?? DEFAULT_MCP_ENDPOINT;
 
-	// Get composed Storybook refs from config
-	const refs = await getRefsFromConfig(options);
-	const compositionAuth = new CompositionAuth();
-
-	// Build sources and manifest provider
-	let sources: Source[] | undefined;
+	const { refs, compositionAuth, sources } = await resolveCompositionSources(options);
 	let createManifestProvider: ((req: IncomingMessage) => ManifestProvider) | undefined;
 
 	if (refs.length > 0) {
-		logger.info(`Initializing composition with ${refs.length} remote Storybook(s)`);
-		await compositionAuth.initialize(refs);
+		logger.info(`Initialized composition with ${refs.length} remote Storybook(s)`);
 		if (compositionAuth.requiresAuth) {
 			logger.info(`Auth required for: ${compositionAuth.authUrls.join(', ')}`);
 		}
 
-		// Build sources array (local + refs)
-		sources = compositionAuth.buildSources();
-		logger.info(`Sources: ${sources.map((s) => s.id).join(', ')}`);
+		logger.info(`Sources: ${(sources ?? []).map((s) => s.id).join(', ')}`);
 
 		// Create manifest provider that handles multi-source
 		createManifestProvider = (req) =>
@@ -216,6 +207,13 @@ export const experimental_devServer: PresetPropertyFn<
 	return app;
 };
 
+export const experimental_storybookAi = async (
+	existingMetadata: StorybookAiMetadata | undefined,
+	options: Parameters<typeof buildStorybookAiMetadata>[0],
+): Promise<StorybookAiMetadata> => {
+	return buildStorybookAiMetadata(options, existingMetadata);
+};
+
 export const features: PresetPropertyFn<'features'> = async (existingFeatures) => {
 	return {
 		...existingFeatures,
@@ -227,30 +225,4 @@ function isStorybookMcpProxyHttpRequest(req: IncomingMessage): boolean {
 	const headerValue =
 		req.headers[STORYBOOK_MCP_PROXY_HEADER_KEY] ?? req.headers[STORYBOOK_MCP_PROXY_HEADER];
 	return hasStorybookMcpProxyHeader(headerValue);
-}
-
-/**
- * Get composed Storybook refs from Storybook config.
- * See: https://storybook.js.org/docs/sharing/storybook-composition
- */
-async function getRefsFromConfig(options: any): Promise<ComposedRef[]> {
-	try {
-		// Get refs from Storybook presets
-		const refs = await options.presets.apply('refs', {});
-
-		if (!refs || typeof refs !== 'object') {
-			return [];
-		}
-
-		// Convert refs object to array, using the config key as the stable ID
-		return Object.entries(refs)
-			.map(([key, value]: [string, any]) => ({
-				id: key,
-				title: value.title || key,
-				url: value.url,
-			}))
-			.filter((ref) => ref.url); // Only include refs with URLs
-	} catch {
-		return [];
-	}
 }

--- a/packages/addon-mcp/src/preset.ts
+++ b/packages/addon-mcp/src/preset.ts
@@ -2,7 +2,10 @@ import { mcpServerHandler } from './mcp-handler.ts';
 import type { PresetPropertyFn, StorybookConfigRaw } from 'storybook/internal/types';
 import { AddonOptions, type AddonOptionsInput } from './types.ts';
 import * as v from 'valibot';
-import { getToolAvailability } from './utils/get-tool-availability.ts';
+import {
+	getEffectiveToolAvailability,
+	getToolAvailability,
+} from './utils/get-tool-availability.ts';
 import htmlTemplate from './template.html';
 import path from 'node:path';
 import {
@@ -101,6 +104,7 @@ export const experimental_devServer: PresetPropertyFn<
 
 	// Same gates the MCP server uses to register these tools, so the page can't
 	// claim a tool is available when it isn't (and vice versa).
+	const multiSource = sources?.some((source) => !!source.url) ?? false;
 	const {
 		moduleGraphSupported,
 		changeDetectionEnabled,
@@ -110,7 +114,7 @@ export const experimental_devServer: PresetPropertyFn<
 		docsFeatureEnabled,
 		testSupported,
 		a11yEnabled,
-	} = await getToolAvailability(options);
+	} = getEffectiveToolAvailability(await getToolAvailability(options), { multiSource });
 
 	const isDevEnabled = addonOptions.toolsets?.dev ?? true;
 	const isDocsEnabled = docsEnabled && (addonOptions.toolsets?.docs ?? true);

--- a/packages/addon-mcp/src/storybook-ai-metadata.test.ts
+++ b/packages/addon-mcp/src/storybook-ai-metadata.test.ts
@@ -118,6 +118,23 @@ describe('buildStorybookAiMetadata', () => {
 		expect(metadata.localTools).toEqual({});
 	});
 
+	it('uses the shared effective availability rule for composed-source docs', () => {
+		const localOnlyAvailability = createAvailability({
+			docsEnabled: false,
+			docsHasManifests: false,
+			docsFeatureEnabled: false,
+		});
+
+		expect(getEffectiveToolAvailability(localOnlyAvailability)).toBe(localOnlyAvailability);
+		expect(
+			getEffectiveToolAvailability(localOnlyAvailability, { multiSource: true }),
+		).toMatchObject({
+			docsEnabled: true,
+			docsHasManifests: true,
+			docsFeatureEnabled: true,
+		});
+	});
+
 	it.each([
 		['dev disabled', { dev: false, docs: true, test: true }],
 		['docs disabled', { dev: true, docs: false, test: true }],

--- a/packages/addon-mcp/src/storybook-ai-metadata.test.ts
+++ b/packages/addon-mcp/src/storybook-ai-metadata.test.ts
@@ -1,0 +1,504 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { McpServer } from 'tmcp';
+import { ValibotJsonSchemaAdapter } from '@tmcp/adapter-valibot';
+import { GET_TOOL_NAME } from '@storybook/mcp';
+import { buildStorybookAiMetadata } from './storybook-ai-metadata.ts';
+import { getAddonVitestConstants } from './tools/run-story-tests.ts';
+import type { AddonContext } from './types.ts';
+import { getManifestStatus } from './tools/is-manifest-available.ts';
+import { isAddonA11yEnabled } from './utils/is-addon-a11y-enabled.ts';
+import { getReviewStatus } from './utils/is-review-available.ts';
+import { isModuleGraphSupported, isModuleGraphSupportedByBuilder } from './utils/module-graph.ts';
+import {
+	GET_STORIES_BY_COMPONENT_TOOL_NAME,
+	GET_UI_BUILDING_INSTRUCTIONS_TOOL_NAME,
+	PREVIEW_STORIES_TOOL_NAME,
+	RUN_STORY_TESTS_TOOL_NAME,
+} from './tools/tool-names.ts';
+import { registerAddonMcpTools } from './tools/tool-registry.ts';
+import type { ToolAvailability } from './utils/get-tool-availability.ts';
+
+vi.mock('./utils/module-graph.ts', () => ({
+	isModuleGraphSupported: vi.fn(),
+	isModuleGraphSupportedByBuilder: vi.fn(),
+}));
+
+vi.mock('./utils/is-review-available.ts', () => ({
+	getReviewStatus: vi.fn(),
+}));
+
+vi.mock('./tools/is-manifest-available.ts', () => ({
+	getManifestStatus: vi.fn(),
+}));
+
+vi.mock('./utils/is-addon-a11y-enabled.ts', () => ({
+	isAddonA11yEnabled: vi.fn(),
+}));
+
+vi.mock('./tools/run-story-tests.ts', async (importActual) => ({
+	...(await importActual<typeof import('./tools/run-story-tests.ts')>()),
+	getAddonVitestConstants: vi.fn(),
+}));
+
+describe('buildStorybookAiMetadata', () => {
+	beforeEach(() => {
+		vi.stubGlobal('fetch', vi.fn(mockManifestFetch(true)));
+		vi.mocked(isModuleGraphSupported).mockResolvedValue(true);
+		vi.mocked(isModuleGraphSupportedByBuilder).mockResolvedValue(true);
+		vi.mocked(getReviewStatus).mockResolvedValue({
+			available: true,
+			hasFeatureFlag: true,
+			hasAddon: true,
+		});
+		vi.mocked(getManifestStatus).mockResolvedValue({
+			available: true,
+			hasManifests: true,
+			hasFeatureFlag: true,
+		});
+		vi.mocked(getAddonVitestConstants).mockResolvedValue({
+			TRIGGER_TEST_RUN_REQUEST: 'TRIGGER_TEST_RUN_REQUEST',
+			TRIGGER_TEST_RUN_RESPONSE: 'TRIGGER_TEST_RUN_RESPONSE',
+		});
+		vi.mocked(isAddonA11yEnabled).mockResolvedValue(true);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('builds the same all-enabled tool descriptors as tmcp tools/list', async () => {
+		const options = createOptions({
+			refs: {
+				remote: { title: 'Remote', url: 'https://example.com/storybook' },
+			},
+		});
+
+		const metadata = await buildStorybookAiMetadata(options);
+		const liveTools = await listRegisteredTools(options, { multiSource: true });
+
+		expect(metadata.tools.map((tool) => tool.name)).toEqual(
+			liveTools.map((tool: { name: string }) => tool.name),
+		);
+		expect(simplifyTools(metadata.tools)).toEqual(simplifyTools(liveTools));
+		expect(metadata.instructions).toContain('## UI Building and Story Writing Workflow');
+		expect(metadata.instructions).toContain('## Validation Workflow');
+		expect(metadata.instructions).toContain('## Documentation Workflow');
+
+		const getDocumentationTool = metadata.tools.find((tool) => tool.name === GET_TOOL_NAME);
+		expect(getDocumentationTool?.inputSchema.properties).toHaveProperty('storybookId');
+
+		const result = await metadata.localTools[GET_UI_BUILDING_INSTRUCTIONS_TOOL_NAME]?.call();
+		expect(result?.content[0]?.text).toContain('@storybook/react-vite');
+		expect(result?.content[0]?.text).toContain('@storybook/react');
+		expect(result?.content[0]?.text).not.toContain('{{FRAMEWORK}}');
+
+		const liveResult = await callRegisteredTool(options, GET_UI_BUILDING_INSTRUCTIONS_TOOL_NAME, {
+			multiSource: true,
+		});
+		expect(result).toEqual(liveResult);
+		expect(isModuleGraphSupported).not.toHaveBeenCalled();
+	});
+
+	it('respects disabled addon toolsets', async () => {
+		const metadata = await buildStorybookAiMetadata(
+			createOptions({
+				toolsets: { dev: false, docs: false, test: false },
+			}),
+		);
+
+		expect(metadata.instructions).toBe('');
+		expect(metadata.tools).toEqual([]);
+		expect(metadata.localTools).toEqual({});
+	});
+
+	it.each([
+		['dev disabled', { dev: false, docs: true, test: true }],
+		['docs disabled', { dev: true, docs: false, test: true }],
+		['test disabled', { dev: true, docs: true, test: false }],
+		['all disabled', { dev: false, docs: false, test: false }],
+	])('matches live tools/list when %s', async (_label, toolsets) => {
+		const options = createOptions({ toolsets });
+
+		const metadata = await buildStorybookAiMetadata(options);
+		const liveTools = await listRegisteredTools(options, { toolsets });
+
+		expect(metadata.tools.map((tool) => tool.name)).toEqual(
+			liveTools.map((tool: { name: string }) => tool.name),
+		);
+		expect(simplifyTools(metadata.tools)).toEqual(simplifyTools(liveTools));
+	});
+
+	it('keeps addon-vitest availability aligned between metadata and live tools/list', async () => {
+		vi.mocked(getAddonVitestConstants).mockResolvedValue(undefined);
+		const options = createOptions();
+
+		const metadata = await buildStorybookAiMetadata(options);
+		const liveTools = await listRegisteredTools(options, {
+			availability: createAvailability({ testSupported: false }),
+		});
+
+		expect(metadata.tools.map((tool) => tool.name)).not.toContain(RUN_STORY_TESTS_TOOL_NAME);
+		expect(metadata.tools.map((tool) => tool.name)).toEqual(
+			liveTools.map((tool: { name: string }) => tool.name),
+		);
+		expect(simplifyTools(metadata.tools)).toEqual(simplifyTools(liveTools));
+	});
+
+	it('does not enable multi-source docs schemas for refs without manifests', async () => {
+		const fetchMock = vi.fn(mockManifestFetch(false));
+		vi.stubGlobal('fetch', fetchMock);
+		const options = createOptions({
+			refs: {
+				remote: { title: 'Remote', url: 'https://example.com/storybook' },
+			},
+		});
+
+		const metadata = await buildStorybookAiMetadata(options);
+		const liveTools = await listRegisteredTools(options, { multiSource: false });
+
+		const getDocumentationTool = metadata.tools.find((tool) => tool.name === GET_TOOL_NAME);
+		expect(getDocumentationTool?.inputSchema.properties).not.toHaveProperty('storybookId');
+		expect(metadata.tools.map((tool) => tool.name)).toEqual(
+			liveTools.map((tool: { name: string }) => tool.name),
+		);
+		expect(simplifyTools(metadata.tools)).toEqual(simplifyTools(liveTools));
+		expect(fetchMock.mock.calls.map(([input]) => getFetchUrl(input))).not.toContain(
+			'https://example.com/storybook/mcp',
+		);
+	});
+
+	it('enables multi-source docs schemas for authenticated refs without calling /mcp', async () => {
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = getFetchUrl(input);
+			if (url.endsWith('/manifests/components.json')) {
+				return new Response('Authentication required', {
+					status: 401,
+					headers: {
+						'WWW-Authenticate':
+							'Bearer resource_metadata="https://private.example.com/.well-known/oauth-protected-resource"',
+					},
+				});
+			}
+			throw new Error(`Unexpected fetch: ${url}`);
+		});
+		vi.stubGlobal('fetch', fetchMock);
+		const options = createOptions({
+			refs: {
+				private: { title: 'Private', url: 'https://private.example.com/storybook' },
+			},
+		});
+
+		const metadata = await buildStorybookAiMetadata(options);
+		const liveTools = await listRegisteredTools(options, { multiSource: true });
+
+		const getDocumentationTool = metadata.tools.find((tool) => tool.name === GET_TOOL_NAME);
+		expect(getDocumentationTool?.inputSchema.properties).toHaveProperty('storybookId');
+		expect(metadata.tools.map((tool) => tool.name)).toEqual(
+			liveTools.map((tool: { name: string }) => tool.name),
+		);
+		expect(simplifyTools(metadata.tools)).toEqual(simplifyTools(liveTools));
+		expect(fetchMock.mock.calls.map(([input]) => getFetchUrl(input))).not.toContain(
+			'https://private.example.com/storybook/mcp',
+		);
+	});
+
+	it('does not resolve composed refs when docs metadata is unavailable', async () => {
+		const fetchMock = vi.fn(async () => {
+			throw new Error('should not fetch refs');
+		});
+		vi.stubGlobal('fetch', fetchMock);
+
+		await buildStorybookAiMetadata(
+			createOptions({
+				refs: {
+					remote: { title: 'Remote', url: 'https://example.com/storybook' },
+				},
+				toolsets: { dev: true, docs: false, test: true },
+			}),
+		);
+
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('deduplicates existing preset metadata by tool name and instruction text', async () => {
+		const options = createOptions({
+			refs: {
+				remote: { title: 'Remote', url: 'https://example.com/storybook' },
+			},
+		});
+		const first = await buildStorybookAiMetadata(options);
+		const merged = await buildStorybookAiMetadata(options, {
+			...first,
+			tools: [
+				{
+					name: PREVIEW_STORIES_TOOL_NAME,
+					description: 'stale descriptor',
+					inputSchema: { type: 'object' },
+				},
+				...first.tools,
+			],
+		});
+
+		expect(merged.instructions).toBe(first.instructions);
+		expect(merged.tools.map((tool) => tool.name)).toEqual(first.tools.map((tool) => tool.name));
+		expect(merged.tools.filter((tool) => tool.name === PREVIEW_STORIES_TOOL_NAME)).toHaveLength(1);
+		expect(
+			merged.tools.find((tool) => tool.name === PREVIEW_STORIES_TOOL_NAME)?.description,
+		).not.toBe('stale descriptor');
+	});
+
+	it('matches live tools/list when the module graph service is unavailable', async () => {
+		vi.mocked(isModuleGraphSupportedByBuilder).mockResolvedValue(false);
+		const options = createOptions({
+			builder: '@storybook/builder-vite',
+			features: { changeDetection: false, componentsManifest: true },
+			toolsets: { dev: true, docs: false, test: false },
+		});
+
+		const metadata = await buildStorybookAiMetadata(options);
+		const liveTools = await listRegisteredTools(options, {
+			availability: createAvailability({
+				moduleGraphSupported: false,
+				changeDetectionEnabled: false,
+			}),
+			toolsets: { dev: true, docs: false, test: false },
+		});
+
+		expect(metadata.tools.map((tool) => tool.name)).not.toContain(
+			GET_STORIES_BY_COMPONENT_TOOL_NAME,
+		);
+		expect(metadata.tools.map((tool) => tool.name)).toEqual(
+			liveTools.map((tool: { name: string }) => tool.name),
+		);
+		expect(simplifyTools(metadata.tools)).toEqual(simplifyTools(liveTools));
+	});
+
+	it('uses builder support instead of the live module-graph service for metadata', async () => {
+		vi.mocked(isModuleGraphSupported).mockResolvedValue(false);
+		vi.mocked(isModuleGraphSupportedByBuilder).mockResolvedValue(true);
+		const options = createOptions({
+			toolsets: { dev: true, docs: false, test: false },
+		});
+
+		const metadata = await buildStorybookAiMetadata(options);
+
+		expect(metadata.tools.map((tool) => tool.name)).toContain(GET_STORIES_BY_COMPONENT_TOOL_NAME);
+		expect(isModuleGraphSupportedByBuilder).toHaveBeenCalled();
+		expect(isModuleGraphSupported).not.toHaveBeenCalled();
+	});
+});
+
+function mockManifestFetch(hasManifest: boolean) {
+	return async (input: RequestInfo | URL) => {
+		const url = getFetchUrl(input);
+		if (url.endsWith('/manifests/components.json') && hasManifest) {
+			return new Response(JSON.stringify({ v: 1, components: {} }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}
+		return new Response('not found', { status: 404 });
+	};
+}
+
+function getFetchUrl(input: RequestInfo | URL): string {
+	return typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+}
+
+function createOptions({
+	builder = '@storybook/builder-vite',
+	features = { changeDetection: true, componentsManifest: true },
+	framework = '@storybook/react-vite',
+	refs = {},
+	toolsets = { dev: true, docs: true, test: true },
+}: {
+	builder?: string | null;
+	features?: Record<string, unknown>;
+	framework?: string;
+	refs?: Record<string, { title?: string; url?: string }>;
+	toolsets?: { dev?: boolean; docs?: boolean; test?: boolean };
+} = {}) {
+	return {
+		configDir: '/project/.storybook',
+		endpoint: undefined,
+		toolsets,
+		presets: {
+			apply: vi.fn(async (key: string, defaultValue?: unknown) => {
+				if (key === 'features') {
+					return features;
+				}
+				if (key === 'core') {
+					return { builder: builder ?? undefined };
+				}
+				if (key === 'framework') {
+					return framework;
+				}
+				if (key === 'refs') {
+					return refs;
+				}
+				return defaultValue;
+			}),
+		},
+	} as any;
+}
+
+function createAvailability(overrides: Partial<ToolAvailability> = {}): ToolAvailability {
+	return {
+		moduleGraphSupported: true,
+		changeDetectionEnabled: true,
+		reviewEnabled: true,
+		docsEnabled: true,
+		docsHasManifests: true,
+		docsFeatureEnabled: true,
+		testSupported: true,
+		a11yEnabled: true,
+		...overrides,
+	};
+}
+
+async function listRegisteredTools(
+	options: AddonContext['options'],
+	{
+		availability = createAvailability(),
+		multiSource = false,
+		toolsets = { dev: true, docs: true, test: true },
+	}: {
+		availability?: ToolAvailability;
+		multiSource?: boolean;
+		toolsets?: AddonContext['toolsets'];
+	} = {},
+) {
+	const adapter = new ValibotJsonSchemaAdapter();
+	const server = new McpServer(
+		{
+			name: 'test-server',
+			version: '1.0.0',
+			description: 'Test server for AI metadata parity',
+		},
+		{
+			adapter,
+			capabilities: {
+				tools: { listChanged: true },
+				resources: { listChanged: true },
+			},
+		},
+	).withContext<AddonContext>();
+
+	await server.receive(
+		{
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'initialize',
+			params: {
+				protocolVersion: '2025-06-18',
+				capabilities: {},
+				clientInfo: { name: 'test', version: '1.0.0' },
+			},
+		},
+		{
+			sessionId: 'test-session',
+		},
+	);
+
+	await registerAddonMcpTools(server, { availability, multiSource });
+
+	const response = await server.receive(
+		{
+			jsonrpc: '2.0',
+			id: 2,
+			method: 'tools/list',
+			params: {},
+		},
+		{
+			sessionId: 'test-session',
+			custom: {
+				origin: 'http://localhost:6006',
+				options,
+				disableTelemetry: true,
+				a11yEnabled: availability.a11yEnabled,
+				toolsets,
+			},
+		},
+	);
+
+	return response.result?.tools ?? [];
+}
+
+async function callRegisteredTool(
+	options: AddonContext['options'],
+	name: string,
+	{
+		availability = createAvailability(),
+		multiSource = false,
+		toolsets = { dev: true, docs: true, test: true },
+	}: {
+		availability?: ToolAvailability;
+		multiSource?: boolean;
+		toolsets?: AddonContext['toolsets'];
+	} = {},
+) {
+	const server = new McpServer(
+		{
+			name: 'test-server',
+			version: '1.0.0',
+			description: 'Test server for AI metadata parity',
+		},
+		{
+			adapter: new ValibotJsonSchemaAdapter(),
+			capabilities: {
+				tools: { listChanged: true },
+				resources: { listChanged: true },
+			},
+		},
+	).withContext<AddonContext>();
+
+	await server.receive(
+		{
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'initialize',
+			params: {
+				protocolVersion: '2025-06-18',
+				capabilities: {},
+				clientInfo: { name: 'test', version: '1.0.0' },
+			},
+		},
+		{
+			sessionId: 'test-session',
+		},
+	);
+
+	await registerAddonMcpTools(server, { availability, multiSource });
+
+	const response = await server.receive(
+		{
+			jsonrpc: '2.0',
+			id: 2,
+			method: 'tools/call',
+			params: { name, arguments: {} },
+		},
+		{
+			sessionId: 'test-session',
+			custom: {
+				origin: 'http://localhost:6006',
+				options,
+				disableTelemetry: true,
+				a11yEnabled: availability.a11yEnabled,
+				toolsets,
+			},
+		},
+	);
+
+	return response.result;
+}
+
+function simplifyTools(tools: any[]) {
+	return tools.map(({ name, title, description, inputSchema, outputSchema, _meta }) => ({
+		name,
+		title,
+		description,
+		inputSchema,
+		outputSchema,
+		_meta,
+	}));
+}

--- a/packages/addon-mcp/src/storybook-ai-metadata.test.ts
+++ b/packages/addon-mcp/src/storybook-ai-metadata.test.ts
@@ -17,7 +17,10 @@ import {
 	RUN_STORY_TESTS_TOOL_NAME,
 } from './tools/tool-names.ts';
 import { registerAddonMcpTools } from './tools/tool-registry.ts';
-import type { ToolAvailability } from './utils/get-tool-availability.ts';
+import {
+	getEffectiveToolAvailability,
+	type ToolAvailability,
+} from './utils/get-tool-availability.ts';
 
 vi.mock('./utils/module-graph.ts', () => ({
 	isModuleGraphSupported: vi.fn(),
@@ -281,10 +284,24 @@ describe('buildStorybookAiMetadata', () => {
 		});
 
 		const metadata = await buildStorybookAiMetadata(options);
+		const liveTools = await listRegisteredTools(options, {
+			availability: getEffectiveToolAvailability(
+				createAvailability({
+					docsEnabled: false,
+					docsHasManifests: false,
+				}),
+				{ multiSource: true },
+			),
+			multiSource: true,
+		});
 
 		const getDocumentationTool = metadata.tools.find((tool) => tool.name === GET_TOOL_NAME);
 		expect(getDocumentationTool?.inputSchema.properties).toHaveProperty('storybookId');
 		expect(metadata.instructions).toContain('## Documentation Workflow');
+		expect(metadata.tools.map((tool) => tool.name)).toEqual(
+			liveTools.map((tool: { name: string }) => tool.name),
+		);
+		expect(simplifyTools(metadata.tools)).toEqual(simplifyTools(liveTools));
 	});
 
 	it('does not run registration side effects for statically disabled toolsets', async () => {

--- a/packages/addon-mcp/src/storybook-ai-metadata.test.ts
+++ b/packages/addon-mcp/src/storybook-ai-metadata.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { McpServer } from 'tmcp';
 import { ValibotJsonSchemaAdapter } from '@tmcp/adapter-valibot';
 import { GET_TOOL_NAME } from '@storybook/mcp';
+import { logger } from 'storybook/internal/node-logger';
 import { buildStorybookAiMetadata } from './storybook-ai-metadata.ts';
 import { getAddonVitestConstants } from './tools/run-story-tests.ts';
 import type { AddonContext } from './types.ts';
@@ -42,6 +43,7 @@ vi.mock('./tools/run-story-tests.ts', async (importActual) => ({
 
 describe('buildStorybookAiMetadata', () => {
 	beforeEach(() => {
+		vi.clearAllMocks();
 		vi.stubGlobal('fetch', vi.fn(mockManifestFetch(true)));
 		vi.mocked(isModuleGraphSupported).mockResolvedValue(true);
 		vi.mocked(isModuleGraphSupportedByBuilder).mockResolvedValue(true);
@@ -63,7 +65,9 @@ describe('buildStorybookAiMetadata', () => {
 	});
 
 	afterEach(() => {
+		vi.clearAllMocks();
 		vi.unstubAllGlobals();
+		vi.useRealTimers();
 	});
 
 	it('builds the same all-enabled tool descriptors as tmcp tools/list', async () => {
@@ -167,6 +171,50 @@ describe('buildStorybookAiMetadata', () => {
 		);
 	});
 
+	it('skips malformed refs without dropping valid refs', async () => {
+		const fetchMock = vi.fn(mockManifestFetch(true));
+		vi.stubGlobal('fetch', fetchMock);
+		const options = createOptions({
+			refs: {
+				missingUrl: { title: 'Missing URL' },
+				nullRef: null,
+				valid: { title: 'Valid', url: 'https://example.com/storybook' },
+			},
+		});
+
+		const metadata = await buildStorybookAiMetadata(options);
+
+		const getDocumentationTool = metadata.tools.find((tool) => tool.name === GET_TOOL_NAME);
+		expect(getDocumentationTool?.inputSchema.properties).toHaveProperty('storybookId');
+		expect(fetchMock.mock.calls.map(([input]) => getFetchUrl(input))).toEqual([
+			'https://example.com/storybook/manifests/components.json',
+		]);
+	});
+
+	it('bounds serverless manifest probe latency', async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+			return new Promise<Response>((_resolve, reject) => {
+				init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+			});
+		});
+		vi.stubGlobal('fetch', fetchMock);
+		const metadataPromise = buildStorybookAiMetadata(
+			createOptions({
+				refs: {
+					remote: { title: 'Remote', url: 'https://example.com/storybook' },
+				},
+			}),
+		);
+
+		await vi.advanceTimersByTimeAsync(3_000);
+		const metadata = await metadataPromise;
+
+		const getDocumentationTool = metadata.tools.find((tool) => tool.name === GET_TOOL_NAME);
+		expect(getDocumentationTool?.inputSchema.properties).not.toHaveProperty('storybookId');
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+
 	it('enables multi-source docs schemas for authenticated refs without calling /mcp', async () => {
 		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
 			const url = getFetchUrl(input);
@@ -218,6 +266,42 @@ describe('buildStorybookAiMetadata', () => {
 		);
 
 		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('enables docs metadata for serverless refs even when local docs are unavailable', async () => {
+		vi.mocked(getManifestStatus).mockResolvedValue({
+			available: false,
+			hasManifests: false,
+			hasFeatureFlag: true,
+		});
+		const options = createOptions({
+			refs: {
+				remote: { title: 'Remote', url: 'https://example.com/storybook' },
+			},
+		});
+
+		const metadata = await buildStorybookAiMetadata(options);
+
+		const getDocumentationTool = metadata.tools.find((tool) => tool.name === GET_TOOL_NAME);
+		expect(getDocumentationTool?.inputSchema.properties).toHaveProperty('storybookId');
+		expect(metadata.instructions).toContain('## Documentation Workflow');
+	});
+
+	it('does not run registration side effects for statically disabled toolsets', async () => {
+		const loggerSpy = vi.spyOn(logger, 'info').mockImplementation(() => {});
+
+		try {
+			await listRegisteredTools(createOptions(), {
+				toolsets: { dev: true, docs: false, test: true },
+				gateRegistrationWithToolsets: true,
+			});
+
+			expect(loggerSpy).not.toHaveBeenCalledWith(
+				'Experimental components manifest feature detected - registering component tools',
+			);
+		} finally {
+			loggerSpy.mockRestore();
+		}
 	});
 
 	it('deduplicates existing preset metadata by tool name and instruction text', async () => {
@@ -315,7 +399,7 @@ function createOptions({
 	builder?: string | null;
 	features?: Record<string, unknown>;
 	framework?: string;
-	refs?: Record<string, { title?: string; url?: string }>;
+	refs?: Record<string, unknown>;
 	toolsets?: { dev?: boolean; docs?: boolean; test?: boolean };
 } = {}) {
 	return {
@@ -362,10 +446,12 @@ async function listRegisteredTools(
 		availability = createAvailability(),
 		multiSource = false,
 		toolsets = { dev: true, docs: true, test: true },
+		gateRegistrationWithToolsets = false,
 	}: {
 		availability?: ToolAvailability;
 		multiSource?: boolean;
 		toolsets?: AddonContext['toolsets'];
+		gateRegistrationWithToolsets?: boolean;
 	} = {},
 ) {
 	const adapter = new ValibotJsonSchemaAdapter();
@@ -400,7 +486,11 @@ async function listRegisteredTools(
 		},
 	);
 
-	await registerAddonMcpTools(server, { availability, multiSource });
+	await registerAddonMcpTools(server, {
+		availability,
+		multiSource,
+		...(gateRegistrationWithToolsets ? { toolsets } : {}),
+	});
 
 	const response = await server.receive(
 		{

--- a/packages/addon-mcp/src/storybook-ai-metadata.ts
+++ b/packages/addon-mcp/src/storybook-ai-metadata.ts
@@ -1,0 +1,133 @@
+import { ValibotJsonSchemaAdapter } from '@tmcp/adapter-valibot';
+import type { Options } from 'storybook/internal/types';
+import * as v from 'valibot';
+import { resolveServerlessCompositionSources } from './auth/resolve-composition-sources.ts';
+import { buildServerInstructions } from './instructions/build-server-instructions.ts';
+import { AddonOptions, type AddonOptionsInput } from './types.ts';
+import {
+	getAddonLocalTools,
+	getAddonToolMetadata,
+	type StorybookAiLocalTool,
+	type ToolMetadata,
+} from './tools/tool-registry.ts';
+import { getToolAvailability } from './utils/get-tool-availability.ts';
+import { isModuleGraphSupportedByBuilder } from './utils/module-graph.ts';
+
+type StorybookAiMetadataPresetOptions = Options & AddonOptionsInput;
+
+export type StorybookAiToolDescriptor = {
+	name: string;
+	title?: string;
+	description?: string;
+	inputSchema: Record<string, unknown>;
+	outputSchema?: Record<string, unknown>;
+	_meta?: Record<string, unknown>;
+};
+
+export type StorybookAiMetadata = {
+	instructions: string;
+	tools: StorybookAiToolDescriptor[];
+	localTools: Record<string, StorybookAiLocalTool>;
+};
+
+const createEmptyInputSchema = () => ({ type: 'object', properties: {} });
+
+export async function buildStorybookAiMetadata(
+	options: StorybookAiMetadataPresetOptions,
+	existingMetadata?: StorybookAiMetadata,
+): Promise<StorybookAiMetadata> {
+	const addonOptions = v.parse(AddonOptions, {
+		endpoint: options.endpoint,
+		toolsets: options.toolsets ?? {},
+	});
+	const toolsets = addonOptions.toolsets;
+	const features = (await options.presets.apply('features', {})) as
+		| { changeDetection?: boolean }
+		| undefined;
+	const devEnabled = toolsets?.dev ?? true;
+	const moduleGraphSupported = await isModuleGraphSupportedByBuilder(options);
+	const availability = await getToolAvailability(options, {
+		features,
+		moduleGraphSupported,
+	});
+	const testEnabled = (toolsets?.test ?? true) && availability.testSupported;
+	const docsEnabled = (toolsets?.docs ?? true) && availability.docsEnabled;
+	const multiSource = docsEnabled
+		? (await resolveServerlessCompositionSources(options)).multiSource
+		: false;
+	const registryContext = { availability, multiSource, toolsets };
+	const toolMetadata = getAddonToolMetadata(registryContext);
+	const localTools: Record<string, StorybookAiLocalTool> = {
+		...existingMetadata?.localTools,
+		...getAddonLocalTools({ ...registryContext, options }),
+	};
+
+	return {
+		instructions: joinInstructions(
+			existingMetadata?.instructions,
+			buildServerInstructions({
+				devEnabled,
+				testEnabled,
+				docsEnabled,
+				changeDetectionEnabled: availability.changeDetectionEnabled,
+				moduleGraphSupported: availability.moduleGraphSupported,
+				reviewEnabled: availability.reviewEnabled,
+			}),
+		),
+		tools: mergeToolDescriptors(
+			existingMetadata?.tools ?? [],
+			await toToolDescriptors(toolMetadata),
+		),
+		localTools,
+	};
+}
+
+async function toToolDescriptors(
+	toolMetadata: ToolMetadata[],
+): Promise<StorybookAiToolDescriptor[]> {
+	const adapter = new ValibotJsonSchemaAdapter();
+
+	return Promise.all(
+		toolMetadata.map(async ({ schema, outputSchema, ...metadata }) => ({
+			...metadata,
+			inputSchema: schema ? await toJsonSchema(adapter, schema) : createEmptyInputSchema(),
+			...(outputSchema ? { outputSchema: await toJsonSchema(adapter, outputSchema) } : {}),
+		})),
+	);
+}
+
+async function toJsonSchema(
+	adapter: ValibotJsonSchemaAdapter,
+	schema: unknown,
+): Promise<Record<string, unknown>> {
+	return (await adapter.toJsonSchema(
+		schema as Parameters<ValibotJsonSchemaAdapter['toJsonSchema']>[0],
+	)) as Record<string, unknown>;
+}
+
+function joinInstructions(...sections: Array<string | undefined>): string {
+	const uniqueSections: string[] = [];
+	const seen = new Set<string>();
+	for (const section of sections) {
+		const trimmed = section?.trim();
+		if (trimmed && !seen.has(trimmed)) {
+			seen.add(trimmed);
+			uniqueSections.push(trimmed);
+		}
+	}
+	return uniqueSections.join('\n\n');
+}
+
+function mergeToolDescriptors(
+	...groups: StorybookAiToolDescriptor[][]
+): StorybookAiToolDescriptor[] {
+	const toolsByName = new Map<string, StorybookAiToolDescriptor>();
+	for (const tool of groups.flat()) {
+		if (toolsByName.has(tool.name)) {
+			// Later preset layers override earlier descriptors and keep their own ordering.
+			toolsByName.delete(tool.name);
+		}
+		toolsByName.set(tool.name, tool);
+	}
+	return [...toolsByName.values()];
+}

--- a/packages/addon-mcp/src/storybook-ai-metadata.ts
+++ b/packages/addon-mcp/src/storybook-ai-metadata.ts
@@ -51,11 +51,13 @@ export async function buildStorybookAiMetadata(
 		moduleGraphSupported,
 	});
 	const testEnabled = (toolsets?.test ?? true) && availability.testSupported;
-	const docsEnabled = (toolsets?.docs ?? true) && availability.docsEnabled;
-	const multiSource = docsEnabled
+	const docsToolsetEnabled = toolsets?.docs ?? true;
+	const multiSource = docsToolsetEnabled
 		? (await resolveServerlessCompositionSources(options)).multiSource
 		: false;
-	const registryContext = { availability, multiSource, toolsets };
+	const docsEnabled = docsToolsetEnabled && (availability.docsEnabled || multiSource);
+	const registryAvailability = { ...availability, docsEnabled };
+	const registryContext = { availability: registryAvailability, multiSource, toolsets };
 	const toolMetadata = getAddonToolMetadata(registryContext);
 	const localTools: Record<string, StorybookAiLocalTool> = {
 		...existingMetadata?.localTools,

--- a/packages/addon-mcp/src/storybook-ai-metadata.ts
+++ b/packages/addon-mcp/src/storybook-ai-metadata.ts
@@ -10,7 +10,10 @@ import {
 	type StorybookAiLocalTool,
 	type ToolMetadata,
 } from './tools/tool-registry.ts';
-import { getToolAvailability } from './utils/get-tool-availability.ts';
+import {
+	getEffectiveToolAvailability,
+	getToolAvailability,
+} from './utils/get-tool-availability.ts';
 import { isModuleGraphSupportedByBuilder } from './utils/module-graph.ts';
 
 type StorybookAiMetadataPresetOptions = Options & AddonOptionsInput;
@@ -55,8 +58,8 @@ export async function buildStorybookAiMetadata(
 	const multiSource = docsToolsetEnabled
 		? (await resolveServerlessCompositionSources(options)).multiSource
 		: false;
-	const docsEnabled = docsToolsetEnabled && (availability.docsEnabled || multiSource);
-	const registryAvailability = { ...availability, docsEnabled };
+	const registryAvailability = getEffectiveToolAvailability(availability, { multiSource });
+	const docsEnabled = docsToolsetEnabled && registryAvailability.docsEnabled;
 	const registryContext = { availability: registryAvailability, multiSource, toolsets };
 	const toolMetadata = getAddonToolMetadata(registryContext);
 	const localTools: Record<string, StorybookAiLocalTool> = {

--- a/packages/addon-mcp/src/tools/display-review.ts
+++ b/packages/addon-mcp/src/tools/display-review.ts
@@ -9,7 +9,7 @@ import { withFriendlyErrors } from '../utils/format-validation-issues.ts';
 import { DEFAULT_MCP_ENDPOINT, PUSH_REVIEW_EVENT, REVIEW_PAGE_PATH } from '../constants.ts';
 import { DISPLAY_REVIEW_TOOL_NAME } from './tool-names.ts';
 
-const DISPLAY_REVIEW_TOOL_DESCRIPTION = `Publish a curated review to Storybook's review page for spot-checking **visual impact**. Each call replaces the single active review.
+export const DISPLAY_REVIEW_TOOL_DESCRIPTION = `Publish a curated review to Storybook's review page for spot-checking **visual impact**. Each call replaces the single active review.
 
 ## When to call
 - **Trigger 1 — visual change** (UI, CSS, theme, i18n): when the user should spot-check rendering. Skip non-visual refactors unless side-effects are plausible. Start from \`get-changed-stories\`; fall back to \`get-stories-by-component\` if change detection is unavailable. Include \`changedFiles\`.
@@ -67,7 +67,7 @@ export const ReviewStateSchema = v.object({
 	description: v.pipe(
 		v.string(),
 		v.description(
-			"Description of the review scope, including what's there, why it's relevant, and what to look for. Preferably one or two sentences. At most 2 paragraphs for reviews spanning multiple topics. Markdown formatting restricted to **bold**, _italic_, and \`code\` (backticks). Use emphasis for the key **what** and _why_, and backticks for literal source code references like component or token names.",
+			"Description of the review scope, including what's there, why it's relevant, and what to look for. Preferably one or two sentences. At most 2 paragraphs for reviews spanning multiple topics. Markdown formatting restricted to **bold**, _italic_, and `code` (backticks). Use emphasis for the key **what** and _why_, and backticks for literal source code references like component or token names.",
 		),
 	),
 	collections: v.array(ReviewCollectionSchema),
@@ -80,7 +80,7 @@ export const ReviewStateSchema = v.object({
 export type ReviewCollection = v.InferOutput<typeof ReviewCollectionSchema>;
 export type ReviewState = v.InferOutput<typeof ReviewStateSchema>;
 
-const DisplayReviewOutput = v.object({
+export const DisplayReviewOutput = v.object({
 	reviewUrl: v.pipe(
 		v.string(),
 		v.description(
@@ -124,6 +124,16 @@ export function buildReviewUrl(ctx: {
 	return `${root.replace(/\/$/, '')}/?path=${REVIEW_PAGE_PATH}`;
 }
 
+export function getDisplayReviewToolMetadata() {
+	return {
+		name: DISPLAY_REVIEW_TOOL_NAME,
+		title: 'Display Storybook review',
+		description: DISPLAY_REVIEW_TOOL_DESCRIPTION,
+		schema: withFriendlyErrors(ReviewStateSchema),
+		outputSchema: DisplayReviewOutput,
+	};
+}
+
 /**
  * Returns the storyIds the agent passed that don't resolve against the live
  * Storybook index. Order-preserving and deduplicated so the error message
@@ -155,15 +165,15 @@ function formatUnknownStoryIdsError(unknownIds: string[]): string {
 	return `Refusing to publish review: ${unknownIds.length} story ${plural} not in the live Storybook index:\n${list}\n\nThis usually means the IDs were inferred from file paths or naming conventions rather than returned by a tool. Resolve real IDs by calling \`get-stories-by-component\` (for components you've edited or want covered) or \`list-all-documentation\` (to browse the index), then retry \`display-review\` with the verified IDs. Do not invent IDs to satisfy this check.`;
 }
 
-export async function addDisplayReviewTool(server: McpServer<any, AddonContext>) {
+export async function addDisplayReviewTool(
+	server: McpServer<any, AddonContext>,
+	enabled: Parameters<McpServer<any, AddonContext>['tool']>[0]['enabled'] = () =>
+		server.ctx.custom?.toolsets?.dev ?? true,
+) {
 	server.tool(
 		{
-			name: DISPLAY_REVIEW_TOOL_NAME,
-			title: 'Display Storybook review',
-			description: DISPLAY_REVIEW_TOOL_DESCRIPTION,
-			schema: withFriendlyErrors(ReviewStateSchema),
-			outputSchema: DisplayReviewOutput,
-			enabled: () => server.ctx.custom?.toolsets?.dev ?? true,
+			...getDisplayReviewToolMetadata(),
+			enabled,
 		},
 		async (input: ReviewState) => {
 			try {

--- a/packages/addon-mcp/src/tools/get-changed-stories.ts
+++ b/packages/addon-mcp/src/tools/get-changed-stories.ts
@@ -12,6 +12,8 @@ import {
 } from '../utils/detect-unreachable-changes.ts';
 import { GET_CHANGED_STORIES_TOOL_NAME } from './tool-names.ts';
 
+export const GET_CHANGED_STORIES_TOOL_DESCRIPTION = `Get Storybook stories marked as new, modified, or related. Returns story metadata only (no URLs).`;
+
 const CHANGE_DETECTION_TYPE = 'storybook/change-detection';
 const INCLUDED_STATUS_VALUES = new Set<StatusValue>([
 	'status-value:new',
@@ -55,13 +57,23 @@ function statusPriority(statusValue: StatusValue): number {
 	return 2;
 }
 
-export async function addGetChangedStoriesTool(server: McpServer<any, AddonContext>) {
+export function getChangedStoriesToolMetadata() {
+	return {
+		name: GET_CHANGED_STORIES_TOOL_NAME,
+		title: 'Get changed stories metadata',
+		description: GET_CHANGED_STORIES_TOOL_DESCRIPTION,
+	};
+}
+
+export async function addGetChangedStoriesTool(
+	server: McpServer<any, AddonContext>,
+	enabled: Parameters<McpServer<any, AddonContext>['tool']>[0]['enabled'] = () =>
+		server.ctx.custom?.toolsets?.dev ?? true,
+) {
 	server.tool(
 		{
-			name: GET_CHANGED_STORIES_TOOL_NAME,
-			title: 'Get changed stories metadata',
-			description: `Get Storybook stories marked as new, modified, or related. Returns story metadata only (no URLs).`,
-			enabled: () => server.ctx.custom?.toolsets?.dev ?? true,
+			...getChangedStoriesToolMetadata(),
+			enabled,
 		},
 		async () => {
 			try {

--- a/packages/addon-mcp/src/tools/get-stories-by-component.ts
+++ b/packages/addon-mcp/src/tools/get-stories-by-component.ts
@@ -17,7 +17,15 @@ import {
 /** When omitted by the caller, applied internally to keep result sets actionable on real codebases. */
 const DEFAULT_MAX_DISTANCE = 3;
 
-const GetStoriesByComponentInput = v.object({
+export const GET_STORIES_BY_COMPONENT_TOOL_DESCRIPTION = `Map component source files to the stories that render them, returning grounded \`storyId\` values from the live Storybook index — hand these to ${PREVIEW_STORIES_TOOL_NAME} instead of guessing.
+
+Reach for this to map specific file paths to stories: when the user names a feature/area, or when \`${GET_CHANGED_STORIES_TOOL_NAME}\` (try it first for "I just edited X") returned nothing or too much. The full file-paths → story-IDs workflow lives in the server instructions.
+
+Never invent IDs from file names, feature names, or memory; if a component has no matches here, it has no stories yet (say so, don't fabricate).
+
+Backed by Storybook's live reverse dependency graph, available only when the dev server runs a builder that supports change detection (e.g. Vite) — otherwise returns a typed error. Results are sorted by \`distance\` (lower = stronger); for shared components like Button or Icon, expect many indirect matches and use \`maxDistance\` to cap noise.`;
+
+export const GetStoriesByComponentInput = v.object({
 	componentPaths: v.pipe(
 		v.array(v.string()),
 		v.minLength(1),
@@ -39,7 +47,7 @@ Defaults to ${DEFAULT_MAX_DISTANCE}; raise it to widen recall, lower it to tight
 	),
 });
 
-const StoryMatch = v.object({
+export const StoryMatch = v.object({
 	storyId: v.string(),
 	title: v.string(),
 	name: v.string(),
@@ -52,7 +60,7 @@ const StoryMatch = v.object({
 	),
 });
 
-const ClippedByMaxDistanceSchema = v.pipe(
+export const ClippedByMaxDistanceSchema = v.pipe(
 	v.object({
 		count: v.number(),
 		distances: v.array(v.number()),
@@ -62,7 +70,7 @@ const ClippedByMaxDistanceSchema = v.pipe(
 	),
 );
 
-const GetStoriesByComponentOutput = v.object({
+export const GetStoriesByComponentOutput = v.object({
 	results: v.array(
 		v.object({
 			componentPath: v.string(),
@@ -78,6 +86,7 @@ const GetStoriesByComponentOutput = v.object({
 	),
 });
 
+export type GetStoriesByComponentInput = v.InferOutput<typeof GetStoriesByComponentInput>;
 export type GetStoriesByComponentOutput = v.InferOutput<typeof GetStoriesByComponentOutput>;
 
 export interface ComponentStoryMatch {
@@ -195,21 +204,25 @@ function applyMaxDistance(
 	return { kept, clipped };
 }
 
-export async function addGetStoriesByComponentTool(server: McpServer<any, AddonContext>) {
+export function getStoriesByComponentToolMetadata() {
+	return {
+		name: GET_STORIES_BY_COMPONENT_TOOL_NAME,
+		title: 'Get stories for component files',
+		description: GET_STORIES_BY_COMPONENT_TOOL_DESCRIPTION,
+		schema: GetStoriesByComponentInput,
+		outputSchema: GetStoriesByComponentOutput,
+	};
+}
+
+export async function addGetStoriesByComponentTool(
+	server: McpServer<any, AddonContext>,
+	enabled: Parameters<McpServer<any, AddonContext>['tool']>[0]['enabled'] = () =>
+		server.ctx.custom?.toolsets?.dev ?? true,
+) {
 	server.tool(
 		{
-			name: GET_STORIES_BY_COMPONENT_TOOL_NAME,
-			title: 'Get stories for component files',
-			description: `Map component source files to the stories that render them, returning grounded \`storyId\` values from the live Storybook index — hand these to ${PREVIEW_STORIES_TOOL_NAME} instead of guessing.
-
-Reach for this to map specific file paths to stories: when the user names a feature/area, or when \`${GET_CHANGED_STORIES_TOOL_NAME}\` (try it first for "I just edited X") returned nothing or too much. The full file-paths → story-IDs workflow lives in the server instructions.
-
-Never invent IDs from file names, feature names, or memory; if a component has no matches here, it has no stories yet (say so, don't fabricate).
-
-Backed by Storybook's live reverse dependency graph, available only when the dev server runs a builder that supports change detection (e.g. Vite) — otherwise returns a typed error. Results are sorted by \`distance\` (lower = stronger); for shared components like Button or Icon, expect many indirect matches and use \`maxDistance\` to cap noise.`,
-			schema: GetStoriesByComponentInput,
-			outputSchema: GetStoriesByComponentOutput,
-			enabled: () => server.ctx.custom?.toolsets?.dev ?? true,
+			...getStoriesByComponentToolMetadata(),
+			enabled,
 		},
 		async (input) => {
 			try {

--- a/packages/addon-mcp/src/tools/get-storybook-story-instructions.ts
+++ b/packages/addon-mcp/src/tools/get-storybook-story-instructions.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from 'tmcp';
+import type { Options } from 'storybook/internal/types';
 import { getAddonVitestConstants } from './run-story-tests.ts';
 import { collectTelemetry } from '../telemetry.ts';
 import { getFinalLinksGuidance } from '../instructions/build-server-instructions.ts';
@@ -15,7 +16,17 @@ import {
 	RUN_STORY_TESTS_TOOL_NAME,
 } from './tool-names.ts';
 
-export async function addGetUIBuildingInstructionsTool(server: McpServer<any, AddonContext>) {
+type BuildStorybookStoryInstructionsOptions = {
+	toolsets?: AddonContext['toolsets'];
+	a11yEnabled?: boolean;
+	addonVitestAvailable?: boolean;
+};
+
+export async function addGetUIBuildingInstructionsTool(
+	server: McpServer<any, AddonContext>,
+	enabled: Parameters<McpServer<any, AddonContext>['tool']>[0]['enabled'] = () =>
+		server.ctx.custom?.toolsets?.dev ?? true,
+) {
 	const addonVitestAvailable = !!(await getAddonVitestConstants());
 
 	server.tool(
@@ -27,21 +38,66 @@ export async function addGetUIBuildingInstructionsTool(server: McpServer<any, Ad
 					(server.ctx.custom?.toolsets?.test ?? true) && addonVitestAvailable;
 				const a11yAvailable = testToolsetAvailable && (server.ctx.custom?.a11yEnabled ?? false);
 
-				const criticalTestBullets = testToolsetAvailable
-					? `
+				return getStorybookStoryInstructionsDescription({
+					testToolsetAvailable,
+					a11yAvailable,
+				});
+			},
+			enabled,
+		},
+		async () => {
+			try {
+				const { options, disableTelemetry } = server.ctx.custom ?? {};
+				if (!options) {
+					throw new Error('Options are required in addon context');
+				}
+
+				if (!disableTelemetry) {
+					await collectTelemetry({
+						event: 'tool:getUIBuildingInstructions',
+						server,
+						toolset: 'dev',
+					});
+				}
+
+				const uiInstructions = await buildStorybookStoryInstructions(options, {
+					toolsets: server.ctx.custom?.toolsets,
+					a11yEnabled: server.ctx.custom?.a11yEnabled,
+					addonVitestAvailable,
+				});
+
+				return {
+					content: [{ type: 'text' as const, text: uiInstructions }],
+				};
+			} catch (error) {
+				return errorToMCPContent(error);
+			}
+		},
+	);
+}
+
+export function getStorybookStoryInstructionsDescription({
+	testToolsetAvailable,
+	a11yAvailable,
+}: {
+	testToolsetAvailable: boolean;
+	a11yAvailable: boolean;
+}) {
+	const criticalTestBullets = testToolsetAvailable
+		? `
 - Running story tests or fixing test failures`
-					: '';
-				const criticalA11yBullets = a11yAvailable
-					? `
+		: '';
+	const criticalA11yBullets = a11yAvailable
+		? `
 - Handling accessibility (a11y) violations in stories (fix semantic issues directly; ask before visual/design changes)`
-					: '';
+		: '';
 
-				const testAndA11yGuidance = testToolsetAvailable
-					? `
+	const testAndA11yGuidance = testToolsetAvailable
+		? `
 - How to handle test failures${a11yAvailable ? ' and accessibility violations' : ''}`
-					: '';
+		: '';
 
-				return `Get comprehensive instructions for writing, testing, and fixing Storybook stories (.stories.tsx, .stories.ts, .stories.jsx, .stories.js, .stories.svelte, .stories.vue files).
+	return `Get comprehensive instructions for writing, testing, and fixing Storybook stories (.stories.tsx, .stories.ts, .stories.jsx, .stories.js, .stories.svelte, .stories.vue files).
 
 CRITICAL: You MUST call this tool before:
 - Creating new Storybook stories or story files
@@ -60,72 +116,65 @@ This tool provides essential Storybook-specific guidance including:
 - Story variants and coverage requirements${testAndA11yGuidance}
 
 Even if you're familiar with Storybook, call this tool to ensure you're following the correct patterns, import paths, and conventions for this specific Storybook setup.`;
-			},
-			enabled: () => server.ctx.custom?.toolsets?.dev ?? true,
-		},
-		async () => {
-			try {
-				const { options, disableTelemetry } = server.ctx.custom ?? {};
-				if (!options) {
-					throw new Error('Options are required in addon context');
-				}
+}
 
-				if (!disableTelemetry) {
-					await collectTelemetry({
-						event: 'tool:getUIBuildingInstructions',
-						server,
-						toolset: 'dev',
-					});
-				}
+export function getStorybookStoryInstructionsToolMetadata(options: {
+	testToolsetAvailable: boolean;
+	a11yAvailable: boolean;
+}) {
+	return {
+		name: GET_UI_BUILDING_INSTRUCTIONS_TOOL_NAME,
+		title: 'Storybook Story Development Instructions',
+		description: getStorybookStoryInstructionsDescription(options),
+	};
+}
 
-				const frameworkPreset = await options.presets.apply('framework');
-				const featuresPreset = await options.presets.apply('features', {});
-				const changeDetectionEnabled = featuresPreset?.changeDetection ?? false;
-				const reviewStatus = await getReviewStatus(options, { features: featuresPreset });
-				const reviewEnabled = reviewStatus.available;
-				const framework =
-					typeof frameworkPreset === 'string' ? frameworkPreset : frameworkPreset?.name;
-				const renderer = frameworkToRendererMap[framework!];
-				const storyLinkingWorkflow = changeDetectionEnabled
-					? `After changing UI, call \`${GET_CHANGED_STORIES_TOOL_NAME}\` first, then use \`${PREVIEW_STORIES_TOOL_NAME}\` with selected \`storyId\` values from those results.`
-					: `After changing UI, call \`${PREVIEW_STORIES_TOOL_NAME}\` and share the most relevant links for the changes.`;
-				const changedStoryFallbackLinkGuidance = changeDetectionEnabled
-					? `When sharing preview/story links (not when ending with a review section): if you did not pass every changed story into \`${PREVIEW_STORIES_TOOL_NAME}\`, include this Storybook fallback link so the user can view the complete changed list: \`/?statuses=affected;modified;new\`.`
-					: `When sharing preview/story links (not when ending with a review section) and you passed only a subset into \`${PREVIEW_STORIES_TOOL_NAME}\`, mention that additional relevant stories may exist in Storybook.`;
+export async function buildStorybookStoryInstructions(
+	options: Options,
+	{
+		toolsets,
+		a11yEnabled = false,
+		addonVitestAvailable,
+	}: BuildStorybookStoryInstructionsOptions = {},
+): Promise<string> {
+	const frameworkPreset = await options.presets.apply('framework');
+	const featuresPreset = await options.presets.apply('features', {});
+	const changeDetectionEnabled = featuresPreset?.changeDetection ?? false;
+	const reviewStatus = await getReviewStatus(options, { features: featuresPreset });
+	const reviewEnabled = reviewStatus.available;
+	const framework = typeof frameworkPreset === 'string' ? frameworkPreset : frameworkPreset?.name;
+	const renderer = frameworkToRendererMap[framework!];
+	const storyLinkingWorkflow = changeDetectionEnabled
+		? `After changing UI, call \`${GET_CHANGED_STORIES_TOOL_NAME}\` first, then use \`${PREVIEW_STORIES_TOOL_NAME}\` with selected \`storyId\` values from those results.`
+		: `After changing UI, call \`${PREVIEW_STORIES_TOOL_NAME}\` and share the most relevant links for the changes.`;
+	const changedStoryFallbackLinkGuidance = changeDetectionEnabled
+		? `When sharing preview/story links (not when ending with a review section): if you did not pass every changed story into \`${PREVIEW_STORIES_TOOL_NAME}\`, include this Storybook fallback link so the user can view the complete changed list: \`/?statuses=affected;modified;new\`.`
+		: `When sharing preview/story links (not when ending with a review section) and you passed only a subset into \`${PREVIEW_STORIES_TOOL_NAME}\`, mention that additional relevant stories may exist in Storybook.`;
 
-				let uiInstructions = storyInstructionsTemplate
-					.replace('{{FRAMEWORK}}', framework)
-					.replace('{{RENDERER}}', renderer ?? framework)
-					.replace('{{STORY_LINKING_WORKFLOW}}', storyLinkingWorkflow)
-					.replace('{{FINAL_LINKS_GUIDANCE}}', getFinalLinksGuidance(reviewEnabled))
-					.replace('{{CHANGED_STORY_FALLBACK_LINK_GUIDANCE}}', changedStoryFallbackLinkGuidance);
+	let uiInstructions = storyInstructionsTemplate
+		.replace('{{FRAMEWORK}}', framework)
+		.replace('{{RENDERER}}', renderer ?? framework)
+		.replace('{{STORY_LINKING_WORKFLOW}}', storyLinkingWorkflow)
+		.replace('{{FINAL_LINKS_GUIDANCE}}', getFinalLinksGuidance(reviewEnabled))
+		.replace('{{CHANGED_STORY_FALLBACK_LINK_GUIDANCE}}', changedStoryFallbackLinkGuidance);
 
-				// Conditionally append story testing instructions if test toolset is enabled and addon-vitest is available
-				const testToolsetAvailable =
-					(server.ctx.custom?.toolsets?.test ?? true) && !!(await getAddonVitestConstants());
+	const resolvedAddonVitestAvailable = addonVitestAvailable ?? !!(await getAddonVitestConstants());
+	const testToolsetAvailable = (toolsets?.test ?? true) && resolvedAddonVitestAvailable;
 
-				if (testToolsetAvailable) {
-					const a11yEnabled = server.ctx.custom?.a11yEnabled ?? false;
-					const a11yFixSuffix = a11yEnabled ? ' (see a11y guidelines below)' : '';
+	if (testToolsetAvailable) {
+		const a11yFixSuffix = a11yEnabled ? ' (see a11y guidelines below)' : '';
 
-					const storyTestingInstructions = storyTestingInstructionsTemplate
-						.replaceAll('{{RUN_STORY_TESTS_TOOL_NAME}}', RUN_STORY_TESTS_TOOL_NAME)
-						.replace('{{A11Y_FIX_SUFFIX}}', a11yFixSuffix);
+		const storyTestingInstructions = storyTestingInstructionsTemplate
+			.replaceAll('{{RUN_STORY_TESTS_TOOL_NAME}}', RUN_STORY_TESTS_TOOL_NAME)
+			.replace('{{A11Y_FIX_SUFFIX}}', a11yFixSuffix);
 
-					uiInstructions += `\n\n${storyTestingInstructions}`;
-					if (a11yEnabled) {
-						uiInstructions += `\n${a11yInstructionsTemplate}`;
-					}
-				}
+		uiInstructions += `\n\n${storyTestingInstructions}`;
+		if (a11yEnabled) {
+			uiInstructions += `\n${a11yInstructionsTemplate}`;
+		}
+	}
 
-				return {
-					content: [{ type: 'text' as const, text: uiInstructions }],
-				};
-			} catch (error) {
-				return errorToMCPContent(error);
-			}
-		},
-	);
+	return uiInstructions;
 }
 
 // TODO: this is a stupid map to maintain and it's not complete, but we can't easily get the current renderer name

--- a/packages/addon-mcp/src/tools/preview-stories.ts
+++ b/packages/addon-mcp/src/tools/preview-stories.ts
@@ -13,8 +13,10 @@ import fs from 'node:fs/promises';
 import { PREVIEW_STORIES_TOOL_NAME } from './tool-names.ts';
 
 export const PREVIEW_STORIES_RESOURCE_URI = `ui://${PREVIEW_STORIES_TOOL_NAME}/preview.html`;
+export const PREVIEW_STORIES_TOOL_DESCRIPTION = `Use this tool to get one or more Storybook preview URLs.
+Include each returned preview URL in your final user-facing response so users can open them directly — unless you're also publishing a curated review via display-review, in which case link the review page instead of listing individual URLs.`;
 
-const PreviewStoriesInput = v.object({
+export const PreviewStoriesInput = v.object({
 	stories: v.pipe(
 		StoryInputArray,
 		v.description(
@@ -26,7 +28,7 @@ Use { absoluteStoryPath + exportName } only when you're already working in a spe
 	),
 });
 
-const PreviewStoriesOutput = v.object({
+export const PreviewStoriesOutput = v.object({
 	stories: v.array(
 		v.union([
 			v.object({
@@ -47,10 +49,25 @@ const PreviewStoriesOutput = v.object({
 	),
 });
 
-type PreviewStoriesInput = v.InferOutput<typeof PreviewStoriesInput>;
+export type PreviewStoriesInput = v.InferOutput<typeof PreviewStoriesInput>;
 export type PreviewStoriesOutput = v.InferOutput<typeof PreviewStoriesOutput>;
 
-export async function addPreviewStoriesTool(server: McpServer<any, AddonContext>) {
+export function getPreviewStoriesToolMetadata() {
+	return {
+		name: PREVIEW_STORIES_TOOL_NAME,
+		title: 'Get story preview URLs',
+		description: PREVIEW_STORIES_TOOL_DESCRIPTION,
+		schema: PreviewStoriesInput,
+		outputSchema: PreviewStoriesOutput,
+		_meta: { ui: { resourceUri: PREVIEW_STORIES_RESOURCE_URI } },
+	};
+}
+
+export async function addPreviewStoriesTool(
+	server: McpServer<any, AddonContext>,
+	enabled: Parameters<McpServer<any, AddonContext>['tool']>[0]['enabled'] = () =>
+		server.ctx.custom?.toolsets?.dev ?? true,
+) {
 	const previewStoryAppScript = await fs.readFile(
 		url.fileURLToPath(
 			import.meta.resolve('@storybook/addon-mcp/internal/preview-stories-app-script'),
@@ -95,14 +112,8 @@ export async function addPreviewStoriesTool(server: McpServer<any, AddonContext>
 
 	server.tool(
 		{
-			name: PREVIEW_STORIES_TOOL_NAME,
-			title: 'Get story preview URLs',
-			description: `Use this tool to get one or more Storybook preview URLs.
-Include each returned preview URL in your final user-facing response so users can open them directly — unless you're also publishing a curated review via display-review, in which case link the review page instead of listing individual URLs.`,
-			schema: PreviewStoriesInput,
-			outputSchema: PreviewStoriesOutput,
-			enabled: () => server.ctx.custom?.toolsets?.dev ?? true,
-			_meta: { ui: { resourceUri: PREVIEW_STORIES_RESOURCE_URI } },
+			...getPreviewStoriesToolMetadata(),
+			enabled,
 		},
 		async (input) => {
 			try {

--- a/packages/addon-mcp/src/tools/run-story-tests.ts
+++ b/packages/addon-mcp/src/tools/run-story-tests.ts
@@ -32,7 +32,7 @@ export async function getAddonVitestConstants() {
 	}
 }
 
-const RunStoryTestsInput = v.object({
+export const RunStoryTestsInput = v.object({
 	stories: v.optional(
 		v.pipe(
 			StoryInputArray,
@@ -56,6 +56,29 @@ Use { absoluteStoryPath + exportName } only when you're currently working in a s
 		true,
 	),
 });
+
+export function getRunStoryTestsToolDescription(a11yEnabled: boolean) {
+	return (
+		`Run story tests.
+Provide stories for focused runs (faster while iterating),
+or omit stories to run all tests for full-project verification.
+Use this continuously to monitor test results as you work on your UI components and stories.
+Results will include passing/failing status` +
+		(a11yEnabled
+			? `, and accessibility violation reports.
+For visual/design accessibility violations (for example color contrast), ask the user before changing styles.`
+			: '.')
+	);
+}
+
+export function getRunStoryTestsToolMetadata({ a11yEnabled }: { a11yEnabled: boolean }) {
+	return {
+		name: RUN_STORY_TESTS_TOOL_NAME,
+		title: 'Storybook Tests',
+		description: getRunStoryTestsToolDescription(a11yEnabled),
+		schema: RunStoryTestsInput,
+	};
+}
 
 /**
  * Creates a queue that ensures concurrent calls are executed in sequence.
@@ -92,32 +115,20 @@ function createAsyncQueue() {
 export async function addRunStoryTestsTool(
 	server: McpServer<any, AddonContext>,
 	{ a11yEnabled }: { a11yEnabled: boolean },
+	enabled: Parameters<McpServer<any, AddonContext>['tool']>[0]['enabled'] = () =>
+		server.ctx.custom?.toolsets?.test ?? true,
 ) {
 	const addonVitestConstants = await getAddonVitestConstants();
 	const testRunQueue = createAsyncQueue();
 
-	const description =
-		`Run story tests.
-Provide stories for focused runs (faster while iterating),
-or omit stories to run all tests for full-project verification.
-Use this continuously to monitor test results as you work on your UI components and stories.
-Results will include passing/failing status` +
-		(a11yEnabled
-			? `, and accessibility violation reports.
-For visual/design accessibility violations (for example color contrast), ask the user before changing styles.`
-			: '.');
-
 	server.tool(
 		{
-			name: RUN_STORY_TESTS_TOOL_NAME,
-			title: 'Storybook Tests',
-			description,
-			schema: RunStoryTestsInput,
+			...getRunStoryTestsToolMetadata({ a11yEnabled }),
 			enabled: () => {
 				if (!addonVitestConstants) {
 					return false;
 				}
-				return server.ctx.custom?.toolsets?.test ?? true;
+				return typeof enabled === 'function' ? enabled() : enabled;
 			},
 		},
 		async (input: v.InferInput<typeof RunStoryTestsInput>) => {

--- a/packages/addon-mcp/src/tools/tool-registry.ts
+++ b/packages/addon-mcp/src/tools/tool-registry.ts
@@ -211,7 +211,10 @@ export async function registerAddonMcpTools(
 	context: AddonToolRegistryContext,
 ) {
 	for (const definition of addonToolDefinitions) {
-		if (isToolAvailable(definition, context)) {
+		if (
+			isToolsetEnabled(definition.toolset, context.toolsets) &&
+			isToolAvailable(definition, context)
+		) {
 			await definition.register(server, context, createToolsetEnabled(server, definition.toolset));
 		}
 	}

--- a/packages/addon-mcp/src/tools/tool-registry.ts
+++ b/packages/addon-mcp/src/tools/tool-registry.ts
@@ -1,0 +1,218 @@
+import type { McpServer } from 'tmcp';
+import type { Options } from 'storybook/internal/types';
+import { logger } from 'storybook/internal/node-logger';
+import {
+	addGetDocumentationTool,
+	addGetStoryDocumentationTool,
+	addListAllDocumentationTool,
+	GET_STORY_TOOL_NAME,
+	GET_TOOL_NAME,
+	getDocumentationToolMetadata,
+	getListAllDocumentationToolMetadata,
+	getStoryDocumentationToolMetadata,
+	LIST_TOOL_NAME,
+} from '@storybook/mcp';
+import type { AddonContext } from '../types.ts';
+import type { ToolAvailability } from '../utils/get-tool-availability.ts';
+import { getDisplayReviewToolMetadata, addDisplayReviewTool } from './display-review.ts';
+import { getChangedStoriesToolMetadata, addGetChangedStoriesTool } from './get-changed-stories.ts';
+import {
+	getStoriesByComponentToolMetadata,
+	addGetStoriesByComponentTool,
+} from './get-stories-by-component.ts';
+import {
+	buildStorybookStoryInstructions,
+	getStorybookStoryInstructionsToolMetadata,
+	addGetUIBuildingInstructionsTool,
+} from './get-storybook-story-instructions.ts';
+import { getPreviewStoriesToolMetadata, addPreviewStoriesTool } from './preview-stories.ts';
+import { getRunStoryTestsToolMetadata, addRunStoryTestsTool } from './run-story-tests.ts';
+import {
+	DISPLAY_REVIEW_TOOL_NAME,
+	GET_CHANGED_STORIES_TOOL_NAME,
+	GET_STORIES_BY_COMPONENT_TOOL_NAME,
+	GET_UI_BUILDING_INSTRUCTIONS_TOOL_NAME,
+	PREVIEW_STORIES_TOOL_NAME,
+	RUN_STORY_TESTS_TOOL_NAME,
+} from './tool-names.ts';
+
+export type ToolMetadata = {
+	name: string;
+	title?: string;
+	description?: string;
+	schema?: unknown;
+	outputSchema?: unknown;
+	_meta?: Record<string, unknown>;
+};
+
+export type StorybookAiToolCallResult = {
+	content: Array<{ type: 'text'; text: string }>;
+	structuredContent?: Record<string, unknown>;
+	isError?: boolean;
+};
+
+export type StorybookAiLocalTool = {
+	call: (input?: Record<string, unknown>) => Promise<StorybookAiToolCallResult>;
+};
+
+export type AddonToolRegistryContext = {
+	availability: ToolAvailability;
+	multiSource?: boolean;
+	toolsets?: AddonContext['toolsets'];
+	options?: Options;
+};
+
+type AddonToolset = keyof NonNullable<AddonContext['toolsets']>;
+type ToolEnabled = Parameters<McpServer<any, AddonContext>['tool']>[0]['enabled'];
+
+type AddonToolDefinition = {
+	name: string;
+	toolset: AddonToolset;
+	available?: (context: AddonToolRegistryContext) => boolean;
+	getMetadata: (context: AddonToolRegistryContext) => ToolMetadata;
+	register: (
+		server: McpServer<any, AddonContext>,
+		context: AddonToolRegistryContext,
+		enabled: ToolEnabled,
+	) => Promise<void>;
+	getLocalTool?: (context: AddonToolRegistryContext & { options: Options }) => StorybookAiLocalTool;
+};
+
+const isToolsetEnabled = (toolset: AddonToolset, toolsets: AddonContext['toolsets'] | undefined) =>
+	toolsets?.[toolset] ?? true;
+
+const isToolAvailable = (definition: AddonToolDefinition, context: AddonToolRegistryContext) =>
+	definition.available?.(context) ?? true;
+
+const isMetadataToolEnabled = (
+	definition: AddonToolDefinition,
+	context: AddonToolRegistryContext,
+) => isToolsetEnabled(definition.toolset, context.toolsets) && isToolAvailable(definition, context);
+
+const createToolsetEnabled =
+	(server: McpServer<any, AddonContext>, toolset: AddonToolset): ToolEnabled =>
+	() =>
+		server.ctx.custom?.toolsets?.[toolset] ?? true;
+
+const addonToolDefinitions: AddonToolDefinition[] = [
+	{
+		name: PREVIEW_STORIES_TOOL_NAME,
+		toolset: 'dev',
+		getMetadata: () => getPreviewStoriesToolMetadata(),
+		register: (server, _context, enabled) => addPreviewStoriesTool(server, enabled),
+	},
+	{
+		name: GET_UI_BUILDING_INSTRUCTIONS_TOOL_NAME,
+		toolset: 'dev',
+		getMetadata: ({ availability, toolsets }) => {
+			const testToolsetAvailable = isToolsetEnabled('test', toolsets) && availability.testSupported;
+			return getStorybookStoryInstructionsToolMetadata({
+				testToolsetAvailable,
+				a11yAvailable: testToolsetAvailable && availability.a11yEnabled,
+			});
+		},
+		register: (server, _context, enabled) => addGetUIBuildingInstructionsTool(server, enabled),
+		getLocalTool: ({ availability, toolsets, options }) => ({
+			call: async () => {
+				const text = await buildStorybookStoryInstructions(options, {
+					toolsets,
+					a11yEnabled: availability.a11yEnabled,
+					addonVitestAvailable: availability.testSupported,
+				});
+				return { content: [{ type: 'text', text }] };
+			},
+		}),
+	},
+	{
+		name: GET_CHANGED_STORIES_TOOL_NAME,
+		toolset: 'dev',
+		available: ({ availability }) => availability.changeDetectionEnabled,
+		getMetadata: () => getChangedStoriesToolMetadata(),
+		register: (server, _context, enabled) => addGetChangedStoriesTool(server, enabled),
+	},
+	{
+		name: GET_STORIES_BY_COMPONENT_TOOL_NAME,
+		toolset: 'dev',
+		available: ({ availability }) => availability.moduleGraphSupported,
+		getMetadata: () => getStoriesByComponentToolMetadata(),
+		register: (server, _context, enabled) => addGetStoriesByComponentTool(server, enabled),
+	},
+	{
+		name: DISPLAY_REVIEW_TOOL_NAME,
+		toolset: 'dev',
+		available: ({ availability }) => availability.reviewEnabled,
+		getMetadata: () => getDisplayReviewToolMetadata(),
+		register: (server, _context, enabled) => addDisplayReviewTool(server, enabled),
+	},
+	{
+		name: RUN_STORY_TESTS_TOOL_NAME,
+		toolset: 'test',
+		available: ({ availability }) => availability.testSupported,
+		getMetadata: ({ availability }) =>
+			getRunStoryTestsToolMetadata({ a11yEnabled: availability.a11yEnabled }),
+		register: (server, { availability }, enabled) =>
+			addRunStoryTestsTool(server, { a11yEnabled: availability.a11yEnabled }, enabled),
+	},
+	{
+		name: LIST_TOOL_NAME,
+		toolset: 'docs',
+		available: ({ availability }) => availability.docsEnabled,
+		getMetadata: () => getListAllDocumentationToolMetadata(),
+		register: async (server, _context, enabled) => {
+			logger.info(
+				'Experimental components manifest feature detected - registering component tools',
+			);
+			await addListAllDocumentationTool(server, enabled);
+		},
+	},
+	{
+		name: GET_TOOL_NAME,
+		toolset: 'docs',
+		available: ({ availability }) => availability.docsEnabled,
+		getMetadata: ({ multiSource }) => getDocumentationToolMetadata({ multiSource }),
+		register: (server, { multiSource }, enabled) =>
+			addGetDocumentationTool(server, enabled, {
+				multiSource,
+			}),
+	},
+	{
+		name: GET_STORY_TOOL_NAME,
+		toolset: 'docs',
+		available: ({ availability }) => availability.docsEnabled,
+		getMetadata: ({ multiSource }) => getStoryDocumentationToolMetadata({ multiSource }),
+		register: (server, { multiSource }, enabled) =>
+			addGetStoryDocumentationTool(server, enabled, {
+				multiSource,
+			}),
+	},
+];
+
+export function getAddonToolMetadata(context: AddonToolRegistryContext): ToolMetadata[] {
+	return addonToolDefinitions
+		.filter((definition) => isMetadataToolEnabled(definition, context))
+		.map((definition) => definition.getMetadata(context));
+}
+
+export function getAddonLocalTools(
+	context: AddonToolRegistryContext & { options: Options },
+): Record<string, StorybookAiLocalTool> {
+	return Object.fromEntries(
+		addonToolDefinitions
+			.filter((definition) => isMetadataToolEnabled(definition, context))
+			.flatMap((definition) => {
+				const localTool = definition.getLocalTool?.(context);
+				return localTool ? [[definition.name, localTool]] : [];
+			}),
+	);
+}
+
+export async function registerAddonMcpTools(
+	server: McpServer<any, AddonContext>,
+	context: AddonToolRegistryContext,
+) {
+	for (const definition of addonToolDefinitions) {
+		if (isToolAvailable(definition, context)) {
+			await definition.register(server, context, createToolsetEnabled(server, definition.toolset));
+		}
+	}
+}

--- a/packages/addon-mcp/src/utils/get-tool-availability.ts
+++ b/packages/addon-mcp/src/utils/get-tool-availability.ts
@@ -38,6 +38,12 @@ export interface GetToolAvailabilityOptions {
 	moduleGraphSupported?: boolean | undefined;
 }
 
+/**
+ * Composed Storybooks with component manifests can back docs tools even when the
+ * local Storybook has no component manifest. Use this before feeding
+ * availability into the shared tool registry so live MCP registration and
+ * serverless AI metadata make the same docs-tool decision.
+ */
 export function getEffectiveToolAvailability(
 	availability: ToolAvailability,
 	{ multiSource = false }: { multiSource?: boolean } = {},

--- a/packages/addon-mcp/src/utils/get-tool-availability.ts
+++ b/packages/addon-mcp/src/utils/get-tool-availability.ts
@@ -38,6 +38,22 @@ export interface GetToolAvailabilityOptions {
 	moduleGraphSupported?: boolean | undefined;
 }
 
+export function getEffectiveToolAvailability(
+	availability: ToolAvailability,
+	{ multiSource = false }: { multiSource?: boolean } = {},
+): ToolAvailability {
+	if (!multiSource) {
+		return availability;
+	}
+
+	return {
+		...availability,
+		docsEnabled: true,
+		docsHasManifests: true,
+		docsFeatureEnabled: true,
+	};
+}
+
 /**
  * Single source of truth for the runtime gates that decide whether each tool is
  * registered (and how the landing page badges it).

--- a/packages/addon-mcp/src/utils/get-tool-availability.ts
+++ b/packages/addon-mcp/src/utils/get-tool-availability.ts
@@ -30,6 +30,12 @@ export interface GetToolAvailabilityOptions {
 	 * risking a different snapshot than the caller already resolved.
 	 */
 	features?: { changeDetection?: boolean } | undefined;
+	/**
+	 * Pre-resolved module-graph support. The live MCP server should omit this so it
+	 * probes the registered open service. Serverless metadata can pass a builder-level
+	 * capability check because no dev-server service exists in that process.
+	 */
+	moduleGraphSupported?: boolean | undefined;
 }
 
 /**
@@ -44,7 +50,7 @@ export interface GetToolAvailabilityOptions {
  */
 export async function getToolAvailability(
 	options: Options,
-	{ features }: GetToolAvailabilityOptions = {},
+	{ features, moduleGraphSupported: moduleGraphSupportedOverride }: GetToolAvailabilityOptions = {},
 ): Promise<ToolAvailability> {
 	const resolvedFeatures =
 		features ??
@@ -52,7 +58,7 @@ export async function getToolAvailability(
 
 	const [moduleGraphSupported, reviewStatus, manifestStatus, addonVitestConstants, a11yEnabled] =
 		await Promise.all([
-			isModuleGraphSupported(),
+			moduleGraphSupportedOverride ?? isModuleGraphSupported(),
 			getReviewStatus(options, { features: resolvedFeatures }),
 			getManifestStatus(options),
 			getAddonVitestConstants(),

--- a/packages/addon-mcp/src/utils/module-graph.ts
+++ b/packages/addon-mcp/src/utils/module-graph.ts
@@ -12,7 +12,9 @@
  * mirror them here; keep them in sync with `core/module-graph` if it changes.
  */
 
+import { importModule } from 'storybook/internal/common';
 import type { Query } from 'storybook/internal/core-server';
+import type { Builder, CoreConfig, Options } from 'storybook/internal/types';
 
 const MODULE_GRAPH_SERVICE_ID = 'core/module-graph';
 
@@ -71,6 +73,24 @@ async function probe(): Promise<GetServiceFn | null> {
  */
 export async function isModuleGraphSupported(): Promise<boolean> {
 	return (await getModuleGraphService()) !== undefined;
+}
+
+export async function isModuleGraphSupportedByBuilder(
+	options: Pick<Options, 'presets'>,
+): Promise<boolean> {
+	const core = (await options.presets.apply('core', {})) as CoreConfig | undefined;
+	const builder = core?.builder;
+	const builderName = typeof builder === 'string' ? builder : builder?.name;
+	if (!builderName) {
+		return false;
+	}
+
+	try {
+		const previewBuilder = (await importModule(builderName)) as Partial<Builder<unknown>>;
+		return typeof previewBuilder.changeDetectionAdapter === 'function';
+	} catch {
+		return false;
+	}
 }
 
 /**

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -11,10 +11,19 @@ import serverInstructions from './instructions.md';
 export { serverInstructions as STORYBOOK_MCP_INSTRUCTIONS };
 
 // Export tools for reuse by addon-mcp
-export { addListAllDocumentationTool, LIST_TOOL_NAME } from './tools/list-all-documentation.ts';
-export { addGetDocumentationTool, GET_TOOL_NAME } from './tools/get-documentation.ts';
+export {
+	addListAllDocumentationTool,
+	getListAllDocumentationToolMetadata,
+	LIST_TOOL_NAME,
+} from './tools/list-all-documentation.ts';
+export {
+	addGetDocumentationTool,
+	getDocumentationToolMetadata,
+	GET_TOOL_NAME,
+} from './tools/get-documentation.ts';
 export {
 	addGetStoryDocumentationTool,
+	getStoryDocumentationToolMetadata,
 	GET_STORY_TOOL_NAME,
 } from './tools/get-documentation-for-story.ts';
 

--- a/packages/mcp/src/tools/get-documentation-for-story.ts
+++ b/packages/mcp/src/tools/get-documentation-for-story.ts
@@ -8,27 +8,37 @@ import { LIST_TOOL_NAME } from './list-all-documentation.ts';
 
 export const GET_STORY_TOOL_NAME = 'get-documentation-for-story';
 
+export const GET_STORY_DOCUMENTATION_TOOL_DESCRIPTION =
+	'Get detailed documentation for a specific story variant of a UI component. Use this when you need to see more usage examples of a component, via the stories written for it.';
+
 const BaseInput = {
 	componentId: v.string(),
 	storyName: v.string(),
 };
+
+export function getStoryDocumentationToolSchema(options?: { multiSource?: boolean }) {
+	return options?.multiSource
+		? v.object({ ...BaseInput, ...StorybookIdField })
+		: v.object(BaseInput);
+}
+
+export function getStoryDocumentationToolMetadata(options?: { multiSource?: boolean }) {
+	return {
+		name: GET_STORY_TOOL_NAME,
+		title: 'Get Documentation for Story',
+		description: GET_STORY_DOCUMENTATION_TOOL_DESCRIPTION,
+		schema: getStoryDocumentationToolSchema(options),
+	};
+}
 
 export async function addGetStoryDocumentationTool(
 	server: McpServer<any, StorybookContext>,
 	enabled?: Parameters<McpServer<any, StorybookContext>['tool']>[0]['enabled'],
 	options?: { multiSource?: boolean },
 ) {
-	const schema = options?.multiSource
-		? v.object({ ...BaseInput, ...StorybookIdField })
-		: v.object(BaseInput);
-
 	server.tool(
 		{
-			name: GET_STORY_TOOL_NAME,
-			title: 'Get Documentation for Story',
-			description:
-				'Get detailed documentation for a specific story variant of a UI component. Use this when you need to see more usage examples of a component, via the stories written for it.',
-			schema,
+			...getStoryDocumentationToolMetadata(options),
 			enabled,
 		},
 		async (input: { componentId: string; storyName: string; storybookId?: string }) => {

--- a/packages/mcp/src/tools/get-documentation.ts
+++ b/packages/mcp/src/tools/get-documentation.ts
@@ -17,25 +17,35 @@ const BaseInput = {
 	id: v.pipe(v.string(), v.description('The component or docs entry ID (e.g., "button")')),
 };
 
+export const GET_DOCUMENTATION_TOOL_DESCRIPTION = `Get documentation for a UI component or docs entry.
+
+Returns the first ${MAX_STORIES_TO_SHOW} stories (including story IDs) with code snippets showing how props are used, plus TypeScript prop definitions. Call this before using a component to avoid hallucinating prop names, types, or valid combinations. Stories reveal real prop usage patterns, interactions, and edge cases that type definitions alone don't show. If the example stories don't show the prop you need, use the ${GET_STORY_TOOL_NAME} tool to fetch the story documentation for the specific story variant you need.
+
+Example: id="button" returns Primary, Secondary, Large stories with code like <Button variant="primary" size="large"> showing actual prop combinations.`;
+
+export function getDocumentationToolSchema(options?: { multiSource?: boolean }) {
+	return options?.multiSource
+		? v.object({ ...BaseInput, ...StorybookIdField })
+		: v.object(BaseInput);
+}
+
+export function getDocumentationToolMetadata(options?: { multiSource?: boolean }) {
+	return {
+		name: GET_TOOL_NAME,
+		title: 'Get Documentation',
+		description: GET_DOCUMENTATION_TOOL_DESCRIPTION,
+		schema: getDocumentationToolSchema(options),
+	};
+}
+
 export async function addGetDocumentationTool(
 	server: McpServer<any, StorybookContext>,
 	enabled?: Parameters<McpServer<any, StorybookContext>['tool']>[0]['enabled'],
 	options?: { multiSource?: boolean },
 ) {
-	const schema = options?.multiSource
-		? v.object({ ...BaseInput, ...StorybookIdField })
-		: v.object(BaseInput);
-
 	server.tool(
 		{
-			name: GET_TOOL_NAME,
-			title: 'Get Documentation',
-			description: `Get documentation for a UI component or docs entry.
-
-Returns the first ${MAX_STORIES_TO_SHOW} stories (including story IDs) with code snippets showing how props are used, plus TypeScript prop definitions. Call this before using a component to avoid hallucinating prop names, types, or valid combinations. Stories reveal real prop usage patterns, interactions, and edge cases that type definitions alone don't show. If the example stories don't show the prop you need, use the ${GET_STORY_TOOL_NAME} tool to fetch the story documentation for the specific story variant you need.
-
-Example: id="button" returns Primary, Secondary, Large stories with code like <Button variant="primary" size="large"> showing actual prop combinations.`,
-			schema,
+			...getDocumentationToolMetadata(options),
 			enabled,
 		},
 		async (input: { id: string; storybookId?: string }) => {

--- a/packages/mcp/src/tools/list-all-documentation.ts
+++ b/packages/mcp/src/tools/list-all-documentation.ts
@@ -9,7 +9,7 @@ import {
 
 export const LIST_TOOL_NAME = 'list-all-documentation';
 
-const ListAllDocumentationInput = v.object({
+export const ListAllDocumentationInput = v.object({
 	withStoryIds: v.optional(
 		v.pipe(
 			v.boolean(),
@@ -21,16 +21,22 @@ const ListAllDocumentationInput = v.object({
 	),
 });
 
+export function getListAllDocumentationToolMetadata() {
+	return {
+		name: LIST_TOOL_NAME,
+		title: 'List All Documentation',
+		description: 'List all available UI components and documentation entries from the Storybook',
+		schema: ListAllDocumentationInput,
+	};
+}
+
 export async function addListAllDocumentationTool(
 	server: McpServer<any, StorybookContext>,
 	enabled?: Parameters<McpServer<any, StorybookContext>['tool']>[0]['enabled'],
 ) {
 	server.tool(
 		{
-			name: LIST_TOOL_NAME,
-			title: 'List All Documentation',
-			description: 'List all available UI components and documentation entries from the Storybook',
-			schema: ListAllDocumentationInput,
+			...getListAllDocumentationToolMetadata(),
 			enabled,
 		},
 		async (input) => {


### PR DESCRIPTION
## Summary

- Exposes `experimental_storybookAi` from the addon preset so Storybook can get AI instructions and MCP-shaped tool descriptors without calling the running MCP HTTP endpoint.
- Adds a shared addon tool registry so live MCP registration and serverless metadata use the same ordered tool surface, descriptions, schemas, and availability gates.
- Extracts `get-storybook-story-instructions` into a local callable builder for serverless CLI execution.

Part of storybookjs/storybook#35210.

## Testing

- `pnpm vitest --project=@storybook/addon-mcp packages/addon-mcp/src/storybook-ai-metadata.test.ts packages/addon-mcp/src/tools/get-storybook-story-instructions.test.ts packages/addon-mcp/src/mcp-handler.test.ts`
- `pnpm --filter @storybook/addon-mcp typecheck && pnpm --filter @storybook/mcp typecheck`
- `pnpm lint`
- `pnpm run format:check`
- `pnpm --filter @storybook/mcp build && pnpm --filter @storybook/addon-mcp build`

Note: `pnpm lint` exits successfully with 3 pre-existing warnings in unrelated tests; build exits successfully with existing `react-docgen-typescript` dependency warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed serverless Storybook AI metadata via `addon-mcp` presets, including MCP-shaped instructions/tool descriptors.
  * Added composition sources resolution with multi-source support, including serverless manifest probing.
  * Introduced the `experimental_storybookAi` preset wrapper.

* **Refactor**
  * Centralized MCP tool registration and metadata generation; tool availability and documentation behavior now properly account for multi-source mode.
  * Reused shared metadata/schema for multiple MCP documentation-related tools.

* **Tests**
  * Expanded Vitest coverage for Storybook AI metadata parity and edge cases.
  * Added MCP handler test coverage for composed refs when local manifests are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->