### PR TITLE
Support split/ref manifest format (experimentalDocgenServer)

### DIFF
--- a/.changeset/split-ref-manifest-formats.md
+++ b/.changeset/split-ref-manifest-formats.md
@@ -1,0 +1,6 @@
+---
+"@storybook/mcp": minor
+"@storybook/addon-mcp": minor
+---
+
+Support v0 (inline) and v1 (split/ref) Storybook manifest formats. `@storybook/mcp` follows `$ref` pointers into sibling `services/` payloads for static and remote sources; `@storybook/addon-mcp` adds an in-process manifest provider for `experimentalDocgenServer` dev mode and fixes composition so local docgen-server and remote v0/v1 composed sources all work.

--- a/apps/internal-storybook/.storybook-composition-docgen-server/main.ts
+++ b/apps/internal-storybook/.storybook-composition-docgen-server/main.ts
@@ -1,0 +1,29 @@
+import { defineMain } from '@storybook/react-vite/node';
+import baseConfig from '../.storybook/main';
+
+/**
+ * Multi-source Storybook with composition refs and `experimentalDocgenServer`.
+ * Used for E2E tests that verify docgen-server mode works for the local source
+ * while still fetching inline (v0) manifests from composed-in remote sources.
+ */
+const config = defineMain({
+	...baseConfig,
+	features: {
+		changeDetection: true,
+		componentsManifest: true,
+		experimentalDocgenServer: true,
+	},
+	// Same public refs as `.storybook-composition/` — remote storybook-ui serves v0 manifests.
+	refs: {
+		'storybook-ui': {
+			title: 'Storybook UI',
+			url: 'https://next--635781f3500dd2c49e189caf.chromatic.com',
+		},
+		'no-manifest': {
+			title: 'No Manifest',
+			url: 'https://66b1e47012f95c6f90c8882e-eplpsjesci.chromatic.com',
+		},
+	},
+});
+
+export default config;

--- a/apps/internal-storybook/.storybook-composition-docgen-server/preview.ts
+++ b/apps/internal-storybook/.storybook-composition-docgen-server/preview.ts
@@ -1,0 +1,1 @@
+export { default } from '../.storybook/preview';

--- a/apps/internal-storybook/package.json
+++ b/apps/internal-storybook/package.json
@@ -10,6 +10,7 @@
 		"test:storybook": "vitest run --project=storybook",
 		"storybook:composition": "storybook dev --port 6007 -c .storybook-composition --loglevel debug --no-open",
 		"storybook:composition:auth": "storybook dev --port 6008 -c .storybook-composition-auth --loglevel debug --no-open",
