### PR TITLE
feat(eval): add codex-cli

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -65,15 +65,15 @@ Different agents support different models:
 | `claude-opus-4.5`      |       ❌        |     ✅      |    ❌     |
 | `claude-sonnet-4.6`    |       ✅        |     ✅      |    ❌     |
 | `claude-haiku-4.5`     |       ✅        |     ✅      |    ❌     |
-| `gpt-5.2`              |       ❌        |     ✅      |    ❌     |
-| `gpt-5.2-codex`        |       ❌        |     ✅      |    ✅¹    |
-| `gpt-5.1-codex-max`    |       ❌        |     ✅      |    ✅¹    |
+| `gpt-5.5`              |       ❌        |     ✅      |    ❌     |
+| `gpt-5.4`              |       ❌        |     ✅      |    ❌     |
+| `gpt-5.4-mini`         |       ❌        |     ✅      |    ❌     |
 | `gemini-3-pro-preview` |       ❌        |     ✅      |    ❌     |
 | `codex-default`        |       ❌        |     ❌      |    ✅     |
 
-> ¹ Explicit Codex model names require **API-key** Codex auth. With a **ChatGPT-account**
-> login, Codex rejects explicit `--model` values — use `codex-default`, which omits
-> `--model` and lets Codex pick the account's entitled model.
+For Codex CLI, use `codex-default`, which omits `--model` and lets Codex pick the
+account's entitled model. This avoids stale or account-specific explicit Codex model
+aliases.
 
 **Example usage:**
 
@@ -81,8 +81,8 @@ Different agents support different models:
 # Claude Code with Opus (advanced-eval)
 node advanced-eval.ts --agent claude-code --model claude-opus-4.5 100-flight-booking-plain
 
-# Copilot CLI with GPT-5.2 (advanced-eval)
-node advanced-eval.ts --agent copilot-cli --model gpt-5.2 100-flight-booking-plain
+# Copilot CLI with GPT-5.5 (advanced-eval)
+node advanced-eval.ts --agent copilot-cli --model gpt-5.5 100-flight-booking-plain
 
 # Codex CLI with the account-default model (works with ChatGPT login)
 node advanced-eval.ts --agent codex-cli --model codex-default 100-flight-booking-plain
