### PR TITLE
Align addon module graph queries with Storybook alpha.9

### DIFF
--- a/apps/internal-storybook/pnpm-lock.yaml
+++ b/apps/internal-storybook/pnpm-lock.yaml
@@ -7,20 +7,20 @@ settings:
 catalogs:
   default:
     '@storybook/addon-a11y':
-      specifier: 10.5.0-alpha.8
-      version: 10.5.0-alpha.8
+      specifier: 10.5.0-alpha.9
+      version: 10.5.0-alpha.9
     '@storybook/addon-docs':
-      specifier: 10.5.0-alpha.8
-      version: 10.5.0-alpha.8
+      specifier: 10.5.0-alpha.9
+      version: 10.5.0-alpha.9
     '@storybook/addon-themes':
-      specifier: 10.5.0-alpha.8
-      version: 10.5.0-alpha.8
+      specifier: 10.5.0-alpha.9
+      version: 10.5.0-alpha.9
     '@storybook/addon-vitest':
-      specifier: 10.5.0-alpha.8
-      version: 10.5.0-alpha.8
+      specifier: 10.5.0-alpha.9
+      version: 10.5.0-alpha.9
     '@storybook/react-vite':
-      specifier: 10.5.0-alpha.8
-      version: 10.5.0-alpha.8
+      specifier: 10.5.0-alpha.9
+      version: 10.5.0-alpha.9
     '@vitest/browser-playwright':
       specifier: 4.0.6
       version: 4.0.6
@@ -28,8 +28,8 @@ catalogs:
       specifier: 1.56.1
       version: 1.56.1
     storybook:
-      specifier: 10.5.0-alpha.8
-      version: 10.5.0-alpha.8
+      specifier: 10.5.0-alpha.9
+      version: 10.5.0-alpha.9
     vite:
       specifier: 7.2.2
       version: 7.2.2
@@ -43,22 +43,22 @@ importers:
     devDependencies:
       '@storybook/addon-a11y':
         specifier: 'catalog:'