+		"storybook:composition:docgen-server": "storybook dev --port 6009 -c .storybook-composition-docgen-server --loglevel debug --no-open",
 		"typecheck": "tsc"
 	},
 	"devDependencies": {

--- a/apps/internal-storybook/pnpm-lock.yaml
+++ b/apps/internal-storybook/pnpm-lock.yaml
@@ -7,20 +7,20 @@ settings:
 catalogs:
   default:
     '@storybook/addon-a11y':
-      specifier: 0.0.0-pr-35189-sha-1274cb62
-      version: 0.0.0-pr-35189-sha-1274cb62
+      specifier: 10.5.0-alpha.8
+      version: 10.5.0-alpha.8
     '@storybook/addon-docs':
-      specifier: 0.0.0-pr-35189-sha-1274cb62
-      version: 0.0.0-pr-35189-sha-1274cb62
+      specifier: 10.5.0-alpha.8
+      version: 10.5.0-alpha.8
     '@storybook/addon-themes':
-      specifier: 0.0.0-pr-35189-sha-1274cb62
-      version: 0.0.0-pr-35189-sha-1274cb62
+      specifier: 10.5.0-alpha.8
+      version: 10.5.0-alpha.8
     '@storybook/addon-vitest':
-      specifier: 0.0.0-pr-35189-sha-1274cb62
-      version: 0.0.0-pr-35189-sha-1274cb62
+      specifier: 10.5.0-alpha.8
+      version: 10.5.0-alpha.8
     '@storybook/react-vite':
-      specifier: 0.0.0-pr-35189-sha-1274cb62
-      version: 0.0.0-pr-35189-sha-1274cb62
+      specifier: 10.5.0-alpha.8
+      version: 10.5.0-alpha.8
     '@vitest/browser-playwright':
       specifier: 4.0.6
       version: 4.0.6
@@ -28,8 +28,8 @@ catalogs:
       specifier: 1.56.1
       version: 1.56.1
     storybook:
-      specifier: 0.0.0-pr-35189-sha-1274cb62
-      version: 0.0.0-pr-35189-sha-1274cb62
+      specifier: 10.5.0-alpha.8
+      version: 10.5.0-alpha.8
     vite:
       specifier: 7.2.2
       version: 7.2.2
@@ -43,22 +43,22 @@ importers:
     devDependencies:
       '@storybook/addon-a11y':
         specifier: 'catalog:'
-        version: 0.0.0-pr-35189-sha-1274cb62(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 10.5.0-alpha.8(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-docs':
         specifier: 'catalog:'
-        version: 0.0.0-pr-35189-sha-1274cb62(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+        version: 10.5.0-alpha.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
       '@storybook/addon-mcp':
         specifier: workspace:*
         version: link:../../packages/addon-mcp
       '@storybook/addon-themes':
         specifier: 'catalog:'
-        version: 0.0.0-pr-35189-sha-1274cb62(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 10.5.0-alpha.8(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-vitest':
         specifier: 'catalog:'
-        version: 0.0.0-pr-35189-sha-1274cb62(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)
+        version: 10.5.0-alpha.8(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 0.0.0-pr-35189-sha-1274cb62(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)
+        version: 10.5.0-alpha.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)
       '@types/react':
         specifier: ^18.2.65
         version: 18.3.28
@@ -82,7 +82,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       storybook:
         specifier: 'catalog:'
-        version: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tinyexec:
         specifier: ^1.0.2
         version: 1.0.2
@@ -937,32 +937,32 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@storybook/addon-a11y@0.0.0-pr-35189-sha-1274cb62':
-    resolution: {integrity: sha512-nVCw6WUcGFjv9c4WRy1eEYSnDVnwR0/h4hvTPpH65YOoWt0dmuR4itiOKzJ/OuCe4LEUsiBR6+Dk7DR8mlKq0A==}
+  '@storybook/addon-a11y@10.5.0-alpha.8':
+    resolution: {integrity: sha512-o7iAzfMKoPwu4kixKh0EK5rQXFCohNVQRmTwTQ5KnCTglpTxnHjG/WBkxbCG1jj6+bS+93LANPQNFKUhyajRNw==}
     peerDependencies:
-      storybook: ^0.0.0-pr-35189-sha-1274cb62
+      storybook: ^10.5.0-alpha.8
 
-  '@storybook/addon-docs@0.0.0-pr-35189-sha-1274cb62':
-    resolution: {integrity: sha512-/vzncSKjGoAW8857RLe8EpFXolRXCtySatgoIm+CB4PYnmUD75vbE6HuvnMW3R8ht7uaDMA+i8LG/qSlf+AR5Q==}
+  '@storybook/addon-docs@10.5.0-alpha.8':
+    resolution: {integrity: sha512-/rWYwz2WmE308YO8lyB5H3a/ZqTQGzjt7y6ey9BfMc4cbMXAa/TbczESo9qpPRTVh6bSxcFFInfmkEMSQJUQAQ==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^0.0.0-pr-35189-sha-1274cb62
+      storybook: ^10.5.0-alpha.8
     peerDependenciesMeta:
       '@types/react':
         optional: true
 
-  '@storybook/addon-themes@0.0.0-pr-35189-sha-1274cb62':
-    resolution: {integrity: sha512-uLgYG7hnKJrtCDLQQsJ8WrFtHUPrlPSntSzCMkGhAQclXeCItvagkVCNGP05jAtM4tXMXPaItIULteWNb2VtOA==}
+  '@storybook/addon-themes@10.5.0-alpha.8':
+    resolution: {integrity: sha512-XXKJlGJ64S7cwtJ6wYIuoTBEDt3D8HG7ktuAGwziXJe2ONJ9a6fd9/VxGvL84LiwcWnz7PfnXn0IMa/dzK/S3Q==}
     peerDependencies:
-      storybook: ^0.0.0-pr-35189-sha-1274cb62
+      storybook: ^10.5.0-alpha.8
 
-  '@storybook/addon-vitest@0.0.0-pr-35189-sha-1274cb62':
-    resolution: {integrity: sha512-u4TfYb8LJ7zBeekivokLPlPg5W6XsoZS/+vn4FMPIKMCEEVQd8KgDtHbrTna7qGFdkQOUA1Lm8Xcyxt+Y0PbNw==}
+  '@storybook/addon-vitest@10.5.0-alpha.8':
+    resolution: {integrity: sha512-maVjReVeQczzmEcBg99iAZqQsRiC+8otIYwch5CarqznD7wUIghCYh9YR+aHHUQInKr1BBRkuhrE//hZEPxw7w==}
     peerDependencies:
       '@vitest/browser': ^3.0.0 || ^4.0.0
       '@vitest/browser-playwright': ^4.0.0
       '@vitest/runner': ^3.0.0 || ^4.0.0
-      storybook: ^0.0.0-pr-35189-sha-1274cb62
+      storybook: ^10.5.0-alpha.8
       vitest: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       '@vitest/browser':
@@ -974,18 +974,18 @@ packages:
       vitest:
         optional: true
 
-  '@storybook/builder-vite@0.0.0-pr-35189-sha-1274cb62':
-    resolution: {integrity: sha512-afYDwcksqEciBgk/5KTEJwsbe10xOkO5hsBJk0tlVbfnyL/0G0fAX9w5RPBrp/E+eqHIW4V3zfSyBv2BqMvSQA==}
+  '@storybook/builder-vite@10.5.0-alpha.8':
+    resolution: {integrity: sha512-3VUg5Tubp/OGmgWJyXSPyDyU9kfJF6/M9BBDkTKdNVZb+tcZuET537hJ7bk3/1cU4XKRdaV9cM5sMtuiazvDOg==}
     peerDependencies:
-      storybook: ^0.0.0-pr-35189-sha-1274cb62
+      storybook: ^10.5.0-alpha.8
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@storybook/csf-plugin@0.0.0-pr-35189-sha-1274cb62':
-    resolution: {integrity: sha512-85exn0R5pLAOcuJR5PTtiTkBQAJGbihwYV30rvRbcGr4FtnBKOold0+1J7Iice51iqzcFHqfjXK8ORPwg/868g==}
+  '@storybook/csf-plugin@10.5.0-alpha.8':
+    resolution: {integrity: sha512-LcVavKC84Bp4sZPr4Ts3aGFZHKJ52xHm2cEznGSnjN1xGTBAoYg5D0MdZZD5fVR+CqfGnEqb/81sbC64zRLzoQ==}
     peerDependencies:
       esbuild: '*'
       rollup: '*'
-      storybook: ^0.0.0-pr-35189-sha-1274cb62
+      storybook: ^10.5.0-alpha.8
       vite: '*'
       webpack: '*'
     peerDependenciesMeta:
@@ -1007,40 +1007,40 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@storybook/react-dom-shim@0.0.0-pr-35189-sha-1274cb62':
-    resolution: {integrity: sha512-uEWCn5tzyCr/6I9TM9uywNQ5O6ihNX4UHPjHkA2+34V2+ew/1LmoF+hgVLDAOWOhUtwvj6e2AkIq4RJtqmqYMw==}
+  '@storybook/react-dom-shim@10.5.0-alpha.8':
+    resolution: {integrity: sha512-NbzZnfql0l3oYv1d0GGsmNeciyKu4HsgEfm4DYzy0JbxYAwQzwcsN9tn0NMkhat1ldfq5JWjGR6+nxRA4nj1iw==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^0.0.0-pr-35189-sha-1274cb62
+      storybook: ^10.5.0-alpha.8
     peerDependenciesMeta:
       '@types/react':
         optional: true
       '@types/react-dom':
         optional: true
 
-  '@storybook/react-vite@0.0.0-pr-35189-sha-1274cb62':
-    resolution: {integrity: sha512-rJ++piI40RNrEkYVpORfZsHouq2QQXYx6QFt0BJzMbCbWVEEyFBmflybXZThDy+AJ2OyhtcLPzan4e3FsWuQ5A==}
+  '@storybook/react-vite@10.5.0-alpha.8':
+    resolution: {integrity: sha512-etSUaRfXUCDKSWBkvI1rPm1wAoPrxNnm3sArpnZGeYGYoyWYhmpi+J+okEzsTt5/zPAkQcBdWSC+il0plMQiDw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^0.0.0-pr-35189-sha-1274cb62
+      storybook: ^10.5.0-alpha.8
       typescript: '>= 4.9.x'
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@storybook/react@0.0.0-pr-35189-sha-1274cb62':
-    resolution: {integrity: sha512-Tz+izrbjYP5lGwXzKtevtUVepow+QGsI2BJMP/ARHnlrQdnD5WDlB9SFbrbVY9Zxfk3n2pwXC7TWYsNhe/qS/g==}
+  '@storybook/react@10.5.0-alpha.8':
+    resolution: {integrity: sha512-8SeeaRflWA2ofEjbSDPwO1VTVgv85X6WlKLpGWKxKGVySHK4Cv1l+oPeouu6JhJ4lq0E5p5vsAQEvJzUiGD5zg==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^0.0.0-pr-35189-sha-1274cb62
+      storybook: ^10.5.0-alpha.8
       typescript: '>= 4.9.x'
     peerDependenciesMeta:
       '@types/react':
@@ -1589,8 +1589,8 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
-  storybook@0.0.0-pr-35189-sha-1274cb62:
-    resolution: {integrity: sha512-IfGdYYVdlYnwubD3snZY3WlYN3U5gb6bluv0ogk/rsSBHW7e8831GLsN3B5gqrW46ch1DDvh3OZj+jMVgA3Wyg==}
+  storybook@10.5.0-alpha.8:
+    resolution: {integrity: sha512-sAFXwToGGeD7oRPRt9KWfmulUDQ/CgiPxwDsWs3BmALF8NwibO0ZbjXy1j9oe85iTC/X9s5YuEQ/yh3Fj3JODQ==}
     hasBin: true
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2335,21 +2335,21 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-a11y@0.0.0-pr-35189-sha-1274cb62(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-a11y@10.5.0-alpha.8(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.1
-      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@storybook/addon-docs@0.0.0-pr-35189-sha-1274cb62(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
+  '@storybook/addon-docs@10.5.0-alpha.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@storybook/csf-plugin': 0.0.0-pr-35189-sha-1274cb62(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+      '@storybook/csf-plugin': 10.5.0-alpha.8(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/react-dom-shim': 0.0.0-pr-35189-sha-1274cb62(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/react-dom-shim': 10.5.0-alpha.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
     optionalDependencies:
       '@types/react': 18.3.28
@@ -2360,16 +2360,16 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-themes@0.0.0-pr-35189-sha-1274cb62(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-themes@10.5.0-alpha.8(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
-      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-vitest@0.0.0-pr-35189-sha-1274cb62(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)':
+  '@storybook/addon-vitest@10.5.0-alpha.8(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       '@vitest/browser': 4.0.6(vite@7.2.2)(vitest@4.0.6)
       '@vitest/browser-playwright': 4.0.6(playwright@1.56.1)(vite@7.2.2)(vitest@4.0.6)
@@ -2379,10 +2379,10 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/builder-vite@0.0.0-pr-35189-sha-1274cb62(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
+  '@storybook/builder-vite@10.5.0-alpha.8(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
     dependencies:
-      '@storybook/csf-plugin': 0.0.0-pr-35189-sha-1274cb62(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
-      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/csf-plugin': 10.5.0-alpha.8(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
       vite: 7.2.2
     transitivePeerDependencies:
@@ -2390,9 +2390,9 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@0.0.0-pr-35189-sha-1274cb62(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
+  '@storybook/csf-plugin@10.5.0-alpha.8(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
     dependencies:
-      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.3
@@ -2406,28 +2406,28 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/react-dom-shim@0.0.0-pr-35189-sha-1274cb62(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/react-dom-shim@10.5.0-alpha.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@storybook/react-vite@0.0.0-pr-35189-sha-1274cb62(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)':
+  '@storybook/react-vite@10.5.0-alpha.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@7.2.2)
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
-      '@storybook/builder-vite': 0.0.0-pr-35189-sha-1274cb62(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
-      '@storybook/react': 0.0.0-pr-35189-sha-1274cb62(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+      '@storybook/builder-vite': 10.5.0-alpha.8(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+      '@storybook/react': 10.5.0-alpha.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 18.3.1
       react-docgen: 8.0.2
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.11
-      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tsconfig-paths: 4.2.0
       vite: 7.2.2
     optionalDependencies:
@@ -2440,15 +2440,15 @@ snapshots:
       - supports-color
       - webpack
 
-  '@storybook/react@0.0.0-pr-35189-sha-1274cb62(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
+  '@storybook/react@10.5.0-alpha.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 0.0.0-pr-35189-sha-1274cb62(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/react-dom-shim': 10.5.0-alpha.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-docgen: 8.0.2
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
@@ -3092,7 +3092,7 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/apps/internal-storybook/pnpm-lock.yaml
+++ b/apps/internal-storybook/pnpm-lock.yaml
@@ -7,20 +7,20 @@ settings:
 catalogs:
   default:
     '@storybook/addon-a11y':
-      specifier: 10.5.0-alpha.7
-      version: 10.5.0-alpha.7
+      specifier: 0.0.0-pr-35189-sha-1274cb62
+      version: 0.0.0-pr-35189-sha-1274cb62
     '@storybook/addon-docs':
-      specifier: 10.5.0-alpha.7
-      version: 10.5.0-alpha.7
+      specifier: 0.0.0-pr-35189-sha-1274cb62
+      version: 0.0.0-pr-35189-sha-1274cb62
     '@storybook/addon-themes':
-      specifier: 10.5.0-alpha.7
-      version: 10.5.0-alpha.7
+      specifier: 0.0.0-pr-35189-sha-1274cb62
+      version: 0.0.0-pr-35189-sha-1274cb62
     '@storybook/addon-vitest':
-      specifier: 10.5.0-alpha.7
-      version: 10.5.0-alpha.7
+      specifier: 0.0.0-pr-35189-sha-1274cb62
+      version: 0.0.0-pr-35189-sha-1274cb62
     '@storybook/react-vite':
-      specifier: 10.5.0-alpha.7
-      version: 10.5.0-alpha.7
+      specifier: 0.0.0-pr-35189-sha-1274cb62
+      version: 0.0.0-pr-35189-sha-1274cb62
     '@vitest/browser-playwright':
       specifier: 4.0.6
       version: 4.0.6
@@ -28,8 +28,8 @@ catalogs:
       specifier: 1.56.1
       version: 1.56.1
     storybook:
-      specifier: 10.5.0-alpha.7
-      version: 10.5.0-alpha.7
+      specifier: 0.0.0-pr-35189-sha-1274cb62
+      version: 0.0.0-pr-35189-sha-1274cb62
     vite:
       specifier: 7.2.2
       version: 7.2.2
@@ -43,22 +43,22 @@ importers:
     devDependencies:
       '@storybook/addon-a11y':
         specifier: 'catalog:'
-        version: 10.5.0-alpha.7(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 0.0.0-pr-35189-sha-1274cb62(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-docs':
         specifier: 'catalog:'
-        version: 10.5.0-alpha.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+        version: 0.0.0-pr-35189-sha-1274cb62(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
       '@storybook/addon-mcp':
         specifier: workspace:*
         version: link:../../packages/addon-mcp
       '@storybook/addon-themes':
         specifier: 'catalog:'
-        version: 10.5.0-alpha.7(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 0.0.0-pr-35189-sha-1274cb62(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-vitest':
         specifier: 'catalog:'
-        version: 10.5.0-alpha.7(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)
+        version: 0.0.0-pr-35189-sha-1274cb62(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 10.5.0-alpha.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)
+        version: 0.0.0-pr-35189-sha-1274cb62(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)
       '@types/react':
         specifier: ^18.2.65
         version: 18.3.28
@@ -82,7 +82,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       storybook:
         specifier: 'catalog:'
-        version: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tinyexec:
         specifier: ^1.0.2
         version: 1.0.2
@@ -937,32 +937,32 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@storybook/addon-a11y@10.5.0-alpha.7':
-    resolution: {integrity: sha512-+EM8VSTcMKNFQjrG30YjoW0R4ytfdfb9yO0C8wXAznEKwqXluQ1BMt69L4RIdL0hnpj0NH4T73PmkNdE8HrLbg==}
+  '@storybook/addon-a11y@0.0.0-pr-35189-sha-1274cb62':
+    resolution: {integrity: sha512-nVCw6WUcGFjv9c4WRy1eEYSnDVnwR0/h4hvTPpH65YOoWt0dmuR4itiOKzJ/OuCe4LEUsiBR6+Dk7DR8mlKq0A==}
     peerDependencies:
-      storybook: ^10.5.0-alpha.7
+      storybook: ^0.0.0-pr-35189-sha-1274cb62
 
-  '@storybook/addon-docs@10.5.0-alpha.7':
-    resolution: {integrity: sha512-69znZcmbgV1Tx2I9KjuRCnwWyY5HPZuLS+qa2QThd5HLGaRCNvr3WCyIfNA4z6pofN5YlQWRl5Ei8htpdZB9bQ==}
+  '@storybook/addon-docs@0.0.0-pr-35189-sha-1274cb62':
+    resolution: {integrity: sha512-/vzncSKjGoAW8857RLe8EpFXolRXCtySatgoIm+CB4PYnmUD75vbE6HuvnMW3R8ht7uaDMA+i8LG/qSlf+AR5Q==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-alpha.7
+      storybook: ^0.0.0-pr-35189-sha-1274cb62
     peerDependenciesMeta:
       '@types/react':
         optional: true
 
-  '@storybook/addon-themes@10.5.0-alpha.7':
-    resolution: {integrity: sha512-RxFPBheOTHGmJXGymtrVqZWnSEjU1s/ga9xIsnhBUPu9NetuUfQASj48RJhtCoGQ+n8V8Oe/pX+3oRiQ9Kkz1g==}
+  '@storybook/addon-themes@0.0.0-pr-35189-sha-1274cb62':
+    resolution: {integrity: sha512-uLgYG7hnKJrtCDLQQsJ8WrFtHUPrlPSntSzCMkGhAQclXeCItvagkVCNGP05jAtM4tXMXPaItIULteWNb2VtOA==}
     peerDependencies:
-      storybook: ^10.5.0-alpha.7
+      storybook: ^0.0.0-pr-35189-sha-1274cb62
 
-  '@storybook/addon-vitest@10.5.0-alpha.7':
-    resolution: {integrity: sha512-12oDJLCxCHDdtDXwxJ1bu4XHeXCjB7CHLGOjGrWCAtCQGNhVM4dDXWZmTJybePsCNsMcjE9E9SNFepr2lj3tkA==}
+  '@storybook/addon-vitest@0.0.0-pr-35189-sha-1274cb62':
+    resolution: {integrity: sha512-u4TfYb8LJ7zBeekivokLPlPg5W6XsoZS/+vn4FMPIKMCEEVQd8KgDtHbrTna7qGFdkQOUA1Lm8Xcyxt+Y0PbNw==}
     peerDependencies:
       '@vitest/browser': ^3.0.0 || ^4.0.0
       '@vitest/browser-playwright': ^4.0.0
       '@vitest/runner': ^3.0.0 || ^4.0.0
-      storybook: ^10.5.0-alpha.7
+      storybook: ^0.0.0-pr-35189-sha-1274cb62
       vitest: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       '@vitest/browser':
@@ -974,18 +974,18 @@ packages:
       vitest:
         optional: true
 
-  '@storybook/builder-vite@10.5.0-alpha.7':
-    resolution: {integrity: sha512-6LV5UKLYP4NJwjeZQIcMnxAFAZ0oEuCcai0STOqt0SU2c6QnJ2ydWPaZC4xbqzr22fQEF77jr/CnsADklx+e3w==}
+  '@storybook/builder-vite@0.0.0-pr-35189-sha-1274cb62':
+    resolution: {integrity: sha512-afYDwcksqEciBgk/5KTEJwsbe10xOkO5hsBJk0tlVbfnyL/0G0fAX9w5RPBrp/E+eqHIW4V3zfSyBv2BqMvSQA==}
     peerDependencies:
-      storybook: ^10.5.0-alpha.7
+      storybook: ^0.0.0-pr-35189-sha-1274cb62
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@storybook/csf-plugin@10.5.0-alpha.7':
-    resolution: {integrity: sha512-fLavxWfht3VH+mqfXJXg4P21eUzBrFsyV8DcBwQTy5qKR0WFF3P+YiT+RgliHH2l5/GWNIk6pRHRDqOmWDpj5w==}
+  '@storybook/csf-plugin@0.0.0-pr-35189-sha-1274cb62':
+    resolution: {integrity: sha512-85exn0R5pLAOcuJR5PTtiTkBQAJGbihwYV30rvRbcGr4FtnBKOold0+1J7Iice51iqzcFHqfjXK8ORPwg/868g==}
     peerDependencies:
       esbuild: '*'
       rollup: '*'
-      storybook: ^10.5.0-alpha.7
+      storybook: ^0.0.0-pr-35189-sha-1274cb62
       vite: '*'
       webpack: '*'
     peerDependenciesMeta:
@@ -1007,40 +1007,40 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@storybook/react-dom-shim@10.5.0-alpha.7':
-    resolution: {integrity: sha512-BTJSZKvtARycttvGIq9Wt72ZmcycCPF5lbv578tpPjy7U2fCK/t9Uj12aITAg6MIppdE17HkJgynPHXQHcC58A==}
+  '@storybook/react-dom-shim@0.0.0-pr-35189-sha-1274cb62':
+    resolution: {integrity: sha512-uEWCn5tzyCr/6I9TM9uywNQ5O6ihNX4UHPjHkA2+34V2+ew/1LmoF+hgVLDAOWOhUtwvj6e2AkIq4RJtqmqYMw==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-alpha.7
+      storybook: ^0.0.0-pr-35189-sha-1274cb62
     peerDependenciesMeta:
       '@types/react':
         optional: true
       '@types/react-dom':
         optional: true
 
-  '@storybook/react-vite@10.5.0-alpha.7':
-    resolution: {integrity: sha512-h/8dkJI3GhUONJyPe5X////vImRJ5E2WteM+Cvrk4xbXyfWyWRds/hcA6NUDknEYJHs1fUTHlHGSRQsSXAXWnw==}
+  '@storybook/react-vite@0.0.0-pr-35189-sha-1274cb62':
+    resolution: {integrity: sha512-rJ++piI40RNrEkYVpORfZsHouq2QQXYx6QFt0BJzMbCbWVEEyFBmflybXZThDy+AJ2OyhtcLPzan4e3FsWuQ5A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-alpha.7
+      storybook: ^0.0.0-pr-35189-sha-1274cb62
       typescript: '>= 4.9.x'
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@storybook/react@10.5.0-alpha.7':
-    resolution: {integrity: sha512-v4lB98nAUXxH7WLGKgLJ1v0CvFiXqvlzrXV7QTwXO1EKpv7CFztyxgVP9B4N8i9Qgqf+sJfCLNe/XYAZZ2bgGw==}
+  '@storybook/react@0.0.0-pr-35189-sha-1274cb62':
+    resolution: {integrity: sha512-Tz+izrbjYP5lGwXzKtevtUVepow+QGsI2BJMP/ARHnlrQdnD5WDlB9SFbrbVY9Zxfk3n2pwXC7TWYsNhe/qS/g==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-alpha.7
+      storybook: ^0.0.0-pr-35189-sha-1274cb62
       typescript: '>= 4.9.x'
     peerDependenciesMeta:
       '@types/react':
@@ -1589,8 +1589,8 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
-  storybook@10.5.0-alpha.7:
-    resolution: {integrity: sha512-DXLEIoXWArqQIdKZZtme1As/igXcC/GueHI/p2C6NK+CwyC4Z5hXaFvEkqbVx9iwyTbUog158hpMh18RnGOG7Q==}
+  storybook@0.0.0-pr-35189-sha-1274cb62:
+    resolution: {integrity: sha512-IfGdYYVdlYnwubD3snZY3WlYN3U5gb6bluv0ogk/rsSBHW7e8831GLsN3B5gqrW46ch1DDvh3OZj+jMVgA3Wyg==}
     hasBin: true
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2335,21 +2335,21 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-a11y@10.5.0-alpha.7(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-a11y@0.0.0-pr-35189-sha-1274cb62(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.1
-      storybook: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@storybook/addon-docs@10.5.0-alpha.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
+  '@storybook/addon-docs@0.0.0-pr-35189-sha-1274cb62(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@storybook/csf-plugin': 10.5.0-alpha.7(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+      '@storybook/csf-plugin': 0.0.0-pr-35189-sha-1274cb62(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/react-dom-shim': 10.5.0-alpha.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/react-dom-shim': 0.0.0-pr-35189-sha-1274cb62(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
     optionalDependencies:
       '@types/react': 18.3.28
@@ -2360,16 +2360,16 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-themes@10.5.0-alpha.7(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-themes@0.0.0-pr-35189-sha-1274cb62(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
-      storybook: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-vitest@10.5.0-alpha.7(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)':
+  '@storybook/addon-vitest@0.0.0-pr-35189-sha-1274cb62(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      storybook: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       '@vitest/browser': 4.0.6(vite@7.2.2)(vitest@4.0.6)
       '@vitest/browser-playwright': 4.0.6(playwright@1.56.1)(vite@7.2.2)(vitest@4.0.6)
@@ -2379,10 +2379,10 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.5.0-alpha.7(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
+  '@storybook/builder-vite@0.0.0-pr-35189-sha-1274cb62(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
     dependencies:
-      '@storybook/csf-plugin': 10.5.0-alpha.7(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
-      storybook: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/csf-plugin': 0.0.0-pr-35189-sha-1274cb62(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
       vite: 7.2.2
     transitivePeerDependencies:
@@ -2390,9 +2390,9 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.5.0-alpha.7(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
+  '@storybook/csf-plugin@0.0.0-pr-35189-sha-1274cb62(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
     dependencies:
-      storybook: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.3
@@ -2406,28 +2406,28 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/react-dom-shim@10.5.0-alpha.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/react-dom-shim@0.0.0-pr-35189-sha-1274cb62(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@storybook/react-vite@10.5.0-alpha.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)':
+  '@storybook/react-vite@0.0.0-pr-35189-sha-1274cb62(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@7.2.2)
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
-      '@storybook/builder-vite': 10.5.0-alpha.7(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
-      '@storybook/react': 10.5.0-alpha.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+      '@storybook/builder-vite': 0.0.0-pr-35189-sha-1274cb62(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+      '@storybook/react': 0.0.0-pr-35189-sha-1274cb62(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 18.3.1
       react-docgen: 8.0.2
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.11
-      storybook: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tsconfig-paths: 4.2.0
       vite: 7.2.2
     optionalDependencies:
@@ -2440,15 +2440,15 @@ snapshots:
       - supports-color
       - webpack
 
-  '@storybook/react@10.5.0-alpha.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
+  '@storybook/react@0.0.0-pr-35189-sha-1274cb62(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.5.0-alpha.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/react-dom-shim': 0.0.0-pr-35189-sha-1274cb62(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-docgen: 8.0.2
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
@@ -3092,7 +3092,7 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/apps/internal-storybook/tests/check-deps.e2e.test.ts
+++ b/apps/internal-storybook/tests/check-deps.e2e.test.ts
@@ -6,6 +6,9 @@ const PACKAGES_TO_CHECK = ['@storybook/addon-docs', '@storybook/react-vite', 'st
 
 const stripPrerelease = (version: string) => version.split(/[+-]/)[0]!;
 
+/** When the catalog pins a PR canary (`0.0.0-pr-*`), compare against that exact version. */
+const isPrCanary = (version: string) => version.startsWith('0.0.0-pr-');
+
 describe('Storybook Dependencies', () => {
 	it('should be using latest versions from registry', async () => {
 		const outdated: Array<{ pkg: string; current: string; latest: string }> = [];
@@ -20,8 +23,9 @@ describe('Storybook Dependencies', () => {
 			const currentVersion =
 				listData[0]?.devDependencies?.[pkg]?.version || listData[0]?.dependencies?.[pkg]?.version;
 
-			// Get registry version for @next tag
-			const viewResult = await x('pnpm', ['view', `${pkg}@next`, 'version'], {
+			// PR canaries are pinned intentionally until the feature ships on @next.
+			const viewTag = isPrCanary(currentVersion) ? currentVersion : '@next';
+			const viewResult = await x('pnpm', ['view', `${pkg}@${viewTag}`, 'version'], {
 				nodeOptions: { cwd: process.cwd() },
 			});
 			const latestVersion = viewResult.stdout.trim();

--- a/apps/internal-storybook/tests/check-deps.e2e.test.ts
+++ b/apps/internal-storybook/tests/check-deps.e2e.test.ts
@@ -6,9 +6,6 @@ const PACKAGES_TO_CHECK = ['@storybook/addon-docs', '@storybook/react-vite', 'st
 
 const stripPrerelease = (version: string) => version.split(/[+-]/)[0]!;
 
-/** When the catalog pins a PR canary (`0.0.0-pr-*`), compare against that exact version. */
-const isPrCanary = (version: string) => version.startsWith('0.0.0-pr-');
-
 describe('Storybook Dependencies', () => {
 	it('should be using latest versions from registry', async () => {
 		const outdated: Array<{ pkg: string; current: string; latest: string }> = [];
@@ -23,9 +20,8 @@ describe('Storybook Dependencies', () => {
 			const currentVersion =
 				listData[0]?.devDependencies?.[pkg]?.version || listData[0]?.dependencies?.[pkg]?.version;
 
-			// PR canaries are pinned intentionally until the feature ships on @next.
-			const viewTag = isPrCanary(currentVersion) ? currentVersion : '@next';
-			const viewResult = await x('pnpm', ['view', `${pkg}@${viewTag}`, 'version'], {
+			// Get registry version for @next tag
+			const viewResult = await x('pnpm', ['view', `${pkg}@next`, 'version'], {
 				nodeOptions: { cwd: process.cwd() },
 			});
 			const latestVersion = viewResult.stdout.trim();

--- a/apps/internal-storybook/tests/mcp-composition-docgen-server.e2e.test.ts
+++ b/apps/internal-storybook/tests/mcp-composition-docgen-server.e2e.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { x } from 'tinyexec';
+import {
+	createMCPRequestBody,
+	parseMCPResponse,
+	waitForMcpEndpoint,
+	killPort,
+	startStorybook,
+	stopStorybook,
+} from './helpers';
+
+const PORT = 6009;
+const MCP_ENDPOINT = `http://localhost:${PORT}/mcp`;
+const STARTUP_TIMEOUT = 60_000;
+
+let storybookProcess: ReturnType<typeof x> | null = null;
+
+async function mcpRequest(method: string, params: any = {}) {
+	const response = await fetch(MCP_ENDPOINT, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(createMCPRequestBody(method, params)),
+	});
+
+	if (!response.ok) {
+		throw new Error(`HTTP error! status: ${response.status}`);
+	}
+
+	return parseMCPResponse(response);
+}
+
+describe('MCP Composition + Docgen Server E2E Tests', () => {
+	beforeAll(async () => {
+		await killPort(PORT);
+		storybookProcess = startStorybook('.storybook-composition-docgen-server', PORT);
+		await waitForMcpEndpoint(MCP_ENDPOINT);
+	}, STARTUP_TIMEOUT);
+
+	afterAll(async () => {
+		await stopStorybook(storybookProcess);
+		storybookProcess = null;
+	});
+
+	describe('Multi-Source Documentation', () => {
+		it('should list documentation from both local (docgen server) and remote (v0) sources', async () => {
+			const response = await mcpRequest('tools/call', {
+				name: 'list-all-documentation',
+				arguments: {},
+			});
+
+			const text = response.result.content[0].text;
+
+			expect(text).toContain('# Local');
+			expect(text).toContain('id: local');
+			expect(text).toContain('# Storybook UI');
+			expect(text).toContain('id: storybook-ui');
+			expect(text).toContain('Button (example-button)');
+			expect(text).toContain('## Components');
+		});
+
+		it('should fetch documentation for a local component via in-process docgen server', async () => {
+			const response = await mcpRequest('tools/call', {
+				name: 'get-documentation',
+				arguments: {
+					id: 'example-button',
+					storybookId: 'local',
+				},
+			});
+
+			expect(response.result).toHaveProperty('content');
+			expect(response.result.content[0].type).toBe('text');
+
+			const text = response.result.content[0].text;
+			expect(text).toContain('# Button');
+			expect(text).toContain('ID: example-button');
+			expect(text).toContain('## Stories');
+			expect(text).toContain('example-button--primary');
+			expect(text).toContain('## Props');
+			expect(text).toContain('label: string');
+			expect(text).toContain('## Docs');
+		});
+
+		it('should fetch documentation for a component from remote v0 source', async () => {
+			const response = await mcpRequest('tools/call', {
+				name: 'get-documentation',
+				arguments: {
+					id: 'example-button',
+					storybookId: 'storybook-ui',
+				},
+			});
+
+			expect(response.result).toHaveProperty('content');
+			expect(response.result.content[0].type).toBe('text');
+
+			const text = response.result.content[0].text;
+			expect(text).toContain('Button');
+			expect(text).toContain('example-button');
+		});
+
+		it('should silently exclude refs that have no manifest', async () => {
+			const response = await mcpRequest('tools/call', {
+				name: 'list-all-documentation',
+				arguments: {},
+			});
+
+			const text = response.result.content[0].text;
+
+			expect(text).not.toContain('No Manifest');
+			expect(text).not.toContain('no-manifest');
+		});
+
+		it('should require storybookId in multi-source mode', async () => {
+			const response = await mcpRequest('tools/call', {
+				name: 'get-documentation',
+				arguments: {
+					id: 'example-button',
+				},
+			});
+
+			expect(response.result.isError).toBe(true);
+			expect(response.result.content[0].text).toContain('storybookId');
+		});
+	});
+
+	describe('Docgen Server Local Manifests', () => {
+		it('should not serve local components.json over HTTP in docgen-server dev mode', async () => {
+			const response = await fetch(`http://localhost:${PORT}/manifests/components.json`);
+			expect(response.status).toBe(404);
+		});
+
+		it('should still resolve local docs through MCP despite HTTP 404', async () => {
+			const response = await mcpRequest('tools/call', {
+				name: 'get-documentation',
+				arguments: {
+					id: 'getting-started--docs',
+					storybookId: 'local',
+				},
+			});
+
+			expect(response.result.isError).toBeFalsy();
+			const text = response.result.content[0].text;
+			expect(text).toContain('Getting Started');
+		});
+	});
+
+	describe('Public Refs (No Auth)', () => {
+		it('should not require authentication for public refs', async () => {
+			const response = await fetch(`http://localhost:${PORT}/.well-known/oauth-protected-resource`);
+			const text = await response.text();
+
+			expect(text).toBe('Not found');
+		});
+	});
+
+	describe('Tools Schema', () => {
+		it('should include storybookId parameter in get-documentation schema', async () => {
+			const response = await mcpRequest('tools/list');
+
+			const getDocTool = response.result.tools.find((t: any) => t.name === 'get-documentation');
+
+			expect(getDocTool).toBeDefined();
+			expect(getDocTool.inputSchema.properties).toHaveProperty('storybookId');
+		});
+	});
+});

--- a/apps/self-host-mcp/README.md
+++ b/apps/self-host-mcp/README.md
@@ -32,6 +32,21 @@ To try this server with your own component library, first build your Storybook s
 
 In practice, you want `components.json` (and `docs.json` if available) in `apps/self-host-mcp/manifests/` before running `pnpm start`.
 
+### Split/ref manifests (`experimentalDocgenServer`)
+
+Newer Storybooks (with `features.experimentalDocgenServer`) emit a _split_ manifest: `components.json`/`docs.json` are shallow indexes that reference per-component/per-doc payloads under a sibling `services/` directory (for example `services/core/docgen/<id>.json`). When your build uses this format, copy **both** directories preserving their layout — keep `services/` as a sibling of `manifests/`:
+
+```
+<root>/
+  manifests/components.json
+  manifests/docs.json
+  services/core/docgen/<id>.json
+  services/core/story-docs/<id>.json
+  services/addon-docs/mdx/<id>.json
+```
+
+Point `--manifestsPath` at the `manifests/` directory (or its remote URL); the server resolves the referenced `services/` files relative to its parent.
+
 ## Run on Netlify Functions
 
 This example also includes a Netlify function at `netlify/functions/mcp.ts` and routing in `netlify.toml`.

--- a/apps/self-host-mcp/server.ts
+++ b/apps/self-host-mcp/server.ts
@@ -1,23 +1,46 @@
 import { createStorybookMcpHandler } from '@storybook/mcp';
 import fs from 'node:fs/promises';
-import { basename, resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+
+/**
+ * Maps a manifest provider path to its `{ base, rel }` location.
+ *
+ * Top-level manifests (`./manifests/<name>.json`) live in `manifestsPath`; split/ref
+ * payloads (`./services/<service>/<id>.json`) live in a sibling `services/` directory,
+ * so they resolve against the Storybook build root (the parent of `manifestsPath`).
+ */
+function resolveManifestTarget(
+	manifestsPath: string,
+	path: string,
+	isRemote: boolean,
+): { base: string; rel: string } {
+	const normalized = path.replace(/^\.?\//, '');
+	if (normalized.startsWith('manifests/')) {
+		return { base: manifestsPath, rel: normalized.slice('manifests/'.length) };
+	}
+	// `services/...` is a sibling of the manifests directory (the build root).
+	const root = isRemote ? manifestsPath.replace(/\/[^/]+\/?$/, '') : dirname(manifestsPath);
+	return { base: root, rel: normalized };
+}
 
 export function createMcpHandler(manifestsPath: string) {
 	return createStorybookMcpHandler({
 		manifestProvider: async (_request: Request | undefined, path: string) => {
-			const fileName = basename(path);
+			const isRemote = manifestsPath.startsWith('http://') || manifestsPath.startsWith('https://');
+			const { base, rel } = resolveManifestTarget(manifestsPath, path, isRemote);
 
-			if (manifestsPath.startsWith('http://') || manifestsPath.startsWith('https://')) {
-				const response = await fetch(`${manifestsPath}/${fileName}`);
+			if (isRemote) {
+				const url = `${base.replace(/\/$/, '')}/${rel}`;
+				const response = await fetch(url);
 				if (!response.ok) {
 					throw new Error(
-						`Failed to fetch manifest from ${manifestsPath}/${fileName}: ${response.status} ${response.statusText}`,
+						`Failed to fetch manifest from ${url}: ${response.status} ${response.statusText}`,
 					);
 				}
 				return await response.text();
 			}
 
-			return await fs.readFile(resolve(manifestsPath, fileName), 'utf-8');
+			return await fs.readFile(resolve(base, rel), 'utf-8');
 		},
 	});
 }
@@ -52,5 +75,7 @@ if (import.meta.main) {
 		},
 	});
 
-	console.log(`@storybook/mcp example server listening on http://localhost:${port}/mcp`);
+	console.log(
+		`@storybook/mcp example server listening on http://localhost:${args.values.port}/mcp`,
+	);
 }

--- a/apps/self-host-mcp/server.ts
+++ b/apps/self-host-mcp/server.ts
@@ -1,6 +1,6 @@
 import { createStorybookMcpHandler } from '@storybook/mcp';
 import fs from 'node:fs/promises';
-import { dirname, resolve } from 'node:path';
+import { dirname, resolve, sep } from 'node:path';
 
 /**
  * Maps a manifest provider path to its `{ base, rel }` location.
@@ -23,6 +23,15 @@ function resolveManifestTarget(
 	return { base: root, rel: normalized };
 }
 
+function resolveManifestFile(base: string, rel: string): string {
+	const resolvedBase = resolve(base);
+	const resolved = resolve(resolvedBase, rel);
+	if (resolved !== resolvedBase && !resolved.startsWith(resolvedBase + sep)) {
+		throw new Error(`Refusing to read manifest outside base: ${rel}`);
+	}
+	return resolved;
+}
+
 export function createMcpHandler(manifestsPath: string) {
 	return createStorybookMcpHandler({
 		manifestProvider: async (_request: Request | undefined, path: string) => {
@@ -40,7 +49,7 @@ export function createMcpHandler(manifestsPath: string) {
 				return await response.text();
 			}
 
-			return await fs.readFile(resolve(base, rel), 'utf-8');
+			return await fs.readFile(resolveManifestFile(base, rel), 'utf-8');
 		},
 	});
 }

--- a/eval/pnpm-lock.yaml
+++ b/eval/pnpm-lock.yaml
@@ -7,17 +7,17 @@ settings:
 catalogs:
   default:
     '@storybook/addon-a11y':
-      specifier: 0.0.0-pr-35189-sha-1274cb62
-      version: 0.0.0-pr-35189-sha-1274cb62
+      specifier: 10.5.0-alpha.8
+      version: 10.5.0-alpha.8
     '@storybook/react-vite':
-      specifier: 0.0.0-pr-35189-sha-1274cb62
-      version: 0.0.0-pr-35189-sha-1274cb62
+      specifier: 10.5.0-alpha.8
+      version: 10.5.0-alpha.8
     playwright:
       specifier: 1.56.1
       version: 1.56.1
     storybook:
-      specifier: 0.0.0-pr-35189-sha-1274cb62
-      version: 0.0.0-pr-35189-sha-1274cb62
+      specifier: 10.5.0-alpha.8
+      version: 10.5.0-alpha.8
     valibot:
       specifier: 1.2.0
       version: 1.2.0
@@ -49,13 +49,13 @@ importers:
         version: 1.1.11(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/addon-a11y':
         specifier: 'catalog:'
-        version: 0.0.0-pr-35189-sha-1274cb62(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 10.5.0-alpha.8(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/mcp':
         specifier: workspace:*
         version: link:../packages/mcp
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 0.0.0-pr-35189-sha-1274cb62(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))
+        version: 10.5.0-alpha.8(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))
       '@tsconfig/node-ts':
         specifier: ^23.6.1
         version: 23.6.3
@@ -127,10 +127,10 @@ importers:
         version: 5.83.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook:
         specifier: 'catalog:'
-        version: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook-addon-test-codegen:
         specifier: ^3.0.0
-        version: 3.0.1(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 3.0.1(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       tinyexec:
         specifier: ^1.0.1
         version: 1.0.2
@@ -1762,23 +1762,23 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@storybook/addon-a11y@0.0.0-pr-35189-sha-1274cb62':
-    resolution: {integrity: sha512-nVCw6WUcGFjv9c4WRy1eEYSnDVnwR0/h4hvTPpH65YOoWt0dmuR4itiOKzJ/OuCe4LEUsiBR6+Dk7DR8mlKq0A==}
+  '@storybook/addon-a11y@10.5.0-alpha.8':
+    resolution: {integrity: sha512-o7iAzfMKoPwu4kixKh0EK5rQXFCohNVQRmTwTQ5KnCTglpTxnHjG/WBkxbCG1jj6+bS+93LANPQNFKUhyajRNw==}
     peerDependencies:
-      storybook: ^0.0.0-pr-35189-sha-1274cb62
+      storybook: ^10.5.0-alpha.8
 
-  '@storybook/builder-vite@0.0.0-pr-35189-sha-1274cb62':
-    resolution: {integrity: sha512-afYDwcksqEciBgk/5KTEJwsbe10xOkO5hsBJk0tlVbfnyL/0G0fAX9w5RPBrp/E+eqHIW4V3zfSyBv2BqMvSQA==}
+  '@storybook/builder-vite@10.5.0-alpha.8':
+    resolution: {integrity: sha512-3VUg5Tubp/OGmgWJyXSPyDyU9kfJF6/M9BBDkTKdNVZb+tcZuET537hJ7bk3/1cU4XKRdaV9cM5sMtuiazvDOg==}
     peerDependencies:
-      storybook: ^0.0.0-pr-35189-sha-1274cb62
+      storybook: ^10.5.0-alpha.8
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@storybook/csf-plugin@0.0.0-pr-35189-sha-1274cb62':
-    resolution: {integrity: sha512-85exn0R5pLAOcuJR5PTtiTkBQAJGbihwYV30rvRbcGr4FtnBKOold0+1J7Iice51iqzcFHqfjXK8ORPwg/868g==}
+  '@storybook/csf-plugin@10.5.0-alpha.8':
+    resolution: {integrity: sha512-LcVavKC84Bp4sZPr4Ts3aGFZHKJ52xHm2cEznGSnjN1xGTBAoYg5D0MdZZD5fVR+CqfGnEqb/81sbC64zRLzoQ==}
     peerDependencies:
       esbuild: '*'
       rollup: '*'
-      storybook: ^0.0.0-pr-35189-sha-1274cb62
+      storybook: ^10.5.0-alpha.8
       vite: '*'
       webpack: '*'
     peerDependenciesMeta:
@@ -1800,40 +1800,40 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@storybook/react-dom-shim@0.0.0-pr-35189-sha-1274cb62':
-    resolution: {integrity: sha512-uEWCn5tzyCr/6I9TM9uywNQ5O6ihNX4UHPjHkA2+34V2+ew/1LmoF+hgVLDAOWOhUtwvj6e2AkIq4RJtqmqYMw==}
+  '@storybook/react-dom-shim@10.5.0-alpha.8':
+    resolution: {integrity: sha512-NbzZnfql0l3oYv1d0GGsmNeciyKu4HsgEfm4DYzy0JbxYAwQzwcsN9tn0NMkhat1ldfq5JWjGR6+nxRA4nj1iw==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^0.0.0-pr-35189-sha-1274cb62
+      storybook: ^10.5.0-alpha.8
     peerDependenciesMeta:
       '@types/react':
         optional: true
       '@types/react-dom':
         optional: true
 
-  '@storybook/react-vite@0.0.0-pr-35189-sha-1274cb62':
-    resolution: {integrity: sha512-rJ++piI40RNrEkYVpORfZsHouq2QQXYx6QFt0BJzMbCbWVEEyFBmflybXZThDy+AJ2OyhtcLPzan4e3FsWuQ5A==}
+  '@storybook/react-vite@10.5.0-alpha.8':
+    resolution: {integrity: sha512-etSUaRfXUCDKSWBkvI1rPm1wAoPrxNnm3sArpnZGeYGYoyWYhmpi+J+okEzsTt5/zPAkQcBdWSC+il0plMQiDw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^0.0.0-pr-35189-sha-1274cb62
+      storybook: ^10.5.0-alpha.8
       typescript: '>= 4.9.x'
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@storybook/react@0.0.0-pr-35189-sha-1274cb62':
-    resolution: {integrity: sha512-Tz+izrbjYP5lGwXzKtevtUVepow+QGsI2BJMP/ARHnlrQdnD5WDlB9SFbrbVY9Zxfk3n2pwXC7TWYsNhe/qS/g==}
+  '@storybook/react@10.5.0-alpha.8':
+    resolution: {integrity: sha512-8SeeaRflWA2ofEjbSDPwO1VTVgv85X6WlKLpGWKxKGVySHK4Cv1l+oPeouu6JhJ4lq0E5p5vsAQEvJzUiGD5zg==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^0.0.0-pr-35189-sha-1274cb62
+      storybook: ^10.5.0-alpha.8
       typescript: '>= 4.9.x'
     peerDependenciesMeta:
       '@types/react':
@@ -3156,8 +3156,8 @@ packages:
     peerDependencies:
       storybook: ^0.0.0-0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0
 
-  storybook@0.0.0-pr-35189-sha-1274cb62:
-    resolution: {integrity: sha512-IfGdYYVdlYnwubD3snZY3WlYN3U5gb6bluv0ogk/rsSBHW7e8831GLsN3B5gqrW46ch1DDvh3OZj+jMVgA3Wyg==}
+  storybook@10.5.0-alpha.8:
+    resolution: {integrity: sha512-sAFXwToGGeD7oRPRt9KWfmulUDQ/CgiPxwDsWs3BmALF8NwibO0ZbjXy1j9oe85iTC/X9s5YuEQ/yh3Fj3JODQ==}
     hasBin: true
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -4752,16 +4752,16 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/addon-a11y@0.0.0-pr-35189-sha-1274cb62(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/addon-a11y@10.5.0-alpha.8(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.1
-      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/builder-vite@0.0.0-pr-35189-sha-1274cb62(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
+  '@storybook/builder-vite@10.5.0-alpha.8(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
     dependencies:
-      '@storybook/csf-plugin': 0.0.0-pr-35189-sha-1274cb62(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
-      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@storybook/csf-plugin': 10.5.0-alpha.8(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
+      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
       vite: 7.3.1(@types/node@24.10.12)
     transitivePeerDependencies:
@@ -4769,9 +4769,9 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@0.0.0-pr-35189-sha-1274cb62(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
+  '@storybook/csf-plugin@10.5.0-alpha.8(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
     dependencies:
-      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.3
@@ -4785,27 +4785,27 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/react-dom-shim@0.0.0-pr-35189-sha-1274cb62(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/react-dom-shim@10.5.0-alpha.8(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@storybook/react-vite@0.0.0-pr-35189-sha-1274cb62(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))':
+  '@storybook/react-vite@10.5.0-alpha.8(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
-      '@storybook/builder-vite': 0.0.0-pr-35189-sha-1274cb62(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
-      '@storybook/react': 0.0.0-pr-35189-sha-1274cb62(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+      '@storybook/builder-vite': 10.5.0-alpha.8(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
+      '@storybook/react': 10.5.0-alpha.8(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 19.2.4
       react-docgen: 8.0.2
       react-dom: 19.2.4(react@19.2.4)
       resolve: 1.22.11
-      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tsconfig-paths: 4.2.0
       vite: 7.3.1(@types/node@24.10.12)
     optionalDependencies:
@@ -4818,15 +4818,15 @@ snapshots:
       - supports-color
       - webpack
 
-  '@storybook/react@0.0.0-pr-35189-sha-1274cb62(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
+  '@storybook/react@10.5.0-alpha.8(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 0.0.0-pr-35189-sha-1274cb62(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@storybook/react-dom-shim': 10.5.0-alpha.8(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react: 19.2.4
       react-docgen: 8.0.2
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     optionalDependencies:
       '@types/react': 18.3.28
       typescript: 5.9.3
@@ -6227,11 +6227,11 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  storybook-addon-test-codegen@3.0.1(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+  storybook-addon-test-codegen@3.0.1(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
-      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/eval/pnpm-lock.yaml
+++ b/eval/pnpm-lock.yaml
@@ -7,17 +7,17 @@ settings:
 catalogs:
   default:
     '@storybook/addon-a11y':
-      specifier: 10.5.0-alpha.7
-      version: 10.5.0-alpha.7
+      specifier: 0.0.0-pr-35189-sha-1274cb62
+      version: 0.0.0-pr-35189-sha-1274cb62
     '@storybook/react-vite':
-      specifier: 10.5.0-alpha.7
-      version: 10.5.0-alpha.7
+      specifier: 0.0.0-pr-35189-sha-1274cb62
+      version: 0.0.0-pr-35189-sha-1274cb62
     playwright:
       specifier: 1.56.1
       version: 1.56.1
     storybook:
-      specifier: 10.5.0-alpha.7
-      version: 10.5.0-alpha.7
+      specifier: 0.0.0-pr-35189-sha-1274cb62
+      version: 0.0.0-pr-35189-sha-1274cb62
     valibot:
       specifier: 1.2.0
       version: 1.2.0
@@ -49,13 +49,13 @@ importers:
         version: 1.1.11(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/addon-a11y':
         specifier: 'catalog:'
-        version: 10.5.0-alpha.7(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 0.0.0-pr-35189-sha-1274cb62(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/mcp':
         specifier: workspace:*
         version: link:../packages/mcp
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 10.5.0-alpha.7(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))
+        version: 0.0.0-pr-35189-sha-1274cb62(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))
       '@tsconfig/node-ts':
         specifier: ^23.6.1
         version: 23.6.3
@@ -127,10 +127,10 @@ importers:
         version: 5.83.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook:
         specifier: 'catalog:'
-        version: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook-addon-test-codegen:
         specifier: ^3.0.0
-        version: 3.0.1(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 3.0.1(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       tinyexec:
         specifier: ^1.0.1
         version: 1.0.2
@@ -1762,23 +1762,23 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@storybook/addon-a11y@10.5.0-alpha.7':
-    resolution: {integrity: sha512-+EM8VSTcMKNFQjrG30YjoW0R4ytfdfb9yO0C8wXAznEKwqXluQ1BMt69L4RIdL0hnpj0NH4T73PmkNdE8HrLbg==}
+  '@storybook/addon-a11y@0.0.0-pr-35189-sha-1274cb62':
+    resolution: {integrity: sha512-nVCw6WUcGFjv9c4WRy1eEYSnDVnwR0/h4hvTPpH65YOoWt0dmuR4itiOKzJ/OuCe4LEUsiBR6+Dk7DR8mlKq0A==}
     peerDependencies:
-      storybook: ^10.5.0-alpha.7
+      storybook: ^0.0.0-pr-35189-sha-1274cb62
 
-  '@storybook/builder-vite@10.5.0-alpha.7':
-    resolution: {integrity: sha512-6LV5UKLYP4NJwjeZQIcMnxAFAZ0oEuCcai0STOqt0SU2c6QnJ2ydWPaZC4xbqzr22fQEF77jr/CnsADklx+e3w==}
+  '@storybook/builder-vite@0.0.0-pr-35189-sha-1274cb62':
+    resolution: {integrity: sha512-afYDwcksqEciBgk/5KTEJwsbe10xOkO5hsBJk0tlVbfnyL/0G0fAX9w5RPBrp/E+eqHIW4V3zfSyBv2BqMvSQA==}
     peerDependencies:
-      storybook: ^10.5.0-alpha.7
+      storybook: ^0.0.0-pr-35189-sha-1274cb62
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@storybook/csf-plugin@10.5.0-alpha.7':
-    resolution: {integrity: sha512-fLavxWfht3VH+mqfXJXg4P21eUzBrFsyV8DcBwQTy5qKR0WFF3P+YiT+RgliHH2l5/GWNIk6pRHRDqOmWDpj5w==}
+  '@storybook/csf-plugin@0.0.0-pr-35189-sha-1274cb62':
+    resolution: {integrity: sha512-85exn0R5pLAOcuJR5PTtiTkBQAJGbihwYV30rvRbcGr4FtnBKOold0+1J7Iice51iqzcFHqfjXK8ORPwg/868g==}
     peerDependencies:
       esbuild: '*'
       rollup: '*'
-      storybook: ^10.5.0-alpha.7
+      storybook: ^0.0.0-pr-35189-sha-1274cb62
       vite: '*'
       webpack: '*'
     peerDependenciesMeta:
@@ -1800,40 +1800,40 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@storybook/react-dom-shim@10.5.0-alpha.7':
-    resolution: {integrity: sha512-BTJSZKvtARycttvGIq9Wt72ZmcycCPF5lbv578tpPjy7U2fCK/t9Uj12aITAg6MIppdE17HkJgynPHXQHcC58A==}
+  '@storybook/react-dom-shim@0.0.0-pr-35189-sha-1274cb62':
+    resolution: {integrity: sha512-uEWCn5tzyCr/6I9TM9uywNQ5O6ihNX4UHPjHkA2+34V2+ew/1LmoF+hgVLDAOWOhUtwvj6e2AkIq4RJtqmqYMw==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-alpha.7
+      storybook: ^0.0.0-pr-35189-sha-1274cb62
     peerDependenciesMeta:
       '@types/react':
         optional: true
       '@types/react-dom':
         optional: true
 
-  '@storybook/react-vite@10.5.0-alpha.7':
-    resolution: {integrity: sha512-h/8dkJI3GhUONJyPe5X////vImRJ5E2WteM+Cvrk4xbXyfWyWRds/hcA6NUDknEYJHs1fUTHlHGSRQsSXAXWnw==}
+  '@storybook/react-vite@0.0.0-pr-35189-sha-1274cb62':
+    resolution: {integrity: sha512-rJ++piI40RNrEkYVpORfZsHouq2QQXYx6QFt0BJzMbCbWVEEyFBmflybXZThDy+AJ2OyhtcLPzan4e3FsWuQ5A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-alpha.7
+      storybook: ^0.0.0-pr-35189-sha-1274cb62
       typescript: '>= 4.9.x'
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@storybook/react@10.5.0-alpha.7':
-    resolution: {integrity: sha512-v4lB98nAUXxH7WLGKgLJ1v0CvFiXqvlzrXV7QTwXO1EKpv7CFztyxgVP9B4N8i9Qgqf+sJfCLNe/XYAZZ2bgGw==}
+  '@storybook/react@0.0.0-pr-35189-sha-1274cb62':
+    resolution: {integrity: sha512-Tz+izrbjYP5lGwXzKtevtUVepow+QGsI2BJMP/ARHnlrQdnD5WDlB9SFbrbVY9Zxfk3n2pwXC7TWYsNhe/qS/g==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-alpha.7
+      storybook: ^0.0.0-pr-35189-sha-1274cb62
       typescript: '>= 4.9.x'
     peerDependenciesMeta:
       '@types/react':
@@ -3156,8 +3156,8 @@ packages:
     peerDependencies:
       storybook: ^0.0.0-0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0
 
-  storybook@10.5.0-alpha.7:
-    resolution: {integrity: sha512-DXLEIoXWArqQIdKZZtme1As/igXcC/GueHI/p2C6NK+CwyC4Z5hXaFvEkqbVx9iwyTbUog158hpMh18RnGOG7Q==}
+  storybook@0.0.0-pr-35189-sha-1274cb62:
+    resolution: {integrity: sha512-IfGdYYVdlYnwubD3snZY3WlYN3U5gb6bluv0ogk/rsSBHW7e8831GLsN3B5gqrW46ch1DDvh3OZj+jMVgA3Wyg==}
     hasBin: true
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -4752,16 +4752,16 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/addon-a11y@10.5.0-alpha.7(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/addon-a11y@0.0.0-pr-35189-sha-1274cb62(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.1
-      storybook: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/builder-vite@10.5.0-alpha.7(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
+  '@storybook/builder-vite@0.0.0-pr-35189-sha-1274cb62(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
     dependencies:
-      '@storybook/csf-plugin': 10.5.0-alpha.7(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
-      storybook: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@storybook/csf-plugin': 0.0.0-pr-35189-sha-1274cb62(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
+      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
       vite: 7.3.1(@types/node@24.10.12)
     transitivePeerDependencies:
@@ -4769,9 +4769,9 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.5.0-alpha.7(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
+  '@storybook/csf-plugin@0.0.0-pr-35189-sha-1274cb62(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
     dependencies:
-      storybook: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.3
@@ -4785,27 +4785,27 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/react-dom-shim@10.5.0-alpha.7(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/react-dom-shim@0.0.0-pr-35189-sha-1274cb62(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@storybook/react-vite@10.5.0-alpha.7(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))':
+  '@storybook/react-vite@0.0.0-pr-35189-sha-1274cb62(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
-      '@storybook/builder-vite': 10.5.0-alpha.7(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
-      '@storybook/react': 10.5.0-alpha.7(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+      '@storybook/builder-vite': 0.0.0-pr-35189-sha-1274cb62(esbuild@0.27.3)(rollup@4.57.1)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
+      '@storybook/react': 0.0.0-pr-35189-sha-1274cb62(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 19.2.4
       react-docgen: 8.0.2
       react-dom: 19.2.4(react@19.2.4)
       resolve: 1.22.11
-      storybook: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tsconfig-paths: 4.2.0
       vite: 7.3.1(@types/node@24.10.12)
     optionalDependencies:
@@ -4818,15 +4818,15 @@ snapshots:
       - supports-color
       - webpack
 
-  '@storybook/react@10.5.0-alpha.7(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
+  '@storybook/react@0.0.0-pr-35189-sha-1274cb62(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.5.0-alpha.7(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@storybook/react-dom-shim': 0.0.0-pr-35189-sha-1274cb62(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react: 19.2.4
       react-docgen: 8.0.2
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     optionalDependencies:
       '@types/react': 18.3.28
       typescript: 5.9.3
@@ -6227,11 +6227,11 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  storybook-addon-test-codegen@3.0.1(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+  storybook-addon-test-codegen@3.0.1(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
-      storybook: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/packages/addon-mcp/pnpm-lock.yaml
+++ b/packages/addon-mcp/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     '@storybook/addon-a11y':
-      specifier: 10.5.0-alpha.7
-      version: 10.5.0-alpha.7
+      specifier: 0.0.0-pr-35189-sha-1274cb62
+      version: 0.0.0-pr-35189-sha-1274cb62
     '@storybook/addon-vitest':
-      specifier: 10.5.0-alpha.7
-      version: 10.5.0-alpha.7
+      specifier: 0.0.0-pr-35189-sha-1274cb62
+      version: 0.0.0-pr-35189-sha-1274cb62
     '@tmcp/adapter-valibot':
       specifier: ^0.1.5
       version: 0.1.5
@@ -19,8 +19,8 @@ catalogs:
       specifier: ^0.8.5
       version: 0.8.5
     storybook:
-      specifier: 10.5.0-alpha.7
-      version: 10.5.0-alpha.7
+      specifier: 0.0.0-pr-35189-sha-1274cb62
+      version: 0.0.0-pr-35189-sha-1274cb62
     tmcp:
       specifier: ^1.19.4
       version: 1.19.4
@@ -53,13 +53,13 @@ importers:
     devDependencies:
       '@storybook/addon-a11y':
         specifier: 'catalog:'
-        version: 10.5.0-alpha.7(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 0.0.0-pr-35189-sha-1274cb62(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/addon-vitest':
         specifier: 'catalog:'
-        version: 10.5.0-alpha.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 0.0.0-pr-35189-sha-1274cb62(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       storybook:
         specifier: 'catalog:'
-        version: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
 packages:
 
@@ -490,18 +490,18 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@storybook/addon-a11y@10.5.0-alpha.7':
-    resolution: {integrity: sha512-+EM8VSTcMKNFQjrG30YjoW0R4ytfdfb9yO0C8wXAznEKwqXluQ1BMt69L4RIdL0hnpj0NH4T73PmkNdE8HrLbg==}
+  '@storybook/addon-a11y@0.0.0-pr-35189-sha-1274cb62':
+    resolution: {integrity: sha512-nVCw6WUcGFjv9c4WRy1eEYSnDVnwR0/h4hvTPpH65YOoWt0dmuR4itiOKzJ/OuCe4LEUsiBR6+Dk7DR8mlKq0A==}
     peerDependencies:
-      storybook: ^10.5.0-alpha.7
+      storybook: ^0.0.0-pr-35189-sha-1274cb62
 
-  '@storybook/addon-vitest@10.5.0-alpha.7':
-    resolution: {integrity: sha512-12oDJLCxCHDdtDXwxJ1bu4XHeXCjB7CHLGOjGrWCAtCQGNhVM4dDXWZmTJybePsCNsMcjE9E9SNFepr2lj3tkA==}
+  '@storybook/addon-vitest@0.0.0-pr-35189-sha-1274cb62':
+    resolution: {integrity: sha512-u4TfYb8LJ7zBeekivokLPlPg5W6XsoZS/+vn4FMPIKMCEEVQd8KgDtHbrTna7qGFdkQOUA1Lm8Xcyxt+Y0PbNw==}
     peerDependencies:
       '@vitest/browser': ^3.0.0 || ^4.0.0
       '@vitest/browser-playwright': ^4.0.0
       '@vitest/runner': ^3.0.0 || ^4.0.0
-      storybook: ^10.5.0-alpha.7
+      storybook: ^0.0.0-pr-35189-sha-1274cb62
       vitest: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       '@vitest/browser':
@@ -768,8 +768,8 @@ packages:
   sqids@0.3.0:
     resolution: {integrity: sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==}
 
-  storybook@10.5.0-alpha.7:
-    resolution: {integrity: sha512-DXLEIoXWArqQIdKZZtme1As/igXcC/GueHI/p2C6NK+CwyC4Z5hXaFvEkqbVx9iwyTbUog158hpMh18RnGOG7Q==}
+  storybook@0.0.0-pr-35189-sha-1274cb62:
+    resolution: {integrity: sha512-IfGdYYVdlYnwubD3snZY3WlYN3U5gb6bluv0ogk/rsSBHW7e8831GLsN3B5gqrW46ch1DDvh3OZj+jMVgA3Wyg==}
     hasBin: true
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -1084,17 +1084,17 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-a11y@10.5.0-alpha.7(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/addon-a11y@0.0.0-pr-35189-sha-1274cb62(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.1
-      storybook: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/addon-vitest@10.5.0-alpha.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/addon-vitest@0.0.0-pr-35189-sha-1274cb62(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      storybook: 10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -1397,7 +1397,7 @@ snapshots:
 
   sqids@0.3.0: {}
 
-  storybook@10.5.0-alpha.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/packages/addon-mcp/pnpm-lock.yaml
+++ b/packages/addon-mcp/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     '@storybook/addon-a11y':
-      specifier: 0.0.0-pr-35189-sha-1274cb62
-      version: 0.0.0-pr-35189-sha-1274cb62
+      specifier: 10.5.0-alpha.8
+      version: 10.5.0-alpha.8
     '@storybook/addon-vitest':
-      specifier: 0.0.0-pr-35189-sha-1274cb62
-      version: 0.0.0-pr-35189-sha-1274cb62
+      specifier: 10.5.0-alpha.8
+      version: 10.5.0-alpha.8
     '@tmcp/adapter-valibot':
       specifier: ^0.1.5
       version: 0.1.5
@@ -19,8 +19,8 @@ catalogs:
       specifier: ^0.8.5
       version: 0.8.5
     storybook:
-      specifier: 0.0.0-pr-35189-sha-1274cb62
-      version: 0.0.0-pr-35189-sha-1274cb62
+      specifier: 10.5.0-alpha.8
+      version: 10.5.0-alpha.8
     tmcp:
       specifier: ^1.19.4
       version: 1.19.4
@@ -53,13 +53,13 @@ importers:
     devDependencies:
       '@storybook/addon-a11y':
         specifier: 'catalog:'
-        version: 0.0.0-pr-35189-sha-1274cb62(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 10.5.0-alpha.8(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/addon-vitest':
         specifier: 'catalog:'
-        version: 0.0.0-pr-35189-sha-1274cb62(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 10.5.0-alpha.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       storybook:
         specifier: 'catalog:'
-        version: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
 packages:
 
@@ -490,18 +490,18 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@storybook/addon-a11y@0.0.0-pr-35189-sha-1274cb62':
-    resolution: {integrity: sha512-nVCw6WUcGFjv9c4WRy1eEYSnDVnwR0/h4hvTPpH65YOoWt0dmuR4itiOKzJ/OuCe4LEUsiBR6+Dk7DR8mlKq0A==}
+  '@storybook/addon-a11y@10.5.0-alpha.8':
+    resolution: {integrity: sha512-o7iAzfMKoPwu4kixKh0EK5rQXFCohNVQRmTwTQ5KnCTglpTxnHjG/WBkxbCG1jj6+bS+93LANPQNFKUhyajRNw==}
     peerDependencies:
-      storybook: ^0.0.0-pr-35189-sha-1274cb62
+      storybook: ^10.5.0-alpha.8
 
-  '@storybook/addon-vitest@0.0.0-pr-35189-sha-1274cb62':
-    resolution: {integrity: sha512-u4TfYb8LJ7zBeekivokLPlPg5W6XsoZS/+vn4FMPIKMCEEVQd8KgDtHbrTna7qGFdkQOUA1Lm8Xcyxt+Y0PbNw==}
+  '@storybook/addon-vitest@10.5.0-alpha.8':
+    resolution: {integrity: sha512-maVjReVeQczzmEcBg99iAZqQsRiC+8otIYwch5CarqznD7wUIghCYh9YR+aHHUQInKr1BBRkuhrE//hZEPxw7w==}
     peerDependencies:
       '@vitest/browser': ^3.0.0 || ^4.0.0
       '@vitest/browser-playwright': ^4.0.0
       '@vitest/runner': ^3.0.0 || ^4.0.0
-      storybook: ^0.0.0-pr-35189-sha-1274cb62
+      storybook: ^10.5.0-alpha.8
       vitest: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       '@vitest/browser':
@@ -768,8 +768,8 @@ packages:
   sqids@0.3.0:
     resolution: {integrity: sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==}
 
-  storybook@0.0.0-pr-35189-sha-1274cb62:
-    resolution: {integrity: sha512-IfGdYYVdlYnwubD3snZY3WlYN3U5gb6bluv0ogk/rsSBHW7e8831GLsN3B5gqrW46ch1DDvh3OZj+jMVgA3Wyg==}
+  storybook@10.5.0-alpha.8:
+    resolution: {integrity: sha512-sAFXwToGGeD7oRPRt9KWfmulUDQ/CgiPxwDsWs3BmALF8NwibO0ZbjXy1j9oe85iTC/X9s5YuEQ/yh3Fj3JODQ==}
     hasBin: true
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -1084,17 +1084,17 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-a11y@0.0.0-pr-35189-sha-1274cb62(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/addon-a11y@10.5.0-alpha.8(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.1
-      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/addon-vitest@0.0.0-pr-35189-sha-1274cb62(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/addon-vitest@10.5.0-alpha.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      storybook: 0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -1397,7 +1397,7 @@ snapshots:
 
   sqids@0.3.0: {}
 
-  storybook@0.0.0-pr-35189-sha-1274cb62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/packages/addon-mcp/src/auth/composition-auth.test.ts
+++ b/packages/addon-mcp/src/auth/composition-auth.test.ts
@@ -178,6 +178,55 @@ describe('CompositionAuth', () => {
 			);
 		});
 
+		it('delegates the local source to localManifestProvider when provided (docgen-server mode)', async () => {
+			const auth = new CompositionAuth();
+
+			const mockFetch = vi.fn();
+			vi.stubGlobal('fetch', mockFetch);
+
+			const localManifestProvider = vi
+				.fn()
+				.mockResolvedValue('{"v":1,"components":{"button":{"id":"button","name":"Button"}}}');
+
+			const provider = auth.createManifestProvider('http://localhost:6006', localManifestProvider);
+			const request = new Request('http://localhost:6006/mcp');
+			const source = { id: 'local', title: 'Local' };
+
+			const result = await provider(request, './manifests/components.json', source);
+
+			// Read in-process, never over loopback HTTP.
+			expect(localManifestProvider).toHaveBeenCalledWith(
+				request,
+				'./manifests/components.json',
+				source,
+			);
+			expect(mockFetch).not.toHaveBeenCalled();
+			expect(result).toContain('button');
+		});
+
+		it('still fetches remote sources over HTTP even when localManifestProvider is provided', async () => {
+			const auth = new CompositionAuth();
+
+			const mockFetch = vi.fn().mockResolvedValue({
+				ok: true,
+				text: () => Promise.resolve('{"v":1,"components":{}}'),
+			});
+			vi.stubGlobal('fetch', mockFetch);
+			const localManifestProvider = vi.fn();
+
+			const provider = auth.createManifestProvider('http://localhost:6006', localManifestProvider);
+			const request = new Request('http://localhost:6006/mcp');
+			const source = { id: 'remote', title: 'Remote', url: 'http://remote.example.com' };
+
+			await provider(request, './manifests/components.json', source);
+
+			expect(localManifestProvider).not.toHaveBeenCalled();
+			expect(mockFetch).toHaveBeenCalledWith(
+				'http://remote.example.com/manifests/components.json',
+				expect.any(Object),
+			);
+		});
+
 		it('fetches from source URL when source provided', async () => {
 			const auth = new CompositionAuth();
 
@@ -282,6 +331,60 @@ describe('CompositionAuth', () => {
 
 			const result = await provider(request, './manifests/components.json');
 			expect(result).toBe(manifestJson);
+		});
+
+		it('returns split/ref service payloads from a remote source (v1)', async () => {
+			const auth = new CompositionAuth();
+			// A `core/story-docs` service file: `stories` is a record keyed by story id, which
+			// does NOT match the top-level component-manifest shape. The provider must return it
+			// verbatim rather than rejecting it as an "invalid manifest".
+			const storyDocsJson = JSON.stringify({
+				components: {
+					button: {
+						id: 'button',
+						name: 'Button',
+						path: 'src/Button.tsx',
+						stories: {
+							'button--primary': { id: 'button--primary', name: 'Primary', snippet: '<Button />' },
+						},
+					},
+				},
+			});
+
+			vi.stubGlobal(
+				'fetch',
+				vi.fn().mockResolvedValue({
+					ok: true,
+					text: () => Promise.resolve(storyDocsJson),
+				}),
+			);
+
+			const provider = auth.createManifestProvider('http://localhost:6006');
+			const request = new Request('http://localhost:6006/mcp');
+			const source = { id: 'remote', title: 'Remote', url: 'http://remote.example.com' };
+
+			const result = await provider(request, './services/core/story-docs/button.json', source);
+			expect(result).toBe(storyDocsJson);
+		});
+
+		it('rejects a remote service payload that is not valid JSON', async () => {
+			const auth = new CompositionAuth();
+			vi.stubGlobal(
+				'fetch',
+				vi.fn().mockResolvedValue({
+					ok: true,
+					// HTML login page masquerading as a 200 — not JSON.
+					text: () => Promise.resolve('<!doctype html><html><body>Login</body></html>'),
+				}),
+			);
+
+			const provider = auth.createManifestProvider('http://localhost:6006');
+			const request = new Request('http://localhost:6006/mcp');
+			const source = { id: 'remote', title: 'Remote', url: 'http://remote.example.com' };
+
+			await expect(
+				provider(request, './services/core/story-docs/button.json', source),
+			).rejects.toThrow(/Invalid manifest response|Authorization/);
 		});
 
 		it('throws when fetch returns non-ok response', async () => {

--- a/packages/addon-mcp/src/auth/composition-auth.ts
+++ b/packages/addon-mcp/src/auth/composition-auth.ts
@@ -144,13 +144,31 @@ export class CompositionAuth {
 		];
 	}
 
-	/** Create a manifest provider for multi-source mode. */
-	createManifestProvider(localOrigin: string): ManifestProvider {
+	/**
+	 * Create a manifest provider for multi-source mode.
+	 *
+	 * Remote sources are always fetched over HTTP (with auth + caching). The local
+	 * source normally fetches from `localOrigin`, but in `experimentalDocgenServer`
+	 * mode core 404s `/manifests/*.json` (the data lives in the open services), so
+	 * callers pass `localManifestProvider` to read the local source in-process
+	 * instead. When omitted, the local source keeps its HTTP behavior.
+	 */
+	createManifestProvider(
+		localOrigin: string,
+		localManifestProvider?: ManifestProvider,
+	): ManifestProvider {
 		return async (request, path, source) => {
 			const token = extractBearerToken(request?.headers.get('Authorization'));
 			const remoteSource: RemoteSource | undefined = source?.url
 				? { ...source, url: source.url }
 				: undefined;
+
+			// Local source in docgen-server mode: there is nothing to fetch over
+			// loopback, so read it in-process.
+			if (!remoteSource && localManifestProvider) {
+				return localManifestProvider(request, path, source);
+			}
+
 			const baseUrl = remoteSource?.url ?? localOrigin;
 			const manifestUrl = `${baseUrl}${path.replace('./', '/')}`;
 			const isRemote = !!remoteSource;
@@ -227,13 +245,20 @@ export class CompositionAuth {
 		}
 
 		const text = await response.text();
-		const schema = url.includes('docs.json') ? DocsManifestMap : ComponentManifestMap;
+
+		const isComponentsManifest = url.includes('components.json');
+		const isDocsManifest = url.includes('docs.json');
+		const schema = isComponentsManifest
+			? ComponentManifestMap
+			: isDocsManifest
+				? DocsManifestMap
+				: v.unknown();
 
 		if (v.safeParse(v.pipe(v.string(), v.parseJson(), schema), text).success) {
 			return text;
 		}
 
-		// Invalid manifest — check /mcp to see if it's an auth issue
+		// Invalid response — check /mcp to see if it's an auth issue
 		if (await this.#isMcpUnauthorized(new URL(url).origin)) {
 			throw new AuthenticationError(url);
 		}

--- a/packages/addon-mcp/src/auth/composition-auth.ts
+++ b/packages/addon-mcp/src/auth/composition-auth.ts
@@ -246,8 +246,12 @@ export class CompositionAuth {
 
 		const text = await response.text();
 
-		const isComponentsManifest = url.includes('components.json');
-		const isDocsManifest = url.includes('docs.json');
+		// Only the top-level manifest paths are sanity-checked against their schemas.
+		// Split/ref service payloads (e.g. `.../services/addon-docs/mdx/<id>--docs.json`)
+		// must not be matched here, so use an exact pathname check rather than a substring.
+		const { pathname } = new URL(url);
+		const isComponentsManifest = pathname.endsWith('/manifests/components.json');
+		const isDocsManifest = pathname.endsWith('/manifests/docs.json');
 		const schema = isComponentsManifest
 			? ComponentManifestMap
 			: isDocsManifest

--- a/packages/addon-mcp/src/manifests/__fixtures__/core-manifest.fixture.json
+++ b/packages/addon-mcp/src/manifests/__fixtures__/core-manifest.fixture.json
@@ -1,0 +1,49 @@
+{
+	"_provenance": "Trimmed verbatim from a real Storybook core build (storybook-static/manifests/{components,docs}.json) produced with experimentalDocgenServer. Used by core-format-contract.test.ts to guard the vendored ref-path helpers against drift. Regenerate from a fresh core build if the manifest format changes.",
+	"components": {
+		"v": 1,
+		"components": {
+			"bench": {
+				"id": "bench",
+				"name": "Bench",
+				"description": "docs enabled",
+				"docgen": { "$ref": "../services/core/docgen/bench.json#/components/bench" },
+				"stories": { "$ref": "../services/core/story-docs/bench.json#/components/bench" }
+			},
+			"button-component": {
+				"id": "button-component",
+				"name": "Button",
+				"description": "docs enabled",
+				"docgen": {
+					"$ref": "../services/core/docgen/button-component.json#/components/button-component"
+				},
+				"stories": {
+					"$ref": "../services/core/story-docs/button-component.json#/components/button-component"
+				},
+				"docs": {
+					"button-component--docs": {
+						"id": "button-component--docs",
+						"name": "Docs",
+						"mdx": {
+							"$ref": "../services/addon-docs/mdx/button-component.json#/components/button-component/docs/button-component--docs"
+						},
+						"summary": "# Button Button component is used to trigger an action or event."
+					}
+				}
+			}
+		}
+	},
+	"docs": {
+		"v": 1,
+		"docs": {
+			"brand-colorpalette--docs": {
+				"id": "brand-colorpalette--docs",
+				"name": "Docs",
+				"mdx": {
+					"$ref": "../services/addon-docs/mdx/brand-colorpalette--docs.json#/components/brand-colorpalette--docs/docs/brand-colorpalette--docs"
+				},
+				"summary": "Dark theme Colors Dark theme Backgrounds Light theme Colors Light theme Backgrounds"
+			}
+		}
+	}
+}

--- a/packages/addon-mcp/src/manifests/core-format-contract.test.ts
+++ b/packages/addon-mcp/src/manifests/core-format-contract.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Contract test guarding the vendored manifest-assembly helpers against drift.
+ *
+ * `core-manifest.fixture.json` is trimmed verbatim from a real Storybook core
+ * build (`storybook-static`). If core changes the `$ref` scheme or the on-disk
+ * `services/` layout, these assertions fail — signalling that `vendored.ts` (and
+ * `in-process-provider.ts`) must be re-synced with core.
+ */
+import { describe, it, expect } from 'vitest';
+import fixture from './__fixtures__/core-manifest.fixture.json' with { type: 'json' };
+import {
+	DOCGEN_SERVICE_ID,
+	MDX_SERVICE_ID,
+	STORY_DOCS_SERVICE_ID,
+	docgenManifestRef,
+	mdxManifestRef,
+	storyDocsManifestRef,
+} from './vendored.ts';
+
+const components = fixture.components.components as Record<string, any>;
+const docs = fixture.docs.docs as Record<string, any>;
+
+describe('vendored ref helpers match core build output', () => {
+	it('reproduces every docgen and story-docs $ref in components.json', () => {
+		for (const [id, entry] of Object.entries(components)) {
+			if (entry.docgen) {
+				expect(docgenManifestRef(id)).toBe(entry.docgen.$ref);
+			}
+			if (entry.stories) {
+				expect(storyDocsManifestRef(id)).toBe(entry.stories.$ref);
+			}
+		}
+	});
+
+	it('reproduces attached-docs mdx $refs in components.json', () => {
+		for (const [componentId, entry] of Object.entries(components)) {
+			if (!entry.docs) {
+				continue;
+			}
+			for (const [docId, row] of Object.entries(entry.docs as Record<string, any>)) {
+				expect(mdxManifestRef(componentId, docId)).toBe(row.mdx.$ref);
+			}
+		}
+	});
+
+	it('reproduces unattached-docs mdx $refs in docs.json', () => {
+		for (const [docId, entry] of Object.entries(docs)) {
+			expect(mdxManifestRef(docId, docId)).toBe(entry.mdx.$ref);
+		}
+	});
+
+	it('keeps service ids in lock-step with the on-disk services/ directory layout', () => {
+		// The $ref paths point at services/<service-id>/<id>.json — the service ids
+		// double as directory names, so a rename here would break path resolution.
+		const sampleDocgenRef = (Object.values(components)[0] as any).docgen.$ref as string;
+		expect(sampleDocgenRef).toContain(`services/${DOCGEN_SERVICE_ID}/`);
+
+		const sampleStoryRef = (Object.values(components)[0] as any).stories.$ref as string;
+		expect(sampleStoryRef).toContain(`services/${STORY_DOCS_SERVICE_ID}/`);
+
+		const sampleMdxRef = (Object.values(docs)[0] as any).mdx.$ref as string;
+		expect(sampleMdxRef).toContain(`services/${MDX_SERVICE_ID}/`);
+	});
+});

--- a/packages/addon-mcp/src/manifests/in-process-provider.test.ts
+++ b/packages/addon-mcp/src/manifests/in-process-provider.test.ts
@@ -39,11 +39,11 @@ const index: StoryIndex = {
 	},
 } as unknown as StoryIndex;
 
-const getDocgen = vi.fn();
-const getDocgenForAllComponents = vi.fn();
-const getStoryDocs = vi.fn();
-const getMdxForComponent = vi.fn();
-const getMdxForAllComponents = vi.fn();
+const docgen = vi.fn();
+const docgenForAllComponents = vi.fn();
+const storyDocs = vi.fn();
+const mdxForComponent = vi.fn();
+const mdxForAllComponents = vi.fn();
 
 function query<T extends (...args: any[]) => any>(loaded: T) {
 	return { loaded, get: vi.fn() };
@@ -54,16 +54,16 @@ beforeEach(() => {
 
 	vi.mocked(getStoryIndex).mockResolvedValue(index);
 
-	getDocgenForAllComponents.mockResolvedValue({
+	docgenForAllComponents.mockResolvedValue({
 		button: { id: 'button', name: 'Button', description: 'A button' },
 	});
-	getDocgen.mockResolvedValue({
+	docgen.mockResolvedValue({
 		id: 'button',
 		name: 'Button',
 		description: 'A button',
 		reactComponentMeta: { props: {} },
 	});
-	getStoryDocs.mockResolvedValue({
+	storyDocs.mockResolvedValue({
 		id: 'button',
 		name: 'Button',
 		path: 'src/Button.tsx',
@@ -72,14 +72,14 @@ beforeEach(() => {
 			'button--primary': { id: 'button--primary', name: 'Primary', snippet: '<Button />' },
 		},
 	});
-	getMdxForComponent.mockResolvedValue({
+	mdxForComponent.mockResolvedValue({
 		id: 'intro--docs',
 		name: 'Intro',
 		docs: {
 			'intro--docs': { id: 'intro--docs', name: 'Intro', title: 'Intro', content: '# Welcome' },
 		},
 	});
-	getMdxForAllComponents.mockResolvedValue({
+	mdxForAllComponents.mockResolvedValue({
 		'intro--docs': {
 			id: 'intro--docs',
 			name: 'Intro',
@@ -89,17 +89,17 @@ beforeEach(() => {
 
 	vi.mocked(getDocgenService).mockResolvedValue({
 		queries: {
-			getDocgen: query(getDocgen),
-			getDocgenForAllComponents: query(getDocgenForAllComponents),
+			docgen: query(docgen),
+			docgenForAllComponents: query(docgenForAllComponents),
 		},
 	} as any);
 	vi.mocked(getStoryDocsService).mockResolvedValue({
-		queries: { getStoryDocs: query(getStoryDocs) },
+		queries: { storyDocs: query(storyDocs) },
 	} as any);
 	vi.mocked(getMdxService).mockResolvedValue({
 		queries: {
-			getMdxForComponent: query(getMdxForComponent),
-			getMdxForAllComponents: query(getMdxForAllComponents),
+			mdxForComponent: query(mdxForComponent),
+			mdxForAllComponents: query(mdxForAllComponents),
 		},
 	} as any);
 });
@@ -134,7 +134,7 @@ describe('createDocgenServerManifestAccess - manifestProvider', () => {
 			await manifestProvider(undefined, './services/core/story-docs/button.json'),
 		);
 
-		expect(getStoryDocs).toHaveBeenCalledWith({ id: 'button' });
+		expect(storyDocs).toHaveBeenCalledWith({ id: 'button' });
 		expect(json.components.button.stories['button--primary'].name).toBe('Primary');
 	});
 
@@ -163,9 +163,9 @@ describe('createDocgenServerManifestAccess - resolveEntry', () => {
 		const resolved = await resolveEntry('button');
 
 		expect(resolved?.kind).toBe('component');
-		expect(getDocgen).toHaveBeenCalledWith({ id: 'button' });
+		expect(docgen).toHaveBeenCalledWith({ id: 'button' });
 		// Crucially, the all-component extraction is never invoked for a single lookup.
-		expect(getDocgenForAllComponents).not.toHaveBeenCalled();
+		expect(docgenForAllComponents).not.toHaveBeenCalled();
 		if (resolved?.kind === 'component') {
 			expect(resolved.component.id).toBe('button');
 			expect(resolved.component.stories).toEqual([

--- a/packages/addon-mcp/src/manifests/in-process-provider.test.ts
+++ b/packages/addon-mcp/src/manifests/in-process-provider.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Options, StoryIndex } from 'storybook/internal/types';
+
+vi.mock('../utils/get-story-index.ts', () => ({ getStoryIndex: vi.fn() }));
+vi.mock('./service-access.ts', () => ({
+	getDocgenService: vi.fn(),
+	getStoryDocsService: vi.fn(),
+	getMdxService: vi.fn(),
+}));
+
+import { createDocgenServerManifestAccess } from './in-process-provider.ts';
+import { getStoryIndex } from '../utils/get-story-index.ts';
+import { getDocgenService, getMdxService, getStoryDocsService } from './service-access.ts';
+
+const options = {} as Options;
+
+/** Story index with one manifest component (`button`) and one unattached doc (`intro--docs`). */
+const index: StoryIndex = {
+	v: 5,
+	entries: {
+		'button--primary': {
+			type: 'story',
+			subtype: 'story',
+			id: 'button--primary',
+			name: 'Primary',
+			title: 'Button',
+			importPath: './Button.stories.tsx',
+			tags: ['manifest'],
+		},
+		'intro--docs': {
+			type: 'docs',
+			id: 'intro--docs',
+			name: 'Intro',
+			title: 'Intro',
+			importPath: './Intro.mdx',
+			storiesImports: [],
+			tags: ['manifest', 'unattached-mdx'],
+		},
+	},
+} as unknown as StoryIndex;
+
+const getDocgen = vi.fn();
+const getDocgenForAllComponents = vi.fn();
+const getStoryDocs = vi.fn();
+const getMdxForComponent = vi.fn();
+const getMdxForAllComponents = vi.fn();
+
+function query<T extends (...args: any[]) => any>(loaded: T) {
+	return { loaded, get: vi.fn() };
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+
+	vi.mocked(getStoryIndex).mockResolvedValue(index);
+
+	getDocgenForAllComponents.mockResolvedValue({
+		button: { id: 'button', name: 'Button', description: 'A button' },
+	});
+	getDocgen.mockResolvedValue({
+		id: 'button',
+		name: 'Button',
+		description: 'A button',
+		reactComponentMeta: { props: {} },
+	});
+	getStoryDocs.mockResolvedValue({
+		id: 'button',
+		name: 'Button',
+		path: 'src/Button.tsx',
+		import: "import { Button } from './Button'",
+		stories: {
+			'button--primary': { id: 'button--primary', name: 'Primary', snippet: '<Button />' },
+		},
+	});
+	getMdxForComponent.mockResolvedValue({
+		id: 'intro--docs',
+		name: 'Intro',
+		docs: {
+			'intro--docs': { id: 'intro--docs', name: 'Intro', title: 'Intro', content: '# Welcome' },
+		},
+	});
+	getMdxForAllComponents.mockResolvedValue({
+		'intro--docs': {
+			id: 'intro--docs',
+			name: 'Intro',
+			docs: { 'intro--docs': { id: 'intro--docs', name: 'Intro' } },
+		},
+	});
+
+	vi.mocked(getDocgenService).mockResolvedValue({
+		queries: {
+			getDocgen: query(getDocgen),
+			getDocgenForAllComponents: query(getDocgenForAllComponents),
+		},
+	} as any);
+	vi.mocked(getStoryDocsService).mockResolvedValue({
+		queries: { getStoryDocs: query(getStoryDocs) },
+	} as any);
+	vi.mocked(getMdxService).mockResolvedValue({
+		queries: {
+			getMdxForComponent: query(getMdxForComponent),
+			getMdxForAllComponents: query(getMdxForAllComponents),
+		},
+	} as any);
+});
+
+describe('createDocgenServerManifestAccess - manifestProvider', () => {
+	it('builds the shallow components.json list surface from the live services', async () => {
+		const { manifestProvider } = createDocgenServerManifestAccess(options);
+		const json = JSON.parse(await manifestProvider(undefined, './manifests/components.json'));
+
+		expect(json.v).toBe(1);
+		expect(json.components.button).toEqual({
+			id: 'button',
+			name: 'Button',
+			description: 'A button',
+			stories: { $ref: '../services/core/story-docs/button.json#/components/button' },
+		});
+	});
+
+	it('builds the shallow docs.json list surface for unattached docs', async () => {
+		const { manifestProvider } = createDocgenServerManifestAccess(options);
+		const json = JSON.parse(await manifestProvider(undefined, './manifests/docs.json'));
+
+		expect(json.docs['intro--docs']).toEqual({
+			id: 'intro--docs',
+			name: 'Intro',
+		});
+	});
+
+	it('serves a single story-docs service file wrapped under { components: { [id] } }', async () => {
+		const { manifestProvider } = createDocgenServerManifestAccess(options);
+		const json = JSON.parse(
+			await manifestProvider(undefined, './services/core/story-docs/button.json'),
+		);
+
+		expect(getStoryDocs).toHaveBeenCalledWith({ id: 'button' });
+		expect(json.components.button.stories['button--primary'].name).toBe('Primary');
+	});
+
+	it('does not expose docgen or mdx service files in dev', async () => {
+		const { manifestProvider } = createDocgenServerManifestAccess(options);
+
+		await expect(manifestProvider(undefined, './services/core/docgen/button.json')).rejects.toThrow(
+			/Unsupported in-process manifest path/,
+		);
+		await expect(
+			manifestProvider(undefined, './services/addon-docs/mdx/intro--docs.json'),
+		).rejects.toThrow(/Unsupported in-process manifest path/);
+	});
+
+	it('throws for unsupported in-process paths', async () => {
+		const { manifestProvider } = createDocgenServerManifestAccess(options);
+		await expect(manifestProvider(undefined, './manifests/unknown.json')).rejects.toThrow(
+			/Unsupported in-process manifest path/,
+		);
+	});
+});
+
+describe('createDocgenServerManifestAccess - resolveEntry', () => {
+	it('resolves one component without triggering all-component docgen', async () => {
+		const { resolveEntry } = createDocgenServerManifestAccess(options);
+		const resolved = await resolveEntry('button');
+
+		expect(resolved?.kind).toBe('component');
+		expect(getDocgen).toHaveBeenCalledWith({ id: 'button' });
+		// Crucially, the all-component extraction is never invoked for a single lookup.
+		expect(getDocgenForAllComponents).not.toHaveBeenCalled();
+		if (resolved?.kind === 'component') {
+			expect(resolved.component.id).toBe('button');
+			expect(resolved.component.stories).toEqual([
+				{ id: 'button--primary', name: 'Primary', snippet: '<Button />' },
+			]);
+		}
+	});
+
+	it('resolves an unattached doc as a doc entry', async () => {
+		const { resolveEntry } = createDocgenServerManifestAccess(options);
+		const resolved = await resolveEntry('intro--docs');
+
+		expect(resolved?.kind).toBe('doc');
+		if (resolved?.kind === 'doc') {
+			expect(resolved.doc).toMatchObject({ id: 'intro--docs', content: '# Welcome' });
+		}
+	});
+
+	it('returns undefined for ids not present in the index', async () => {
+		const { resolveEntry } = createDocgenServerManifestAccess(options);
+		await expect(resolveEntry('missing')).resolves.toBeUndefined();
+	});
+});
+
+describe('createDocgenServerManifestAccess - graceful fallback', () => {
+	it('still lists components (name = id, no $refs) when services are unavailable', async () => {
+		vi.mocked(getDocgenService).mockResolvedValue(undefined);
+		vi.mocked(getStoryDocsService).mockResolvedValue(undefined);
+		vi.mocked(getMdxService).mockResolvedValue(undefined);
+
+		const { manifestProvider, resolveEntry } = createDocgenServerManifestAccess(options);
+		const json = JSON.parse(await manifestProvider(undefined, './manifests/components.json'));
+
+		// Without a docgen payload the index entry falls back to id-as-name and omits docgen $ref.
+		expect(json.components.button).toMatchObject({ id: 'button', name: 'button' });
+		expect(json.components.button.docgen).toBeUndefined();
+		// stories ref still present because the entry is story-backed.
+		expect(json.components.button.stories).toEqual({
+			$ref: '../services/core/story-docs/button.json#/components/button',
+		});
+
+		const resolved = await resolveEntry('button');
+		expect(resolved?.kind).toBe('component');
+	});
+});

--- a/packages/addon-mcp/src/manifests/in-process-provider.ts
+++ b/packages/addon-mcp/src/manifests/in-process-provider.ts
@@ -1,0 +1,263 @@
+/**
+ * In-process manifest access for Storybook's dev server when
+ * `experimentalDocgenServer` is enabled.
+ *
+ * In that mode `/manifests/*.json` is deliberately 404'd by core and data lives in
+ * the open services. Rather than fetch over loopback HTTP, this builds the shallow
+ * list-all surface directly from the live services and additionally exposes a
+ * `resolveEntry` hook so single-entry tools never trigger all-component docgen
+ * extraction.
+ */
+
+import type { DocsIndexEntry, IndexEntry, Options, StoryIndex } from 'storybook/internal/types';
+import {
+	adaptCoreComponent,
+	adaptCoreDoc,
+	type CoreDocgenComponent,
+	type CoreDocgenPayload,
+	type CoreMdxDoc,
+	type Doc,
+	type ResolvedEntry,
+	type Source,
+} from '@storybook/mcp';
+
+import { getStoryIndex } from '../utils/get-story-index.ts';
+import {
+	STORY_DOCS_SERVICE_ID,
+	Tag,
+	getComponentIdFromEntry,
+	selectComponentEntriesByComponentId,
+	storyDocsManifestRef,
+} from './vendored.ts';
+import { getDocgenService, getMdxService, getStoryDocsService } from './service-access.ts';
+
+type ManifestProvider = (
+	request: Request | undefined,
+	path: string,
+	source?: Source,
+) => Promise<string>;
+
+type ResolveEntry = (id: string, source?: Source) => Promise<ResolvedEntry | undefined>;
+
+export interface DocgenServerManifestAccess {
+	manifestProvider: ManifestProvider;
+	resolveEntry: ResolveEntry;
+}
+
+interface IndexClassification {
+	/** Component ids selected with the same rules as core's manifest generator. */
+	componentIds: string[];
+	/** Component ids backed by a story entry (so they have a story-docs payload). */
+	storyBasedIds: Set<string>;
+	/** Attached docs index entries grouped by owning component id. */
+	attachedDocsByComponent: Map<string, DocsIndexEntry[]>;
+	/** Standalone docs index entries keyed by their own id. */
+	unattachedDocs: Map<string, DocsIndexEntry>;
+}
+
+function classifyIndex(index: StoryIndex): IndexClassification {
+	const entries = Object.values(index.entries).filter(
+		(entry): entry is IndexEntry => entry.tags?.includes(Tag.MANIFEST) ?? false,
+	);
+	const selected = selectComponentEntriesByComponentId(entries);
+
+	const storyBasedIds = new Set<string>();
+	for (const [id, entry] of selected) {
+		if (entry.type === 'story') {
+			storyBasedIds.add(id);
+		}
+	}
+
+	const attachedDocsByComponent = new Map<string, DocsIndexEntry[]>();
+	const unattachedDocs = new Map<string, DocsIndexEntry>();
+	for (const entry of entries) {
+		if (entry.type !== 'docs') {
+			continue;
+		}
+		if (entry.tags?.includes(Tag.UNATTACHED_MDX)) {
+			unattachedDocs.set(entry.id, entry);
+		} else if (entry.tags?.includes(Tag.ATTACHED_MDX)) {
+			const componentId = getComponentIdFromEntry(entry);
+			const list = attachedDocsByComponent.get(componentId) ?? [];
+			list.push(entry);
+			attachedDocsByComponent.set(componentId, list);
+		}
+	}
+
+	return {
+		componentIds: [...selected.keys()],
+		storyBasedIds,
+		attachedDocsByComponent,
+		unattachedDocs,
+	};
+}
+
+/**
+ * Builds the shallow `components.json` surface used by `list-all-documentation`.
+ *
+ * In dev, single component/doc lookups use `resolveEntry`, so this index does not
+ * carry docgen or MDX refs. The only ref it exposes is `stories`, which
+ * `list-all-documentation --withStoryIds` follows to avoid running full docgen.
+ */
+async function buildComponentsManifest(cls: IndexClassification): Promise<string> {
+	const docgenService = await getDocgenService();
+	// All components must be listed even without a prior extraction, so load (not just read).
+	const allDocgen = docgenService
+		? await docgenService.queries.getDocgenForAllComponents.loaded()
+		: {};
+
+	const components: Record<string, Record<string, unknown>> = {};
+	for (const id of cls.componentIds) {
+		const payload: CoreDocgenPayload | undefined = allDocgen[id];
+
+		components[id] = {
+			id,
+			name: payload?.name ?? id,
+			...(payload?.description !== undefined ? { description: payload.description } : {}),
+			...(payload?.summary !== undefined ? { summary: payload.summary } : {}),
+			...(cls.storyBasedIds.has(id) ? { stories: { $ref: storyDocsManifestRef(id) } } : {}),
+		};
+	}
+
+	return JSON.stringify({ v: 1, components });
+}
+
+/** Builds the ref-based unattached `docs.json` index, or `undefined` when there are none. */
+async function buildDocsManifest(cls: IndexClassification): Promise<string | undefined> {
+	if (cls.unattachedDocs.size === 0) {
+		return undefined;
+	}
+
+	const mdxService = await getMdxService();
+	const allMdx = mdxService ? await mdxService.queries.getMdxForAllComponents.loaded() : {};
+
+	const docs: Record<string, Record<string, unknown>> = {};
+	for (const [docId, entry] of cls.unattachedDocs) {
+		const payload = allMdx[docId]?.docs[docId];
+		docs[docId] = {
+			id: docId,
+			name: entry.name,
+			...(payload?.summary !== undefined ? { summary: payload.summary } : {}),
+		};
+	}
+
+	return JSON.stringify({ v: 1, docs });
+}
+
+const STORY_DOCS_SERVICE_PREFIX = `services/${STORY_DOCS_SERVICE_ID}/`;
+
+function matchStoryDocsServicePath(normalizedPath: string): string | undefined {
+	if (normalizedPath.startsWith(STORY_DOCS_SERVICE_PREFIX) && normalizedPath.endsWith('.json')) {
+		return normalizedPath.slice(STORY_DOCS_SERVICE_PREFIX.length, -'.json'.length);
+	}
+	return undefined;
+}
+
+/** Wraps one story-docs payload as `{ components: { [id]: payload } }`. */
+async function buildStoryDocsServiceFile(id: string): Promise<string> {
+	const storyDocsService = await getStoryDocsService();
+	const payload = storyDocsService
+		? await storyDocsService.queries.getStoryDocs.loaded({ id })
+		: undefined;
+	return JSON.stringify({ components: payload === undefined ? {} : { [id]: payload } });
+}
+
+async function resolveComponent(
+	id: string,
+	cls: IndexClassification,
+): Promise<ResolvedEntry | undefined> {
+	const [docgenService, storyDocsService, mdxService] = await Promise.all([
+		getDocgenService(),
+		getStoryDocsService(),
+		getMdxService(),
+	]);
+
+	const [docgen, storyDocs] = await Promise.all([
+		docgenService ? docgenService.queries.getDocgen.loaded({ id }) : undefined,
+		storyDocsService ? storyDocsService.queries.getStoryDocs.loaded({ id }) : undefined,
+	]);
+
+	const attached = cls.attachedDocsByComponent.get(id) ?? [];
+	let docs: Record<string, CoreMdxDoc> | undefined;
+	if (attached.length > 0 && mdxService) {
+		const mdxPayload = await mdxService.queries.getMdxForComponent.loaded({ id });
+		if (mdxPayload?.docs) {
+			docs = {};
+			for (const entry of attached) {
+				const doc = mdxPayload.docs[entry.id];
+				if (doc) {
+					docs[entry.id] = doc as CoreMdxDoc;
+				}
+			}
+		}
+	}
+
+	const core: CoreDocgenComponent = {
+		...docgen,
+		id,
+		name: docgen?.name ?? id,
+		...(storyDocs?.stories ? { stories: storyDocs.stories } : {}),
+		...(storyDocs?.import ? { import: storyDocs.import } : {}),
+		...(docs ? { docs } : {}),
+	};
+
+	return { kind: 'component', component: adaptCoreComponent(core) };
+}
+
+async function resolveStandaloneDoc(id: string): Promise<ResolvedEntry | undefined> {
+	const mdxService = await getMdxService();
+	const payload = mdxService
+		? await mdxService.queries.getMdxForComponent.loaded({ id })
+		: undefined;
+	const doc = payload?.docs?.[id];
+	if (!doc) {
+		return undefined;
+	}
+	return { kind: 'doc', doc: adaptCoreDoc(doc as CoreMdxDoc) as Doc };
+}
+
+/**
+ * Builds the in-process manifest provider and single-entry resolver for
+ * docgen-server mode. The closures read the live story index and services on each
+ * call (both internally cached), so they stay in lock-step with HMR.
+ */
+export function createDocgenServerManifestAccess(options: Options): DocgenServerManifestAccess {
+	const manifestProvider: ManifestProvider = async (_request, path) => {
+		const normalized = path.replace(/^\.?\//, '');
+
+		if (normalized === 'manifests/components.json') {
+			const cls = classifyIndex(await getStoryIndex(options));
+			return buildComponentsManifest(cls);
+		}
+
+		if (normalized === 'manifests/docs.json') {
+			const cls = classifyIndex(await getStoryIndex(options));
+			const docs = await buildDocsManifest(cls);
+			if (docs === undefined) {
+				throw new Error('No unattached docs manifest available');
+			}
+			return docs;
+		}
+
+		const storyDocsId = matchStoryDocsServicePath(normalized);
+		if (storyDocsId) {
+			return buildStoryDocsServiceFile(storyDocsId);
+		}
+
+		throw new Error(`Unsupported in-process manifest path: ${path}`);
+	};
+
+	const resolveEntry: ResolveEntry = async (id) => {
+		const cls = classifyIndex(await getStoryIndex(options));
+
+		if (cls.unattachedDocs.has(id)) {
+			return resolveStandaloneDoc(id);
+		}
+		if (cls.componentIds.includes(id)) {
+			return resolveComponent(id, cls);
+		}
+		return undefined;
+	};
+
+	return { manifestProvider, resolveEntry };
+}

--- a/packages/addon-mcp/src/manifests/in-process-provider.ts
+++ b/packages/addon-mcp/src/manifests/in-process-provider.ts
@@ -103,7 +103,7 @@ async function buildComponentsManifest(cls: IndexClassification): Promise<string
 	const docgenService = await getDocgenService();
 	// All components must be listed even without a prior extraction, so load (not just read).
 	const allDocgen = docgenService
-		? await docgenService.queries.getDocgenForAllComponents.loaded()
+		? await docgenService.queries.docgenForAllComponents.loaded()
 		: {};
 
 	const components: Record<string, Record<string, unknown>> = {};
@@ -129,7 +129,7 @@ async function buildDocsManifest(cls: IndexClassification): Promise<string | und
 	}
 
 	const mdxService = await getMdxService();
-	const allMdx = mdxService ? await mdxService.queries.getMdxForAllComponents.loaded() : {};
+	const allMdx = mdxService ? await mdxService.queries.mdxForAllComponents.loaded() : {};
 
 	const docs: Record<string, Record<string, unknown>> = {};
 	for (const [docId, entry] of cls.unattachedDocs) {
@@ -157,7 +157,7 @@ function matchStoryDocsServicePath(normalizedPath: string): string | undefined {
 async function buildStoryDocsServiceFile(id: string): Promise<string> {
 	const storyDocsService = await getStoryDocsService();
 	const payload = storyDocsService
-		? await storyDocsService.queries.getStoryDocs.loaded({ id })
+		? await storyDocsService.queries.storyDocs.loaded({ id })
 		: undefined;
 	return JSON.stringify({ components: payload === undefined ? {} : { [id]: payload } });
 }
@@ -173,14 +173,14 @@ async function resolveComponent(
 	]);
 
 	const [docgen, storyDocs] = await Promise.all([
-		docgenService ? docgenService.queries.getDocgen.loaded({ id }) : undefined,
-		storyDocsService ? storyDocsService.queries.getStoryDocs.loaded({ id }) : undefined,
+		docgenService ? docgenService.queries.docgen.loaded({ id }) : undefined,
+		storyDocsService ? storyDocsService.queries.storyDocs.loaded({ id }) : undefined,
 	]);
 
 	const attached = cls.attachedDocsByComponent.get(id) ?? [];
 	let docs: Record<string, CoreMdxDoc> | undefined;
 	if (attached.length > 0 && mdxService) {
-		const mdxPayload = await mdxService.queries.getMdxForComponent.loaded({ id });
+		const mdxPayload = await mdxService.queries.mdxForComponent.loaded({ id });
 		if (mdxPayload?.docs) {
 			docs = {};
 			for (const entry of attached) {
@@ -207,7 +207,7 @@ async function resolveComponent(
 async function resolveStandaloneDoc(id: string): Promise<ResolvedEntry | undefined> {
 	const mdxService = await getMdxService();
 	const payload = mdxService
-		? await mdxService.queries.getMdxForComponent.loaded({ id })
+		? await mdxService.queries.mdxForComponent.loaded({ id })
 		: undefined;
 	const doc = payload?.docs?.[id];
 	if (!doc) {

--- a/packages/addon-mcp/src/manifests/in-process-provider.ts
+++ b/packages/addon-mcp/src/manifests/in-process-provider.ts
@@ -133,7 +133,7 @@ async function buildDocsManifest(cls: IndexClassification): Promise<string | und
 
 	const docs: Record<string, Record<string, unknown>> = {};
 	for (const [docId, entry] of cls.unattachedDocs) {
-		const payload = allMdx[docId]?.docs[docId];
+		const payload = allMdx[docId]?.docs?.[docId];
 		docs[docId] = {
 			id: docId,
 			name: entry.name,

--- a/packages/addon-mcp/src/manifests/in-process-provider.ts
+++ b/packages/addon-mcp/src/manifests/in-process-provider.ts
@@ -206,9 +206,7 @@ async function resolveComponent(
 
 async function resolveStandaloneDoc(id: string): Promise<ResolvedEntry | undefined> {
 	const mdxService = await getMdxService();
-	const payload = mdxService
-		? await mdxService.queries.mdxForComponent.loaded({ id })
-		: undefined;
+	const payload = mdxService ? await mdxService.queries.mdxForComponent.loaded({ id }) : undefined;
 	const doc = payload?.docs?.[id];
 	if (!doc) {
 		return undefined;

--- a/packages/addon-mcp/src/manifests/service-access.test.ts
+++ b/packages/addon-mcp/src/manifests/service-access.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// `service-access` caches `getService` at module scope, so each test resets the
+// module registry and re-mocks `storybook/internal/core-server` before importing.
+beforeEach(() => {
+	vi.resetModules();
+	vi.doUnmock('storybook/internal/core-server');
+});
+
+describe('service-access getService guard', () => {
+	it('returns the resolved service when core exports getService', async () => {
+		const service = { queries: {} };
+		const getService = vi.fn().mockReturnValue(service);
+		vi.doMock('storybook/internal/core-server', () => ({ getService }));
+
+		const { getDocgenService } = await import('./service-access.ts');
+		await expect(getDocgenService()).resolves.toBe(service);
+		expect(getService).toHaveBeenCalledWith('core/docgen');
+	});
+
+	it('resolves to undefined on older Storybook without a getService export', async () => {
+		vi.doMock('storybook/internal/core-server', () => ({}));
+
+		const { getDocgenService, getStoryDocsService, getMdxService } =
+			await import('./service-access.ts');
+		await expect(getDocgenService()).resolves.toBeUndefined();
+		await expect(getStoryDocsService()).resolves.toBeUndefined();
+		await expect(getMdxService()).resolves.toBeUndefined();
+	});
+
+	it('resolves to undefined when the service is not registered (getService throws)', async () => {
+		const getService = vi.fn(() => {
+			throw new Error('service not registered');
+		});
+		vi.doMock('storybook/internal/core-server', () => ({ getService }));
+
+		const { getMdxService } = await import('./service-access.ts');
+		await expect(getMdxService()).resolves.toBeUndefined();
+	});
+
+	it('resolves to undefined when the core-server import itself fails', async () => {
+		vi.doMock('storybook/internal/core-server', () => {
+			throw new Error('module not found');
+		});
+
+		const { getDocgenService } = await import('./service-access.ts');
+		await expect(getDocgenService()).resolves.toBeUndefined();
+	});
+});

--- a/packages/addon-mcp/src/manifests/service-access.ts
+++ b/packages/addon-mcp/src/manifests/service-access.ts
@@ -18,11 +18,11 @@ import { DOCGEN_SERVICE_ID, MDX_SERVICE_ID, STORY_DOCS_SERVICE_ID } from './vend
 
 /**
  * MDX service handle from `@storybook/addon-docs`. Core exports the manifest-writer
- * slice via {@link MdxServiceContract}; addon-docs also registers `getMdxForComponent`.
+ * slice via {@link MdxServiceContract}; addon-docs also registers `mdxForComponent`.
  */
 type MdxService = {
 	queries: MdxServiceContract['queries'] & {
-		getMdxForComponent: Query<{ id: string }, MdxPayload | undefined>;
+		mdxForComponent: Query<{ id: string }, MdxPayload | undefined>;
 	};
 };
 

--- a/packages/addon-mcp/src/manifests/service-access.ts
+++ b/packages/addon-mcp/src/manifests/service-access.ts
@@ -1,0 +1,75 @@
+/**
+ * Guarded access to Storybook's open services from the dev server process.
+ *
+ * `getService` is reached through a dynamic import of `storybook/internal/core-server`
+ * and only ever entered in `experimentalDocgenServer` mode; on older Storybook
+ * versions (no such export) or when a service is not registered, every accessor
+ * resolves to `undefined` so the addon cleanly falls back to the fetch-based path.
+ */
+
+import type {
+	getService as getServiceFn,
+	MdxPayload,
+	MdxServiceContract,
+} from 'storybook/internal/core-server';
+import type { DocgenService, Query, StoryDocsService } from 'storybook/open-service';
+
+import { DOCGEN_SERVICE_ID, MDX_SERVICE_ID, STORY_DOCS_SERVICE_ID } from './vendored.ts';
+
+/**
+ * MDX service handle from `@storybook/addon-docs`. Core exports the manifest-writer
+ * slice via {@link MdxServiceContract}; addon-docs also registers `getMdxForComponent`.
+ */
+type MdxService = {
+	queries: MdxServiceContract['queries'] & {
+		getMdxForComponent: Query<{ id: string }, MdxPayload | undefined>;
+	};
+};
+
+type GetService = typeof getServiceFn;
+
+let cachedGetService: GetService | null | undefined;
+
+/**
+ * Resolves `getService` once via a dynamic import. Returns `undefined` on Storybook
+ * versions that don't export it (so callers fall back to the fetch-based path).
+ */
+async function loadGetService(): Promise<GetService | undefined> {
+	if (cachedGetService !== undefined) {
+		return cachedGetService ?? undefined;
+	}
+	try {
+		const mod: unknown = await import('storybook/internal/core-server');
+		const getService = (mod as { getService?: GetService }).getService;
+		cachedGetService = getService ?? null;
+		return getService;
+	} catch {
+		cachedGetService = null;
+		return undefined;
+	}
+}
+
+async function getServiceSafely<T>(id: string): Promise<T | undefined> {
+	const getService = await loadGetService();
+	if (!getService) {
+		return undefined;
+	}
+	try {
+		return getService<T>(id);
+	} catch {
+		// Service not registered (e.g. addon-docs absent, or feature off).
+		return undefined;
+	}
+}
+
+export function getDocgenService(): Promise<DocgenService | undefined> {
+	return getServiceSafely<DocgenService>(DOCGEN_SERVICE_ID);
+}
+
+export function getStoryDocsService(): Promise<StoryDocsService | undefined> {
+	return getServiceSafely<StoryDocsService>(STORY_DOCS_SERVICE_ID);
+}
+
+export function getMdxService(): Promise<MdxService | undefined> {
+	return getServiceSafely<MdxService>(MDX_SERVICE_ID);
+}

--- a/packages/addon-mcp/src/manifests/vendored.ts
+++ b/packages/addon-mcp/src/manifests/vendored.ts
@@ -1,0 +1,98 @@
+/**
+ * Vendored (source-copied) manifest-assembly helpers from Storybook core.
+ *
+ * These are intentionally copied rather than imported so `@storybook/addon-mcp`
+ * does not couple to internal core exports that vary across prereleases (the only
+ * runtime core dependency is a guarded `getService`, see `service-access.ts`).
+ *
+ * Provenance — keep aligned with these upstream sources:
+ *  - `core/src/common/utils/select-component-entry.ts`
+ *    (`selectComponentEntriesByComponentId`, `getStoryImportPathFromEntry`,
+ *    `STORY_FILE_TEST_REGEXP`)
+ *  - `core/src/common/utils/component-id.ts` (`getComponentIdFromEntry`)
+ *  - `core/src/shared/constants/tags.ts` (`Tag`)
+ *  - `core/src/shared/open-service/services/docgen/paths.ts`,
+ *    `.../story-docs/paths.ts`,
+ *    `core/src/core-server/utils/manifests/mdx-manifest.ts` (ref path helpers)
+ */
+
+import type { DocsIndexEntry, IndexEntry } from 'storybook/internal/types';
+
+/** System tags used by Storybook for categorizing stories and docs entries. */
+export const Tag = {
+	ATTACHED_MDX: 'attached-mdx',
+	UNATTACHED_MDX: 'unattached-mdx',
+	MANIFEST: 'manifest',
+} as const;
+
+/** Open-service ids (also the on-disk directory names under `services/`). */
+export const DOCGEN_SERVICE_ID = 'core/docgen';
+export const STORY_DOCS_SERVICE_ID = 'core/story-docs';
+export const MDX_SERVICE_ID = 'addon-docs/mdx';
+
+/**
+ * Derives the componentId portion of a story index entry id. Story ids have the
+ * shape `<componentId>--<storyName>`; the prefix before the first `--` is the
+ * stable component identifier.
+ */
+export function getComponentIdFromEntry(entry: Pick<IndexEntry, 'id'>): string {
+	return entry.id.split('--')[0] ?? entry.id;
+}
+
+function isAttachedDocsEntry(
+	entry: IndexEntry,
+): entry is DocsIndexEntry & { storiesImports: [string, ...string[]] } {
+	return (
+		entry.type === 'docs' &&
+		entry.tags?.includes(Tag.ATTACHED_MDX) === true &&
+		(entry as DocsIndexEntry).storiesImports.length > 0
+	);
+}
+
+function isEligibleStoryEntry(entry: IndexEntry): boolean {
+	return entry.type === 'story' && entry.subtype === 'story';
+}
+
+/**
+ * Picks one index entry per componentId: story entries win; attached docs fill gaps
+ * only where no story exists for that componentId.
+ */
+export function selectComponentEntriesByComponentId(
+	indexEntries: IndexEntry[],
+): Map<string, IndexEntry> {
+	const entriesByComponentId = new Map<string, IndexEntry>();
+
+	for (const entry of indexEntries) {
+		if (!isEligibleStoryEntry(entry)) {
+			continue;
+		}
+		entriesByComponentId.set(getComponentIdFromEntry(entry), entry);
+	}
+
+	for (const entry of indexEntries) {
+		if (!isAttachedDocsEntry(entry)) {
+			continue;
+		}
+		const componentId = getComponentIdFromEntry(entry);
+		if (!entriesByComponentId.has(componentId)) {
+			entriesByComponentId.set(componentId, entry);
+		}
+	}
+
+	return entriesByComponentId;
+}
+
+/** `$ref` target for one component's docgen payload, relative to `manifests/`. */
+export function docgenManifestRef(id: string): string {
+	return `../services/${DOCGEN_SERVICE_ID}/${id}.json#/components/${id}`;
+}
+
+/** `$ref` target for one component's story-docs payload, relative to `manifests/`. */
+export function storyDocsManifestRef(id: string): string {
+	return `../services/${STORY_DOCS_SERVICE_ID}/${id}.json#/components/${id}`;
+}
+
+/** `$ref` target for one MDX doc, relative to `manifests/`. */
+export function mdxManifestRef(componentId: string, docId: string): string {
+	return `../services/${MDX_SERVICE_ID}/${componentId}.json#/components/${componentId}/docs/${docId}`;
+}

--- a/packages/addon-mcp/src/mcp-handler.ts
+++ b/packages/addon-mcp/src/mcp-handler.ts
@@ -18,6 +18,7 @@ import type { CompositionAuth } from './auth/index.ts';
 import { buildServerInstructions } from './instructions/build-server-instructions.ts';
 import { DEFAULT_MCP_ENDPOINT } from './constants.ts';
 import { registerAddonMcpTools } from './tools/tool-registry.ts';
+import type { DocgenServerManifestAccess } from './manifests/in-process-provider.ts';
 
 let transport: HttpTransport<AddonContext> | undefined;
 let origin: string | undefined;
@@ -107,6 +108,12 @@ type McpServerHandlerParams = {
 		path: string,
 		source?: Source,
 	) => Promise<string>;
+	/**
+	 * Optional in-process single-entry resolver for `experimentalDocgenServer` mode.
+	 * Selected (alongside `manifestProvider`) by the caller; the doc tools only consult
+	 * it for the local source. Undefined on older Storybook versions / when the feature is off.
+	 */
+	resolveEntry?: DocgenServerManifestAccess['resolveEntry'];
 	/** Composition auth handler for multi-source mode */
 	compositionAuth: CompositionAuth;
 };
@@ -119,6 +126,7 @@ export const mcpServerHandler = async ({
 	endpoint = DEFAULT_MCP_ENDPOINT,
 	sources,
 	manifestProvider,
+	resolveEntry,
 	compositionAuth,
 }: McpServerHandlerParams) => {
 	// Initialize MCP server and transport on first request, with concurrency safety
@@ -143,6 +151,7 @@ export const mcpServerHandler = async ({
 		request: webRequest,
 		sources,
 		manifestProvider,
+		resolveEntry,
 		// Telemetry handlers for component manifest tools
 		...(!disableTelemetry && {
 			onListAllDocumentation: async ({ manifests, resultText, sources: sourceManifests }) => {

--- a/packages/addon-mcp/src/preset.ts
+++ b/packages/addon-mcp/src/preset.ts
@@ -14,6 +14,7 @@ import { logger } from 'storybook/internal/node-logger';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { DEFAULT_MCP_ENDPOINT } from './constants.ts';
 import { buildStorybookAiMetadata, type StorybookAiMetadata } from './storybook-ai-metadata.ts';
+import { createDocgenServerManifestAccess } from './manifests/in-process-provider.ts';
 
 export const previewAnnotations: PresetPropertyFn<'previewAnnotations'> = async (
 	existingAnnotations = [],
@@ -36,7 +37,18 @@ export const experimental_devServer: PresetPropertyFn<
 	const origin = `http://localhost:${options.port}`;
 	const endpoint = addonOptions.endpoint ?? DEFAULT_MCP_ENDPOINT;
 
-	const { refs, compositionAuth, sources } = await resolveCompositionSources(options);
+	const { refs, compositionAuth, sources, multiSource } = await resolveCompositionSources(options);
+
+	// Single source of truth for manifest access. In `experimentalDocgenServer` mode the
+	// local Storybook's `/manifests/*.json` are 404'd by core, so its manifest data is read
+	// in-process from the open services instead of over loopback HTTP. This access is created
+	// here (the one place that owns provider selection) and reused for both the standalone
+	// local source and the local branch of the composition provider.
+	const rawAvailability = await getToolAvailability(options);
+	const docgenServerAccess = rawAvailability.docgenServer
+		? createDocgenServerManifestAccess(options)
+		: undefined;
+
 	let createManifestProvider: ((req: IncomingMessage) => ManifestProvider) | undefined;
 
 	if (refs.length > 0) {
@@ -47,9 +59,23 @@ export const experimental_devServer: PresetPropertyFn<
 
 		logger.info(`Sources: ${(sources ?? []).map((s) => s.id).join(', ')}`);
 
-		// Create manifest provider that handles multi-source
-		createManifestProvider = () => compositionAuth.createManifestProvider(origin);
+		// Composition provider fetches remote sources over HTTP; the local source delegates
+		// to the in-process docgen-server access when that mode is on.
+		createManifestProvider = () =>
+			compositionAuth.createManifestProvider(origin, docgenServerAccess?.manifestProvider);
 	}
+
+	// Resolves the manifest access passed to `mcpServerHandler` for one request: the
+	// composition provider when refs are configured, otherwise the in-process provider when
+	// docgen-server mode is on, otherwise core's default HTTP provider (undefined). The
+	// in-process `resolveEntry` is always forwarded — the doc tools only consult it for the
+	// local source, so it is harmless in multi-source mode.
+	const manifestAccessFor = (req: IncomingMessage) => ({
+		manifestProvider: createManifestProvider
+			? createManifestProvider(req)
+			: docgenServerAccess?.manifestProvider,
+		resolveEntry: docgenServerAccess?.resolveEntry,
+	});
 
 	// Serve .well-known/oauth-protected-resource for MCP auth
 	app!.get('/.well-known/oauth-protected-resource', (_req, res) => {
@@ -87,15 +113,13 @@ export const experimental_devServer: PresetPropertyFn<
 			addonOptions,
 			endpoint,
 			sources,
-			manifestProvider: createManifestProvider?.(req),
+			...manifestAccessFor(req),
 			compositionAuth,
 		});
 	});
 
 	// Same gates the MCP server uses to register these tools, so the page can't
 	// claim a tool is available when it isn't (and vice versa).
-	const multiSource = sources?.some((source) => !!source.url) ?? false;
-	const rawAvailability = await getToolAvailability(options);
 	const {
 		moduleGraphSupported,
 		changeDetectionEnabled,
@@ -122,7 +146,7 @@ export const experimental_devServer: PresetPropertyFn<
 				addonOptions,
 				endpoint,
 				sources,
-				manifestProvider: createManifestProvider?.(req),
+				...manifestAccessFor(req),
 				compositionAuth,
 			});
 		}

--- a/packages/addon-mcp/src/storybook-ai-metadata.test.ts
+++ b/packages/addon-mcp/src/storybook-ai-metadata.test.ts
@@ -58,6 +58,7 @@ describe('buildStorybookAiMetadata', () => {
 			available: true,
 			hasManifests: true,
 			hasFeatureFlag: true,
+			docgenServer: false,
 		});
 		vi.mocked(getAddonVitestConstants).mockResolvedValue({
 			TRIGGER_TEST_RUN_REQUEST: 'TRIGGER_TEST_RUN_REQUEST',
@@ -292,6 +293,7 @@ describe('buildStorybookAiMetadata', () => {
 			available: false,
 			hasManifests: false,
 			hasFeatureFlag: true,
+			docgenServer: false,
 		});
 		const options = createOptions({
 			refs: {
@@ -469,6 +471,7 @@ function createAvailability(overrides: Partial<ToolAvailability> = {}): ToolAvai
 		docsFeatureEnabled: true,
 		testSupported: true,
 		a11yEnabled: true,
+		docgenServer: false,
 		...overrides,
 	};
 }

--- a/packages/addon-mcp/src/tools/is-manifest-available.test.ts
+++ b/packages/addon-mcp/src/tools/is-manifest-available.test.ts
@@ -8,18 +8,25 @@ function createMockOptions({
 	hasManifests = false,
 	hasLegacyComponentManifestGenerator = false,
 	hasFeaturesObject = true,
+	docgenServer = false,
 }: {
 	featureFlag?: boolean;
 	featureFlagName?: 'componentsManifest' | 'experimentalComponentsManifest';
 	hasManifests?: boolean;
 	hasLegacyComponentManifestGenerator?: boolean;
 	hasFeaturesObject?: boolean;
+	docgenServer?: boolean;
 } = {}): Options {
 	return {
 		presets: {
 			apply: vi.fn(async (key: string) => {
 				if (key === 'features') {
-					return hasFeaturesObject ? { [featureFlagName]: featureFlag } : {};
+					return hasFeaturesObject
+						? {
+								[featureFlagName]: featureFlag,
+								...(docgenServer ? { experimentalDocgenServer: true } : {}),
+							}
+						: {};
 				}
 				if (key === 'experimental_manifests') {
 					return hasManifests ? { components: { v: 1, components: {} } } : undefined;
@@ -38,22 +45,32 @@ describe('getManifestStatus', () => {
 		{
 			description: 'both feature flag and manifests are present',
 			options: { featureFlag: true, hasManifests: true },
-			expected: { available: true, hasManifests: true, hasFeatureFlag: true },
+			expected: { available: true, hasManifests: true, hasFeatureFlag: true, docgenServer: false },
 		},
 		{
 			description: 'both feature flag and legacy component manifest generator are present',
 			options: { featureFlag: true, hasLegacyComponentManifestGenerator: true },
-			expected: { available: true, hasManifests: true, hasFeatureFlag: true },
+			expected: { available: true, hasManifests: true, hasFeatureFlag: true, docgenServer: false },
 		},
 		{
 			description: 'missing manifests (unsupported framework)',
 			options: { featureFlag: true, hasManifests: false },
-			expected: { available: false, hasManifests: false, hasFeatureFlag: true },
+			expected: {
+				available: false,
+				hasManifests: false,
+				hasFeatureFlag: true,
+				docgenServer: false,
+			},
 		},
 		{
 			description: 'missing feature flag',
 			options: { featureFlag: false, hasManifests: true },
-			expected: { available: false, hasManifests: true, hasFeatureFlag: false },
+			expected: {
+				available: false,
+				hasManifests: true,
+				hasFeatureFlag: false,
+				docgenServer: false,
+			},
 		},
 		{
 			description: 'both are missing',
@@ -62,12 +79,18 @@ describe('getManifestStatus', () => {
 				available: false,
 				hasManifests: false,
 				hasFeatureFlag: false,
+				docgenServer: false,
 			},
 		},
 		{
 			description: 'features object is missing the flag',
 			options: { hasManifests: true, hasFeaturesObject: false },
-			expected: { available: false, hasManifests: true, hasFeatureFlag: false },
+			expected: {
+				available: false,
+				hasManifests: true,
+				hasFeatureFlag: false,
+				docgenServer: false,
+			},
 		},
 		{
 			description: 'legacy experimentalComponentsManifest flag is true (backwards compat)',
@@ -76,7 +99,7 @@ describe('getManifestStatus', () => {
 				featureFlagName: 'experimentalComponentsManifest' as const,
 				hasManifests: true,
 			},
-			expected: { available: true, hasManifests: true, hasFeatureFlag: true },
+			expected: { available: true, hasManifests: true, hasFeatureFlag: true, docgenServer: false },
 		},
 		{
 			description: 'legacy experimentalComponentsManifest flag is false (backwards compat)',
@@ -85,7 +108,17 @@ describe('getManifestStatus', () => {
 				featureFlagName: 'experimentalComponentsManifest' as const,
 				hasManifests: true,
 			},
-			expected: { available: false, hasManifests: true, hasFeatureFlag: false },
+			expected: {
+				available: false,
+				hasManifests: true,
+				hasFeatureFlag: false,
+				docgenServer: false,
+			},
+		},
+		{
+			description: 'experimentalDocgenServer mode reports manifests available via the services',
+			options: { featureFlag: true, hasManifests: false, docgenServer: true },
+			expected: { available: true, hasManifests: true, hasFeatureFlag: true, docgenServer: true },
 		},
 	])('should return correct status when $description', async ({ options, expected }) => {
 		const mockOptions = createMockOptions(options);
@@ -113,6 +146,7 @@ describe('getManifestStatus', () => {
 			available: false,
 			hasManifests: false,
 			hasFeatureFlag: true,
+			docgenServer: false,
 		});
 	});
 });

--- a/packages/addon-mcp/src/tools/is-manifest-available.ts
+++ b/packages/addon-mcp/src/tools/is-manifest-available.ts
@@ -1,9 +1,27 @@
 import type { Options } from 'storybook/internal/types';
 
+export type ManifestFeatures = {
+	componentsManifest?: boolean;
+	experimentalComponentsManifest?: boolean;
+	experimentalDocgenServer?: boolean;
+};
+
+export const hasComponentManifestFeature = (features: ManifestFeatures | undefined): boolean =>
+	!!(features?.componentsManifest ?? features?.experimentalComponentsManifest);
+
+export const isDocgenServerMode = (features: ManifestFeatures | undefined): boolean =>
+	!!(features?.experimentalDocgenServer && features?.componentsManifest);
+
 export type ManifestStatus = {
 	available: boolean;
 	hasManifests: boolean;
 	hasFeatureFlag: boolean;
+	/**
+	 * `experimentalDocgenServer` mode: the split/ref manifest format served from the
+	 * open services. In dev, `/manifests/*.json` is 404'd by core, so the addon reads
+	 * manifest data in-process instead of fetching it.
+	 */
+	docgenServer: boolean;
 };
 
 export const getManifestStatus = async (options: Options): Promise<ManifestStatus> => {
@@ -21,15 +39,20 @@ export const getManifestStatus = async (options: Options): Promise<ManifestStatu
 		options.presets.apply('experimental_componentManifestGenerator'),
 	]);
 
+	const hasFeatureFlag = hasComponentManifestFeature(features);
+
+	// In docgen-server mode the dev `experimental_manifests` shell may be empty
+	// (component rows are built from the docgen service, not the preset), so detect
+	// it explicitly and treat manifests as available.
+	const docgenServer = isDocgenServerMode(features);
+
 	const hasManifests =
-		(manifests && 'components' in manifests) || !!legacyComponentManifestGenerator;
-	const hasFeatureFlag = !!(
-		features?.componentsManifest ?? features?.experimentalComponentsManifest
-	);
+		docgenServer || (manifests && 'components' in manifests) || !!legacyComponentManifestGenerator;
 
 	return {
 		available: hasFeatureFlag && hasManifests,
 		hasManifests,
 		hasFeatureFlag,
+		docgenServer,
 	};
 };

--- a/packages/addon-mcp/src/utils/get-tool-availability.ts
+++ b/packages/addon-mcp/src/utils/get-tool-availability.ts
@@ -1,7 +1,7 @@
 import type { Options } from 'storybook/internal/types';
 import { isModuleGraphSupported } from './module-graph.ts';
 import { getReviewStatus } from './is-review-available.ts';
-import { getManifestStatus } from '../tools/is-manifest-available.ts';
+import { getManifestStatus, type ManifestFeatures } from '../tools/is-manifest-available.ts';
 import { getAddonVitestConstants } from '../tools/run-story-tests.ts';
 import { isAddonA11yEnabled } from './is-addon-a11y-enabled.ts';
 
@@ -22,6 +22,8 @@ export interface ToolAvailability {
 	testSupported: boolean;
 	/** `@storybook/addon-a11y` is enabled. Gates the accessibility sub-feature of `run-story-tests`. */
 	a11yEnabled: boolean;
+	/** `experimentalDocgenServer` mode: read manifest data in-process from the open services. */
+	docgenServer: boolean;
 }
 
 export interface GetToolAvailabilityOptions {
@@ -29,7 +31,7 @@ export interface GetToolAvailabilityOptions {
 	 * Pre-resolved `features` preset. Pass it to avoid re-applying the preset and
 	 * risking a different snapshot than the caller already resolved.
 	 */
-	features?: { changeDetection?: boolean } | undefined;
+	features?: (ManifestFeatures & { changeDetection?: boolean }) | undefined;
 	/**
 	 * Pre-resolved module-graph support. The live MCP server should omit this so it
 	 * probes the registered open service. Serverless metadata can pass a builder-level
@@ -76,7 +78,9 @@ export async function getToolAvailability(
 ): Promise<ToolAvailability> {
 	const resolvedFeatures =
 		features ??
-		((await options.presets.apply('features', {})) as { changeDetection?: boolean } | undefined);
+		((await options.presets.apply('features', {})) as
+			| (ManifestFeatures & { changeDetection?: boolean })
+			| undefined);
 
 	const [moduleGraphSupported, reviewStatus, manifestStatus, addonVitestConstants, a11yEnabled] =
 		await Promise.all([
@@ -96,5 +100,6 @@ export async function getToolAvailability(
 		docsFeatureEnabled: manifestStatus.hasFeatureFlag,
 		testSupported: !!addonVitestConstants,
 		a11yEnabled,
+		docgenServer: manifestStatus.docgenServer,
 	};
 }

--- a/packages/mcp/bin.ts
+++ b/packages/mcp/bin.ts
@@ -23,7 +23,7 @@ import type { StorybookContext } from './src/types.ts';
 import { parseArgs } from 'node:util';
 import * as fs from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
-import { basename, resolve, dirname } from 'node:path';
+import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const serverInstructions = readFileSync(
@@ -64,12 +64,22 @@ const args = parseArgs({
 transport.listen({
 	manifestProvider: async (_request, path) => {
 		const { manifestsDir } = args.values;
-		const fullPath = `${manifestsDir}/${basename(path)}`;
+		const isRemote = manifestsDir.startsWith('http://') || manifestsDir.startsWith('https://');
 
-		if (manifestsDir.startsWith('http://') || manifestsDir.startsWith('https://')) {
-			const res = await fetch(fullPath);
+		// Top-level manifests (`./manifests/<name>.json`) live in `manifestsDir`; split/ref
+		// payloads (`./services/<service>/<id>.json`) live in a sibling `services/` directory.
+		const normalized = path.replace(/^\.?\//, '');
+		const { base, rel } = normalized.startsWith('manifests/')
+			? { base: manifestsDir, rel: normalized.slice('manifests/'.length) }
+			: {
+					base: isRemote ? manifestsDir.replace(/\/[^/]+\/?$/, '') : dirname(manifestsDir),
+					rel: normalized,
+				};
+
+		if (isRemote) {
+			const res = await fetch(`${base.replace(/\/$/, '')}/${rel}`);
 			return await res.text();
 		}
-		return await fs.readFile(fullPath, 'utf-8');
+		return await fs.readFile(resolve(base, rel), 'utf-8');
 	},
 });

--- a/packages/mcp/bin.ts
+++ b/packages/mcp/bin.ts
@@ -23,13 +23,22 @@ import type { StorybookContext } from './src/types.ts';
 import { parseArgs } from 'node:util';
 import * as fs from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { resolve, dirname, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const serverInstructions = readFileSync(
 	resolve(dirname(fileURLToPath(import.meta.url)), './src/instructions.md'),
 	'utf-8',
 );
+
+function resolveManifestFile(base: string, rel: string): string {
+	const resolvedBase = resolve(base);
+	const resolved = resolve(resolvedBase, rel);
+	if (resolved !== resolvedBase && !resolved.startsWith(resolvedBase + sep)) {
+		throw new Error(`Refusing to read manifest outside base: ${rel}`);
+	}
+	return resolved;
+}
 
 const adapter = new ValibotJsonSchemaAdapter();
 const server = new McpServer(
@@ -78,8 +87,11 @@ transport.listen({
 
 		if (isRemote) {
 			const res = await fetch(`${base.replace(/\/$/, '')}/${rel}`);
+			if (!res.ok) {
+				throw new Error(`Failed to fetch manifest (${res.status}) from ${res.url}`);
+			}
 			return await res.text();
 		}
-		return await fs.readFile(resolve(base, rel), 'utf-8');
+		return await fs.readFile(resolveManifestFile(base, rel), 'utf-8');
 	},
 });

--- a/packages/mcp/fixtures/default/components.json
+++ b/packages/mcp/fixtures/default/components.json
@@ -1,5 +1,5 @@
 {
-	"v": 1,
+	"v": 0,
 	"components": {
 		"button": {
 			"id": "button",

--- a/packages/mcp/fixtures/default/docs.json
+++ b/packages/mcp/fixtures/default/docs.json
@@ -1,5 +1,5 @@
 {
-	"v": 1,
+	"v": 0,
 	"docs": {
 		"getting-started": {
 			"id": "getting-started",

--- a/packages/mcp/fixtures/full-manifest.fixture.json
+++ b/packages/mcp/fixtures/full-manifest.fixture.json
@@ -1,5 +1,5 @@
 {
-	"v": 1,
+	"v": 0,
 	"components": {
 		"button": {
 			"id": "button",

--- a/packages/mcp/fixtures/small-docs-manifest.fixture.json
+++ b/packages/mcp/fixtures/small-docs-manifest.fixture.json
@@ -1,5 +1,5 @@
 {
-	"v": 1,
+	"v": 0,
 	"docs": {
 		"getting-started": {
 			"id": "getting-started",

--- a/packages/mcp/fixtures/small-manifest.fixture.json
+++ b/packages/mcp/fixtures/small-manifest.fixture.json
@@ -1,5 +1,5 @@
 {
-	"v": 1,
+	"v": 0,
 	"components": {
 		"button": {
 			"id": "button",

--- a/packages/mcp/fixtures/with-errors.fixture.json
+++ b/packages/mcp/fixtures/with-errors.fixture.json
@@ -1,5 +1,5 @@
 {
-	"v": 1,
+	"v": 0,
 	"components": {
 		"success-component-with-mixed-stories": {
 			"id": "success-component-with-mixed-stories",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -33,10 +33,30 @@ export {
 	DOCS_MANIFEST_PATH,
 	RequiresOwnMcpError,
 	getMultiSourceManifests,
+	resolveComponentEntry,
+	resolveComponentStories,
+	resolveDoc,
 } from './utils/get-manifest.ts';
 
+// Adapters from Storybook's open-service ("core format") payloads to the internal shape.
+export { adaptCoreComponent, adaptCoreDoc, adaptCoreStories } from './utils/adapt-core-manifest.ts';
+
 // Export types for reuse
-export type { RequiresOwnMcpNotice, StorybookContext, Source, SourceManifests } from './types.ts';
+export type {
+	RequiresOwnMcpNotice,
+	StorybookContext,
+	ResolvedEntry,
+	Source,
+	SourceManifests,
+	Doc,
+	Story,
+	CoreDocgenPayload,
+	CoreDocgenComponent,
+	CoreMdxPayload,
+	CoreMdxDoc,
+	CoreStoryDocsPayload,
+	CoreStoryDoc,
+} from './types.ts';
 
 // copied from tmcp internals as it's not exposed
 type InitializeRequestParams = {

--- a/packages/mcp/src/tools/get-documentation-for-story.ts
+++ b/packages/mcp/src/tools/get-documentation-for-story.ts
@@ -88,7 +88,7 @@ export async function addGetStoryDocumentationTool(
 				// local source — single-source (no `source`) or the urlless `local` source in a
 				// composition. Remote sources (with a `url`) fall through to the fetch path.
 				if (ctx?.resolveEntry && !source?.url) {
-					const resolved = await ctx.resolveEntry(componentId);
+					const resolved = await ctx.resolveEntry(componentId, source);
 					if (resolved?.kind === 'component') {
 						component = resolved.component;
 					}

--- a/packages/mcp/src/tools/get-documentation-for-story.ts
+++ b/packages/mcp/src/tools/get-documentation-for-story.ts
@@ -2,7 +2,8 @@ import * as v from 'valibot';
 import type { McpServer } from 'tmcp';
 import type { StorybookContext } from '../types.ts';
 import { StorybookIdField } from '../types.ts';
-import { errorToMCPContent, getManifests, resolveComponentDocgen } from '../utils/get-manifest.ts';
+import { errorToMCPContent, getManifests, resolveComponentEntry } from '../utils/get-manifest.ts';
+import type { ComponentManifest } from '../types.ts';
 import { formatStoryDocumentation } from '../utils/manifest-formatter/markdown.ts';
 import { LIST_TOOL_NAME } from './list-all-documentation.ts';
 
@@ -79,9 +80,34 @@ export async function addGetStoryDocumentationTool(
 					}
 				}
 
-				const manifest = await getManifests(ctx?.request, ctx?.manifestProvider, source);
+				let component: ComponentManifest | undefined;
 
-				let component = manifest.componentManifest?.components[componentId];
+				// Dev (experimentalDocgenServer): resolve a single entry in-process, bypassing
+				// the all-component manifest index so one lookup never triggers all-docgen.
+				// The in-process services back the local Storybook only, so this is used for the
+				// local source — single-source (no `source`) or the urlless `local` source in a
+				// composition. Remote sources (with a `url`) fall through to the fetch path.
+				if (ctx?.resolveEntry && !source?.url) {
+					const resolved = await ctx.resolveEntry(componentId);
+					if (resolved?.kind === 'component') {
+						component = resolved.component;
+					}
+				} else {
+					const manifest = await getManifests(ctx?.request, ctx?.manifestProvider, source);
+					const componentEntry = manifest.componentManifest?.components[componentId];
+
+					// Built/static/remote. v1 (split/ref) index rows carry `$ref`s to externalized
+					// payloads, which these helpers follow; v0 (inline) rows have no `$ref`s and are
+					// returned unchanged. Either way the result is a fully-resolved entry.
+					if (componentEntry) {
+						component = await resolveComponentEntry(
+							componentEntry,
+							ctx?.request,
+							ctx?.manifestProvider,
+							source,
+						);
+					}
+				}
 
 				if (!component) {
 					return {
@@ -95,20 +121,14 @@ export async function addGetStoryDocumentationTool(
 					};
 				}
 
-				// Externalized-docgen manifests carry only a stub here; fetch the full data.
-				if (component.docgen?.$ref) {
-					component = await resolveComponentDocgen(
-						component,
-						ctx?.request,
-						ctx?.manifestProvider,
-						source,
-					);
-				}
-
-				const story = component.stories?.find((s) => s.name === storyName);
+				const story = Array.isArray(component.stories)
+					? component.stories.find((s) => s.name === storyName)
+					: undefined;
 
 				if (!story) {
-					const availableStories = component.stories?.map((s) => s.name).join(', ') ?? 'none';
+					const availableStories = Array.isArray(component.stories)
+						? component.stories.map((s) => s.name).join(', ')
+						: 'none';
 					return {
 						content: [
 							{

--- a/packages/mcp/src/tools/get-documentation.test.ts
+++ b/packages/mcp/src/tools/get-documentation.test.ts
@@ -624,7 +624,7 @@ describe('getDocumentationTool', () => {
 			});
 
 			// The urlless local source is resolved in-process; the all-component index is never built.
-			expect(resolveEntry).toHaveBeenCalledWith('button');
+			expect(resolveEntry).toHaveBeenCalledWith('button', sources[0]);
 			expect(getManifestsSpy).not.toHaveBeenCalled();
 			expect((response.result as any).content[0].text).toContain('# Button');
 		});
@@ -928,7 +928,7 @@ http://remote.example.com/mcp`);
 			});
 
 			// The single-entry hook is used, and the all-component manifest index is never fetched.
-			expect(resolveEntry).toHaveBeenCalledWith('button');
+			expect(resolveEntry).toHaveBeenCalledWith('button', undefined);
 			expect(getManifestsSpy).not.toHaveBeenCalled();
 			expect((response.result as any).content[0].text).toContain('# Button');
 			expect((response.result as any).content[0].text).toContain('button--primary');
@@ -952,7 +952,7 @@ http://remote.example.com/mcp`);
 				custom: { request: mockHttpRequest, resolveEntry },
 			});
 
-			expect(resolveEntry).toHaveBeenCalledWith('intro');
+			expect(resolveEntry).toHaveBeenCalledWith('intro', undefined);
 			expect(getManifestsSpy).not.toHaveBeenCalled();
 			expect((response.result as any).content[0].text).toContain('# Welcome');
 		});

--- a/packages/mcp/src/tools/get-documentation.test.ts
+++ b/packages/mcp/src/tools/get-documentation.test.ts
@@ -597,6 +597,63 @@ describe('getDocumentationTool', () => {
 			expect(getManifestsSpy).toHaveBeenCalledWith(mockHttpRequest, undefined, sources[0]);
 		});
 
+		it('resolves the local source in-process via resolveEntry (composition + docgen-server)', async () => {
+			getManifestsSpy.mockClear();
+			const resolveEntry = vi.fn().mockResolvedValue({
+				kind: 'component',
+				component: {
+					id: 'button',
+					name: 'Button',
+					stories: [{ id: 'button--primary', name: 'Primary', snippet: '<Button />' }],
+				},
+			});
+
+			const request = {
+				jsonrpc: '2.0' as const,
+				id: 1,
+				method: 'tools/call',
+				params: {
+					name: GET_TOOL_NAME,
+					arguments: { id: 'button', storybookId: 'local' },
+				},
+			};
+
+			const mockHttpRequest = new Request('https://example.com/mcp');
+			const response = await server.receive(request, {
+				custom: { request: mockHttpRequest, sources, resolveEntry },
+			});
+
+			// The urlless local source is resolved in-process; the all-component index is never built.
+			expect(resolveEntry).toHaveBeenCalledWith('button');
+			expect(getManifestsSpy).not.toHaveBeenCalled();
+			expect((response.result as any).content[0].text).toContain('# Button');
+		});
+
+		it('does not use resolveEntry for a remote source even when one is present', async () => {
+			const resolveEntry = vi.fn();
+			getManifestsSpy.mockResolvedValue({
+				componentManifest: remoteManifest,
+			});
+
+			const request = {
+				jsonrpc: '2.0' as const,
+				id: 1,
+				method: 'tools/call',
+				params: {
+					name: GET_TOOL_NAME,
+					arguments: { id: 'badge', storybookId: 'remote' },
+				},
+			};
+
+			const mockHttpRequest = new Request('https://example.com/mcp');
+			await server.receive(request, {
+				custom: { request: mockHttpRequest, sources, resolveEntry },
+			});
+
+			expect(resolveEntry).not.toHaveBeenCalled();
+			expect(getManifestsSpy).toHaveBeenCalledWith(mockHttpRequest, undefined, sources[1]);
+		});
+
 		it('should pass remote source to getManifests', async () => {
 			getManifestsSpy.mockResolvedValue({
 				componentManifest: remoteManifest,
@@ -838,6 +895,86 @@ http://remote.example.com/mcp`);
 				}),
 				resultText: expect.any(String),
 			});
+		});
+	});
+
+	describe('resolveEntry hook (dev / experimentalDocgenServer)', () => {
+		beforeEach(() => {
+			getManifestsSpy.mockClear();
+		});
+
+		it('resolves a single component via resolveEntry without building the index', async () => {
+			const resolveEntry = vi.fn().mockResolvedValue({
+				kind: 'component',
+				component: {
+					id: 'button',
+					name: 'Button',
+					stories: [
+						{ id: 'button--primary', name: 'Primary', snippet: '<Button variant="primary" />' },
+					],
+				},
+			});
+
+			const request = {
+				jsonrpc: '2.0' as const,
+				id: 1,
+				method: 'tools/call',
+				params: { name: GET_TOOL_NAME, arguments: { id: 'button' } },
+			};
+
+			const mockHttpRequest = new Request('https://example.com/mcp');
+			const response = await server.receive(request, {
+				custom: { request: mockHttpRequest, resolveEntry },
+			});
+
+			// The single-entry hook is used, and the all-component manifest index is never fetched.
+			expect(resolveEntry).toHaveBeenCalledWith('button');
+			expect(getManifestsSpy).not.toHaveBeenCalled();
+			expect((response.result as any).content[0].text).toContain('# Button');
+			expect((response.result as any).content[0].text).toContain('button--primary');
+		});
+
+		it('resolves a single docs entry via resolveEntry', async () => {
+			const resolveEntry = vi.fn().mockResolvedValue({
+				kind: 'doc',
+				doc: { id: 'intro', name: 'Intro', title: 'Introduction', content: '# Welcome' },
+			});
+
+			const request = {
+				jsonrpc: '2.0' as const,
+				id: 1,
+				method: 'tools/call',
+				params: { name: GET_TOOL_NAME, arguments: { id: 'intro' } },
+			};
+
+			const mockHttpRequest = new Request('https://example.com/mcp');
+			const response = await server.receive(request, {
+				custom: { request: mockHttpRequest, resolveEntry },
+			});
+
+			expect(resolveEntry).toHaveBeenCalledWith('intro');
+			expect(getManifestsSpy).not.toHaveBeenCalled();
+			expect((response.result as any).content[0].text).toContain('# Welcome');
+		});
+
+		it('returns not-found when resolveEntry yields nothing', async () => {
+			const resolveEntry = vi.fn().mockResolvedValue(undefined);
+
+			const request = {
+				jsonrpc: '2.0' as const,
+				id: 1,
+				method: 'tools/call',
+				params: { name: GET_TOOL_NAME, arguments: { id: 'nope' } },
+			};
+
+			const mockHttpRequest = new Request('https://example.com/mcp');
+			const response = await server.receive(request, {
+				custom: { request: mockHttpRequest, resolveEntry },
+			});
+
+			expect(getManifestsSpy).not.toHaveBeenCalled();
+			expect((response.result as any).isError).toBe(true);
+			expect((response.result as any).content[0].text).toContain('not found');
 		});
 	});
 });

--- a/packages/mcp/src/tools/get-documentation.ts
+++ b/packages/mcp/src/tools/get-documentation.ts
@@ -2,7 +2,12 @@ import * as v from 'valibot';
 import type { McpServer } from 'tmcp';
 import type { ComponentManifest, Doc, StorybookContext } from '../types.ts';
 import { StorybookIdField } from '../types.ts';
-import { getManifests, errorToMCPContent, resolveComponentDocgen } from '../utils/get-manifest.ts';
+import {
+	getManifests,
+	errorToMCPContent,
+	resolveComponentEntry,
+	resolveDoc,
+} from '../utils/get-manifest.ts';
 import { LIST_TOOL_NAME } from './list-all-documentation.ts';
 import {
 	formatComponentManifest,
@@ -86,14 +91,45 @@ export async function addGetDocumentationTool(
 					}
 				}
 
-				const { componentManifest, docsManifest } = await getManifests(
-					ctx?.request,
-					ctx?.manifestProvider,
-					source,
-				);
+				let component: ComponentManifest | undefined;
+				let docsEntry: Doc | undefined;
 
-				let component = componentManifest.components[id];
-				const docsEntry = docsManifest?.docs[id];
+				// Dev (experimentalDocgenServer): resolve a single entry in-process, bypassing
+				// the all-component manifest index so one lookup never triggers all-docgen.
+				// The in-process services back the local Storybook only, so this is used for the
+				// local source — single-source (no `source`) or the urlless `local` source in a
+				// composition. Remote sources (with a `url`) fall through to the fetch path.
+				if (ctx?.resolveEntry && !source?.url) {
+					const resolved = await ctx.resolveEntry(id);
+					if (resolved?.kind === 'component') {
+						component = resolved.component;
+					} else if (resolved?.kind === 'doc') {
+						docsEntry = resolved.doc;
+					}
+				} else {
+					const { componentManifest, docsManifest } = await getManifests(
+						ctx?.request,
+						ctx?.manifestProvider,
+						source,
+					);
+
+					const componentEntry = componentManifest.components[id];
+					const docEntry = docsManifest?.docs[id];
+
+					// Built/static/remote. v1 (split/ref) index rows carry `$ref`s to externalized
+					// payloads, which these helpers follow; v0 (inline) rows have no `$ref`s and are
+					// returned unchanged. Either way the result is a fully-resolved entry.
+					if (componentEntry) {
+						component = await resolveComponentEntry(
+							componentEntry,
+							ctx?.request,
+							ctx?.manifestProvider,
+							source,
+						);
+					} else if (docEntry) {
+						docsEntry = await resolveDoc(docEntry, ctx?.request, ctx?.manifestProvider, source);
+					}
+				}
 
 				if (!component && !docsEntry) {
 					const suffix = storybookId ? ` in source "${storybookId}"` : '';
@@ -111,15 +147,6 @@ export async function addGetDocumentationTool(
 						],
 						isError: true,
 					};
-				}
-
-				if (component?.docgen?.$ref) {
-					component = await resolveComponentDocgen(
-						component,
-						ctx?.request,
-						ctx?.manifestProvider,
-						source,
-					);
 				}
 
 				const documentation = component ?? docsEntry!;

--- a/packages/mcp/src/tools/get-documentation.ts
+++ b/packages/mcp/src/tools/get-documentation.ts
@@ -100,7 +100,7 @@ export async function addGetDocumentationTool(
 				// local source — single-source (no `source`) or the urlless `local` source in a
 				// composition. Remote sources (with a `url`) fall through to the fetch path.
 				if (ctx?.resolveEntry && !source?.url) {
-					const resolved = await ctx.resolveEntry(id);
+					const resolved = await ctx.resolveEntry(id, source);
 					if (resolved?.kind === 'component') {
 						component = resolved.component;
 					} else if (resolved?.kind === 'doc') {

--- a/packages/mcp/src/tools/list-all-documentation.test.ts
+++ b/packages/mcp/src/tools/list-all-documentation.test.ts
@@ -2,10 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { McpServer } from 'tmcp';
 import { ValibotJsonSchemaAdapter } from '@tmcp/adapter-valibot';
 import { addListAllDocumentationTool, LIST_TOOL_NAME } from './list-all-documentation.ts';
-import type { StorybookContext } from '../types.ts';
-import smallManifestFixture from '../../fixtures/small-manifest.fixture.json' with { type: 'json' };
-import smallDocsManifestFixture from '../../fixtures/small-docs-manifest.fixture.json' with { type: 'json' };
+import type { ComponentManifestMap, DocsManifestMap, StorybookContext } from '../types.ts';
+import smallManifestFixtureRaw from '../../fixtures/small-manifest.fixture.json' with { type: 'json' };
+import smallDocsManifestFixtureRaw from '../../fixtures/small-docs-manifest.fixture.json' with { type: 'json' };
 import * as getManifest from '../utils/get-manifest.ts';
+
+// JSON imports widen the `v` literal to `number`, so re-type the fixtures against
+// the discriminated-union schema for use in strongly-typed mocks.
+const smallManifestFixture = smallManifestFixtureRaw as unknown as ComponentManifestMap;
+const smallDocsManifestFixture = smallDocsManifestFixtureRaw as unknown as DocsManifestMap;
 
 describe('listAllDocumentationTool', () => {
 	let server: McpServer<any, StorybookContext>;
@@ -111,8 +116,8 @@ describe('listAllDocumentationTool', () => {
 			{ id: 'remote', title: 'Remote', url: 'http://remote.example.com' },
 		];
 
-		const remoteManifest = {
-			v: 1,
+		const remoteManifest: ComponentManifestMap = {
+			v: 0,
 			components: {
 				badge: {
 					id: 'badge',

--- a/packages/mcp/src/tools/list-all-documentation.ts
+++ b/packages/mcp/src/tools/list-all-documentation.ts
@@ -58,6 +58,40 @@ export async function addListAllDocumentationTool(
 						ctx.manifestProvider,
 					);
 
+					// Like single-source mode, split/ref (v1) sources keep stories behind a
+					// `$ref`; resolve them per source so story sub-bullets render. Failures
+					// are isolated to a source so one bad source can't break the whole list.
+					if (withStoryIds) {
+						await Promise.all(
+							multiSourceManifests.map(async (sourceManifest) => {
+								if (sourceManifest.error || sourceManifest.notice) return;
+								try {
+									const components: Record<string, ComponentManifestEntry> =
+										sourceManifest.componentManifest.components;
+									const entries = Object.entries(components);
+									const resolved = await mapWithConcurrency(
+										entries,
+										16,
+										async ([id, component]) => {
+											const storiesResolved = await resolveComponentStories(
+												component,
+												ctx.request,
+												ctx.manifestProvider,
+												sourceManifest.source,
+											);
+											return [id, storiesResolved] as const;
+										},
+									);
+									for (const [id, component] of resolved) {
+										components[id] = component;
+									}
+								} catch {
+									// Leave this source's rows unresolved rather than failing the listing.
+								}
+							}),
+						);
+					}
+
 					const lists = formatMultiSourceManifestsToLists(multiSourceManifests, {
 						withStoryIds,
 					});

--- a/packages/mcp/src/tools/list-all-documentation.ts
+++ b/packages/mcp/src/tools/list-all-documentation.ts
@@ -7,6 +7,7 @@ import {
 	errorToMCPContent,
 	resolveComponentStories,
 } from '../utils/get-manifest.ts';
+import { mapWithConcurrency } from '../utils/map-with-concurrency.ts';
 import {
 	formatMultiSourceManifestsToLists,
 	formatManifestsToLists,
@@ -94,15 +95,18 @@ export async function addListAllDocumentationTool(
 					// parsed map's version. Resolution mutates the entries in place for formatting.
 					const components: Record<string, ComponentManifestEntry> =
 						manifests.componentManifest.components;
-					await Promise.all(
-						Object.entries(components).map(async ([id, component]) => {
-							components[id] = await resolveComponentStories(
-								component,
-								ctx?.request,
-								ctx?.manifestProvider,
-							);
-						}),
-					);
+					const entries = Object.entries(components);
+					const resolved = await mapWithConcurrency(entries, 16, async ([id, component]) => {
+						const storiesResolved = await resolveComponentStories(
+							component,
+							ctx?.request,
+							ctx?.manifestProvider,
+						);
+						return [id, storiesResolved] as const;
+					});
+					for (const [id, component] of resolved) {
+						components[id] = component;
+					}
 				}
 
 				const lists = formatManifestsToLists(manifests, {

--- a/packages/mcp/src/tools/list-all-documentation.ts
+++ b/packages/mcp/src/tools/list-all-documentation.ts
@@ -1,7 +1,12 @@
 import type { McpServer } from 'tmcp';
 import * as v from 'valibot';
-import type { StorybookContext } from '../types.ts';
-import { getManifests, getMultiSourceManifests, errorToMCPContent } from '../utils/get-manifest.ts';
+import type { ComponentManifestEntry, StorybookContext } from '../types.ts';
+import {
+	getManifests,
+	getMultiSourceManifests,
+	errorToMCPContent,
+	resolveComponentStories,
+} from '../utils/get-manifest.ts';
 import {
 	formatMultiSourceManifestsToLists,
 	formatManifestsToLists,
@@ -81,6 +86,24 @@ export async function addListAllDocumentationTool(
 
 				// Single-source mode: existing behavior
 				const manifests = await getManifests(ctx?.request, ctx?.manifestProvider);
+
+				// Split/ref format keeps stories behind a `$ref`; resolve them only when story
+				// ids are requested so plain listing stays cheap.
+				if (withStoryIds) {
+					// Widened so resolved (inline) components can be written back regardless of the
+					// parsed map's version. Resolution mutates the entries in place for formatting.
+					const components: Record<string, ComponentManifestEntry> =
+						manifests.componentManifest.components;
+					await Promise.all(
+						Object.entries(components).map(async ([id, component]) => {
+							components[id] = await resolveComponentStories(
+								component,
+								ctx?.request,
+								ctx?.manifestProvider,
+							);
+						}),
+					);
+				}
 
 				const lists = formatManifestsToLists(manifests, {
 					withStoryIds,

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -83,11 +83,31 @@ export type StorybookContext = {
 			| { foundDocumentation?: never; resultText?: never }
 		),
 	) => void | Promise<void>;
+	/**
+	 * Optional in-process resolver for a single component or docs entry, used in
+	 * Storybook's dev server when `experimentalDocgenServer` is enabled. When set,
+	 * single-entry tools (`get-documentation`, `get-documentation-for-story`) call
+	 * this instead of fetching the (potentially all-component) manifest index, so a
+	 * single lookup never triggers docgen extraction for every component.
+	 *
+	 * Returns the fully-resolved component or doc in `@storybook/mcp`'s internal
+	 * shape (already adapted from the open-service payloads), or `undefined` when the
+	 * id is unknown.
+	 */
+	resolveEntry?: (id: string, source?: Source) => Promise<ResolvedEntry | undefined>;
 };
+
+/**
+ * Result of resolving a single id via {@link StorybookContext.resolveEntry}: either a
+ * fully-resolved component manifest or a standalone docs entry.
+ */
+export type ResolvedEntry =
+	| { kind: 'component'; component: ComponentManifest }
+	| { kind: 'doc'; doc: Doc };
 
 const JSDocTag = v.record(v.string(), v.array(v.string()));
 
-const Error = v.object({
+const ManifestError = v.object({
 	name: v.string(),
 	message: v.string(),
 });
@@ -96,7 +116,7 @@ const BaseManifest = v.object({
 	name: v.string(),
 	description: v.optional(v.string()),
 	jsDocTags: v.optional(JSDocTag),
-	error: v.optional(Error),
+	error: v.optional(ManifestError),
 });
 
 const Story = v.object({
@@ -108,19 +128,13 @@ const Story = v.object({
 export type Story = v.InferOutput<typeof Story>;
 
 /**
- * A docs entry represents MDX documentation that can be attached to a component
- * or standalone (unattached).
+ * A JSON Reference (`{ $ref }`) pointing at a value in another manifest document.
+ * Used by the v1 (split/ref) manifest format for docgen, story-docs and MDX payloads.
  */
-const Doc = v.object({
-	id: v.string(),
-	name: v.string(),
-	title: v.string(),
-	path: v.string(),
-	content: v.string(),
-	summary: v.optional(v.string()),
-	error: v.optional(Error),
+export const JsonRef = v.object({
+	$ref: v.string(),
 });
-export type Doc = v.InferOutput<typeof Doc>;
+export type JsonRef = v.InferOutput<typeof JsonRef>;
 
 /**
  * Component documentation from react-docgen-typescript, extended with export name.
@@ -128,22 +142,44 @@ export type Doc = v.InferOutput<typeof Doc>;
  */
 export type ComponentDocWithExportName = ComponentDoc & { exportName: string };
 
-/**
- * A JSON Reference to externalized component data, e.g.
- * `"../services/core/docgen/button.json#/components/button"`. Used by the
- * externalized-docgen manifest format, where the top-level component manifest
- * only carries lightweight stubs and the full data lives in a referenced file.
- * The path is resolved relative to the component manifest's location.
- */
-export const DocgenRef = v.object({
-	$ref: v.string(),
-});
-export type DocgenRef = v.InferOutput<typeof DocgenRef>;
+// ---------------------------------------------------------------------------
+// Manifest formats
+//
+// Storybook writes one of two manifest formats, distinguished by the top-level
+// `v` field on `components.json` / `docs.json` (see Storybook core:
+// `renderers/react/.../componentManifest/generator.ts` emits `v: 0`,
+// `core-server/.../components-ref-manifest.ts` emits `v: 1`):
+//
+//   • v0 — inline/legacy: every component carries its docgen, stories array and
+//     attached docs (with MDX `content`) inline.
+//   • v1 — split/ref: `components.json`/`docs.json` are shallow indexes; the heavy
+//     docgen, story-docs and MDX payloads live in sibling `services/*.json` files
+//     and are referenced via `$ref`. (Storybook's in-process dev provider emits an
+//     even shallower v1 index — `docgen`/`mdx` refs omitted — because single
+//     entries are resolved in-process instead, see `StorybookContext.resolveEntry`.)
+//
+// The two formats are kept as separate schemas so each version's exact shape is
+// explicit, then combined into a `v`-discriminated union at the map level. Anything
+// that needs to branch on the version can read `map.v` or match the per-version
+// schemas directly.
+// ---------------------------------------------------------------------------
 
-const BaseComponentProperties = v.object({
+// ---- v0: inline / legacy ----
+
+/** Inline (v0) docs entry: the full MDX `content` is embedded. */
+export const DocV0 = v.object({
+	id: v.string(),
+	name: v.string(),
+	title: v.optional(v.string()),
+	path: v.optional(v.string()),
+	content: v.optional(v.string()),
+	summary: v.optional(v.string()),
+	error: v.optional(ManifestError),
+});
+export type DocV0 = v.InferOutput<typeof DocV0>;
+
+const BaseInlineComponentProperties = v.object({
 	...BaseManifest.entries,
-	// Optional: stub entries in the externalized-docgen manifest format omit `path`
-	// (it lives in the referenced docgen file alongside the rest of the component data).
 	path: v.optional(v.string()),
 	summary: v.optional(v.string()),
 	import: v.optional(v.string()),
@@ -153,44 +189,202 @@ const BaseComponentProperties = v.object({
 });
 
 export const SubcomponentManifest = v.object({
-	...BaseComponentProperties.entries,
+	...BaseInlineComponentProperties.entries,
 });
-
 export type SubcomponentManifest = v.InferOutput<typeof SubcomponentManifest>;
 
-export const ComponentManifest = v.object({
-	...BaseComponentProperties.entries,
+/** Inline (v0) component: docgen, stories and attached docs are all embedded. */
+export const ComponentManifestV0 = v.object({
+	...BaseInlineComponentProperties.entries,
 	id: v.string(),
 	stories: v.optional(v.array(Story)),
 	subcomponents: v.optional(v.record(v.string(), SubcomponentManifest)),
-	docs: v.optional(v.record(v.string(), Doc)),
-	// Present on stub entries in the externalized-docgen manifest format. When set,
-	// the full component data must be resolved from the referenced file.
-	docgen: v.optional(DocgenRef),
+	docs: v.optional(v.record(v.string(), DocV0)),
 });
-export type ComponentManifest = v.InferOutput<typeof ComponentManifest>;
+export type ComponentManifestV0 = v.InferOutput<typeof ComponentManifestV0>;
 
-export const ComponentManifestMap = v.object({
-	// Optional: externalized docgen files (referenced via `docgen.$ref`) are shaped
-	// like a component manifest map but omit the top-level version field.
-	v: v.optional(v.number()),
-	components: v.record(v.string(), ComponentManifest),
+export const ComponentManifestMapV0 = v.object({
+	v: v.literal(0),
+	components: v.record(v.string(), ComponentManifestV0),
 });
+export type ComponentManifestMapV0 = v.InferOutput<typeof ComponentManifestMapV0>;
+
+export const DocsManifestMapV0 = v.object({
+	v: v.literal(0),
+	docs: v.record(v.string(), DocV0),
+});
+export type DocsManifestMapV0 = v.InferOutput<typeof DocsManifestMapV0>;
+
+// ---- v1: split / ref ----
+
+/**
+ * Shallow (v1) docs entry. The full MDX payload (title/path/content) lives behind
+ * `mdx.$ref`; `mdx` is optional because Storybook's in-process dev index omits it
+ * (those entries are resolved in-process via {@link StorybookContext.resolveEntry}).
+ */
+export const DocV1 = v.object({
+	id: v.string(),
+	name: v.string(),
+	summary: v.optional(v.string()),
+	mdx: v.optional(JsonRef),
+	error: v.optional(ManifestError),
+});
+export type DocV1 = v.InferOutput<typeof DocV1>;
+
+/**
+ * Shallow (v1) component index row. Identity + summary are inlined for cheap
+ * listing; docgen and story-docs live behind `$ref`s, attached docs behind nested
+ * `mdx.$ref`s. `docgen`/`stories` are optional (the in-process dev index omits
+ * `docgen`, and docs-only components have neither).
+ */
+export const ComponentManifestV1 = v.object({
+	id: v.string(),
+	name: v.string(),
+	description: v.optional(v.string()),
+	summary: v.optional(v.string()),
+	error: v.optional(ManifestError),
+	docgen: v.optional(JsonRef),
+	stories: v.optional(JsonRef),
+	docs: v.optional(v.record(v.string(), DocV1)),
+});
+export type ComponentManifestV1 = v.InferOutput<typeof ComponentManifestV1>;
+
+export const ComponentManifestMapV1 = v.object({
+	v: v.literal(1),
+	components: v.record(v.string(), ComponentManifestV1),
+});
+export type ComponentManifestMapV1 = v.InferOutput<typeof ComponentManifestMapV1>;
+
+export const DocsManifestMapV1 = v.object({
+	v: v.literal(1),
+	docs: v.record(v.string(), DocV1),
+});
+export type DocsManifestMapV1 = v.InferOutput<typeof DocsManifestMapV1>;
+
+// ---- discriminated unions (the wire schema for top-level manifests) ----
+
+/** `components.json`, discriminated on `v` (0 = inline, 1 = split/ref). */
+export const ComponentManifestMap = v.variant('v', [
+	ComponentManifestMapV0,
+	ComponentManifestMapV1,
+]);
 export type ComponentManifestMap = v.InferOutput<typeof ComponentManifestMap>;
 
 /**
- * Manifest for unattached/standalone documentation entries.
- * Served at /manifests/docs.json
+ * `docs.json` for unattached/standalone documentation entries (served at
+ * `/manifests/docs.json`), discriminated on `v`.
  */
-export const DocsManifestMap = v.object({
-	v: v.number(),
-	docs: v.record(v.string(), Doc),
-});
+export const DocsManifestMap = v.variant('v', [DocsManifestMapV0, DocsManifestMapV1]);
 export type DocsManifestMap = v.InferOutput<typeof DocsManifestMap>;
+
+// ---- working / resolved types ----
+
+/**
+ * A component index row as it appears in either format: inline (v0) or shallow
+ * ref (v1). This is what {@link resolveComponentEntry} consumes before following any
+ * `$ref`s.
+ */
+export type ComponentManifestEntry = ComponentManifestV0 | ComponentManifestV1;
+
+/** A docs index row as it appears in either format: inline (v0) or shallow ref (v1). */
+export type DocEntry = DocV0 | DocV1;
+
+/**
+ * A fully-resolved component, as consumed by the tools and formatters: inline shape
+ * (stories as an array, attached docs with `content`, docgen inlined). Identical to
+ * the v0 shape — v1 rows are resolved into it by following their `$ref`s
+ * (`resolveComponentEntry`) or built in-process (`adaptCoreComponent`).
+ */
+export type ComponentManifest = ComponentManifestV0;
+
+/** A fully-resolved docs entry (inline `content`), as consumed by tools and formatters. */
+export type Doc = DocV0;
 
 export type AllManifests = {
 	componentManifest: ComponentManifestMap;
 	docsManifest?: DocsManifestMap;
+};
+
+/**
+ * Open-service payload contracts (the "core format") that Storybook's
+ * `experimentalDocgenServer` mode produces. `@storybook/mcp` adapts these into its
+ * internal {@link ComponentManifest}/{@link Doc} shapes in one place
+ * (`adaptCoreComponent`/`adaptCoreDoc`). Defined structurally (not as schemas) so
+ * the addon can build them in-process without importing Storybook core.
+ */
+
+/** One story snippet from the `core/story-docs` service. */
+export type CoreStoryDoc = {
+	id: string;
+	name: string;
+	snippet?: string;
+	description?: string;
+	summary?: string;
+	error?: { name: string; message: string };
+};
+
+/** One MDX doc from the `addon-docs/mdx` service. */
+export type CoreMdxDoc = {
+	id: string;
+	name: string;
+	path?: string;
+	title?: string;
+	content?: string;
+	summary?: string;
+	error?: { name: string; message: string };
+};
+
+/**
+ * Payload returned by the `addon-docs/mdx` service for a component or standalone
+ * docs entry.
+ */
+export type CoreMdxPayload = {
+	id: string;
+	name: string;
+	docs: Record<string, CoreMdxDoc>;
+};
+
+/** Payload returned by the `core/story-docs` service for one component. */
+export type CoreStoryDocsPayload = {
+	id: string;
+	name: string;
+	path: string;
+	import?: string;
+	stories: Record<string, CoreStoryDoc>;
+	error?: { name: string; message: string };
+};
+
+/**
+ * Payload returned by the `core/docgen` service for one component. `argTypes` (a
+ * UI-normalized view) is intentionally ignored by the adapter; prop types come
+ * from `reactComponentMeta`/`react*` fields.
+ */
+export type CoreDocgenPayload = {
+	id: string;
+	name: string;
+	path?: string;
+	description?: string;
+	summary?: string;
+	jsDocTags?: Record<string, string[]>;
+	import?: string;
+	reactComponentMeta?: unknown;
+	reactDocgen?: unknown;
+	reactDocgenTypescript?: unknown;
+	subcomponents?: Record<string, unknown>;
+	error?: { name: string; message: string };
+	[key: string]: unknown;
+};
+
+/**
+ * A component assembled from the `core/docgen` payload plus the `core/story-docs`
+ * stories and resolved attached MDX docs.
+ */
+export type CoreDocgenComponent = CoreDocgenPayload & {
+	import?: string;
+	/** Story snippets, either as a story-docs record or an already-resolved array. */
+	stories?: Record<string, CoreStoryDoc> | Story[];
+	/** Attached docs keyed by doc id (resolved MDX payloads). */
+	docs?: Record<string, CoreMdxDoc>;
 };
 
 /**

--- a/packages/mcp/src/utils/adapt-core-manifest.test.ts
+++ b/packages/mcp/src/utils/adapt-core-manifest.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { adaptCoreComponent, adaptCoreDoc, adaptCoreStories } from './adapt-core-manifest.ts';
+import type { CoreDocgenComponent } from '../types.ts';
+
+describe('adaptCoreStories', () => {
+	it('maps a story-docs record into a Story[]', () => {
+		expect(
+			adaptCoreStories({
+				'button--primary': { id: 'button--primary', name: 'Primary', snippet: '<Button />' },
+				'button--secondary': { id: 'button--secondary', name: 'Secondary' },
+			}),
+		).toEqual([
+			{ id: 'button--primary', name: 'Primary', snippet: '<Button />' },
+			{ id: 'button--secondary', name: 'Secondary' },
+		]);
+	});
+
+	it('returns an already-resolved array unchanged', () => {
+		const stories = [{ name: 'Primary', snippet: '<Button />' }];
+		expect(adaptCoreStories(stories)).toBe(stories);
+	});
+
+	it('returns undefined when there are no stories', () => {
+		expect(adaptCoreStories(undefined)).toBeUndefined();
+	});
+});
+
+describe('adaptCoreDoc', () => {
+	it('keeps optional fields when present and omits them otherwise', () => {
+		expect(
+			adaptCoreDoc({ id: 'intro', name: 'Intro', title: 'Introduction', content: '# Hi' }),
+		).toEqual({ id: 'intro', name: 'Intro', title: 'Introduction', content: '# Hi' });
+
+		expect(adaptCoreDoc({ id: 'intro', name: 'Intro' })).toEqual({ id: 'intro', name: 'Intro' });
+	});
+});
+
+describe('adaptCoreComponent', () => {
+	it('passes reactComponentMeta through and drops argTypes', () => {
+		const core: CoreDocgenComponent = {
+			id: 'button',
+			name: 'Button',
+			path: 'src/Button.tsx',
+			reactComponentMeta: { props: { label: { type: { name: 'string' }, required: true } } },
+			argTypes: { label: { control: 'text' } },
+		};
+
+		const result = adaptCoreComponent(core);
+
+		expect(result.reactComponentMeta).toEqual(core.reactComponentMeta);
+		expect('argTypes' in result).toBe(false);
+		expect(result.path).toBe('src/Button.tsx');
+	});
+
+	it('maps the story-docs record and attached docs into the internal shape', () => {
+		const core: CoreDocgenComponent = {
+			id: 'button',
+			name: 'Button',
+			stories: {
+				'button--primary': { id: 'button--primary', name: 'Primary', snippet: '<Button />' },
+			},
+			import: "import { Button } from './Button'",
+			docs: {
+				'button--docs': { id: 'button--docs', name: 'Docs', title: 'Button', content: '# Button' },
+			},
+		};
+
+		const result = adaptCoreComponent(core);
+
+		expect(result.stories).toEqual([
+			{ id: 'button--primary', name: 'Primary', snippet: '<Button />' },
+		]);
+		expect(result.import).toBe("import { Button } from './Button'");
+		expect(result.docs).toEqual({
+			'button--docs': { id: 'button--docs', name: 'Docs', title: 'Button', content: '# Button' },
+		});
+	});
+
+	it('keeps subcomponents (incl. their reactComponentMeta) intact', () => {
+		const core: CoreDocgenComponent = {
+			id: 'button',
+			name: 'Button',
+			subcomponents: {
+				Icon: { name: 'Icon', path: 'src/Icon.tsx', reactComponentMeta: { props: {} } },
+			},
+		};
+
+		const result = adaptCoreComponent(core);
+		expect(result.subcomponents).toEqual(core.subcomponents);
+	});
+});

--- a/packages/mcp/src/utils/adapt-core-manifest.ts
+++ b/packages/mcp/src/utils/adapt-core-manifest.ts
@@ -1,0 +1,49 @@
+import type { ComponentManifest, CoreDocgenComponent, CoreMdxDoc, Doc, Story } from '../types.ts';
+
+/**
+ * Adapts Storybook's `experimentalDocgenServer` open-service payloads (the "core
+ * format") into `@storybook/mcp`'s internal {@link ComponentManifest}/{@link Doc}
+ * shapes. This is the single place that bridges the two formats, used by both the
+ * ref-resolution path (built/static/remote manifests) and the addon's in-process
+ * `resolveEntry` hook (dev).
+ *
+ * Only `argTypes` is dropped: prop types still come from `reactComponentMeta` and
+ * the `react*` docgen-engine fields, which are passed through unchanged.
+ */
+
+const ARG_TYPES_KEY = 'argTypes';
+
+/** Converts the story-docs `stories` record (or an already-resolved array) into `Story[]`. */
+export function adaptCoreStories(stories: CoreDocgenComponent['stories']): Story[] | undefined {
+	if (!stories) {
+		return undefined;
+	}
+	if (Array.isArray(stories)) {
+		return stories;
+	}
+	return Object.values(stories);
+}
+
+/** Adapts one MDX service payload into a {@link Doc}. */
+export function adaptCoreDoc(doc: CoreMdxDoc): Doc {
+	return { ...doc };
+}
+
+/** Adapts a core-format component (docgen + story-docs + attached MDX) into a {@link ComponentManifest}. */
+export function adaptCoreComponent(core: CoreDocgenComponent): ComponentManifest {
+	const { stories, docs, [ARG_TYPES_KEY]: _argTypes, ...rest } = core;
+	const component = { ...rest } as ComponentManifest;
+
+	const adaptedStories = adaptCoreStories(stories);
+	if (adaptedStories) {
+		component.stories = adaptedStories;
+	}
+
+	if (docs) {
+		component.docs = Object.fromEntries(
+			Object.entries(docs).map(([id, doc]) => [id, adaptCoreDoc(doc)]),
+		);
+	}
+
+	return component;
+}

--- a/packages/mcp/src/utils/get-manifest.test.ts
+++ b/packages/mcp/src/utils/get-manifest.test.ts
@@ -4,10 +4,12 @@ import {
 	getMultiSourceManifests,
 	ManifestGetError,
 	parseDocgenRef,
-	resolveComponentDocgen,
+	resolveComponentEntry,
+	resolveComponentStories,
+	resolveDoc,
 	RequiresOwnMcpError,
 } from './get-manifest.ts';
-import type { ComponentManifest } from '../types.ts';
+import type { ComponentManifest, ComponentManifestV1, Doc, DocV1 } from '../types.ts';
 import type { ComponentManifestMap, DocsManifestMap, Source } from '../types.ts';
 
 global.fetch = vi.fn();
@@ -256,7 +258,7 @@ Invalid key: Expected "components" but received undefined]`);
 	describe('success cases', () => {
 		it('should successfully fetch and parse a valid manifest', async () => {
 			const validManifest: ComponentManifestMap = {
-				v: 1,
+				v: 0,
 				components: {
 					button: {
 						id: 'button',
@@ -286,7 +288,7 @@ Invalid key: Expected "components" but received undefined]`);
 			['http://localhost:6006/custom-mcp', 'http://localhost:6006'],
 		])('should derive manifest URLs from the request origin for %s', async (requestUrl, origin) => {
 			const validManifest: ComponentManifestMap = {
-				v: 1,
+				v: 0,
 				components: {
 					button: {
 						id: 'button',
@@ -309,7 +311,7 @@ Invalid key: Expected "components" but received undefined]`);
 
 		it('should successfully fetch and parse both component and docs manifests', async () => {
 			const validComponentManifest: ComponentManifestMap = {
-				v: 1,
+				v: 0,
 				components: {
 					button: {
 						id: 'button',
@@ -320,9 +322,9 @@ Invalid key: Expected "components" but received undefined]`);
 				},
 			};
 
-			const validDocsManifest: DocsManifestMap = {
-				v: 1,
-				docs: {
+		const validDocsManifest: DocsManifestMap = {
+			v: 0,
+			docs: {
 					'getting-started': {
 						id: 'getting-started',
 						name: 'Getting Started',
@@ -352,7 +354,7 @@ Invalid key: Expected "components" but received undefined]`);
 	describe('manifestProvider', () => {
 		it('should use manifestProvider when provided', async () => {
 			const validManifest: ComponentManifestMap = {
-				v: 1,
+				v: 0,
 				components: {
 					button: {
 						id: 'button',
@@ -384,7 +386,7 @@ Invalid key: Expected "components" but received undefined]`);
 
 		it('should allow manifestProvider to work without request', async () => {
 			const validManifest: ComponentManifestMap = {
-				v: 1,
+				v: 0,
 				components: {
 					button: {
 						id: 'button',
@@ -414,7 +416,7 @@ Invalid key: Expected "components" but received undefined]`);
 
 		it('should fallback to fetch when manifestProvider is not provided', async () => {
 			const validManifest: ComponentManifestMap = {
-				v: 1,
+				v: 0,
 				components: {
 					button: {
 						id: 'button',
@@ -466,7 +468,7 @@ Invalid key: Expected "components" but received undefined]`);
 		};
 
 		const localManifest: ComponentManifestMap = {
-			v: 1,
+			v: 0,
 			components: {
 				button: {
 					id: 'button',
@@ -477,7 +479,7 @@ Invalid key: Expected "components" but received undefined]`);
 		};
 
 		const remoteManifest: ComponentManifestMap = {
-			v: 1,
+			v: 0,
 			components: {
 				badge: {
 					id: 'badge',
@@ -625,8 +627,8 @@ describe('parseDocgenRef', () => {
 	});
 });
 
-describe('resolveComponentDocgen', () => {
-	const stub: ComponentManifest = {
+describe('resolveComponentEntry', () => {
+	const stub: ComponentManifestV1 = {
 		id: 'button',
 		name: 'Button',
 		description: 'A button',
@@ -636,7 +638,7 @@ describe('resolveComponentDocgen', () => {
 	it('returns the component unchanged when it has no docgen $ref', async () => {
 		const plain: ComponentManifest = { id: 'button', name: 'Button', path: 'src/Button.tsx' };
 		const provider = vi.fn();
-		await expect(resolveComponentDocgen(plain, undefined, provider)).resolves.toBe(plain);
+		await expect(resolveComponentEntry(plain, undefined, provider)).resolves.toBe(plain);
 		expect(provider).not.toHaveBeenCalled();
 	});
 
@@ -654,7 +656,7 @@ describe('resolveComponentDocgen', () => {
 			}),
 		);
 
-		const resolved = await resolveComponentDocgen(stub, undefined, provider);
+		const resolved = await resolveComponentEntry(stub, undefined, provider);
 
 		// Provider is asked for the resolved (relative) path of the referenced file.
 		expect(provider).toHaveBeenCalledWith(
@@ -670,8 +672,162 @@ describe('resolveComponentDocgen', () => {
 
 	it('throws when the JSON pointer does not resolve', async () => {
 		const provider = vi.fn().mockResolvedValue(JSON.stringify({ components: {} }));
-		await expect(resolveComponentDocgen(stub, undefined, provider)).rejects.toThrow(
+		await expect(resolveComponentEntry(stub, undefined, provider)).rejects.toThrow(
 			ManifestGetError,
 		);
+	});
+});
+
+describe('resolveComponentEntry (split/ref format)', () => {
+	// Provider that serves the per-component service files referenced from the index.
+	const provider = vi.fn(async (_req: Request | undefined, path: string) => {
+		switch (path) {
+			case './services/core/docgen/button.json':
+				return JSON.stringify({
+					components: {
+						button: {
+							id: 'button',
+							name: 'Button',
+							path: 'src/Button.tsx',
+							jsDocTags: {},
+							reactComponentMeta: {
+								props: { label: { type: { name: 'string' }, required: true } },
+							},
+							// argTypes must be dropped by the adapter.
+							argTypes: { label: { control: 'text' } },
+						},
+					},
+				});
+			case './services/core/story-docs/button.json':
+				return JSON.stringify({
+					components: {
+						button: {
+							id: 'button',
+							name: 'Button',
+							path: 'src/Button.tsx',
+							import: "import { Button } from './Button'",
+							stories: {
+								'button--primary': {
+									id: 'button--primary',
+									name: 'Primary',
+									snippet: '<Button />',
+								},
+							},
+						},
+					},
+				});
+			case './services/addon-docs/mdx/button.json':
+				return JSON.stringify({
+					components: {
+						button: {
+							id: 'button',
+							name: 'Button',
+							docs: {
+								'button--docs': {
+									id: 'button--docs',
+									name: 'Docs',
+									title: 'Button',
+									content: '# Button',
+								},
+							},
+						},
+					},
+				});
+			default:
+				throw new ManifestGetError(`unexpected path ${path}`);
+		}
+	});
+
+	beforeEach(() => {
+		provider.mockClear();
+	});
+
+	const indexEntry: ComponentManifestV1 = {
+		id: 'button',
+		name: 'Button',
+		summary: 'A button',
+		docgen: { $ref: '../services/core/docgen/button.json#/components/button' },
+		stories: { $ref: '../services/core/story-docs/button.json#/components/button' },
+		docs: {
+			'button--docs': {
+				id: 'button--docs',
+				name: 'Docs',
+				mdx: {
+					$ref: '../services/addon-docs/mdx/button.json#/components/button/docs/button--docs',
+				},
+			},
+		},
+	};
+
+	it('follows docgen, story-docs and mdx refs and adapts to the internal shape', async () => {
+		const resolved = await resolveComponentEntry(indexEntry, undefined, provider);
+
+		// docgen: reactComponentMeta passed through, argTypes dropped.
+		expect(resolved.reactComponentMeta).toEqual({
+			props: { label: { type: { name: 'string' }, required: true } },
+		});
+		expect('argTypes' in resolved).toBe(false);
+		expect(resolved.path).toBe('src/Button.tsx');
+		// story-docs record -> Story[]
+		expect(resolved.stories).toEqual([
+			{ id: 'button--primary', name: 'Primary', snippet: '<Button />' },
+		]);
+		expect(resolved.import).toBe("import { Button } from './Button'");
+		// mdx ref row -> resolved Doc
+		expect(resolved.docs?.['button--docs']).toEqual({
+			id: 'button--docs',
+			name: 'Docs',
+			title: 'Button',
+			content: '# Button',
+		});
+		// identity from the index entry is authoritative
+		expect(resolved.id).toBe('button');
+	});
+
+	it('returns inline (v0) entries unchanged without calling the provider', async () => {
+		const inline: ComponentManifest = {
+			id: 'button',
+			name: 'Button',
+			stories: [{ name: 'Primary', snippet: '<Button />' }],
+		};
+		const localProvider = vi.fn();
+		await expect(resolveComponentEntry(inline, undefined, localProvider)).resolves.toBe(inline);
+		expect(localProvider).not.toHaveBeenCalled();
+	});
+
+	it('resolveComponentStories follows only the stories ref', async () => {
+		const resolved = await resolveComponentStories(indexEntry, undefined, provider);
+		expect(resolved.stories).toEqual([
+			{ id: 'button--primary', name: 'Primary', snippet: '<Button />' },
+		]);
+		// Only the story-docs file is fetched (not docgen/mdx).
+		expect(provider).toHaveBeenCalledTimes(1);
+		expect(provider).toHaveBeenCalledWith(
+			undefined,
+			'./services/core/story-docs/button.json',
+			undefined,
+		);
+	});
+
+	it('resolveDoc follows a standalone doc mdx ref', async () => {
+		const docRow: DocV1 = {
+			id: 'button--docs',
+			name: 'Docs',
+			mdx: { $ref: '../services/addon-docs/mdx/button.json#/components/button/docs/button--docs' },
+		};
+		const resolved = await resolveDoc(docRow, undefined, provider);
+		expect(resolved).toEqual({
+			id: 'button--docs',
+			name: 'Docs',
+			title: 'Button',
+			content: '# Button',
+		});
+	});
+
+	it('resolveDoc returns inline docs unchanged', async () => {
+		const inlineDoc: Doc = { id: 'intro', name: 'Intro', title: 'Intro', content: '# Hi' };
+		const localProvider = vi.fn();
+		await expect(resolveDoc(inlineDoc, undefined, localProvider)).resolves.toBe(inlineDoc);
+		expect(localProvider).not.toHaveBeenCalled();
 	});
 });

--- a/packages/mcp/src/utils/get-manifest.test.ts
+++ b/packages/mcp/src/utils/get-manifest.test.ts
@@ -3,7 +3,7 @@ import {
 	getManifests,
 	getMultiSourceManifests,
 	ManifestGetError,
-	parseDocgenRef,
+	parseManifestRef,
 	resolveComponentEntry,
 	resolveComponentStories,
 	resolveDoc,
@@ -604,23 +604,23 @@ Invalid key: Expected "components" but received undefined]`);
 	});
 });
 
-describe('parseDocgenRef', () => {
+describe('parseManifestRef', () => {
 	it('resolves a `../`-prefixed ref relative to the component manifest location', () => {
-		expect(parseDocgenRef('../services/core/docgen/button.json#/components/button')).toEqual({
+		expect(parseManifestRef('../services/core/docgen/button.json#/components/button')).toEqual({
 			path: './services/core/docgen/button.json',
 			pointer: ['components', 'button'],
 		});
 	});
 
 	it('resolves a sibling ref within the manifests directory', () => {
-		expect(parseDocgenRef('./button.json#/components/button')).toEqual({
+		expect(parseManifestRef('./button.json#/components/button')).toEqual({
 			path: './manifests/button.json',
 			pointer: ['components', 'button'],
 		});
 	});
 
 	it('decodes JSON-pointer escape sequences', () => {
-		expect(parseDocgenRef('../x.json#/a~1b/c~0d')).toEqual({
+		expect(parseManifestRef('../x.json#/a~1b/c~0d')).toEqual({
 			path: './x.json',
 			pointer: ['a/b', 'c~d'],
 		});

--- a/packages/mcp/src/utils/get-manifest.test.ts
+++ b/packages/mcp/src/utils/get-manifest.test.ts
@@ -322,9 +322,9 @@ Invalid key: Expected "components" but received undefined]`);
 				},
 			};
 
-		const validDocsManifest: DocsManifestMap = {
-			v: 0,
-			docs: {
+			const validDocsManifest: DocsManifestMap = {
+				v: 0,
+				docs: {
 					'getting-started': {
 						id: 'getting-started',
 						name: 'Getting Started',

--- a/packages/mcp/src/utils/get-manifest.ts
+++ b/packages/mcp/src/utils/get-manifest.ts
@@ -219,7 +219,7 @@ export async function getManifests(
  * with pointer `["components", "button"]`. The same base (`manifests/`) applies to
  * docgen, story-docs and MDX refs.
  */
-export function parseDocgenRef(ref: string): { path: string; pointer: string[] } {
+export function parseManifestRef(ref: string): { path: string; pointer: string[] } {
 	const [filePath = '', hash = ''] = ref.split('#');
 
 	// Directory of the component manifest (e.g. "manifests/"), used as the base for
@@ -248,7 +248,7 @@ async function fetchRefValue<T>(
 	provider: ManifestProvider,
 	source: Source | undefined,
 ): Promise<T> {
-	const { path, pointer } = parseDocgenRef(ref);
+	const { path, pointer } = parseManifestRef(ref);
 	const jsonString = await provider(request, path, source);
 
 	let target: unknown;
@@ -313,6 +313,7 @@ export async function resolveComponentEntry(
 		name: component.name,
 		...(component.description !== undefined ? { description: component.description } : {}),
 		...(component.summary !== undefined ? { summary: component.summary } : {}),
+		...(component.error !== undefined ? { error: component.error } : {}),
 	};
 
 	if (docgenRef) {
@@ -324,6 +325,7 @@ export async function resolveComponentEntry(
 			name: component.name,
 			...(component.description !== undefined ? { description: component.description } : {}),
 			...(component.summary !== undefined ? { summary: component.summary } : {}),
+			...(component.error !== undefined ? { error: component.error } : {}),
 		};
 	}
 

--- a/packages/mcp/src/utils/get-manifest.ts
+++ b/packages/mcp/src/utils/get-manifest.ts
@@ -321,7 +321,9 @@ export async function resolveComponentEntry(
 			...core,
 			...payload,
 			id: component.id,
-			name: payload.name ?? component.name,
+			name: component.name,
+			...(component.description !== undefined ? { description: component.description } : {}),
+			...(component.summary !== undefined ? { summary: component.summary } : {}),
 		};
 	}
 

--- a/packages/mcp/src/utils/get-manifest.ts
+++ b/packages/mcp/src/utils/get-manifest.ts
@@ -1,12 +1,20 @@
 import {
-	ComponentManifest,
 	ComponentManifestMap,
 	DocsManifestMap,
 	type AllManifests,
+	type ComponentManifest,
+	type ComponentManifestEntry,
+	type CoreDocgenComponent,
+	type CoreDocgenPayload,
+	type CoreMdxDoc,
+	type CoreStoryDocsPayload,
+	type Doc,
+	type DocEntry,
 	type Source,
 	type SourceManifests,
 } from '../types.ts';
 import * as v from 'valibot';
+import { adaptCoreComponent, adaptCoreDoc, adaptCoreStories } from './adapt-core-manifest.ts';
 import { formatRequiresOwnMcpNotice, getSourceMcpEndpoint } from './requires-own-mcp.ts';
 
 type SourceWithUrl = Source & { url: string };
@@ -22,6 +30,9 @@ type ManifestProvider = (
  */
 export const COMPONENT_MANIFEST_PATH = './manifests/components.json';
 export const DOCS_MANIFEST_PATH = './manifests/docs.json';
+
+/** Empty placeholder manifest used for sources that errored or need their own MCP endpoint. */
+const EMPTY_COMPONENT_MANIFEST: ComponentManifestMap = { v: 1, components: {} };
 
 /**
  * Error thrown when getting or parsing a manifest fails
@@ -199,13 +210,14 @@ export async function getManifests(
 }
 
 /**
- * Resolves a docgen `$ref` into the provider path of the referenced file and the
+ * Resolves a `$ref` into the provider path of the referenced file and the
  * JSON-pointer segments into it.
  *
  * The `$ref` file path is relative to the component manifest's location, e.g.
  * `"../services/core/docgen/button.json#/components/button"` from
  * `./manifests/components.json` resolves to `./services/core/docgen/button.json`
- * with pointer `["components", "button"]`.
+ * with pointer `["components", "button"]`. The same base (`manifests/`) applies to
+ * docgen, story-docs and MDX refs.
  */
 export function parseDocgenRef(ref: string): { path: string; pointer: string[] } {
 	const [filePath = '', hash = ''] = ref.split('#');
@@ -227,23 +239,16 @@ export function parseDocgenRef(ref: string): { path: string; pointer: string[] }
 }
 
 /**
- * Resolves a stub component (externalized-docgen manifest format) into a full
- * component manifest by fetching the referenced docgen file and reading the
- * pointed-to entry. Components without a `docgen.$ref` are returned unchanged.
+ * Fetches the file a `$ref` points at (verbatim — never a fabricated path) and
+ * walks its JSON pointer, returning the pointed-to value.
  */
-export async function resolveComponentDocgen(
-	component: ComponentManifest,
-	request?: Request,
-	manifestProvider?: ManifestProvider,
-	source?: Source,
-): Promise<ComponentManifest> {
-	const ref = component.docgen?.$ref;
-	if (!ref) {
-		return component;
-	}
-
+async function fetchRefValue<T>(
+	ref: string,
+	request: Request | undefined,
+	provider: ManifestProvider,
+	source: Source | undefined,
+): Promise<T> {
 	const { path, pointer } = parseDocgenRef(ref);
-	const provider = manifestProvider ?? defaultManifestProvider;
 	const jsonString = await provider(request, path, source);
 
 	let target: unknown;
@@ -251,7 +256,7 @@ export async function resolveComponentDocgen(
 		target = JSON.parse(jsonString);
 	} catch (error) {
 		throw new ManifestGetError(
-			`Failed to parse externalized docgen referenced by "${ref}"`,
+			`Failed to parse externalized payload referenced by "${ref}"`,
 			path,
 			error instanceof Error ? error : undefined,
 		);
@@ -262,22 +267,152 @@ export async function resolveComponentDocgen(
 			target = (target as Record<string, unknown>)[key];
 		} else {
 			throw new ManifestGetError(
-				`Docgen reference "${ref}" could not be resolved: missing "${key}".`,
+				`Reference "${ref}" could not be resolved: missing "${key}".`,
 				path,
 			);
 		}
 	}
 
-	const resolved = parseManifest({
-		jsonString: JSON.stringify(target),
-		schema: ComponentManifest,
-		name: 'component docgen',
-		url: path,
-	});
+	return target as T;
+}
 
-	// Stub fields (id/name/description) are authoritative for identity; the resolved
-	// entry supplies path/stories/docgen data.
-	return { ...component, ...resolved };
+/**
+ * Resolves a component index entry into a full component manifest by following any
+ * `$ref`s it carries (docgen, story-docs, attached MDX docs), then adapting the
+ * core-format payloads into `@storybook/mcp`'s internal shape.
+ *
+ * Refs are read verbatim from the entry — never fabricated from an id — so a
+ * provider is only ever asked for top-level manifest paths or paths a manifest
+ * already pointed at. Components without any `$ref` (inline/v0 format, or entries
+ * already resolved in-process) are returned unchanged.
+ */
+export async function resolveComponentEntry(
+	component: ComponentManifestEntry,
+	request?: Request,
+	manifestProvider?: ManifestProvider,
+	source?: Source,
+): Promise<ComponentManifest> {
+	const docgenRef = 'docgen' in component ? component.docgen?.$ref : undefined;
+	const storiesRef =
+		component.stories && !Array.isArray(component.stories) ? component.stories.$ref : undefined;
+	const docEntries: [string, DocEntry][] = component.docs ? Object.entries(component.docs) : [];
+	const docRefs = docEntries.filter(([, doc]) => 'mdx' in doc && !!doc.mdx?.$ref);
+
+	if (!docgenRef && !storiesRef && docRefs.length === 0) {
+		// No `$ref`s to follow: this is an inline (v0) entry already in resolved form
+		// (or a v1 row with nothing to resolve).
+		return component as ComponentManifest;
+	}
+
+	const provider = manifestProvider ?? defaultManifestProvider;
+
+	// Identity fields from the index entry are authoritative; the docgen payload
+	// supplies path/props/jsDocTags/subcomponents.
+	let core: CoreDocgenComponent = {
+		id: component.id,
+		name: component.name,
+		...(component.description !== undefined ? { description: component.description } : {}),
+		...(component.summary !== undefined ? { summary: component.summary } : {}),
+	};
+
+	if (docgenRef) {
+		const payload = await fetchRefValue<CoreDocgenPayload>(docgenRef, request, provider, source);
+		core = {
+			...core,
+			...payload,
+			id: component.id,
+			name: payload.name ?? component.name,
+		};
+	}
+
+	// Preserve inline stories (mixed/v0) when there's no story-docs ref to follow.
+	if (Array.isArray(component.stories)) {
+		core.stories = component.stories;
+	}
+
+	if (storiesRef) {
+		const storyDocs = await fetchRefValue<CoreStoryDocsPayload | null>(
+			storiesRef,
+			request,
+			provider,
+			source,
+		);
+		if (storyDocs?.stories) {
+			core.stories = storyDocs.stories;
+		}
+		if (storyDocs?.import) {
+			core.import = storyDocs.import;
+		}
+	}
+
+	if (docEntries.length > 0) {
+		const docs: Record<string, CoreMdxDoc> = {};
+		for (const [docId, doc] of docEntries) {
+			const mdxRef = 'mdx' in doc ? doc.mdx?.$ref : undefined;
+			docs[docId] = mdxRef
+				? await fetchRefValue<CoreMdxDoc>(mdxRef, request, provider, source)
+				: (doc as CoreMdxDoc);
+		}
+		core.docs = docs;
+	}
+
+	return adaptCoreComponent(core);
+}
+
+/**
+ * Resolves only a component's stories `$ref` (story-docs payload) into a `Story[]`,
+ * leaving docgen/docs refs untouched. Used by `list-all-documentation` when story
+ * ids are requested, so listing doesn't pay for docgen/MDX resolution it won't show.
+ */
+export async function resolveComponentStories(
+	component: ComponentManifestEntry,
+	request?: Request,
+	manifestProvider?: ManifestProvider,
+	source?: Source,
+): Promise<ComponentManifest> {
+	if (!component.stories || Array.isArray(component.stories)) {
+		// Already inline (v0) or no stories: nothing to follow.
+		return component as ComponentManifest;
+	}
+
+	const provider = manifestProvider ?? defaultManifestProvider;
+	const storyDocs = await fetchRefValue<CoreStoryDocsPayload | null>(
+		component.stories.$ref,
+		request,
+		provider,
+		source,
+	);
+
+	return {
+		...component,
+		stories: storyDocs?.stories ? adaptCoreStories(storyDocs.stories) : [],
+	} as ComponentManifest;
+}
+
+/**
+ * Resolves a standalone docs entry, following its `mdx.$ref` when present.
+ * Inline docs (v0) are returned unchanged.
+ */
+export async function resolveDoc(
+	doc: DocEntry,
+	request?: Request,
+	manifestProvider?: ManifestProvider,
+	source?: Source,
+): Promise<Doc> {
+	const ref = 'mdx' in doc ? doc.mdx?.$ref : undefined;
+	if (!ref) {
+		// Inline (v0) doc, already in resolved form.
+		return doc as Doc;
+	}
+
+	const provider = manifestProvider ?? defaultManifestProvider;
+	const payload = await fetchRefValue<CoreMdxDoc>(ref, request, provider, source);
+
+	return adaptCoreDoc({
+		...payload,
+		id: payload.id ?? doc.id,
+		name: payload.name ?? doc.name,
+	});
 }
 
 /**
@@ -356,7 +491,7 @@ export async function getMultiSourceManifests(
 				if (error instanceof RequiresOwnMcpError) {
 					return {
 						source,
-						componentManifest: { v: 1, components: {} },
+						componentManifest: EMPTY_COMPONENT_MANIFEST,
 						notice: {
 							kind: 'requires-own-mcp' as const,
 							endpoint: error.endpoint,
@@ -366,7 +501,7 @@ export async function getMultiSourceManifests(
 				const errorMessage = error instanceof Error ? error.message : String(error);
 				return {
 					source,
-					componentManifest: { v: 1, components: {} },
+					componentManifest: EMPTY_COMPONENT_MANIFEST,
 					error: errorMessage,
 				};
 			}

--- a/packages/mcp/src/utils/manifest-formatter/markdown.test.ts
+++ b/packages/mcp/src/utils/manifest-formatter/markdown.test.ts
@@ -1103,7 +1103,7 @@ describe('MarkdownFormatter - formatManifestsToLists', () => {
 		it('should format a single component', () => {
 			const manifests: AllManifests = {
 				componentManifest: {
-					v: 1,
+					v: 0,
 					components: {
 						button: {
 							id: 'button',
@@ -1126,7 +1126,7 @@ describe('MarkdownFormatter - formatManifestsToLists', () => {
 		it('should format multiple components', () => {
 			const manifests: AllManifests = {
 				componentManifest: {
-					v: 1,
+					v: 0,
 					components: {
 						button: {
 							id: 'button',
@@ -1161,7 +1161,7 @@ describe('MarkdownFormatter - formatManifestsToLists', () => {
 		it('should include story sub-bullets when withStoryIds is true', () => {
 			const manifests: AllManifests = {
 				componentManifest: {
-					v: 1,
+					v: 0,
 					components: {
 						button: {
 							id: 'button',
@@ -1192,7 +1192,7 @@ describe('MarkdownFormatter - formatManifestsToLists', () => {
 		it('should include summary when provided', () => {
 			const manifests: AllManifests = {
 				componentManifest: {
-					v: 1,
+					v: 0,
 					components: {
 						button: {
 							id: 'button',
@@ -1216,7 +1216,7 @@ describe('MarkdownFormatter - formatManifestsToLists', () => {
 		it('should prefer summary over description', () => {
 			const manifests: AllManifests = {
 				componentManifest: {
-					v: 1,
+					v: 0,
 					components: {
 						button: {
 							id: 'button',
@@ -1238,7 +1238,7 @@ describe('MarkdownFormatter - formatManifestsToLists', () => {
 		it('should use description when summary is not provided', () => {
 			const manifests: AllManifests = {
 				componentManifest: {
-					v: 1,
+					v: 0,
 					components: {
 						button: {
 							id: 'button',
@@ -1262,7 +1262,7 @@ describe('MarkdownFormatter - formatManifestsToLists', () => {
 		it('should truncate long descriptions to 90 characters', () => {
 			const manifests: AllManifests = {
 				componentManifest: {
-					v: 1,
+					v: 0,
 					components: {
 						button: {
 							id: 'button',
@@ -1288,7 +1288,7 @@ describe('MarkdownFormatter - formatManifestsToLists', () => {
 		it('should not truncate descriptions under 90 characters', () => {
 			const manifests: AllManifests = {
 				componentManifest: {
-					v: 1,
+					v: 0,
 					components: {
 						button: {
 							id: 'button',
@@ -1309,7 +1309,7 @@ describe('MarkdownFormatter - formatManifestsToLists', () => {
 		it('should omit summary when neither summary nor description provided', () => {
 			const manifests: AllManifests = {
 				componentManifest: {
-					v: 1,
+					v: 0,
 					components: {
 						button: {
 							id: 'button',
@@ -1334,7 +1334,7 @@ describe('MarkdownFormatter - formatManifestsToLists', () => {
 		it('should include docs section when docsManifest is provided', () => {
 			const manifests: AllManifests = {
 				componentManifest: {
-					v: 1,
+					v: 0,
 					components: {
 						button: {
 							id: 'button',
@@ -1344,7 +1344,7 @@ describe('MarkdownFormatter - formatManifestsToLists', () => {
 					},
 				},
 				docsManifest: {
-					v: 1,
+					v: 0,
 					docs: {
 						'getting-started': {
 							id: 'getting-started',
@@ -1373,7 +1373,7 @@ describe('MarkdownFormatter - formatManifestsToLists', () => {
 		it('should format multiple docs entries', () => {
 			const manifests: AllManifests = {
 				componentManifest: {
-					v: 1,
+					v: 0,
 					components: {
 						button: {
 							id: 'button',
@@ -1383,7 +1383,7 @@ describe('MarkdownFormatter - formatManifestsToLists', () => {
 					},
 				},
 				docsManifest: {
-					v: 1,
+					v: 0,
 					docs: {
 						'getting-started': {
 							id: 'getting-started',
@@ -1414,7 +1414,7 @@ describe('MarkdownFormatter - formatManifestsToLists', () => {
 		it('should omit docs section when docsManifest is not provided', () => {
 			const manifests: AllManifests = {
 				componentManifest: {
-					v: 1,
+					v: 0,
 					components: {
 						button: {
 							id: 'button',
@@ -1433,7 +1433,7 @@ describe('MarkdownFormatter - formatManifestsToLists', () => {
 		it('should use doc.summary when provided instead of extracting from content', () => {
 			const manifests: AllManifests = {
 				componentManifest: {
-					v: 1,
+					v: 0,
 					components: {
 						button: {
 							id: 'button',
@@ -1443,7 +1443,7 @@ describe('MarkdownFormatter - formatManifestsToLists', () => {
 					},
 				},
 				docsManifest: {
-					v: 1,
+					v: 0,
 					docs: {
 						'custom-summary': {
 							id: 'custom-summary',
@@ -1474,7 +1474,7 @@ describe('MarkdownFormatter - formatManifestsToLists', () => {
 		it('should extract summary from content when doc.summary is not provided', () => {
 			const manifests: AllManifests = {
 				componentManifest: {
-					v: 1,
+					v: 0,
 					components: {
 						button: {
 							id: 'button',
@@ -1484,7 +1484,7 @@ describe('MarkdownFormatter - formatManifestsToLists', () => {
 					},
 				},
 				docsManifest: {
-					v: 1,
+					v: 0,
 					docs: {
 						'auto-summary': {
 							id: 'auto-summary',

--- a/packages/mcp/src/utils/manifest-formatter/markdown.ts
+++ b/packages/mcp/src/utils/manifest-formatter/markdown.ts
@@ -1,8 +1,10 @@
 import type {
 	AllManifests,
 	ComponentManifest,
+	ComponentManifestEntry,
 	SubcomponentManifest,
 	Doc,
+	DocEntry,
 	SourceManifests,
 	Story,
 } from '../../types.ts';
@@ -26,7 +28,7 @@ type ListFormattingOptions = {
 	withStoryIds?: boolean;
 };
 
-function formatComponentLine(component: ComponentManifest): string {
+function formatComponentLine(component: ComponentManifestEntry): string {
 	const summary =
 		component.summary ??
 		(component.description
@@ -41,9 +43,12 @@ function formatComponentLine(component: ComponentManifest): string {
 	return `- ${component.name} (${component.id})`;
 }
 
-function formatDocLine(doc: Doc): string {
-	const summary = doc.summary ?? extractDocsSummary(doc.content);
-	return `- ${doc.title} (${doc.id})${summary ? `: ${summary}` : ''}`;
+function formatDocLine(doc: DocEntry): string {
+	// `title`/`content` only exist on inline (v0) docs; v1 index rows carry just a summary.
+	const title = 'title' in doc ? doc.title : undefined;
+	const content = 'content' in doc ? doc.content : undefined;
+	const summary = doc.summary ?? extractDocsSummary(content ?? '');
+	return `- ${title ?? doc.name} (${doc.id})${summary ? `: ${summary}` : ''}`;
 }
 
 function formatStorySubLine(story: Story): string {
@@ -240,11 +245,12 @@ export function formatComponentManifest(componentManifest: ComponentManifest): s
 	const parsedDocgen = getParsedDocgen(componentManifest);
 
 	// Stories section
-	if (componentManifest.stories && componentManifest.stories.length > 0) {
+	const stories = Array.isArray(componentManifest.stories) ? componentManifest.stories : [];
+	if (stories.length > 0) {
 		parts.push('## Stories');
 		parts.push('');
 
-		const storiesWithSnippets = componentManifest.stories.filter((s) => s.snippet);
+		const storiesWithSnippets = stories.filter((s) => s.snippet);
 
 		// Check if component has props - if not, show all stories fully
 		const hasProps = parsedDocgen && Object.keys(parsedDocgen.props).length > 0;
@@ -287,7 +293,7 @@ export function formatComponentManifest(componentManifest: ComponentManifest): s
 	// Attached docs section
 	if (componentManifest.docs && Object.keys(componentManifest.docs).length > 0) {
 		const docsWithContent = Object.values(componentManifest.docs).filter(
-			(doc) => doc.content.trim().length > 0,
+			(doc) => (doc.content ?? '').trim().length > 0,
 		);
 
 		if (docsWithContent.length > 0) {
@@ -298,7 +304,7 @@ export function formatComponentManifest(componentManifest: ComponentManifest): s
 				parts.push(`### ${doc.name}`);
 				parts.push('');
 
-				parts.push(doc.content);
+				parts.push(doc.content ?? '');
 				parts.push('');
 			}
 		}
@@ -311,9 +317,9 @@ export function formatComponentManifest(componentManifest: ComponentManifest): s
  * Format a single doc manifest into markdown.
  */
 export function formatDocsManifest(doc: Doc): string {
-	return dedent`# ${doc.title}
+	return dedent`# ${doc.title ?? doc.name}
 
-			${doc.content}`;
+			${doc.content ?? ''}`;
 }
 
 /**
@@ -331,8 +337,8 @@ export function formatManifestsToLists(
 	parts.push('');
 	for (const component of Object.values(manifests.componentManifest.components)) {
 		parts.push(formatComponentLine(component));
-		if (options.withStoryIds) {
-			for (const story of component.stories ?? []) {
+		if (options.withStoryIds && Array.isArray(component.stories)) {
+			for (const story of component.stories) {
 				parts.push(formatStorySubLine(story));
 			}
 		}
@@ -381,8 +387,8 @@ export function formatMultiSourceManifestsToLists(
 			parts.push('');
 			for (const component of components) {
 				parts.push(formatComponentLine(component));
-				if (options.withStoryIds) {
-					for (const story of component.stories ?? []) {
+				if (options.withStoryIds && Array.isArray(component.stories)) {
+					for (const story of component.stories) {
 						parts.push(formatStorySubLine(story));
 					}
 				}
@@ -410,7 +416,9 @@ export function formatStoryDocumentation(
 	componentManifest: ComponentManifest,
 	storyName: string,
 ): string {
-	const story = componentManifest.stories?.find((s) => s.name === storyName);
+	const story = Array.isArray(componentManifest.stories)
+		? componentManifest.stories.find((s) => s.name === storyName)
+		: undefined;
 
 	if (!story || !story.snippet) {
 		return '';

--- a/packages/mcp/src/utils/map-with-concurrency.ts
+++ b/packages/mcp/src/utils/map-with-concurrency.ts
@@ -11,7 +11,7 @@ export async function mapWithConcurrency<T, R>(
 	}
 
 	const concurrency = Math.max(1, Math.min(limit, items.length));
-	const results = new Array<R>(items.length);
+	const results = Array<R>(items.length);
 	let nextIndex = 0;
 
 	async function worker(): Promise<void> {

--- a/packages/mcp/src/utils/map-with-concurrency.ts
+++ b/packages/mcp/src/utils/map-with-concurrency.ts
@@ -1,0 +1,26 @@
+/**
+ * Maps `items` with at most `limit` concurrent in-flight `fn` calls.
+ */
+export async function mapWithConcurrency<T, R>(
+	items: readonly T[],
+	limit: number,
+	fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+	if (items.length === 0) {
+		return [];
+	}
+
+	const concurrency = Math.max(1, Math.min(limit, items.length));
+	const results = new Array<R>(items.length);
+	let nextIndex = 0;
+
+	async function worker(): Promise<void> {
+		while (nextIndex < items.length) {
+			const index = nextIndex++;
+			results[index] = await fn(items[index]!, index);
+		}
+	}
+
+	await Promise.all(Array.from({ length: concurrency }, () => worker()));
+	return results;
+}

--- a/packages/mcp/src/utils/map-with-concurrency.ts
+++ b/packages/mcp/src/utils/map-with-concurrency.ts
@@ -10,7 +10,10 @@ export async function mapWithConcurrency<T, R>(
 		return [];
 	}
 
-	const concurrency = Math.max(1, Math.min(limit, items.length));
+	// Guard against a non-finite `limit` (e.g. NaN), which would otherwise make
+	// `concurrency` NaN and spawn zero workers, leaving results unfilled.
+	const safeLimit = Number.isFinite(limit) ? limit : items.length;
+	const concurrency = Math.max(1, Math.min(safeLimit, items.length));
 	const results = Array<R>(items.length);
 	let nextIndex = 0;
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,19 +6,19 @@ packages:
   - '!eval/tasks/*/trials/*/project'
 
 catalog:
-  '@storybook/addon-a11y': 0.0.0-pr-35189-sha-1274cb62
-  '@storybook/addon-docs': 0.0.0-pr-35189-sha-1274cb62
-  '@storybook/addon-themes': 0.0.0-pr-35189-sha-1274cb62
-  '@storybook/addon-vitest': 0.0.0-pr-35189-sha-1274cb62
-  '@storybook/react-vite': 0.0.0-pr-35189-sha-1274cb62
+  '@storybook/addon-a11y': 10.5.0-alpha.8
+  '@storybook/addon-docs': 10.5.0-alpha.8
+  '@storybook/addon-themes': 10.5.0-alpha.8
+  '@storybook/addon-vitest': 10.5.0-alpha.8
+  '@storybook/react-vite': 10.5.0-alpha.8
   '@types/semver': 7.7.1
   '@tmcp/adapter-valibot': ^0.1.5
   '@tmcp/transport-http': ^0.8.5
   '@tmcp/transport-stdio': ^0.4.3
   '@vitest/browser-playwright': 4.0.6
-  eslint-plugin-storybook: 0.0.0-pr-35189-sha-1274cb62
+  eslint-plugin-storybook: 10.5.0-alpha.8
   playwright: 1.56.1
-  storybook: 0.0.0-pr-35189-sha-1274cb62
+  storybook: 10.5.0-alpha.8
   tmcp: ^1.19.4
   semver: 7.8.1
   tsdown: ^0.15.12
@@ -30,10 +30,10 @@ catalog:
 catalogs:
   trials:
     '@eslint/js': 9.39.1
-    '@storybook/addon-a11y': 0.0.0-pr-35189-sha-1274cb62
-    '@storybook/addon-docs': 0.0.0-pr-35189-sha-1274cb62
-    '@storybook/addon-vitest': 0.0.0-pr-35189-sha-1274cb62
-    '@storybook/react-vite': 0.0.0-pr-35189-sha-1274cb62
+    '@storybook/addon-a11y': 10.5.0-alpha.8
+    '@storybook/addon-docs': 10.5.0-alpha.8
+    '@storybook/addon-vitest': 10.5.0-alpha.8
+    '@storybook/react-vite': 10.5.0-alpha.8
     '@types/node': 24.10.1
     '@types/react': 19.2.6
     '@types/react-dom': 19.2.3
@@ -42,11 +42,11 @@ catalogs:
     eslint: 9.39.1
     eslint-plugin-react-hooks: 7.0.1
     eslint-plugin-react-refresh: 0.4.24
-    eslint-plugin-storybook: 0.0.0-pr-35189-sha-1274cb62
+    eslint-plugin-storybook: 10.5.0-alpha.8
     globals: 16.5.0
     react: 19.2.0
     react-dom: 19.2.0
-    storybook: 0.0.0-pr-35189-sha-1274cb62
+    storybook: 10.5.0-alpha.8
     typescript: 5.9.3
     typescript-eslint: 8.47.0
     vite: 7.2.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,19 +6,19 @@ packages:
   - '!eval/tasks/*/trials/*/project'
 
 catalog:
-  '@storybook/addon-a11y': 10.5.0-alpha.7
-  '@storybook/addon-docs': 10.5.0-alpha.7
-  '@storybook/addon-themes': 10.5.0-alpha.7
-  '@storybook/addon-vitest': 10.5.0-alpha.7
-  '@storybook/react-vite': 10.5.0-alpha.7
+  '@storybook/addon-a11y': 0.0.0-pr-35189-sha-1274cb62
+  '@storybook/addon-docs': 0.0.0-pr-35189-sha-1274cb62
+  '@storybook/addon-themes': 0.0.0-pr-35189-sha-1274cb62
+  '@storybook/addon-vitest': 0.0.0-pr-35189-sha-1274cb62
+  '@storybook/react-vite': 0.0.0-pr-35189-sha-1274cb62
   '@types/semver': 7.7.1
   '@tmcp/adapter-valibot': ^0.1.5
   '@tmcp/transport-http': ^0.8.5
   '@tmcp/transport-stdio': ^0.4.3
   '@vitest/browser-playwright': 4.0.6
-  eslint-plugin-storybook: 10.5.0-alpha.7
+  eslint-plugin-storybook: 0.0.0-pr-35189-sha-1274cb62
   playwright: 1.56.1
-  storybook: 10.5.0-alpha.7
+  storybook: 0.0.0-pr-35189-sha-1274cb62
   tmcp: ^1.19.4
   semver: 7.8.1
   tsdown: ^0.15.12
@@ -30,10 +30,10 @@ catalog:
 catalogs:
   trials:
     '@eslint/js': 9.39.1
-    '@storybook/addon-a11y': 10.5.0-alpha.7
-    '@storybook/addon-docs': 10.5.0-alpha.7
-    '@storybook/addon-vitest': 10.5.0-alpha.7
-    '@storybook/react-vite': 10.5.0-alpha.7
+    '@storybook/addon-a11y': 0.0.0-pr-35189-sha-1274cb62
+    '@storybook/addon-docs': 0.0.0-pr-35189-sha-1274cb62
+    '@storybook/addon-vitest': 0.0.0-pr-35189-sha-1274cb62
+    '@storybook/react-vite': 0.0.0-pr-35189-sha-1274cb62
     '@types/node': 24.10.1
     '@types/react': 19.2.6
     '@types/react-dom': 19.2.3
@@ -42,11 +42,11 @@ catalogs:
     eslint: 9.39.1
     eslint-plugin-react-hooks: 7.0.1
     eslint-plugin-react-refresh: 0.4.24
-    eslint-plugin-storybook: 10.5.0-alpha.7
+    eslint-plugin-storybook: 0.0.0-pr-35189-sha-1274cb62
     globals: 16.5.0
     react: 19.2.0
     react-dom: 19.2.0
-    storybook: 10.5.0-alpha.7
+    storybook: 0.0.0-pr-35189-sha-1274cb62
     typescript: 5.9.3
     typescript-eslint: 8.47.0
     vite: 7.2.2


### PR DESCRIPTION
## TL;DR

Adds support for Storybook's split/ref manifest format (`experimentalDocgenServer`): shallow `components.json`/`docs.json` indexes with per-component payloads under `services/`. Manifests are discriminated by `v` (0 = inline, 1 = split/ref). In dev, `addon-mcp` reads open services in-process; `@storybook/mcp` follows `$ref`s for static/remote paths and adapts core-format payloads into its internal shape. Composition works for local docgen-server + remote v0/v1 composed sources.

## Review guide

Read in commit order — each commit is one layer:

| # | Commit | What to review |
|---|--------|----------------|
| 1 | Bump Storybook to docgen-server canary | `pnpm-workspace.yaml` + lockfiles |
| 2 | Split v0/v1 manifest schemas and add core-format adapter | `@storybook/mcp` types, fixtures, `adapt-core-manifest` |
| 3 | Resolve manifest $refs in @storybook/mcp | `get-manifest.ts`, formatters, `bin.ts` |
| 4 | Wire split/ref resolution into docs tools | `get-documentation`, `list-all-documentation`, `resolveEntry` hook |
| 5 | Add in-process manifest provider | `addon-mcp/manifests/` (vendored helpers, service access, provider) |
| 6 | Wire docgen-server mode and fix composition | **highest risk** — `preset.ts`, `composition-auth.ts`, handler wiring |
| 7 | Add composition + docgen-server E2E | internal-storybook config + e2e tests (QA proof) |
| 8 | Support nested services/ paths in self-host | `apps/self-host-mcp/` path resolution + docs |

### Core files (start here)

- `packages/mcp/src/types.ts` — v0/v1 discriminated union schemas
- `packages/mcp/src/utils/get-manifest.ts` — ref following + adaptation entry points
- `packages/addon-mcp/src/manifests/in-process-provider.ts` — dev-mode `manifestProvider` + `resolveEntry`
- `packages/addon-mcp/src/preset.ts` + `composition-auth.ts` — single provider creation site; local docgen-server delegation in composition

### Mechanical / lower risk

- `packages/mcp/fixtures/*` — relabeled inline fixtures from `v: 1` → `v: 0`
- `packages/addon-mcp/src/manifests/vendored.ts` — source-copied core assembly (drift guarded by contract test)
- Lockfile updates from Storybook canary pin

## Architecture

- **Dev (docgen-server)**: `addon-mcp` calls open services in-process; `get-documentation` uses `resolveEntry(id)` for the local source so single lookups never trigger all-docgen. Core 404s `/manifests/*.json` in this mode.
- **Static/remote**: `@storybook/mcp` follows `$ref` strings from fetched indexes — never fabricates paths. v0 entries pass through unchanged (no `$ref`s).
- **Composition**: remote sources fetched over HTTP (v0 or v1); local source delegates to in-process provider when docgen-server is on. Service `$ref` payloads are JSON-sanity-checked, not forced into top-level manifest schemas.
- **Adaptation**: core-format → internal shape in one place (`adapt-core-manifest`).

## Rollout / dependencies

Requires Storybook core with `experimentalDocgenServer` + `componentsManifest` ([storybook PR #35189](https://github.com/storybookjs/storybook/pull/35189) canary `0.0.0-pr-35189-sha-1274cb62`). Validated locally against that canary; CI runs against `10.5.0-alpha.7` and remains green (graceful fallback when open services are absent).

## Test plan

- [x] `pnpm check` — build, lint, typecheck, unit tests
- [x] E2E: single-source MCP endpoint (`mcp-endpoint.e2e.test.ts`)
- [x] E2E: composition with v0 remote (`mcp-composition.e2e.test.ts`)
- [x] E2E: composition + local docgen-server + v0 remote (`mcp-composition-docgen-server.e2e.test.ts`)
- [x] Static build + `bin.ts` over `storybook-static/manifests` + `services/`
- [x] Unit tests: ref resolution, `resolveEntry` hook, in-process provider, vendoring contract, composition auth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for split/ref manifest formats (v0/v1) across documentation retrieval and listing.
  * Enabled an in-process docgen-server mode to resolve local documentation without extra manifest fetches.
  * Enhanced `get-documentation` resolution to support a single-entry resolver and story-level availability.
* **Bug Fixes**
  * Fixed manifest fetching and reference resolution for both local and remote sources, including safer local path handling.
  * Improved robustness when manifest fields are missing or non-array, reducing errors in markdown output.
* **Documentation**
  * Documented split/ref manifest directory layout for self-hosted setups.
* **Tests**
  * Added and updated E2E and contract tests for docgen-server behavior and resolver correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->