### PR TITLE
Never assert display-review in the 9xx line

### DIFF
--- a/agent-eval/.gitignore
+++ b/agent-eval/.gitignore
@@ -11,3 +11,4 @@ results/
 .env.*
 !.env.example
 .env*.local
+.env*

--- a/agent-eval/evals/901-create-component-atom-reshaped-detailed/EVAL.ts
+++ b/agent-eval/evals/901-create-component-atom-reshaped-detailed/EVAL.ts
@@ -1,7 +1,6 @@
 import { test } from 'vitest';
-import { expectDisplayReviewForVisualChange, expectWorkflowCalls } from '#test-utils';
+import { expectWorkflowCalls } from '#test-utils';
 
-test('uses Storybook story instructions and publishes a display review', () => {
-	expectWorkflowCalls(['get-storybook-story-instructions', 'display-review']);
-	expectDisplayReviewForVisualChange();
+test('uses Storybook story instructions and previews the stories', () => {
+	expectWorkflowCalls(['get-storybook-story-instructions', 'preview-stories']);
 });

--- a/agent-eval/evals/901-create-component-atom-reshaped-explicit-stories/EVAL.ts
+++ b/agent-eval/evals/901-create-component-atom-reshaped-explicit-stories/EVAL.ts
@@ -1,7 +1,6 @@
 import { test } from 'vitest';
-import { expectDisplayReviewForVisualChange, expectWorkflowCalls } from '#test-utils';
+import { expectWorkflowCalls } from '#test-utils';
 
-test('uses Storybook story instructions and publishes a display review', () => {
-	expectWorkflowCalls(['get-storybook-story-instructions', 'display-review']);
-	expectDisplayReviewForVisualChange();
+test('uses Storybook story instructions and previews the stories', () => {
+	expectWorkflowCalls(['get-storybook-story-instructions', 'preview-stories']);
 });

--- a/agent-eval/evals/902-create-component-composite-reshaped-concise/EVAL.ts
+++ b/agent-eval/evals/902-create-component-composite-reshaped-concise/EVAL.ts
@@ -1,7 +1,6 @@
 import { test } from 'vitest';
-import { expectDisplayReviewForVisualChange, expectWorkflowCalls } from '#test-utils';
+import { expectWorkflowCalls } from '#test-utils';
 
-test('uses the Storybook creation, test, and review workflow', () => {
-	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'display-review']);
-	expectDisplayReviewForVisualChange();
+test('uses the Storybook creation, test, and preview workflow', () => {
+	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'preview-stories']);
 });

--- a/agent-eval/evals/902-create-component-composite-reshaped-detailed/EVAL.ts
+++ b/agent-eval/evals/902-create-component-composite-reshaped-detailed/EVAL.ts
@@ -1,7 +1,6 @@
 import { test } from 'vitest';
-import { expectDisplayReviewForVisualChange, expectWorkflowCalls } from '#test-utils';
+import { expectWorkflowCalls } from '#test-utils';
 
-test('uses the Storybook creation, test, and review workflow', () => {
-	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'display-review']);
-	expectDisplayReviewForVisualChange();
+test('uses the Storybook creation, test, and preview workflow', () => {
+	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'preview-stories']);
 });

--- a/agent-eval/evals/902-create-component-composite-reshaped-explicit-stories/EVAL.ts
+++ b/agent-eval/evals/902-create-component-composite-reshaped-explicit-stories/EVAL.ts
@@ -1,7 +1,6 @@
 import { test } from 'vitest';
-import { expectDisplayReviewForVisualChange, expectWorkflowCalls } from '#test-utils';
+import { expectWorkflowCalls } from '#test-utils';
 
-test('uses the Storybook creation, test, and review workflow', () => {
-	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'display-review']);
-	expectDisplayReviewForVisualChange();
+test('uses the Storybook creation, test, and preview workflow', () => {
+	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'preview-stories']);
 });

--- a/agent-eval/evals/903-create-component-async-fetch-reshaped-concise/EVAL.ts
+++ b/agent-eval/evals/903-create-component-async-fetch-reshaped-concise/EVAL.ts
@@ -1,7 +1,6 @@
 import { test } from 'vitest';
