### PR TITLE
fix(ade): skip sb installation if no explicit skill invocation

### DIFF
--- a/packages/claude-plugin/skills/stories/SKILL.md
+++ b/packages/claude-plugin/skills/stories/SKILL.md
@@ -38,7 +38,7 @@ stories in sync with every frontend component you create, modify, or delete.
   - If this skill is not explicitly invoked by the user, silently ignore this skill.
   - Otherwise, ask the user whether they want to set up Storybook and write stories.
   - If the user decline, silently skip all story work, finish the component change (if any), and move on.
-  - If the user accepts, invoke the **storybook-setup** skill to set up Storybook and write stories.
+  - If the user accepts, invoke the **storybook-init** skill to set up Storybook and write stories.
 - Storybook must be a canary version (0.0.0-canary) or at least version 10.5. If an older version is
   installed, invoke the **storybook-upgrade** skill to upgrade it before
   proceeding.

--- a/packages/claude-plugin/skills/stories/SKILL.md
+++ b/packages/claude-plugin/skills/stories/SKILL.md
@@ -34,7 +34,9 @@ stories in sync with every frontend component you create, modify, or delete.
 
 ## Prerequisites
 
-- Storybook must be installed in the project. If it is not installed and if this skill is not explicitly invoked by the user, silently ignore this skill.
+ - Storybook must be installed in the project. If it is not installed:
+   - If this skill is not explicitly invoked by the user, silently ignore this skill.
+   - Otherwise, follow the instructions in "When Storybook is not installed" below.
 - Storybook must be a canary version (0.0.0-canary) or at least version 10.5. If an older version is
   installed, invoke the **storybook-upgrade** skill to upgrade it before
   proceeding.

--- a/packages/claude-plugin/skills/stories/SKILL.md
+++ b/packages/claude-plugin/skills/stories/SKILL.md
@@ -34,11 +34,11 @@ stories in sync with every frontend component you create, modify, or delete.
 
 ## Prerequisites
 
- - Storybook must be installed in the project. If it is not installed:
-   - If this skill is not explicitly invoked by the user, silently ignore this skill.
-   - Otherwise, ask the user whether they want to set up Storybook and write stories.
-    - If the user decline, silently skip all story work, finish the component change (if any), and move on.
-    - If the user accepts, invoke the **storybook-setup** skill to set up Storybook and write stories.
+- Storybook must be installed in the project. If it is not installed:
+  - If this skill is not explicitly invoked by the user, silently ignore this skill.
+  - Otherwise, ask the user whether they want to set up Storybook and write stories.
+  - If the user decline, silently skip all story work, finish the component change (if any), and move on.
+  - If the user accepts, invoke the **storybook-setup** skill to set up Storybook and write stories.
 - Storybook must be a canary version (0.0.0-canary) or at least version 10.5. If an older version is
   installed, invoke the **storybook-upgrade** skill to upgrade it before
   proceeding.

--- a/packages/claude-plugin/skills/stories/SKILL.md
+++ b/packages/claude-plugin/skills/stories/SKILL.md
@@ -34,8 +34,7 @@ stories in sync with every frontend component you create, modify, or delete.
 
 ## Prerequisites
 
-- Storybook must be installed in the project. If it is not, go to
-  "When Storybook is not installed" below and stop here unless the user opts in.
+- Storybook must be installed in the project. If it is not installed and if this skill is not explicitly invoked by the user, silently ignore this skill.
 - Storybook must be a canary version (0.0.0-canary) or at least version 10.5. If an older version is
   installed, invoke the **storybook-upgrade** skill to upgrade it before
   proceeding.

--- a/packages/claude-plugin/skills/stories/SKILL.md
+++ b/packages/claude-plugin/skills/stories/SKILL.md
@@ -36,50 +36,12 @@ stories in sync with every frontend component you create, modify, or delete.
 
  - Storybook must be installed in the project. If it is not installed:
    - If this skill is not explicitly invoked by the user, silently ignore this skill.
-   - Otherwise, follow the instructions in "When Storybook is not installed" below.
+   - Otherwise, ask the user whether they want to set up Storybook and write stories.
+    - If the user decline, silently skip all story work, finish the component change (if any), and move on.
+    - If the user accepts, invoke the **storybook-setup** skill to set up Storybook and write stories.
 - Storybook must be a canary version (0.0.0-canary) or at least version 10.5. If an older version is
   installed, invoke the **storybook-upgrade** skill to upgrade it before
   proceeding.
