### PR TITLE
Claude plugin: Simplify launch autoPort guidance

### DIFF
--- a/packages/claude-plugin/plugin.test.ts
+++ b/packages/claude-plugin/plugin.test.ts
@@ -40,7 +40,7 @@ function normalizeMarketplace(marketplace: ClaudeMarketplaceJson) {
 	};
 }
 
-describe('Storybook Claude plugin CLI validation', () => {
+describe('Claude launch skill guidance', () => {
 	it('keeps Claude launch guidance scoped to autoPort without shell interpolation', () => {
 		const launchSkill = readFileSync(
 			resolve(packageRoot, 'skills/storybook-setup-claude-launch/SKILL.md'),
@@ -48,13 +48,12 @@ describe('Storybook Claude plugin CLI validation', () => {
 		);
 
 		expect(launchSkill).toContain('autoPort: true');
-		expect(launchSkill).toContain('existing Storybook script');
-		expect(launchSkill).toContain('Storybook invocation directory');
-		expect(launchSkill).not.toContain('$PORT');
-		expect(launchSkill).not.toContain('%PORT%');
+		expect(launchSkill).not.toMatch(/--port|\$\{?PORT\}?|\$env:PORT|%PORT%/i);
 		expect(launchSkill).not.toContain('--ci');
 	});
+});
 
+describe('Storybook Claude plugin CLI validation', () => {
 	it('keeps root and package-local marketplaces in sync', () => {
 		const packageMarketplace = readMarketplace(
 			resolve(packageRoot, '.claude-plugin/marketplace.json'),

--- a/packages/claude-plugin/plugin.test.ts
+++ b/packages/claude-plugin/plugin.test.ts
@@ -41,6 +41,20 @@ function normalizeMarketplace(marketplace: ClaudeMarketplaceJson) {
 }
 
 describe('Storybook Claude plugin CLI validation', () => {
+	it('keeps Claude launch guidance scoped to autoPort without shell interpolation', () => {
+		const launchSkill = readFileSync(
+			resolve(packageRoot, 'skills/storybook-setup-claude-launch/SKILL.md'),
+			'utf8',
+		);
+
+		expect(launchSkill).toContain('autoPort: true');
+		expect(launchSkill).toContain('existing Storybook script');
+		expect(launchSkill).toContain('Storybook invocation directory');
+		expect(launchSkill).not.toContain('$PORT');
+		expect(launchSkill).not.toContain('%PORT%');
+		expect(launchSkill).not.toContain('--ci');
+	});
+
 	it('keeps root and package-local marketplaces in sync', () => {
 		const packageMarketplace = readMarketplace(
 			resolve(packageRoot, '.claude-plugin/marketplace.json'),

--- a/packages/claude-plugin/plugin.test.ts
+++ b/packages/claude-plugin/plugin.test.ts
@@ -48,7 +48,11 @@ describe('Claude launch skill guidance', () => {
 		);
 
 		expect(launchSkill).toContain('autoPort: true');
-		expect(launchSkill).not.toMatch(/--port|\$\{?PORT\}?|\$env:PORT|%PORT%/i);
+		expect(launchSkill).toContain('preferred package manager');
+		expect(launchSkill).toContain('existing Storybook script');
+		expect(launchSkill).toContain('Storybook invocation directory');
+		expect(launchSkill).not.toMatch(/(?:^|[^\w])--port\b|\$\{?PORT\}?|\$env:PORT|%PORT%/i);
+		expect(launchSkill).not.toMatch(/runtimeArgs.+storybook.+dev/i);
 		expect(launchSkill).not.toContain('--ci');
 	});
 });

--- a/packages/claude-plugin/plugin.test.ts
+++ b/packages/claude-plugin/plugin.test.ts
@@ -52,7 +52,7 @@ describe('Claude launch skill guidance', () => {
 		expect(launchSkill).toContain('existing Storybook script');
 		expect(launchSkill).toContain('Storybook invocation directory');
 		expect(launchSkill).not.toMatch(/(?:^|[^\w])--port\b|\$\{?PORT\}?|\$env:PORT|%PORT%/i);
-		expect(launchSkill).not.toMatch(/runtimeArgs.+storybook.+dev/i);
+		expect(launchSkill).not.toMatch(/runtimeArgs[\s\S]+storybook[\s\S]+dev/i);
 		expect(launchSkill).not.toContain('--ci');
 	});
 });

--- a/packages/claude-plugin/skills/storybook-setup-claude-launch/SKILL.md
+++ b/packages/claude-plugin/skills/storybook-setup-claude-launch/SKILL.md
@@ -16,19 +16,13 @@ Use this skill when Storybook is configured but Claude needs a `.claude/launch.j
 
 1. Inspect the project's Storybook scripts and preferred package manager.
 2. Inspect any existing `.claude/launch.json`.
-3. Add or repair a Storybook launch entry that runs the existing Storybook script from the Storybook invocation directory.
+3. Add or repair a Storybook launch entry with `autoPort: true` that runs the existing Storybook script from the Storybook invocation directory.
 4. Keep other launch entries intact.
 5. Verify the launch entry by using the Claude launcher or by inspecting the saved launch config.
 
 Use the project's existing Storybook script instead of inventing a new command whenever possible.
 
 NEVER start Storybook with a Bash command or background task — not `npm run storybook`, not `storybook dev`, not `run_in_background`, not a detached process. "Start the preview" always means invoking the **Claude launcher** on the `.claude/launch.json` Storybook entry. A backgrounded dev server is not a launcher-managed preview and will not satisfy the story workflow.
-
-## Claude Launch Config Details
-
-- `autoPort` must be set to `true` to avoid port conflicts.
-- Storybook command must pass a `--port` flag set to the launcher-provided port env var, using the appropriate interpolation syntax for the target shell/launcher (for example, `--port $PORT` in a POSIX shell or `--port %PORT%` on Windows), so Storybook starts on the expected port.
-- Storybook command must use the `--ci` flag to skip prompts and ensure it can run in a non-interactive environment.
 
 ## If this skill is invoked when creating stories
 


### PR DESCRIPTION
Refs storybookjs/storybook#35257
Depends on storybookjs/storybook#35259 landing or being available as a canary. Do not merge or release this guidance until the Storybook version targeted by the plugin includes the core `PORT` autoPort support.

## What changed

- Kept the existing Claude launch setup workflow that discovers the project's Storybook script, package manager, and invocation directory.
- Moved the `autoPort: true` requirement into that existing workflow step.
- Removed the stale launch details that required `--port $PORT` / `%PORT%` and `--ci`.

## Scope

This intentionally does not remove, merge, or broadly rewrite Claude plugin skills. It also does not slim down the `stories` skill beyond the behavior directly required by storybookjs/storybook#35257.

## Verification

- `pnpm exec oxfmt packages/claude-plugin/skills/storybook-setup-claude-launch/SKILL.md`
- `pnpm test:run packages/claude-plugin/plugin.test.ts`
- Searched the Claude plugin package for `$PORT`, `%PORT%`, and `--ci`; no matching launch guidance remains.
- Manually inspected the skill guidance: it still requires `autoPort: true`, still preserves the existing project script/package-manager/cwd behavior, and no longer prescribes shell interpolation or `--ci`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite for Claude launch skill guidance validation, checking expected content and format compliance.

* **Documentation**
  * Updated Storybook launch workflow instructions with explicit numbered steps for configuring autoPort and verifying launch entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->