-import { expectDisplayReviewForVisualChange, expectWorkflowCalls } from '#test-utils';
+import { expectWorkflowCalls } from '#test-utils';
 
-test('uses the Storybook creation, test, and review workflow', () => {
-	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'display-review']);
-	expectDisplayReviewForVisualChange();
+test('uses the Storybook creation, test, and preview workflow', () => {
+	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'preview-stories']);
 });

--- a/agent-eval/evals/903-create-component-async-fetch-reshaped-detailed/EVAL.ts
+++ b/agent-eval/evals/903-create-component-async-fetch-reshaped-detailed/EVAL.ts
@@ -1,7 +1,6 @@
 import { test } from 'vitest';
-import { expectDisplayReviewForVisualChange, expectWorkflowCalls } from '#test-utils';
+import { expectWorkflowCalls } from '#test-utils';
 
-test('uses the Storybook creation, test, and review workflow', () => {
-	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'display-review']);
-	expectDisplayReviewForVisualChange();
+test('uses the Storybook creation, test, and preview workflow', () => {
+	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'preview-stories']);
 });

--- a/agent-eval/evals/903-create-component-async-fetch-reshaped-explicit-stories/EVAL.ts
+++ b/agent-eval/evals/903-create-component-async-fetch-reshaped-explicit-stories/EVAL.ts
@@ -1,7 +1,6 @@
 import { test } from 'vitest';
-import { expectDisplayReviewForVisualChange, expectWorkflowCalls } from '#test-utils';
+import { expectWorkflowCalls } from '#test-utils';
 
-test('uses the Storybook creation, test, and review workflow', () => {
-	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'display-review']);
-	expectDisplayReviewForVisualChange();
+test('uses the Storybook creation, test, and preview workflow', () => {
+	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'preview-stories']);
 });

--- a/agent-eval/evals/904-create-component-async-module-reshaped-concise/EVAL.ts
+++ b/agent-eval/evals/904-create-component-async-module-reshaped-concise/EVAL.ts
@@ -1,7 +1,6 @@
 import { test } from 'vitest';
-import { expectDisplayReviewForVisualChange, expectWorkflowCalls } from '#test-utils';
+import { expectWorkflowCalls } from '#test-utils';
 
-test('uses the Storybook creation, test, and review workflow', () => {
-	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'display-review']);
-	expectDisplayReviewForVisualChange();
+test('uses the Storybook creation, test, and preview workflow', () => {
+	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'preview-stories']);
 });

--- a/agent-eval/evals/904-create-component-async-module-reshaped-detailed/EVAL.ts
+++ b/agent-eval/evals/904-create-component-async-module-reshaped-detailed/EVAL.ts
@@ -1,7 +1,6 @@
 import { test } from 'vitest';
-import { expectDisplayReviewForVisualChange, expectWorkflowCalls } from '#test-utils';
+import { expectWorkflowCalls } from '#test-utils';
 
-test('uses the Storybook creation, test, and review workflow', () => {
-	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'display-review']);
-	expectDisplayReviewForVisualChange();
+test('uses the Storybook creation, test, and preview workflow', () => {
+	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'preview-stories']);
 });

--- a/agent-eval/evals/904-create-component-async-module-reshaped-explicit-stories/EVAL.ts
+++ b/agent-eval/evals/904-create-component-async-module-reshaped-explicit-stories/EVAL.ts
@@ -1,7 +1,6 @@
 import { test } from 'vitest';
-import { expectDisplayReviewForVisualChange, expectWorkflowCalls } from '#test-utils';
+import { expectWorkflowCalls } from '#test-utils';
 
-test('uses the Storybook creation, test, and review workflow', () => {
-	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'display-review']);
-	expectDisplayReviewForVisualChange();
+test('uses the Storybook creation, test, and preview workflow', () => {
+	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'preview-stories']);
 });

--- a/agent-eval/evals/905-existing-component-write-story-reshaped-concise/EVAL.ts
+++ b/agent-eval/evals/905-existing-component-write-story-reshaped-concise/EVAL.ts
@@ -1,7 +1,6 @@
 import { test } from 'vitest';