-
-### When Storybook is not installed
-
-Installing and configuring Storybook is invasive, so it is the **user's choice**.
-Never set it up on your own initiative as a side effect of a component change.
-
-Before asking the user anything, check whether they have already declined. A
-decline can apply at two scopes:
-
-- **User-level** — the user never wants Storybook set up in any project.
-- **Project-level** — the user only declined for this project.
-
-1. **Look for a previously recorded decline.** If you find one that applies here
-   (at either scope), the user has ALREADY refused Storybook. Do NOT ask again —
-   silently skip all story work, finish the component change (if any), and move
-   on.
-2. **If there is no recorded decline**, briefly tell the user the project has no
-   Storybook and ask whether they want to set it up (and write stories). Offer
-   three choices:
-   - **Yes** — set it up for this project.
-   - **No, not for this project** — decline at the project level.
-   - **No, and don't ask me again in any project** — decline at the user level.
-3. **If the user declines**, remember that decision durably so future
-   invocations don't re-ask, recording the scope they chose (this project vs.
-   all projects) and a short paraphrase of their reason. Choose an appropriate
-   place and format yourself — but do NOT commit it to the project's version
-   control; if the only durable option lives inside the repo, keep it out of
-   commits (e.g. via `.gitignore`). Then finish the component change (if any)
-   without any story work. If the user explicitly asked for story work, STOP and
-   report that Storybook is required for it.
-
-4. **If the user opts in**, set Storybook up via the setup skills
-   (`storybook-init` / `storybook-setup`), then resume this workflow from
-   Step 1. If you recorded a decline at either scope from a previous "no", clear
-   it.
-
-**Gate:** Do NOT install Storybook, scaffold `.storybook/`, add Storybook
-dependencies, or invoke the setup skills unless the user has explicitly opted in
-this time. A recorded decline at either scope MUST be respected on every later
-invocation without re-prompting.
 
 ## Load the rules (before touching any story file)
 

--- a/packages/codex-plugin/plugins/storybook/skills/stories/SKILL.md
+++ b/packages/codex-plugin/plugins/storybook/skills/stories/SKILL.md
@@ -27,7 +27,7 @@ stories in sync with every frontend component you create, modify, or delete.
   - If this skill is not explicitly invoked by the user, silently ignore this skill.
   - Otherwise, ask the user whether they want to set up Storybook and write stories.
     - If the user decline, silently skip all story work, finish the component change (if any), and move on.
-    - If the user accepts, invoke the **setup** skill to set up Storybook and write stories.
+    - If the user accepts, invoke the **init** skill to set up Storybook and write stories.
 - Storybook must be a canary version (0.0.0-canary) or at least version 10.5. If an older version is
   installed, invoke the **upgrade** skill to upgrade it before
   proceeding.

--- a/packages/codex-plugin/plugins/storybook/skills/stories/SKILL.md
+++ b/packages/codex-plugin/plugins/storybook/skills/stories/SKILL.md
@@ -23,52 +23,14 @@ stories in sync with every frontend component you create, modify, or delete.
 
 ## Prerequisites
 
- - Storybook must be installed in the project. If it is not installed:
-   - If this skill is not explicitly invoked by the user, silently ignore this skill.
-   - Otherwise, follow the instructions in "When Storybook is not installed" below.
+- Storybook must be installed in the project. If it is not installed:
+  - If this skill is not explicitly invoked by the user, silently ignore this skill.
+  - Otherwise, ask the user whether they want to set up Storybook and write stories.
+    - If the user decline, silently skip all story work, finish the component change (if any), and move on.
+    - If the user accepts, invoke the **setup** skill to set up Storybook and write stories.
 - Storybook must be a canary version (0.0.0-canary) or at least version 10.5. If an older version is
   installed, invoke the **upgrade** skill to upgrade it before
   proceeding.