-        version: 10.5.0-alpha.8(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 10.5.0-alpha.9(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-docs':
         specifier: 'catalog:'
-        version: 10.5.0-alpha.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+        version: 10.5.0-alpha.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
       '@storybook/addon-mcp':
         specifier: workspace:*
         version: link:../../packages/addon-mcp
       '@storybook/addon-themes':
         specifier: 'catalog:'
-        version: 10.5.0-alpha.8(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 10.5.0-alpha.9(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-vitest':
         specifier: 'catalog:'
-        version: 10.5.0-alpha.8(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)
+        version: 10.5.0-alpha.9(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 10.5.0-alpha.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)
+        version: 10.5.0-alpha.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)
       '@types/react':
         specifier: ^18.2.65
         version: 18.3.28
@@ -82,7 +82,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       storybook:
         specifier: 'catalog:'
-        version: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tinyexec:
         specifier: ^1.0.2
         version: 1.0.2
@@ -937,32 +937,32 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@storybook/addon-a11y@10.5.0-alpha.8':
-    resolution: {integrity: sha512-o7iAzfMKoPwu4kixKh0EK5rQXFCohNVQRmTwTQ5KnCTglpTxnHjG/WBkxbCG1jj6+bS+93LANPQNFKUhyajRNw==}
+  '@storybook/addon-a11y@10.5.0-alpha.9':
+    resolution: {integrity: sha512-Y3/Ah56WbU2V+UWDur8+//MTHBGKn1VZHXz3a+/FmCJ48VcxgPoIF/GlGoA86i/XQG4yQD3rlBJ88acp4Pa+YQ==}
     peerDependencies:
-      storybook: ^10.5.0-alpha.8
+      storybook: ^10.5.0-alpha.9
 
-  '@storybook/addon-docs@10.5.0-alpha.8':
-    resolution: {integrity: sha512-/rWYwz2WmE308YO8lyB5H3a/ZqTQGzjt7y6ey9BfMc4cbMXAa/TbczESo9qpPRTVh6bSxcFFInfmkEMSQJUQAQ==}
+  '@storybook/addon-docs@10.5.0-alpha.9':
+    resolution: {integrity: sha512-MlgTH1LV/dfFf4DjDIMjPCBQOit1K0mCKcyy/PSaxFFImdMiYaeKU6QDgwq1e00rfXpbA+FDr6a2+OORdBap0g==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-alpha.8
+      storybook: ^10.5.0-alpha.9
     peerDependenciesMeta:
       '@types/react':
         optional: true
 
-  '@storybook/addon-themes@10.5.0-alpha.8':
-    resolution: {integrity: sha512-XXKJlGJ64S7cwtJ6wYIuoTBEDt3D8HG7ktuAGwziXJe2ONJ9a6fd9/VxGvL84LiwcWnz7PfnXn0IMa/dzK/S3Q==}
+  '@storybook/addon-themes@10.5.0-alpha.9':
+    resolution: {integrity: sha512-GCBrJ0kuNueGYy1luAdZOuZroCNIgO5WH1JkU8VF+2Fn9sxc3ODYMs7t+2VVhOdz2C9shbC5+1/x5uAPDae7GQ==}
     peerDependencies:
-      storybook: ^10.5.0-alpha.8
+      storybook: ^10.5.0-alpha.9
 
-  '@storybook/addon-vitest@10.5.0-alpha.8':
-    resolution: {integrity: sha512-maVjReVeQczzmEcBg99iAZqQsRiC+8otIYwch5CarqznD7wUIghCYh9YR+aHHUQInKr1BBRkuhrE//hZEPxw7w==}
+  '@storybook/addon-vitest@10.5.0-alpha.9':
+    resolution: {integrity: sha512-78JWqbyKhsZcyjXFPNk4TTnXiuSlsxP51UHefDDh0tsA/EfuFFar+Na3QpOUIxNa8+LnoGHm4FqLpwM2aolOZg==}
     peerDependencies:
       '@vitest/browser': ^3.0.0 || ^4.0.0
       '@vitest/browser-playwright': ^4.0.0
       '@vitest/runner': ^3.0.0 || ^4.0.0
-      storybook: ^10.5.0-alpha.8
+      storybook: ^10.5.0-alpha.9
       vitest: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       '@vitest/browser':
@@ -974,18 +974,18 @@ packages:
       vitest:
         optional: true
 
-  '@storybook/builder-vite@10.5.0-alpha.8':
-    resolution: {integrity: sha512-3VUg5Tubp/OGmgWJyXSPyDyU9kfJF6/M9BBDkTKdNVZb+tcZuET537hJ7bk3/1cU4XKRdaV9cM5sMtuiazvDOg==}
+  '@storybook/builder-vite@10.5.0-alpha.9':
+    resolution: {integrity: sha512-cOpTLHjHr0nvjnJ31nF0zkyDLHpZ5CaCi2mGEwbLf2+fCGf6hJPEUsgG7knb+czMrauuIsNeLB6Ge512ACbhKw==}
     peerDependencies:
-      storybook: ^10.5.0-alpha.8
+      storybook: ^10.5.0-alpha.9
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@storybook/csf-plugin@10.5.0-alpha.8':
-    resolution: {integrity: sha512-LcVavKC84Bp4sZPr4Ts3aGFZHKJ52xHm2cEznGSnjN1xGTBAoYg5D0MdZZD5fVR+CqfGnEqb/81sbC64zRLzoQ==}
+  '@storybook/csf-plugin@10.5.0-alpha.9':
+    resolution: {integrity: sha512-L6TG57Qh5UPrDKDbi0LzkhxiEeHCKGySF9mWaPXUGwU1VpCstvB8t7dCbWcLfcfN/lJUP0OnoHNvYhRgZDw+Ow==}
     peerDependencies:
       esbuild: '*'
       rollup: '*'
-      storybook: ^10.5.0-alpha.8
+      storybook: ^10.5.0-alpha.9
       vite: '*'
       webpack: '*'
     peerDependenciesMeta:
@@ -1007,40 +1007,40 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@storybook/react-dom-shim@10.5.0-alpha.8':
-    resolution: {integrity: sha512-NbzZnfql0l3oYv1d0GGsmNeciyKu4HsgEfm4DYzy0JbxYAwQzwcsN9tn0NMkhat1ldfq5JWjGR6+nxRA4nj1iw==}
+  '@storybook/react-dom-shim@10.5.0-alpha.9':
+    resolution: {integrity: sha512-Ymb5jM6XP9o1ZQmvlwiYdAe0eROEetbbYN2lyAxKu2dVGfXX+QKdhGYfRlkVyIzRci2PnkTQ0B1yJXQrNiEw7g==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-alpha.8
+      storybook: ^10.5.0-alpha.9
     peerDependenciesMeta:
       '@types/react':
         optional: true
       '@types/react-dom':
         optional: true
 
-  '@storybook/react-vite@10.5.0-alpha.8':
-    resolution: {integrity: sha512-etSUaRfXUCDKSWBkvI1rPm1wAoPrxNnm3sArpnZGeYGYoyWYhmpi+J+okEzsTt5/zPAkQcBdWSC+il0plMQiDw==}
+  '@storybook/react-vite@10.5.0-alpha.9':
+    resolution: {integrity: sha512-xZ5US5vGksGn6w6ftt9li9Jrcx8RLrXiy4dLaFCqiNcvefCLfZaJNsCOPnYKRAwKbTkq5TlZb8UbUBdQJBia+w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-alpha.8
+      storybook: ^10.5.0-alpha.9
       typescript: '>= 4.9.x'
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@storybook/react@10.5.0-alpha.8':
-    resolution: {integrity: sha512-8SeeaRflWA2ofEjbSDPwO1VTVgv85X6WlKLpGWKxKGVySHK4Cv1l+oPeouu6JhJ4lq0E5p5vsAQEvJzUiGD5zg==}
+  '@storybook/react@10.5.0-alpha.9':
+    resolution: {integrity: sha512-VDVe38Qs8aBGGEk8qOL9P2a/feKCdBVtIlqgiOKTD65sKvMWRtWg5ppvjLloHQePw9msshkxiLTD/8c7SHqIJA==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-alpha.8
+      storybook: ^10.5.0-alpha.9
       typescript: '>= 4.9.x'
     peerDependenciesMeta:
       '@types/react':
@@ -1589,8 +1589,8 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
-  storybook@10.5.0-alpha.8:
-    resolution: {integrity: sha512-sAFXwToGGeD7oRPRt9KWfmulUDQ/CgiPxwDsWs3BmALF8NwibO0ZbjXy1j9oe85iTC/X9s5YuEQ/yh3Fj3JODQ==}
+  storybook@10.5.0-alpha.9:
+    resolution: {integrity: sha512-1O9hZIdnUabX42pbGp7kpDVHhNowHpbIvBiael0ors566i5yBmfX10lxAlRuPdoab0hQL08iHLKPwdOQ+N4SKg==}
     hasBin: true
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2335,21 +2335,21 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-a11y@10.5.0-alpha.8(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-a11y@10.5.0-alpha.9(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.1
-      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@storybook/addon-docs@10.5.0-alpha.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
+  '@storybook/addon-docs@10.5.0-alpha.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@storybook/csf-plugin': 10.5.0-alpha.8(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+      '@storybook/csf-plugin': 10.5.0-alpha.9(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/react-dom-shim': 10.5.0-alpha.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/react-dom-shim': 10.5.0-alpha.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
     optionalDependencies:
       '@types/react': 18.3.28
@@ -2360,16 +2360,16 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-themes@10.5.0-alpha.8(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-themes@10.5.0-alpha.9(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
-      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-vitest@10.5.0-alpha.8(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)':
+  '@storybook/addon-vitest@10.5.0-alpha.9(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       '@vitest/browser': 4.0.6(vite@7.2.2)(vitest@4.0.6)
       '@vitest/browser-playwright': 4.0.6(playwright@1.56.1)(vite@7.2.2)(vitest@4.0.6)
@@ -2379,10 +2379,10 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.5.0-alpha.8(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
+  '@storybook/builder-vite@10.5.0-alpha.9(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
     dependencies:
-      '@storybook/csf-plugin': 10.5.0-alpha.8(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
-      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/csf-plugin': 10.5.0-alpha.9(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+      storybook: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
       vite: 7.2.2
     transitivePeerDependencies:
@@ -2390,9 +2390,9 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.5.0-alpha.8(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
+  '@storybook/csf-plugin@10.5.0-alpha.9(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
     dependencies:
-      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.3
@@ -2406,28 +2406,28 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/react-dom-shim@10.5.0-alpha.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/react-dom-shim@10.5.0-alpha.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@storybook/react-vite@10.5.0-alpha.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)':
+  '@storybook/react-vite@10.5.0-alpha.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@7.2.2)
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
-      '@storybook/builder-vite': 10.5.0-alpha.8(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
-      '@storybook/react': 10.5.0-alpha.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+      '@storybook/builder-vite': 10.5.0-alpha.9(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+      '@storybook/react': 10.5.0-alpha.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 18.3.1
       react-docgen: 8.0.2
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.11
-      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tsconfig-paths: 4.2.0
       vite: 7.2.2
     optionalDependencies:
@@ -2440,15 +2440,15 @@ snapshots:
       - supports-color
       - webpack
 
-  '@storybook/react@10.5.0-alpha.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
+  '@storybook/react@10.5.0-alpha.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.5.0-alpha.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/react-dom-shim': 10.5.0-alpha.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-docgen: 8.0.2
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
@@ -3092,7 +3092,7 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/eval/pnpm-lock.yaml
+++ b/eval/pnpm-lock.yaml
@@ -7,17 +7,17 @@ settings:
 catalogs:
   default:
     '@storybook/addon-a11y':
-      specifier: 10.5.0-alpha.8
-      version: 10.5.0-alpha.8
+      specifier: 10.5.0-alpha.9
+      version: 10.5.0-alpha.9
     '@storybook/react-vite':
-      specifier: 10.5.0-alpha.8
-      version: 10.5.0-alpha.8
+      specifier: 10.5.0-alpha.9
+      version: 10.5.0-alpha.9
     playwright:
       specifier: 1.56.1
       version: 1.56.1
     storybook:
-      specifier: 10.5.0-alpha.8
-      version: 10.5.0-alpha.8
+      specifier: 10.5.0-alpha.9
+      version: 10.5.0-alpha.9
     valibot:
       specifier: 1.2.0
       version: 1.2.0
@@ -49,13 +49,13 @@ importers:
         version: 1.1.11(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/addon-a11y':
         specifier: 'catalog:'
-        version: 10.5.0-alpha.8(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 10.5.0-alpha.9(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/mcp':
         specifier: workspace:*
         version: link:../packages/mcp
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 10.5.0-alpha.8(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))
+        version: 10.5.0-alpha.9(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))
       '@tsconfig/node-ts':
         specifier: ^23.6.1
         version: 23.6.3
@@ -127,10 +127,10 @@ importers:
         version: 5.83.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook:
         specifier: 'catalog:'
-        version: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook-addon-test-codegen:
         specifier: ^3.0.0
-        version: 3.0.1(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 3.0.1(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       tinyexec:
         specifier: ^1.0.1
         version: 1.0.2
@@ -1762,23 +1762,23 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@storybook/addon-a11y@10.5.0-alpha.8':
-    resolution: {integrity: sha512-o7iAzfMKoPwu4kixKh0EK5rQXFCohNVQRmTwTQ5KnCTglpTxnHjG/WBkxbCG1jj6+bS+93LANPQNFKUhyajRNw==}
+  '@storybook/addon-a11y@10.5.0-alpha.9':
+    resolution: {integrity: sha512-Y3/Ah56WbU2V+UWDur8+//MTHBGKn1VZHXz3a+/FmCJ48VcxgPoIF/GlGoA86i/XQG4yQD3rlBJ88acp4Pa+YQ==}
     peerDependencies:
-      storybook: ^10.5.0-alpha.8
+      storybook: ^10.5.0-alpha.9
 
-  '@storybook/builder-vite@10.5.0-alpha.8':
-    resolution: {integrity: sha512-3VUg5Tubp/OGmgWJyXSPyDyU9kfJF6/M9BBDkTKdNVZb+tcZuET537hJ7bk3/1cU4XKRdaV9cM5sMtuiazvDOg==}
+  '@storybook/builder-vite@10.5.0-alpha.9':
+    resolution: {integrity: sha512-cOpTLHjHr0nvjnJ31nF0zkyDLHpZ5CaCi2mGEwbLf2+fCGf6hJPEUsgG7knb+czMrauuIsNeLB6Ge512ACbhKw==}
     peerDependencies:
-      storybook: ^10.5.0-alpha.8
+      storybook: ^10.5.0-alpha.9
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@storybook/csf-plugin@10.5.0-alpha.8':
-    resolution: {integrity: sha512-LcVavKC84Bp4sZPr4Ts3aGFZHKJ52xHm2cEznGSnjN1xGTBAoYg5D0MdZZD5fVR+CqfGnEqb/81sbC64zRLzoQ==}
+  '@storybook/csf-plugin@10.5.0-alpha.9':
+    resolution: {integrity: sha512-L6TG57Qh5UPrDKDbi0LzkhxiEeHCKGySF9mWaPXUGwU1VpCstvB8t7dCbWcLfcfN/lJUP0OnoHNvYhRgZDw+Ow==}
     peerDependencies:
       esbuild: '*'
       rollup: '*'
-      storybook: ^10.5.0-alpha.8
+      storybook: ^10.5.0-alpha.9
       vite: '*'
       webpack: '*'
     peerDependenciesMeta:
@@ -1800,40 +1800,40 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@storybook/react-dom-shim@10.5.0-alpha.8':
-    resolution: {integrity: sha512-NbzZnfql0l3oYv1d0GGsmNeciyKu4HsgEfm4DYzy0JbxYAwQzwcsN9tn0NMkhat1ldfq5JWjGR6+nxRA4nj1iw==}
+  '@storybook/react-dom-shim@10.5.0-alpha.9':
+    resolution: {integrity: sha512-Ymb5jM6XP9o1ZQmvlwiYdAe0eROEetbbYN2lyAxKu2dVGfXX+QKdhGYfRlkVyIzRci2PnkTQ0B1yJXQrNiEw7g==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-alpha.8
+      storybook: ^10.5.0-alpha.9
     peerDependenciesMeta:
       '@types/react':
         optional: true
       '@types/react-dom':
         optional: true
 
-  '@storybook/react-vite@10.5.0-alpha.8':
-    resolution: {integrity: sha512-etSUaRfXUCDKSWBkvI1rPm1wAoPrxNnm3sArpnZGeYGYoyWYhmpi+J+okEzsTt5/zPAkQcBdWSC+il0plMQiDw==}
+  '@storybook/react-vite@10.5.0-alpha.9':
+    resolution: {integrity: sha512-xZ5US5vGksGn6w6ftt9li9Jrcx8RLrXiy4dLaFCqiNcvefCLfZaJNsCOPnYKRAwKbTkq5TlZb8UbUBdQJBia+w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-alpha.8
+      storybook: ^10.5.0-alpha.9
       typescript: '>= 4.9.x'
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@storybook/react@10.5.0-alpha.8':
-    resolution: {integrity: sha512-8SeeaRflWA2ofEjbSDPwO1VTVgv85X6WlKLpGWKxKGVySHK4Cv1l+oPeouu6JhJ4lq0E5p5vsAQEvJzUiGD5zg==}
+  '@storybook/react@10.5.0-alpha.9':
+    resolution: {integrity: sha512-VDVe38Qs8aBGGEk8qOL9P2a/feKCdBVtIlqgiOKTD65sKvMWRtWg5ppvjLloHQePw9msshkxiLTD/8c7SHqIJA==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-alpha.8
+      storybook: ^10.5.0-alpha.9
       typescript: '>= 4.9.x'
     peerDependenciesMeta:
       '@types/react':
@@ -3156,8 +3156,8 @@ packages:
     peerDependencies:
       storybook: ^0.0.0-0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0
 
-  storybook@10.5.0-alpha.8:
-    resolution: {integrity: sha512-sAFXwToGGeD7oRPRt9KWfmulUDQ/CgiPxwDsWs3BmALF8NwibO0ZbjXy1j9oe85iTC/X9s5YuEQ/yh3Fj3JODQ==}
+  storybook@10.5.0-alpha.9:
+    resolution: {integrity: sha512-1O9hZIdnUabX42pbGp7kpDVHhNowHpbIvBiael0ors566i5yBmfX10lxAlRuPdoab0hQL08iHLKPwdOQ+N4SKg==}
     hasBin: true
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -4752,16 +4752,16 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/addon-a11y@10.5.0-alpha.8(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/addon-a11y@10.5.0-alpha.9(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.1
-      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/builder-vite@10.5.0-alpha.8(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
+  '@storybook/builder-vite@10.5.0-alpha.9(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
     dependencies:
-      '@storybook/csf-plugin': 10.5.0-alpha.8(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
-      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@storybook/csf-plugin': 10.5.0-alpha.9(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
+      storybook: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
       vite: 7.3.1(@types/node@24.10.12)
     transitivePeerDependencies:
@@ -4769,9 +4769,9 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.5.0-alpha.8(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
+  '@storybook/csf-plugin@10.5.0-alpha.9(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
     dependencies:
-      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.3
@@ -4785,27 +4785,27 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/react-dom-shim@10.5.0-alpha.8(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/react-dom-shim@10.5.0-alpha.9(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@storybook/react-vite@10.5.0-alpha.8(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))':
+  '@storybook/react-vite@10.5.0-alpha.9(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
-      '@storybook/builder-vite': 10.5.0-alpha.8(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
-      '@storybook/react': 10.5.0-alpha.8(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+      '@storybook/builder-vite': 10.5.0-alpha.9(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
+      '@storybook/react': 10.5.0-alpha.9(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 19.2.4
       react-docgen: 8.0.2
       react-dom: 19.2.4(react@19.2.4)
       resolve: 1.22.11
-      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tsconfig-paths: 4.2.0
       vite: 7.3.1(@types/node@24.10.12)
     optionalDependencies:
@@ -4818,15 +4818,15 @@ snapshots:
       - supports-color
       - webpack
 
-  '@storybook/react@10.5.0-alpha.8(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
+  '@storybook/react@10.5.0-alpha.9(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.5.0-alpha.8(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@storybook/react-dom-shim': 10.5.0-alpha.9(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react: 19.2.4
       react-docgen: 8.0.2
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     optionalDependencies:
       '@types/react': 18.3.28
       typescript: 5.9.3
@@ -6227,11 +6227,11 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  storybook-addon-test-codegen@3.0.1(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+  storybook-addon-test-codegen@3.0.1(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
-      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/packages/addon-mcp/pnpm-lock.yaml
+++ b/packages/addon-mcp/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     '@storybook/addon-a11y':
-      specifier: 10.5.0-alpha.8
-      version: 10.5.0-alpha.8
+      specifier: 10.5.0-alpha.9
+      version: 10.5.0-alpha.9
     '@storybook/addon-vitest':
-      specifier: 10.5.0-alpha.8
-      version: 10.5.0-alpha.8
+      specifier: 10.5.0-alpha.9
+      version: 10.5.0-alpha.9
     '@tmcp/adapter-valibot':
       specifier: ^0.1.5
       version: 0.1.5
@@ -19,8 +19,8 @@ catalogs:
       specifier: ^0.8.5
       version: 0.8.5
     storybook:
-      specifier: 10.5.0-alpha.8
-      version: 10.5.0-alpha.8
+      specifier: 10.5.0-alpha.9
+      version: 10.5.0-alpha.9
     tmcp:
       specifier: ^1.19.4
       version: 1.19.4
@@ -53,13 +53,13 @@ importers:
     devDependencies:
       '@storybook/addon-a11y':
         specifier: 'catalog:'
-        version: 10.5.0-alpha.8(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 10.5.0-alpha.9(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/addon-vitest':
         specifier: 'catalog:'
-        version: 10.5.0-alpha.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 10.5.0-alpha.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       storybook:
         specifier: 'catalog:'
-        version: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
 packages:
 
@@ -490,18 +490,18 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@storybook/addon-a11y@10.5.0-alpha.8':
-    resolution: {integrity: sha512-o7iAzfMKoPwu4kixKh0EK5rQXFCohNVQRmTwTQ5KnCTglpTxnHjG/WBkxbCG1jj6+bS+93LANPQNFKUhyajRNw==}
+  '@storybook/addon-a11y@10.5.0-alpha.9':
+    resolution: {integrity: sha512-Y3/Ah56WbU2V+UWDur8+//MTHBGKn1VZHXz3a+/FmCJ48VcxgPoIF/GlGoA86i/XQG4yQD3rlBJ88acp4Pa+YQ==}
     peerDependencies:
-      storybook: ^10.5.0-alpha.8
+      storybook: ^10.5.0-alpha.9
 
-  '@storybook/addon-vitest@10.5.0-alpha.8':
-    resolution: {integrity: sha512-maVjReVeQczzmEcBg99iAZqQsRiC+8otIYwch5CarqznD7wUIghCYh9YR+aHHUQInKr1BBRkuhrE//hZEPxw7w==}
+  '@storybook/addon-vitest@10.5.0-alpha.9':
+    resolution: {integrity: sha512-78JWqbyKhsZcyjXFPNk4TTnXiuSlsxP51UHefDDh0tsA/EfuFFar+Na3QpOUIxNa8+LnoGHm4FqLpwM2aolOZg==}
     peerDependencies:
       '@vitest/browser': ^3.0.0 || ^4.0.0
       '@vitest/browser-playwright': ^4.0.0
       '@vitest/runner': ^3.0.0 || ^4.0.0
-      storybook: ^10.5.0-alpha.8
+      storybook: ^10.5.0-alpha.9
       vitest: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       '@vitest/browser':
@@ -768,8 +768,8 @@ packages:
   sqids@0.3.0:
     resolution: {integrity: sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==}
 
-  storybook@10.5.0-alpha.8:
-    resolution: {integrity: sha512-sAFXwToGGeD7oRPRt9KWfmulUDQ/CgiPxwDsWs3BmALF8NwibO0ZbjXy1j9oe85iTC/X9s5YuEQ/yh3Fj3JODQ==}
+  storybook@10.5.0-alpha.9:
+    resolution: {integrity: sha512-1O9hZIdnUabX42pbGp7kpDVHhNowHpbIvBiael0ors566i5yBmfX10lxAlRuPdoab0hQL08iHLKPwdOQ+N4SKg==}
     hasBin: true
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -1084,17 +1084,17 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-a11y@10.5.0-alpha.8(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/addon-a11y@10.5.0-alpha.9(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.1
-      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/addon-vitest@10.5.0-alpha.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/addon-vitest@10.5.0-alpha.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      storybook: 10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -1397,7 +1397,7 @@ snapshots:
 
   sqids@0.3.0: {}
 
-  storybook@10.5.0-alpha.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  storybook@10.5.0-alpha.9(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/packages/addon-mcp/src/tools/get-changed-stories.test.ts
+++ b/packages/addon-mcp/src/tools/get-changed-stories.test.ts
@@ -28,15 +28,15 @@ vi.mock('storybook/internal/core-server', () => ({
 }));
 
 /**
- * Builds a `core/module-graph` runtime stub. `getStoriesForFiles` maps the batched input files to
+ * Builds a `core/module-graph` runtime stub. `storiesForFiles` maps the batched input files to
  * positional hit lists — an empty list marks a file as unreachable from every story.
  */
-function moduleGraphStub(getStoriesForFiles: (files: string[]) => Array<Array<unknown>>) {
+function moduleGraphStub(storiesForFiles: (files: string[]) => Array<Array<unknown>>) {
 	return {
 		queries: {
-			getStatus: { loaded: async () => ({ value: 'ready' as const }) },
-			getStoriesForFiles: {
-				loaded: async ({ files }: { files: string[] }) => getStoriesForFiles(files),
+			status: { loaded: async () => ({ value: 'ready' as const }) },
+			storiesForFiles: {
+				loaded: async ({ files }: { files: string[] }) => storiesForFiles(files),
 			},
 		},
 	};

--- a/packages/addon-mcp/src/utils/detect-unreachable-changes.test.ts
+++ b/packages/addon-mcp/src/utils/detect-unreachable-changes.test.ts
@@ -4,6 +4,7 @@ import {
 	formatPartialCoverageHint,
 	formatUnreachableHint,
 } from './detect-unreachable-changes.ts';
+import type { ModuleGraphStatus, ModuleGraphStoryHit } from './module-graph.ts';
 
 describe('formatUnreachableHint', () => {
 	it('returns empty string when there are no unreachable files', () => {
@@ -99,17 +100,17 @@ describe('detectUnreachableChanges', () => {
 	});
 
 	function mockService(opts: {
-		status?: import('./module-graph.ts').ModuleGraphStatus;
+		status?: ModuleGraphStatus;
 		/** Maps the batched input files to positional hit lists. */
-		getStoriesForFiles: (files: string[]) => import('./module-graph.ts').ModuleGraphStoryHit[][];
+		storiesForFiles: (files: string[]) => ModuleGraphStoryHit[][];
 	}) {
 		const status = opts.status ?? { value: 'ready' };
 		vi.doMock('storybook/internal/core-server', () => ({
 			getService: () => ({
 				queries: {
-					getStatus: { loaded: async () => status },
-					getStoriesForFiles: {
-						loaded: async ({ files }: { files: string[] }) => opts.getStoriesForFiles(files),
+					status: { loaded: async () => status },
+					storiesForFiles: {
+						loaded: async ({ files }: { files: string[] }) => opts.storiesForFiles(files),
 					},
 				},
 			}),
@@ -125,7 +126,7 @@ describe('detectUnreachableChanges', () => {
 	it('lists working-tree files that the reverse-graph does not reach', async () => {
 		mockService({
 			// reverse-graph knows about Badge.tsx but NOT theme.ts
-			getStoriesForFiles: (files) =>
+			storiesForFiles: (files) =>
 				files.map((f) =>
 					f.endsWith('Badge.tsx') ? [{ storyFile: './src/Badge.stories.tsx', depth: 1 }] : [],
 				),
@@ -137,8 +138,7 @@ describe('detectUnreachableChanges', () => {
 
 	it('returns [] when every modified file IS in the graph', async () => {
 		mockService({
-			getStoriesForFiles: (files) =>
-				files.map(() => [{ storyFile: './src/x.stories.tsx', depth: 1 }]),
+			storiesForFiles: (files) => files.map(() => [{ storyFile: './src/x.stories.tsx', depth: 1 }]),
 		});
 		mockGit(' M src/components/Badge/Badge.tsx\n');
 		const { detectUnreachableChanges } = await import('./detect-unreachable-changes.ts');
@@ -165,7 +165,7 @@ describe('detectUnreachableChanges', () => {
 	it('returns [] when the module graph is not ready', async () => {
 		mockService({
 			status: { value: 'booting' },
-			getStoriesForFiles: (files) => files.map(() => []),
+			storiesForFiles: (files) => files.map(() => []),
 		});
 		mockGit(' M src/styles/theme.ts\n');
 		const { detectUnreachableChanges } = await import('./detect-unreachable-changes.ts');
@@ -173,28 +173,28 @@ describe('detectUnreachableChanges', () => {
 	});
 
 	it('returns [] when the working tree is clean', async () => {
-		mockService({ getStoriesForFiles: (files) => files.map(() => []) });
+		mockService({ storiesForFiles: (files) => files.map(() => []) });
 		mockGit('');
 		const { detectUnreachableChanges } = await import('./detect-unreachable-changes.ts');
 		expect(await detectUnreachableChanges()).toEqual([]);
 	});
 
 	it('ignores non-source files (css, json, lockfiles, …)', async () => {
-		mockService({ getStoriesForFiles: (files) => files.map(() => []) });
+		mockService({ storiesForFiles: (files) => files.map(() => []) });
 		mockGit(' M src/styles/theme.css\n M package-lock.json\n M src/styles/theme.ts\n');
 		const { detectUnreachableChanges } = await import('./detect-unreachable-changes.ts');
 		expect(await detectUnreachableChanges()).toEqual(['src/styles/theme.ts']);
 	});
 
 	it('handles rename lines (`R  old -> new`) by keeping the new path', async () => {
-		mockService({ getStoriesForFiles: (files) => files.map(() => []) });
+		mockService({ storiesForFiles: (files) => files.map(() => []) });
 		mockGit('R  src/old.ts -> src/new.ts\n');
 		const { detectUnreachableChanges } = await import('./detect-unreachable-changes.ts');
 		expect(await detectUnreachableChanges()).toEqual(['src/new.ts']);
 	});
 
 	it('returns [] gracefully when git fails (not a repo, etc.)', async () => {
-		mockService({ getStoriesForFiles: (files) => files.map(() => []) });
+		mockService({ storiesForFiles: (files) => files.map(() => []) });
 		vi.doMock('node:child_process', () => ({
 			execSync: () => {
 				throw new Error('not a git repository');
@@ -205,7 +205,7 @@ describe('detectUnreachableChanges', () => {
 	});
 
 	it('caps the list at maxFiles to keep the agent response small', async () => {
-		mockService({ getStoriesForFiles: (files) => files.map(() => []) });
+		mockService({ storiesForFiles: (files) => files.map(() => []) });
 		const many = Array.from({ length: 50 }, (_, i) => ` M src/f${i}.ts\n`).join('');
 		mockGit(many);
 		const { detectUnreachableChanges } = await import('./detect-unreachable-changes.ts');
@@ -217,7 +217,7 @@ describe('detectUnreachableChanges', () => {
 		// first chunk already satisfies the cap, so we must not query the remaining ~150 files.
 		const queried: string[] = [];
 		mockService({
-			getStoriesForFiles: (files) => {
+			storiesForFiles: (files) => {
 				queried.push(...files);
 				return files.map(() => []);
 			},

--- a/packages/addon-mcp/src/utils/detect-unreachable-changes.ts
+++ b/packages/addon-mcp/src/utils/detect-unreachable-changes.ts
@@ -44,7 +44,7 @@ function parsePorcelain(output: string): string[] {
 export async function detectUnreachableChanges(maxFiles = 10): Promise<string[]> {
 	const moduleGraph = await getModuleGraphService();
 	if (!moduleGraph) return [];
-	const status = await moduleGraph.queries.getStatus.loaded(undefined);
+	const status = await moduleGraph.queries.status.loaded(undefined);
 	if (status.value !== 'ready') return [];
 	// Matches what the dev server uses, so paths line up with the reverse-index keys.
 	const workingDir = process.cwd();
@@ -77,7 +77,7 @@ export async function detectUnreachableChanges(maxFiles = 10): Promise<string[]>
 		// reachable files.
 		const absChunk = chunk.map((rel) => slash(path.resolve(workingDir, rel)));
 		// One batched lookup per chunk; output is positional (result `i` corresponds to `absChunk[i]`).
-		const hits = await moduleGraph.queries.getStoriesForFiles.loaded({ files: absChunk });
+		const hits = await moduleGraph.queries.storiesForFiles.loaded({ files: absChunk });
 		for (const [i, rel] of chunk.entries()) {
 			if (unreachable.length >= maxFiles) break;
 			if ((hits[i]?.length ?? 0) === 0) unreachable.push(rel);

--- a/packages/addon-mcp/src/utils/module-graph.ts
+++ b/packages/addon-mcp/src/utils/module-graph.ts
@@ -25,7 +25,7 @@ export interface ModuleGraphErrorLike {
 	stack?: string;
 }
 
-/** Lifecycle status of the module graph; mirrors the service's `getStatus` query output. */
+/** Lifecycle status of the module graph; mirrors the service's `status` query output. */
 export type ModuleGraphStatus =
 	| { value: 'booting' }
 	| { value: 'ready' }
@@ -40,12 +40,15 @@ export interface ModuleGraphStoryHit {
 	depth: number;
 }
 
-/** The subset of the `core/module-graph` runtime service surface that addon-mcp consumes. */
+type ModuleGraphStatusQuery = Query<undefined, ModuleGraphStatus>;
+type ModuleGraphStoriesForFilesQuery = Query<{ files: string[] }, ModuleGraphStoryHit[][]>;
+
+/** The subset of the `core/module-graph` runtime service surface addon-mcp consumes. */
 export interface ModuleGraphService {
 	queries: {
-		getStatus: Query<undefined, ModuleGraphStatus>;
+		status: ModuleGraphStatusQuery;
 		/** Positional: result `i` corresponds to input `files[i]`. */
-		getStoriesForFiles: Query<{ files: string[] }, ModuleGraphStoryHit[][]>;
+		storiesForFiles: ModuleGraphStoriesForFilesQuery;
 	};
 }
 
@@ -97,7 +100,7 @@ export async function isModuleGraphSupportedByBuilder(
  * Resolves the `core/module-graph` runtime service, or `undefined` when Storybook doesn't ship the
  * open-service API or the service isn't registered (e.g. a builder without change detection, or the
  * dev server isn't running). A non-undefined result doesn't mean the graph is built — await
- * `queries.getStatus.loaded(undefined)` and check for the `ready` status.
+ * `queries.status.loaded(undefined)` and check for the `ready` status.
  */
 export async function getModuleGraphService(): Promise<ModuleGraphService | undefined> {
 	const getService = await probe();

--- a/packages/addon-mcp/src/utils/resolve-component-stories.test.ts
+++ b/packages/addon-mcp/src/utils/resolve-component-stories.test.ts
@@ -51,8 +51,8 @@ function setupService(opts: {
 	const storiesByFile = opts.storiesByFile ?? {};
 	const stub = {
 		queries: {
-			getStatus: { loaded: async () => status },
-			getStoriesForFiles: {
+			status: { loaded: async () => status },
+			storiesForFiles: {
 				loaded: async ({ files }: { files: string[] }) => files.map((f) => storiesByFile[f] ?? []),
 			},
 		},

--- a/packages/addon-mcp/src/utils/resolve-component-stories.ts
+++ b/packages/addon-mcp/src/utils/resolve-component-stories.ts
@@ -72,7 +72,7 @@ function toStoryIndexPath(importPath: string): string {
 
 /**
  * Map story-index-relative story-file path → story IDs declared in that file. Skips virtual entries.
- * Keys match the `storyFile` values returned by the module graph's `getStoriesForFiles`.
+ * Keys match the `storyFile` values returned by the module graph's `storiesForFiles`.
  */
 function buildStoryIdsByFile(storyIndex: StoryIndex): Map<string, Set<string>> {
 	const storyIdsByFile = new Map<string, Set<string>>();
@@ -100,6 +100,10 @@ function reasonForStatus(status: ModuleGraphStatus): string {
 			return `Storybook's story module graph failed to build: ${status.error.message}`;
 		case 'ready':
 			return "Storybook's story module graph is ready.";
+		default: {
+			const exhaustive: never = status;
+			return exhaustive;
+		}
 	}
 }
 
@@ -159,9 +163,9 @@ export async function resolveComponentStories(
 		};
 	}
 
-	// `getStatus.loaded` awaits the graph's settle barrier, so by the time it resolves the status is
+	// `status.loaded` awaits the graph's settle barrier, so by the time it resolves the status is
 	// no longer `booting` unless the graph genuinely never built — handle every non-ready case.
-	const status = await moduleGraph.queries.getStatus.loaded(undefined);
+	const status = await moduleGraph.queries.status.loaded(undefined);
 	if (status.value !== 'ready') {
 		return { available: false, reason: reasonForStatus(status) };
 	}
@@ -203,7 +207,7 @@ export async function resolveComponentStories(
 	const allTargets = [...new Set(resolved.flatMap((c) => c.targets))];
 	const hitsByTarget = new Map<string, ModuleGraphStoryHit[]>();
 	if (allTargets.length > 0) {
-		const batched = await moduleGraph.queries.getStoriesForFiles.loaded({ files: allTargets });
+		const batched = await moduleGraph.queries.storiesForFiles.loaded({ files: allTargets });
 		// Output is positional: result `i` corresponds to input `allTargets[i]`.
 		allTargets.forEach((target, i) => {
 			hitsByTarget.set(target, batched[i] ?? []);

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,19 +6,19 @@ packages:
   - '!eval/tasks/*/trials/*/project'
 
 catalog:
-  '@storybook/addon-a11y': 10.5.0-alpha.8
-  '@storybook/addon-docs': 10.5.0-alpha.8
-  '@storybook/addon-themes': 10.5.0-alpha.8
-  '@storybook/addon-vitest': 10.5.0-alpha.8
-  '@storybook/react-vite': 10.5.0-alpha.8
+  '@storybook/addon-a11y': 10.5.0-alpha.9
+  '@storybook/addon-docs': 10.5.0-alpha.9
+  '@storybook/addon-themes': 10.5.0-alpha.9
+  '@storybook/addon-vitest': 10.5.0-alpha.9
+  '@storybook/react-vite': 10.5.0-alpha.9
   '@types/semver': 7.7.1
   '@tmcp/adapter-valibot': ^0.1.5
   '@tmcp/transport-http': ^0.8.5
   '@tmcp/transport-stdio': ^0.4.3
   '@vitest/browser-playwright': 4.0.6
-  eslint-plugin-storybook: 10.5.0-alpha.8
+  eslint-plugin-storybook: 10.5.0-alpha.9
   playwright: 1.56.1
-  storybook: 10.5.0-alpha.8
+  storybook: 10.5.0-alpha.9
   tmcp: ^1.19.4
   semver: 7.8.1
   tsdown: ^0.15.12
@@ -30,10 +30,10 @@ catalog:
 catalogs:
   trials:
     '@eslint/js': 9.39.1
-    '@storybook/addon-a11y': 10.5.0-alpha.8
-    '@storybook/addon-docs': 10.5.0-alpha.8
-    '@storybook/addon-vitest': 10.5.0-alpha.8
-    '@storybook/react-vite': 10.5.0-alpha.8
+    '@storybook/addon-a11y': 10.5.0-alpha.9
+    '@storybook/addon-docs': 10.5.0-alpha.9
+    '@storybook/addon-vitest': 10.5.0-alpha.9
+    '@storybook/react-vite': 10.5.0-alpha.9
     '@types/node': 24.10.1
     '@types/react': 19.2.6
     '@types/react-dom': 19.2.3
@@ -42,11 +42,11 @@ catalogs:
     eslint: 9.39.1
     eslint-plugin-react-hooks: 7.0.1
     eslint-plugin-react-refresh: 0.4.24
-    eslint-plugin-storybook: 10.5.0-alpha.8
+    eslint-plugin-storybook: 10.5.0-alpha.9
     globals: 16.5.0
     react: 19.2.0
     react-dom: 19.2.0
-    storybook: 10.5.0-alpha.8
+    storybook: 10.5.0-alpha.9
     typescript: 5.9.3
     typescript-eslint: 8.47.0
     vite: 7.2.2


### PR DESCRIPTION
## Summary

- Align addon-mcp's `core/module-graph` consumers to Storybook's renamed `status` and `storiesForFiles` open-service queries.
- Update `get-changed-stories` / `get-stories-by-component` unit stubs to exercise the noun-style Storybook query names directly.
- Upgrade Storybook catalog pins and tracked package lockfiles from `10.5.0-alpha.8` to `10.5.0-alpha.9`.

## Evidence

This fixes the remaining addon-mcp alignment missed by `1e56c352d2e70617bc9729b8cc46e825d2a38998`, which updated docgen/story-docs/MDX query names but did not touch module-graph callers.

The failing eval transcript reproduced `Error: Cannot read properties of undefined (reading 'loaded')` from both `get-changed-stories` and `get-stories-by-component`. Root cause: Storybook commit `9278e79e79860bd3d51cf112cac5500df4a3c5f7` (`refactor(open-service): drop redundant get prefix from query names`) renamed module graph queries including `getStoriesForFiles -> storiesForFiles` and `getStatus -> status`. That change shipped through Storybook PR https://github.com/storybookjs/storybook/pull/35214. Storybook kept deprecated aliases for `getStatus` and `getGraphRevision`, but not for `getStoriesForFiles`, so addon-mcp read `.loaded` from `undefined`.

The module-graph service is still an alpha-train surface here, so this PR intentionally does not preserve compatibility with earlier alpha query names. I also checked npm dist-tags during this work; `storybook` and `@storybook/react-vite` both still have `next: 10.5.0-alpha.9`. Prior Slack searches found no exact existing report for this crash in `#sb-ade-plugins`; only older/adjacent module-graph discussions surfaced.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @storybook/mcp build` (passes; existing third-party `react-docgen-typescript` declaration warnings are still emitted)
- `pnpm --filter @storybook/addon-mcp build`
- `pnpm --filter @storybook/addon-mcp typecheck`
- `pnpm exec oxfmt --check packages/addon-mcp/src/utils/module-graph.ts packages/addon-mcp/src/utils/resolve-component-stories.test.ts packages/addon-mcp/src/utils/detect-unreachable-changes.test.ts packages/addon-mcp/src/tools/get-changed-stories.test.ts`
- `pnpm exec oxlint --type-aware packages/addon-mcp/src/utils/module-graph.ts packages/addon-mcp/src/utils/resolve-component-stories.test.ts packages/addon-mcp/src/utils/detect-unreachable-changes.test.ts packages/addon-mcp/src/tools/get-changed-stories.test.ts`
- `pnpm vitest --project=@storybook/addon-mcp run packages/addon-mcp/src/utils/resolve-component-stories.test.ts packages/addon-mcp/src/utils/detect-unreachable-changes.test.ts packages/addon-mcp/src/tools/get-changed-stories.test.ts` (3 files, 45 tests)
- `pnpm --filter @storybook/addon-mcp test -- --run` (26 files, 340 tests)
- Live alpha.9 smoke after rebuilding addon-mcp: `pnpm --dir apps/internal-storybook storybook` logged `storybook v10.5.0-alpha.9`, `Change detection enabled`, and `Change detection graph built: 4 stories, 12 deps tracked`.
- Live `/mcp` smoke on alpha.9:
  - `get-stories-by-component` for `apps/internal-storybook/stories/components/Button.tsx` returned 9 story matches across Button/Header/Page instead of the `loaded` error.
  - `get-changed-stories` returned `No new, modified, or related stories detected.` instead of the `loaded` error.