-import { expectDisplayReviewForVisualChange, expectWorkflowCalls } from '#test-utils';
+import { expectWorkflowCalls } from '#test-utils';
 
-test('uses the Storybook creation, test, and review workflow', () => {
-	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'display-review']);
-	expectDisplayReviewForVisualChange();
+test('uses the Storybook creation, test, and preview workflow', () => {
+	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'preview-stories']);
 });

--- a/agent-eval/evals/905-existing-component-write-story-reshaped-detailed/EVAL.ts
+++ b/agent-eval/evals/905-existing-component-write-story-reshaped-detailed/EVAL.ts
@@ -1,7 +1,6 @@
 import { test } from 'vitest';
-import { expectDisplayReviewForVisualChange, expectWorkflowCalls } from '#test-utils';
+import { expectWorkflowCalls } from '#test-utils';
 
-test('uses the Storybook creation, test, and review workflow', () => {
-	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'display-review']);
-	expectDisplayReviewForVisualChange();
+test('uses the Storybook creation, test, and preview workflow', () => {
+	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'preview-stories']);
 });

--- a/agent-eval/evals/906-existing-component-edit-story-reshaped-concise/EVAL.ts
+++ b/agent-eval/evals/906-existing-component-edit-story-reshaped-concise/EVAL.ts
@@ -1,7 +1,6 @@
 import { test } from 'vitest';
-import { expectDisplayReviewForVisualChange, expectWorkflowCalls } from '#test-utils';
+import { expectWorkflowCalls } from '#test-utils';
 
-test('uses the Storybook creation, test, and review workflow', () => {
-	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'display-review']);
-	expectDisplayReviewForVisualChange();
+test('uses the Storybook creation, test, and preview workflow', () => {
+	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'preview-stories']);
 });

--- a/agent-eval/evals/906-existing-component-edit-story-reshaped-detailed/EVAL.ts
+++ b/agent-eval/evals/906-existing-component-edit-story-reshaped-detailed/EVAL.ts
@@ -1,7 +1,6 @@
 import { test } from 'vitest';
-import { expectDisplayReviewForVisualChange, expectWorkflowCalls } from '#test-utils';
+import { expectWorkflowCalls } from '#test-utils';
 
-test('uses the Storybook creation, test, and review workflow', () => {
-	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'display-review']);
-	expectDisplayReviewForVisualChange();
+test('uses the Storybook creation, test, and preview workflow', () => {
+	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'preview-stories']);
 });

--- a/agent-eval/evals/907-existing-component-change-component-reshaped-concise/EVAL.ts
+++ b/agent-eval/evals/907-existing-component-change-component-reshaped-concise/EVAL.ts
@@ -1,7 +1,6 @@
 import { test } from 'vitest';
-import { expectDisplayReviewForVisualChange, expectWorkflowCalls } from '#test-utils';
+import { expectWorkflowCalls } from '#test-utils';
 
-test('uses the Storybook creation, test, and review workflow', () => {
-	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'display-review']);
-	expectDisplayReviewForVisualChange();
+test('uses the Storybook creation, test, and preview workflow', () => {
+	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'preview-stories']);
 });

--- a/agent-eval/evals/907-existing-component-change-component-reshaped-detailed/EVAL.ts
+++ b/agent-eval/evals/907-existing-component-change-component-reshaped-detailed/EVAL.ts
@@ -1,7 +1,6 @@
 import { test } from 'vitest';
-import { expectDisplayReviewForVisualChange, expectWorkflowCalls } from '#test-utils';
+import { expectWorkflowCalls } from '#test-utils';
 
-test('uses the Storybook creation, test, and review workflow', () => {
-	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'display-review']);
-	expectDisplayReviewForVisualChange();
+test('uses the Storybook creation, test, and preview workflow', () => {
+	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'preview-stories']);
 });

--- a/agent-eval/evals/907-existing-component-change-component-reshaped-explicit-stories/EVAL.ts
+++ b/agent-eval/evals/907-existing-component-change-component-reshaped-explicit-stories/EVAL.ts
@@ -1,7 +1,6 @@
 import { test } from 'vitest';
-import { expectDisplayReviewForVisualChange, expectWorkflowCalls } from '#test-utils';
+import { expectWorkflowCalls } from '#test-utils';
 