-
-### When Storybook is not installed
-
-Installing and configuring Storybook is invasive, so it is the **user's choice**.
-Never set it up on your own initiative as a side effect of a component change.
-
-Before asking the user anything, check whether they have already declined. A
-decline can apply at two scopes:
-
-- **User-level** — the user never wants Storybook set up in any project.
-- **Project-level** — the user only declined for this project.
-
-1. **Look for a previously recorded decline.** If you find one that applies here
-   (at either scope), the user has ALREADY refused Storybook. Do NOT ask again —
-   silently skip all story work, finish the component change (if any), and move
-   on.
-2. **If there is no recorded decline**, briefly tell the user the project has no
-   Storybook and ask whether they want to set it up (and write stories). Offer
-   three choices:
-   - **Yes** — set it up for this project.
-   - **No, not for this project** — decline at the project level.
-   - **No, and don't ask me again in any project** — decline at the user level.
-3. **If the user declines**, remember that decision durably so future
-   invocations don't re-ask, recording the scope they chose (this project vs.
-   all projects) and a short paraphrase of their reason. Choose an appropriate
-   place and format yourself — but do NOT commit it to the project's version
-   control; if the only durable option lives inside the repo, keep it out of
-   commits (e.g. via `.gitignore`). Then finish the component change (if any)
-   without any story work. If the user explicitly asked for story work, STOP and
-   report that Storybook is required for it.
-
-4. **If the user opts in**, set Storybook up via the setup skills
-   (`init` / `setup`), then resume this workflow from
-   Step 1. If you recorded a decline at either scope from a previous "no", clear
-   it.
-
-**Gate:** Do NOT install Storybook, scaffold `.storybook/`, add Storybook
-dependencies, or invoke the setup skills unless the user has explicitly opted in
-this time. A recorded decline at either scope MUST be respected on every later
-invocation without re-prompting.
 
 ## Load the rules (before touching any story file)
 

--- a/packages/codex-plugin/plugins/storybook/skills/stories/SKILL.md
+++ b/packages/codex-plugin/plugins/storybook/skills/stories/SKILL.md
@@ -23,7 +23,9 @@ stories in sync with every frontend component you create, modify, or delete.
 
 ## Prerequisites
 
-- Storybook must be installed in the project. If it is not installed and if this skill is not explicitly invoked by the user, silently ignore this skill.
+ - Storybook must be installed in the project. If it is not installed:
+   - If this skill is not explicitly invoked by the user, silently ignore this skill.
+   - Otherwise, follow the instructions in "When Storybook is not installed" below.
 - Storybook must be a canary version (0.0.0-canary) or at least version 10.5. If an older version is
   installed, invoke the **upgrade** skill to upgrade it before
   proceeding.

--- a/packages/codex-plugin/plugins/storybook/skills/stories/SKILL.md
+++ b/packages/codex-plugin/plugins/storybook/skills/stories/SKILL.md
@@ -23,7 +23,7 @@ stories in sync with every frontend component you create, modify, or delete.
 
 ## Prerequisites
 
-- Storybook must be installed in the project. If it is not, go to "When Storybook is not installed" below and stop here unless the user opts in.
+- Storybook must be installed in the project. If it is not installed and if this skill is not explicitly invoked by the user, silently ignore this skill.
 - Storybook must be a canary version (0.0.0-canary) or at least version 10.5. If an older version is
   installed, invoke the **upgrade** skill to upgrade it before
   proceeding.


### PR DESCRIPTION
This pull request updates the prerequisites for Storybook-related skills to clarify the behavior when Storybook is not installed. Now, the skills will silently ignore the absence of Storybook unless the user explicitly invokes the skill, instead of stopping and requiring user opt-in.

**Storybook Skill Prerequisite Updates:**

* Updated the prerequisite instructions in `SKILL.md` files to specify that if Storybook is not installed and the skill is not explicitly invoked by the user, the skill should be silently ignored. [[1]](diffhunk://#diff-82c7b7ac13c662c4bed1eb4a272a699530970104c45c2ef7b031363e5e39cba0L37-R37) [[2]](diffhunk://#diff-ff59803e6fadff805e759bd4b0f599ebd36e8171b385c3beac9e6f462dfc8fedL26-R26)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when Storybook isn’t installed: story-related tasks are now skipped automatically unless the skill was explicitly invoked. When invoked, the user is prompted to set up Storybook and proceed; declining will skip story work while still allowing any non-story component changes to complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->