@@ -94,7 +94,7 @@ node advanced-eval.ts --agent codex-cli --model codex-default 100-flight-booking
 > To use models other than `claude-sonnet-4.6` with the Copilot CLI, you must first enable them in your GitHub account settings:
 >
 > 1. Go to [GitHub Copilot Features Settings](https://github.com/settings/copilot/features)
-> 2. Enable the models you want to use (e.g., GPT-5.1 Codex Max, GPT-5.2, Claude Opus 4.5)
+> 2. Enable the models you want to use (e.g., GPT-5.5, GPT-5.4, Claude Opus 4.5)
 > 3. Save your settings
 > 4. Wait up to 30 minutes
 >

--- a/eval/README.md
+++ b/eval/README.md
@@ -4,7 +4,7 @@ A CLI-based eval harness for testing AI coding agents' ability to build UI compo
 
 ## What is this?
 
-This eval harness runs automated trials where AI coding agents (Claude Code CLI or GitHub Copilot CLI) are given prompts to build UI components. Each trial:
+This eval harness runs automated trials where AI coding agents (Claude Code CLI, GitHub Copilot CLI, or Codex CLI) are given prompts to build UI components. Each trial:
 
 1. **Prepares** a fresh Vite + React + Storybook project
 2. **Executes** the agent with a prompt and optional context (MCP servers, component manifests, or extra prompts)
@@ -22,6 +22,7 @@ The goal is to measure how well agents can use Storybook's MCP tools to build pr
 - Playwright (`npx playwright install`)
 - Claude Code CLI (`npm install -g @anthropic-ai/claude-code`) - for `claude-code` agent
 - GitHub Copilot CLI (`gh extension install github/gh-copilot`) - for `copilot-cli` agent
+- Codex CLI (`npm install -g @openai/codex`, then `codex login`) - for `codex-cli` agent
 
 ## Quick Start
 
@@ -42,7 +43,7 @@ The following options apply to `advanced-eval.ts`:
 
 | Option           | Short | Type    | Description                                                                                               |
 | ---------------- | ----- | ------- | --------------------------------------------------------------------------------------------------------- |
-| `--agent`        | `-a`  | string  | Which agent to use (`claude-code` or `copilot-cli`)                                                       |
+| `--agent`        | `-a`  | string  | Which agent to use (`claude-code`, `copilot-cli`, or `codex-cli`)                                         |
 | `--model`        | `-m`  | string  | Which model to use (see [Model Selection](#model-selection) below)                                        |
 | `--context`      | `-c`  | string  | Context type: `false`, `storybook-dev`, `*.json` (manifest), `mcp.config.json`, or `*.md` (extra prompts) |
 | `--verbose`      | `-v`  | boolean | Show detailed logs during execution                                                                       |
@@ -58,16 +59,21 @@ The following options apply to `advanced-eval.ts`:
 
 Different agents support different models:
 
-| Model                  | Claude Code CLI | Copilot CLI |
-| ---------------------- | :-------------: | :---------: |
-| `claude-opus-4.6`      |       ✅        |     ✅      |
-| `claude-opus-4.5`      |       ❌        |     ✅      |
-| `claude-sonnet-4.6`    |       ✅        |     ✅      |
-| `claude-haiku-4.5`     |       ✅        |     ✅      |
-| `gpt-5.2`              |       ❌        |     ✅      |
-| `gpt-5.2-codex`        |       ❌        |     ✅      |
-| `gpt-5.1-codex-max`    |       ❌        |     ✅      |
-| `gemini-3-pro-preview` |       ❌        |     ✅      |
+| Model                  | Claude Code CLI | Copilot CLI | Codex CLI |
+| ---------------------- | :-------------: | :---------: | :-------: |
+| `claude-opus-4.6`      |       ✅        |     ✅      |    ❌     |
+| `claude-opus-4.5`      |       ❌        |     ✅      |    ❌     |
+| `claude-sonnet-4.6`    |       ✅        |     ✅      |    ❌     |
+| `claude-haiku-4.5`     |       ✅        |     ✅      |    ❌     |
+| `gpt-5.2`              |       ❌        |     ✅      |    ❌     |
+| `gpt-5.2-codex`        |       ❌        |     ✅      |    ✅¹    |
+| `gpt-5.1-codex-max`    |       ❌        |     ✅      |    ✅¹    |
+| `gemini-3-pro-preview` |       ❌        |     ✅      |    ❌     |
+| `codex-default`        |       ❌        |     ❌      |    ✅     |
+
+> ¹ Explicit Codex model names require **API-key** Codex auth. With a **ChatGPT-account**
+> login, Codex rejects explicit `--model` values — use `codex-default`, which omits
+> `--model` and lets Codex pick the account's entitled model.
 
 **Example usage:**
 
@@ -77,6 +83,9 @@ node advanced-eval.ts --agent claude-code --model claude-opus-4.5 100-flight-boo
 
 # Copilot CLI with GPT-5.2 (advanced-eval)
 node advanced-eval.ts --agent copilot-cli --model gpt-5.2 100-flight-booking-plain
+
+# Codex CLI with the account-default model (works with ChatGPT login)
+node advanced-eval.ts --agent codex-cli --model codex-default 100-flight-booking-plain
 ```
 
 > [!IMPORTANT]

--- a/eval/config.ts
+++ b/eval/config.ts
@@ -1,7 +1,9 @@
 import { claudeCodeCli } from './lib/agents/claude-code-cli.ts';
 import { copilotCli } from './lib/agents/copilot-cli.ts';
+import { codexCli } from './lib/agents/codex-cli.ts';
 
 export const agents = {
 	'claude-code': claudeCodeCli,
 	'copilot-cli': copilotCli,
+	'codex-cli': codexCli,
 };

--- a/eval/lib/agents/codex-cli.ts
+++ b/eval/lib/agents/codex-cli.ts
@@ -17,6 +17,34 @@ import type {
 const USAGE_0 = { input_tokens: 0, output_tokens: 0 } as const;
 
 /**
+ * Per-token USD pricing for Codex models. The Codex CLI does not report a USD cost
+ * (its `--json` stream only includes token counts), so we estimate it from the reported
+ * usage. All current GPT-5 codex tiers share the same public pricing
+ * (input $1.25/1M, cached input $0.125/1M, output $10/1M); the estimate is approximate
+ * and N/A for ChatGPT-subscription billing.
+ *
+ * @see https://platform.openai.com/docs/pricing
+ */
+const CODEX_PRICING = {
+	input: 1.25e-6,
+	cachedInput: 1.25e-7,
+	output: 1e-5,
+} as const;
+
+/**
+ * Estimates USD cost from Codex token usage. `input_tokens` is inclusive of
+ * `cached_input_tokens`, which are billed at the cheaper cache-read rate.
+ */
+function estimateCodexCost(usage: { input: number; cached: number; output: number }): number {
+	const uncachedInput = Math.max(0, usage.input - usage.cached);
+	return (
+		uncachedInput * CODEX_PRICING.input +
+		usage.cached * CODEX_PRICING.cachedInput +
+		usage.output * CODEX_PRICING.output
+	);
+}
+
+/**
  * Shapes of the `codex exec --json` (experimental) event stream.
  * Each stdout line is one JSON object. We only model the fields we consume.
  */
@@ -180,7 +208,7 @@ export const codexCli: Agent = {
 
 		const t0 = Date.now();
 		let stderr = '';
-		let turnUsage: { input?: number; output?: number } | undefined;
+		let turnUsage: { input: number; cached: number; output: number } | undefined;
 		let assistantCount = 0;
 		let toolCount = 0;
 		let turnFailedError: string | undefined;
@@ -289,9 +317,11 @@ export const codexCli: Agent = {
 						handleItem(event.item);
 						log.message(`Agent is working, ${assistantCount} messages, ${toolCount} tool calls`);
 					} else if (event.type === 'turn.completed') {
+						// codex exec emits a single turn.completed with the session's total usage.
 						turnUsage = {
-							input: event.usage?.input_tokens,
-							output: event.usage?.output_tokens,
+							input: event.usage?.input_tokens ?? 0,
+							cached: event.usage?.cached_input_tokens ?? 0,
+							output: event.usage?.output_tokens ?? 0,
 						};
 					} else if (event.type === 'turn.failed') {
 						turnFailedError = event.error?.message ?? 'turn failed';
@@ -309,10 +339,9 @@ export const codexCli: Agent = {
 		const elapsedMs = Date.now() - t0;
 		const isError =
 			turnFailedError !== undefined || (stderr.trim().length > 0 && assistantCount === 0);
-		const totalTokens =
-			turnUsage && (turnUsage.input !== undefined || turnUsage.output !== undefined)
-				? (turnUsage.input ?? 0) + (turnUsage.output ?? 0)
-				: undefined;
+		const totalTokens = turnUsage ? turnUsage.input + turnUsage.output : undefined;
+		// Codex does not report a USD cost; estimate it from the reported token usage.
+		const estimatedCost = turnUsage ? Number(estimateCodexCost(turnUsage).toFixed(4)) : undefined;
 
 		const numTurns = Math.max(assistantCount, 1) + toolCount * 2;
 		const resultMessage: ResultMessage = {
@@ -321,7 +350,7 @@ export const codexCli: Agent = {
 			duration_ms: elapsedMs,
 			duration_api_ms: elapsedMs,
 			num_turns: numTurns,
-			total_cost_usd: 0,
+			total_cost_usd: estimatedCost ?? 0,
 			ms: elapsedMs,
 			...(totalTokens !== undefined && { tokenCount: totalTokens }),
 		};
@@ -338,6 +367,7 @@ export const codexCli: Agent = {
 		return {
 			agent: 'Codex CLI',
 			model: codexModel,
+			...(estimatedCost !== undefined && { cost: estimatedCost }),
 			duration: Math.round(elapsedMs / 1000),
 			durationApi: Math.round(elapsedMs / 1000),
 			turns: numTurns,

--- a/eval/lib/agents/codex-cli.ts
+++ b/eval/lib/agents/codex-cli.ts
@@ -1,0 +1,346 @@
+import { x } from 'tinyexec';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { spinner, log as clackLog } from '@clack/prompts';
+import type { Agent, McpServerConfig, CodexModel } from '../../types.ts';
+import { CODEX_MODELS, CODEX_MODEL_MAP } from '../../types.ts';
+import { runHook } from '../run-hook.ts';
+import type {
+	AssistantMessage,
+	ResultMessage,
+	ToolResultContent,
+	ToolUseContent,
+	TranscriptMessage,
+	UserMessage,
+} from '../../templates/result-docs/transcript.types.ts';
+
+const USAGE_0 = { input_tokens: 0, output_tokens: 0 } as const;
+
+/**
+ * Shapes of the `codex exec --json` (experimental) event stream.
+ * Each stdout line is one JSON object. We only model the fields we consume.
+ */
+type CodexItem =
+	| { id: string; type: 'agent_message'; text: string }
+	| { id: string; type: 'reasoning'; text?: string }
+	| {
+			id: string;
+			type: 'command_execution';
+			command: string;
+			aggregated_output?: string;
+			exit_code?: number | null;
+			status?: string;
+	  }
+	| {
+			id: string;
+			type: 'mcp_tool_call';
+			server: string;
+			tool: string;
+			arguments?: Record<string, unknown>;
+			result?: {
+				content?: Array<{ type: string; text?: string }>;
+				structured_content?: unknown;
+			} | null;
+			error?: string | null;
+			status?: string;
+	  }
+	| { id: string; type: string; [key: string]: unknown };
+
+type CodexEvent = {
+	type: string;
+	item?: CodexItem;
+	usage?: {
+		input_tokens?: number;
+		cached_input_tokens?: number;
+		output_tokens?: number;
+		reasoning_output_tokens?: number;
+	};
+	error?: { message?: string };
+};
+
+/** Stringifies an MCP tool result's content for the transcript tool_result. */
+function stringifyMcpResult(item: Extract<CodexItem, { type: 'mcp_tool_call' }>): string {
+	if (item.error) {
+		return `Error: ${item.error}`;
+	}
+	const content = item.result?.content;
+	if (Array.isArray(content)) {
+		return content
+			.filter((c) => c.type === 'text' && typeof c.text === 'string')
+			.map((c) => c.text ?? '')
+			.join('');
+	}
+	return item.result ? JSON.stringify(item.result) : '';
+}
+
+/**
+ * Converts our normalized MCP server config into `codex exec -c` config overrides.
+ * Returns the flat list of CLI args (pairs of `-c key=value`).
+ *
+ * The value portion is parsed by Codex as TOML; JSON encoding of strings/arrays is
+ * valid TOML, so we encode with JSON.stringify.
+ */
+function buildMcpConfigArgs(mcpServers: McpServerConfig): string[] {
+	const args: string[] = [];
+	const add = (key: string, tomlValue: string) => {
+		args.push('-c', `${key}=${tomlValue}`);
+	};
+
+	for (const name of Object.keys(mcpServers)) {
+		const server = mcpServers[name];
+		if (!server) continue;
+		const base = `mcp_servers.${name}`;
+
+		switch (server.type) {
+			case 'http': {
+				add(`${base}.url`, JSON.stringify(server.url));
+				if (server.headers && Object.keys(server.headers).length > 0) {
+					add(`${base}.http_headers`, JSON.stringify(server.headers));
+				}
+				break;
+			}
+			case 'stdio': {
+				add(`${base}.command`, JSON.stringify(server.command));
+				if (server.args && server.args.length > 0) {
+					add(`${base}.args`, JSON.stringify(server.args));
+				}
+				if (server.env) {
+					add(`${base}.env`, JSON.stringify(server.env));
+				}
+				break;
+			}
+			default: {
+				const unsupported: never = server;
+				throw new Error(`Unsupported server type: ${(unsupported as { type: string }).type}`);
+			}
+		}
+	}
+
+	return args;
+}
+
+export const codexCli: Agent = {
+	async execute(prompt, trialArgs, mcpServerConfig) {
+		const { projectPath, resultsPath, model: selectedModel } = trialArgs;
+
+		// Validate that the model is supported by Codex CLI
+		if (!CODEX_MODELS.includes(selectedModel as CodexModel)) {
+			throw new Error(
+				`Model "${selectedModel}" is not supported by Codex CLI. Available models: ${CODEX_MODELS.join(', ')}`,
+			);
+		}
+		const codexModel = selectedModel as CodexModel;
+		const codexModelFlag = CODEX_MODEL_MAP[codexModel];
+
+		const log = spinner();
+		await runHook('pre-execute-agent', trialArgs);
+		log.start(`Executing prompt with Codex CLI (model: ${codexModel})`);
+
+		const hasMcp = Boolean(mcpServerConfig && Object.keys(mcpServerConfig).length > 0);
+
+		const args = [
+			'exec',
+			'--json',
+			// Run from the user's auth but ignore their global config.toml so trials are not
+			// polluted by the developer's personal Codex settings/MCP servers (auth still
+			// resolves from CODEX_HOME).
+			'--ignore-user-config',
+			'--skip-git-repo-check',
+			// Equivalent to Claude's --dangerously-skip-permissions: let the agent write files
+			// and run commands without approval prompts (the eval is the sandbox boundary).
+			'--dangerously-bypass-approvals-and-sandbox',
+			'--color',
+			'never',
+			'-C',
+			projectPath,
+			// An empty flag value (e.g. the `codex-default` model) means "let Codex pick the
+			// account-default model" — required for ChatGPT-account auth, which rejects
+			// explicit codex model names.
+			...(codexModelFlag ? ['-m', codexModelFlag] : []),
+			...(hasMcp ? buildMcpConfigArgs(mcpServerConfig!) : []),
+			// Read the prompt from stdin (robust against prompts containing leading dashes).
+			'-',
+		];
+
+		const messages: TranscriptMessage[] = [
+			{
+				type: 'system',
+				subtype: 'init',
+				agent: 'Codex CLI',
+				model: codexModel,
+				tools: [],
+				mcp_servers: (hasMcp ? Object.keys(mcpServerConfig!) : []).map((name) => ({
+					name,
+					status: 'unknown',
+				})),
+				cwd: projectPath,
+				ms: 0,
+			},
+		];
+
+		const t0 = Date.now();
+		let stderr = '';
+		let turnUsage: { input?: number; output?: number } | undefined;
+		let assistantCount = 0;
+		let toolCount = 0;
+		let turnFailedError: string | undefined;
+
+		const pushAssistantText = (text: string) => {
+			if (!text.trim()) return;
+			assistantCount++;
+			messages.push({
+				type: 'assistant',
+				message: { content: [{ type: 'text', text }], usage: USAGE_0 },
+				ms: 0,
+			} satisfies AssistantMessage);
+		};
+
+		const pushToolUse = (toolUse: ToolUseContent, result: string) => {
+			toolCount++;
+			messages.push({
+				type: 'assistant',
+				message: { content: [toolUse], usage: USAGE_0 },
+				ms: 0,
+			} satisfies AssistantMessage);
+			const toolResult: ToolResultContent = {
+				type: 'tool_result',
+				tool_use_id: toolUse.id,
+				content: result,
+			};
+			messages.push({
+				type: 'user',
+				message: { content: [toolResult] },
+				ms: 0,
+			} satisfies UserMessage);
+		};
+
+		const handleItem = (item: CodexItem) => {
+			switch (item.type) {
+				case 'agent_message': {
+					pushAssistantText((item as Extract<CodexItem, { type: 'agent_message' }>).text ?? '');
+					break;
+				}
+				case 'command_execution': {
+					const cmd = item as Extract<CodexItem, { type: 'command_execution' }>;
+					pushToolUse(
+						{
+							type: 'tool_use',
+							id: cmd.id,
+							name: 'Bash',
+							input: { command: cmd.command },
+							isMCP: false,
+						},
+						cmd.aggregated_output ?? '',
+					);
+					break;
+				}
+				case 'mcp_tool_call': {
+					const call = item as Extract<CodexItem, { type: 'mcp_tool_call' }>;
+					pushToolUse(
+						{
+							type: 'tool_use',
+							id: call.id,
+							// Mirror the canonical Claude MCP tool naming (`mcp__<server>__<tool>`)
+							// so the MCP-tools grader matches expectations via includes().
+							name: `mcp__${call.server}__${call.tool}`,
+							input: call.arguments ?? {},
+							isMCP: true,
+						},
+						stringifyMcpResult(call),
+					);
+					break;
+				}
+				default:
+					// reasoning, todo_list, file changes, etc. — not needed for grading.
+					break;
+			}
+		};
+
+		try {
+			const codexProcess = x('codex', args, {
+				nodeOptions: {
+					cwd: projectPath,
+					stdio: ['pipe', 'pipe', 'pipe'],
+				},
+			});
+
+			// Feed the prompt via stdin and close it.
+			if (codexProcess.process?.stdin) {
+				codexProcess.process.stdin.write(prompt);
+				codexProcess.process.stdin.end();
+			}
+
+			// tinyexec yields stdout line-by-line (newlines stripped); a chunk may still
+			// contain multiple lines, so split defensively and parse each JSONL event.
+			for await (const chunk of codexProcess) {
+				for (const line of String(chunk).split(/\r?\n/)) {
+					const trimmed = line.trim();
+					if (!trimmed) continue;
+
+					let event: CodexEvent;
+					try {
+						event = JSON.parse(trimmed) as CodexEvent;
+					} catch {
+						// Non-JSON line (e.g. a stray log); ignore.
+						continue;
+					}
+
+					if (event.type === 'item.completed' && event.item) {
+						handleItem(event.item);
+						log.message(`Agent is working, ${assistantCount} messages, ${toolCount} tool calls`);
+					} else if (event.type === 'turn.completed') {
+						turnUsage = {
+							input: event.usage?.input_tokens,
+							output: event.usage?.output_tokens,
+						};
+					} else if (event.type === 'turn.failed') {
+						turnFailedError = event.error?.message ?? 'turn failed';
+					}
+				}
+			}
+
+			await codexProcess;
+		} catch (error: unknown) {
+			const err = error as { stderr?: string; message?: string };
+			stderr = err?.stderr || err?.message || String(error);
+			clackLog.error(`Codex CLI failed: ${stderr.split('\n')[0] || 'unknown error'}`);
+		}
+
+		const elapsedMs = Date.now() - t0;
+		const isError =
+			turnFailedError !== undefined || (stderr.trim().length > 0 && assistantCount === 0);
+		const totalTokens =
+			turnUsage && (turnUsage.input !== undefined || turnUsage.output !== undefined)
+				? (turnUsage.input ?? 0) + (turnUsage.output ?? 0)
+				: undefined;
+
+		const numTurns = Math.max(assistantCount, 1) + toolCount * 2;
+		const resultMessage: ResultMessage = {
+			type: 'result',
+			subtype: isError ? 'error' : 'success',
+			duration_ms: elapsedMs,
+			duration_api_ms: elapsedMs,
+			num_turns: numTurns,
+			total_cost_usd: 0,
+			ms: elapsedMs,
+			...(totalTokens !== undefined && { tokenCount: totalTokens }),
+		};
+		messages.push(resultMessage);
+
+		await fs.writeFile(
+			path.join(resultsPath, 'transcript.json'),
+			JSON.stringify({ prompt, promptTokenCount: 0, promptCost: 0, messages }, null, 2),
+		);
+
+		await runHook('post-execute-agent', trialArgs);
+		log.stop(isError ? 'Codex CLI completed with errors' : 'Codex CLI completed');
+
+		return {
+			agent: 'Codex CLI',
+			model: codexModel,
+			duration: Math.round(elapsedMs / 1000),
+			durationApi: Math.round(elapsedMs / 1000),
+			turns: numTurns,
+		};
+	},
+};

--- a/eval/lib/agents/codex-cli.ts
+++ b/eval/lib/agents/codex-cli.ts
@@ -117,13 +117,16 @@ function buildMcpConfigArgs(mcpServers: McpServerConfig): string[] {
 	for (const name of Object.keys(mcpServers)) {
 		const server = mcpServers[name];
 		if (!server) continue;
-		const base = `mcp_servers.${name}`;
+		const base = `mcp_servers.${JSON.stringify(name)}`;
 
 		switch (server.type) {
 			case 'http': {
 				add(`${base}.url`, JSON.stringify(server.url));
 				if (server.headers && Object.keys(server.headers).length > 0) {
-					add(`${base}.http_headers`, JSON.stringify(server.headers));
+					const headersToml = `{ ${Object.entries(server.headers)
+						.map(([k, v]) => `${JSON.stringify(k)} = ${JSON.stringify(v)}`)
+						.join(', ')} }`;
+					add(`${base}.http_headers`, headersToml);
 				}
 				break;
 			}

--- a/eval/lib/agents/codex-cli.ts
+++ b/eval/lib/agents/codex-cli.ts
@@ -340,8 +340,7 @@ export const codexCli: Agent = {
 		}
 
 		const elapsedMs = Date.now() - t0;
-		const isError =
-			turnFailedError !== undefined || (stderr.trim().length > 0 && assistantCount === 0);
+		const isError = turnFailedError !== undefined || stderr.trim().length > 0;
 		const totalTokens = turnUsage ? turnUsage.input + turnUsage.output : undefined;
 		// Codex does not report a USD cost; estimate it from the reported token usage.
 		const estimatedCost = turnUsage ? Number(estimateCodexCost(turnUsage).toFixed(4)) : undefined;

--- a/eval/lib/collect-args.ts
+++ b/eval/lib/collect-args.ts
@@ -9,6 +9,7 @@ import {
 	SUPPORTED_MODELS,
 	CLAUDE_MODELS,
 	COPILOT_MODELS,
+	CODEX_MODELS,
 	type Context,
 	type McpServerConfig,
 	type SupportedModel,
@@ -355,6 +356,7 @@ export async function collectArgs(): Promise<CollectedArgs> {
 					options: [
 						{ value: 'claude-code', label: 'Claude Code CLI' },
 						{ value: 'copilot-cli', label: 'GitHub Copilot CLI' },
+						{ value: 'codex-cli', label: 'Codex CLI' },
 					],
 				});
 
@@ -369,7 +371,11 @@ export async function collectArgs(): Promise<CollectedArgs> {
 				// Determine available models based on selected agent
 				const selectedAgent = results.agent;
 				const availableModels: readonly SupportedModel[] =
-					selectedAgent === 'claude-code' ? CLAUDE_MODELS : COPILOT_MODELS;
+					selectedAgent === 'claude-code'
+						? CLAUDE_MODELS
+						: selectedAgent === 'codex-cli'
+							? CODEX_MODELS
+							: COPILOT_MODELS;
 
 				if (opts.model) {
 					// Validate that the provided model is valid for the selected agent

--- a/eval/templates/result-docs/summary.stories.tsx
+++ b/eval/templates/result-docs/summary.stories.tsx
@@ -163,7 +163,7 @@ export const SomeTestsFailed: Story = {
 export const AccessibilityViolations: Story = {
 	args: {
 		agent: 'Copilot CLI',
-		model: 'gpt-5.1-codex-max',
+		model: 'gpt-5.5',
 		cost: 0.3298,
 		duration: 298,
 		durationApi: 234,
@@ -378,7 +378,7 @@ export const WithMcpToolsExpectationsFailed: Story = {
 export const WithMcpToolsManyInvocations: Story = {
 	args: {
 		agent: 'Copilot CLI',
-		model: 'gpt-5.1-codex-max',
+		model: 'gpt-5.5',
 		cost: 0.5234,
 		duration: 423,
 		durationApi: 378,

--- a/eval/types.ts
+++ b/eval/types.ts
@@ -9,9 +9,9 @@ export const SUPPORTED_MODELS = [
 	'claude-opus-4.5',
 	'claude-sonnet-4.6',
 	'claude-haiku-4.5',
-	'gpt-5.2-codex',
-	'gpt-5.2',
-	'gpt-5.1-codex-max',
+	'gpt-5.5',
+	'gpt-5.4',
+	'gpt-5.4-mini',
 	'gemini-3-pro-preview',
 	// Codex CLI account-default model: the agent omits `--model` and lets Codex pick the
 	// model the account is entitled to. Required for ChatGPT-account Codex auth, which
@@ -49,9 +49,9 @@ export const COPILOT_MODELS = [
 	'claude-opus-4.5',
 	'claude-sonnet-4.6',
 	'claude-haiku-4.5',
-	'gpt-5.2-codex',
-	'gpt-5.2',
-	'gpt-5.1-codex-max',
+	'gpt-5.5',
+	'gpt-5.4',
+	'gpt-5.4-mini',
 	'gemini-3-pro-preview',
 ] as const satisfies readonly SupportedModel[];
 
@@ -60,11 +60,7 @@ export type CopilotModel = (typeof COPILOT_MODELS)[number];
 /**
  * Models that are supported by the Codex CLI.
  */
-export const CODEX_MODELS = [
-	'codex-default',
-	'gpt-5.2-codex',
-	'gpt-5.1-codex-max',
-] as const satisfies readonly SupportedModel[];
+export const CODEX_MODELS = ['codex-default'] as const satisfies readonly SupportedModel[];
 
 /**
  * Mapping from our standard model names to Codex CLI `--model` flag values.
@@ -73,8 +69,6 @@ export const CODEX_MODELS = [
  */
 export const CODEX_MODEL_MAP: Record<(typeof CODEX_MODELS)[number], string> = {
 	'codex-default': '',
-	'gpt-5.2-codex': 'gpt-5.2-codex',
-	'gpt-5.1-codex-max': 'gpt-5.1-codex-max',
 };
 
 export type CodexModel = (typeof CODEX_MODELS)[number];

--- a/eval/types.ts
+++ b/eval/types.ts
@@ -13,6 +13,10 @@ export const SUPPORTED_MODELS = [
 	'gpt-5.2',
 	'gpt-5.1-codex-max',
 	'gemini-3-pro-preview',
+	// Codex CLI account-default model: the agent omits `--model` and lets Codex pick the
+	// model the account is entitled to. Required for ChatGPT-account Codex auth, which
+	// rejects explicit codex model names (those need API-key auth).
+	'codex-default',
 ] as const;
 
 export type SupportedModel = (typeof SUPPORTED_MODELS)[number];
@@ -52,6 +56,28 @@ export const COPILOT_MODELS = [
 ] as const satisfies readonly SupportedModel[];
 
 export type CopilotModel = (typeof COPILOT_MODELS)[number];
+
+/**
+ * Models that are supported by the Codex CLI.
+ */
+export const CODEX_MODELS = [
+	'codex-default',
+	'gpt-5.2-codex',
+	'gpt-5.1-codex-max',
+] as const satisfies readonly SupportedModel[];
+
+/**
+ * Mapping from our standard model names to Codex CLI `--model` flag values.
+ * The Codex CLI accepts these slugs directly. An empty string means "omit `--model`"
+ * so Codex uses the account-default model (the only option for ChatGPT-account auth).
+ */
+export const CODEX_MODEL_MAP: Record<(typeof CODEX_MODELS)[number], string> = {
+	'codex-default': '',
+	'gpt-5.2-codex': 'gpt-5.2-codex',
+	'gpt-5.1-codex-max': 'gpt-5.1-codex-max',
+};
+
+export type CodexModel = (typeof CODEX_MODELS)[number];
 
 export type TrialArgs = {
 	trialPath: string;


### PR DESCRIPTION
This pull request adds support for the Codex CLI as a new agent in the eval harness, allowing automated trials to use Codex alongside Claude Code CLI and GitHub Copilot CLI. It includes updates to documentation, configuration, agent selection logic, and model handling to fully integrate Codex CLI into the evaluation workflow.

**Codex CLI agent integration:**

* Implements a new `codex-cli` agent in `codex-cli.ts`, handling prompt execution, MCP server config, transcript generation, and error handling for Codex CLI.
* Registers the `codex-cli` agent in the `agents` export in `config.ts`, making it available for use in trials.
* Updates agent selection logic in `collect-args.ts` to include `codex-cli` as a selectable agent and ensures the correct models are available depending on the agent chosen. [[1]](diffhunk://#diff-b65ef99d2e8505c2d01c71d9ac52318947ef14abf679690ff60023113e40c28dR359) [[2]](diffhunk://#diff-b65ef99d2e8505c2d01c71d9ac52318947ef14abf679690ff60023113e40c28dL372-R378) [[3]](diffhunk://#diff-b65ef99d2e8505c2d01c71d9ac52318947ef14abf679690ff60023113e40c28dR12)

**Model support and mapping:**

* Adds Codex CLI-specific models (`codex-default`, `gpt-5.2-codex`, `gpt-5.1-codex-max`) and a mapping from model names to Codex CLI `--model` flags in `types.ts`, including logic for handling account-default model selection.

**Documentation updates:**

* Updates `README.md` to document Codex CLI support, installation instructions, agent options, model compatibility matrix, and usage examples. It also explains the difference between API-key and ChatGPT-account authentication for Codex models. [[1]](diffhunk://#diff-200b06e6451b0ae17aabf76d04d151b2b212a01c053dfa5570c110f0ca5165acL7-R7) [[2]](diffhunk://#diff-200b06e6451b0ae17aabf76d04d151b2b212a01c053dfa5570c110f0ca5165acR25) [[3]](diffhunk://#diff-200b06e6451b0ae17aabf76d04d151b2b212a01c053dfa5570c110f0ca5165acL45-R46) [[4]](diffhunk://#diff-200b06e6451b0ae17aabf76d04d151b2b212a01c053dfa5570c110f0ca5165acL61-R76) [[5]](diffhunk://#diff-200b06e6451b0ae17aabf76d04d151b2b212a01c053dfa5570c110f0ca5165acR86-R88)
* Adds `codex-default` to the list of supported models in `types.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Codex CLI as a supported agent in the Storybook MCP Eval Harness, including Codex model selection with “account default” behavior.
  * Enhanced transcript output for Codex runs (assistant messages, command output, and MCP tool calls) and reports duration, turn counts, token usage, and estimated cost.
* **Documentation**
  * Updated the harness documentation with Codex CLI setup/login steps, supported agent/model options, and example eval commands.
* **Chores**
  * Refreshed select Storybook result summary examples to use the newer model slug.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->