-test('uses the Storybook creation, test, and review workflow', () => {
-	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'display-review']);
-	expectDisplayReviewForVisualChange();
+test('uses the Storybook creation, test, and preview workflow', () => {
+	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'preview-stories']);
 });

--- a/agent-eval/evals/909-run-tests-after-component-creation/EVAL.ts
+++ b/agent-eval/evals/909-run-tests-after-component-creation/EVAL.ts
@@ -1,17 +1,11 @@
 import { expect, test } from 'vitest';
-import {
-	expectDisplayReviewForVisualChange,
-	expectWorkflowCalls,
-	getWorkflowCalls,
-	type StorybookWorkflowCall,
-} from '#test-utils';
+import { expectWorkflowCalls, getWorkflowCalls, type StorybookWorkflowCall } from '#test-utils';
 
 function hasStoriesInput(call: StorybookWorkflowCall): boolean {
 	return Array.isArray(call.input.stories) && call.input.stories.length > 0;
 }
 
-test('creates stories, runs focused story tests, and publishes a display review', () => {
-	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'display-review']);
+test('creates stories, runs focused story tests, and previews the stories', () => {
+	expectWorkflowCalls(['get-storybook-story-instructions', 'run-story-tests', 'preview-stories']);
 	expect(getWorkflowCalls('run-story-tests').some(hasStoriesInput)).toBe(true);
-	expectDisplayReviewForVisualChange();
 });

--- a/agent-eval/evals/911-fix-failing-tests-vitest-cli/EVAL.ts
+++ b/agent-eval/evals/911-fix-failing-tests-vitest-cli/EVAL.ts
@@ -1,10 +1,5 @@
 import { expect, test } from 'vitest';
-import {
-	expectDisplayReviewForVisualChange,
-	expectWorkflowCalls,
-	getShellCommands,
-	getWorkflowCalls,
-} from '#test-utils';
+import { expectWorkflowCalls, getShellCommands, getWorkflowCalls } from '#test-utils';
 
 function usesVitestCli(command: string): boolean {
 	return /(^|\s)npx\s+vitest\s+run(\s|$)/.test(command);
@@ -13,6 +8,5 @@ function usesVitestCli(command: string): boolean {
 test('reruns the Vitest CLI after fixing failures', () => {
 	expect(getShellCommands().filter(usesVitestCli).length).toBeGreaterThanOrEqual(2);
 	expect(getWorkflowCalls('run-story-tests').length).toBe(0);
-	expectWorkflowCalls(['display-review']);
-	expectDisplayReviewForVisualChange();
+	expectWorkflowCalls(['preview-stories']);
 });

--- a/agent-eval/evals/911-fix-failing-tests/EVAL.ts
+++ b/agent-eval/evals/911-fix-failing-tests/EVAL.ts
@@ -1,12 +1,7 @@
 import { expect, test } from 'vitest';
-import {
-	expectDisplayReviewForVisualChange,
-	expectWorkflowCalls,
-	getWorkflowCalls,
-} from '#test-utils';
+import { expectWorkflowCalls, getWorkflowCalls } from '#test-utils';
 
-test('reruns story tests after fixing failures and publishes a display review', () => {
-	expectWorkflowCalls(['run-story-tests', 'display-review']);
+test('reruns story tests after fixing failures and previews the stories', () => {
+	expectWorkflowCalls(['run-story-tests', 'preview-stories']);
 	expect(getWorkflowCalls('run-story-tests').length).toBeGreaterThanOrEqual(2);
-	expectDisplayReviewForVisualChange();
 });


### PR DESCRIPTION
The 9xx evals run against the latest stable release, which has no review tooling — asserting display-review there can never pass. Assert preview-stories instead, like 901-concise, and drop the review-payload checks across all 9xx variants.

Cherry-picked from `kasper/slim-mcp-server-instructions` (#320) so it can land on main independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Storybook-related flows now emphasize previewing stories as part of the workflow.
  * Test coverage was updated to reflect story preview and test-run steps in more scenarios.

* **Bug Fixes**
  * Replaced outdated review-oriented expectations with preview-based behavior for component workflows.
  * Improved consistency in how post-change story workflows are validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->