### PR TITLE
Make agent-eval fully independent of the Vercel AI Gateway

### DIFF
--- a/.github/workflows/agent-eval.yml
+++ b/.github/workflows/agent-eval.yml
@@ -93,7 +93,6 @@ jobs:
           EVAL_EXTRA_EVALS: ${{ (inputs.extra_evals || contains(github.event.pull_request.labels.*.name, 'ci:extra-evals')) && '1' || '' }}
           EVAL_EXTRA_MODELS: ${{ (inputs.extra_models || contains(github.event.pull_request.labels.*.name, 'ci:extra-models')) && '1' || '' }}
           EVAL_STORYBOOK_LATEST: ${{ (inputs.storybook_latest || contains(github.event.pull_request.labels.*.name, 'ci:storybook-latest')) && '1' || '' }}
-          AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/agent-eval/.env.example
+++ b/agent-eval/.env.example
@@ -1,9 +1,9 @@
 # API Keys
-# For optional failure classification or vercel-ai-gateway agents:
-# AI_GATEWAY_API_KEY=your-ai-gateway-api-key
-
-# For direct Claude Code API:
+# For direct Claude Code API and failure classification:
 ANTHROPIC_API_KEY=sk-ant-...
+
+# Alternative for failure classification and vercel-ai-gateway/* agents:
+# AI_GATEWAY_API_KEY=your-ai-gateway-api-key
 
 # For direct OpenAI Codex API:
 # OPENAI_API_KEY=sk-proj-...

--- a/agent-eval/README.md
+++ b/agent-eval/README.md
@@ -17,7 +17,7 @@ Test AI coding agents to measure what actually works.
    ```
 
    Edit `.env.local` and add your API keys (see comments in `.env.example` for options):
-   - **Agent keys**: `AI_GATEWAY_API_KEY` is required for the Claude Code experiments (they route through the Vercel AI Gateway) and for failure classification. `OPENAI_API_KEY` is required for the Codex experiments, which use the direct Codex API.
+   - **Agent keys**: `ANTHROPIC_API_KEY` is required for the Claude Code experiments, which use the direct Anthropic API. `AI_GATEWAY_API_KEY` is required for failure classification. `OPENAI_API_KEY` is required for the Codex experiments, which use the direct Codex API.
    - **Sandbox access**: this suite is configured with `sandbox: 'auto'`, which uses Vercel Sandbox when access-token credentials (`VERCEL_PROJECT_ID`, `VERCEL_TEAM_ID`, and `VERCEL_TOKEN`) are present and falls back to local Docker otherwise. Set `sandbox: 'docker'` to force Docker-only experiments.
 
 ## Running Evals
@@ -98,9 +98,9 @@ runtime/build contexts.
 
 Configured experiments:
 
-- `cc-mcp-opus-high`: Claude Code (Opus at high effort) through the `vercel-ai-gateway/claude-code` agent (requires `AI_GATEWAY_API_KEY`) with project-local Storybook MCP config in `.mcp.json`.
+- `cc-mcp-opus-high`: Claude Code (Opus at high effort) through the `claude-code` agent (direct Anthropic API, requires `ANTHROPIC_API_KEY`) with project-local Storybook MCP config in `.mcp.json`.
 - `codex-mcp-gpt-5.5-medium`: Codex (gpt-5.5 at medium reasoning effort) with project-local Storybook MCP config in `.codex/config.toml`.
-- `cc-plugin-opus-high`: Claude Code (Opus at high effort) through the `vercel-ai-gateway/claude-code` agent (requires `AI_GATEWAY_API_KEY`) with Storybook plugin skills copied to `.claude/skills`.
+- `cc-plugin-opus-high`: Claude Code (Opus at high effort) through the `claude-code` agent (direct Anthropic API, requires `ANTHROPIC_API_KEY`) with Storybook plugin skills copied to `.claude/skills`.
 - `cc-plugin-sonnet-medium`: Claude Code (Sonnet at medium effort) plugin variant; runs zero evals unless `EVAL_EXTRA_MODELS=1` is set.
 - `cc-mcp-sonnet-medium`: Claude Code (Sonnet at medium effort) MCP variant; runs zero evals unless `EVAL_EXTRA_MODELS=1` is set.
 - `codex-plugin-gpt-5.5-medium`: Codex (gpt-5.5 at medium reasoning effort) with Storybook plugin skills copied to `.agents/skills`.

--- a/agent-eval/README.md
+++ b/agent-eval/README.md
@@ -17,7 +17,7 @@ Test AI coding agents to measure what actually works.
    ```
 
    Edit `.env.local` and add your API keys (see comments in `.env.example` for options):
-   - **Agent keys**: `ANTHROPIC_API_KEY` is required for the Claude Code experiments, which use the direct Anthropic API. `AI_GATEWAY_API_KEY` is required for failure classification. `OPENAI_API_KEY` is required for the Codex experiments, which use the direct Codex API.
+   - **Agent keys**: `ANTHROPIC_API_KEY` is required for the Claude Code experiments and for failure classification, both of which use the direct Anthropic API. `OPENAI_API_KEY` is required for the Codex experiments, which use the direct Codex API.
    - **Sandbox access**: this suite is configured with `sandbox: 'auto'`, which uses Vercel Sandbox when access-token credentials (`VERCEL_PROJECT_ID`, `VERCEL_TEAM_ID`, and `VERCEL_TOKEN`) are present and falls back to local Docker otherwise. Set `sandbox: 'docker'` to force Docker-only experiments.
 
 ## Running Evals

--- a/agent-eval/experiments/cc-mcp-opus-high.ts
+++ b/agent-eval/experiments/cc-mcp-opus-high.ts
@@ -4,7 +4,7 @@ import { setupSandbox, writeClaudeMcpConfig } from '../lib/templates.ts';
 
 export default {
 	...DEFAULT_EXPERIMENT_CONFIG,
-	agent: 'vercel-ai-gateway/claude-code', // requires AI_GATEWAY_API_KEY
+	agent: 'claude-code', // direct Anthropic API, requires ANTHROPIC_API_KEY
 	// Pin what the CLI would pick by default (Opus 4.8 at high effort) so the
 	// experiment name stays accurate when the CLI defaults change.
 	model: 'opus',

--- a/agent-eval/experiments/cc-mcp-sonnet-medium.ts
+++ b/agent-eval/experiments/cc-mcp-sonnet-medium.ts
@@ -4,7 +4,7 @@ import { setupSandbox, writeClaudeMcpConfig } from '../lib/templates.ts';
 
 export default {
 	...DEFAULT_EXPERIMENT_CONFIG,
-	agent: 'vercel-ai-gateway/claude-code', // requires AI_GATEWAY_API_KEY
+	agent: 'claude-code', // direct Anthropic API, requires ANTHROPIC_API_KEY
 	model: 'sonnet',
 	agentOptions: { effort: 'medium' },
 	// Runs zero evals unless EVAL_EXTRA_MODELS=1 is set; see EXTRA_MODEL_EVALS.

--- a/agent-eval/experiments/cc-plugin-opus-high.ts
+++ b/agent-eval/experiments/cc-plugin-opus-high.ts
@@ -8,7 +8,7 @@ import {
 
 export default {
 	...DEFAULT_EXPERIMENT_CONFIG,
-	agent: 'vercel-ai-gateway/claude-code', // requires AI_GATEWAY_API_KEY
+	agent: 'claude-code', // direct Anthropic API, requires ANTHROPIC_API_KEY
 	// Pin what the CLI would pick by default (Opus 4.8 at high effort) so the
 	// experiment name stays accurate when the CLI defaults change.
 	model: 'opus',

--- a/agent-eval/experiments/cc-plugin-sonnet-medium.ts
+++ b/agent-eval/experiments/cc-plugin-sonnet-medium.ts
@@ -8,7 +8,7 @@ import {
 
 export default {
 	...DEFAULT_EXPERIMENT_CONFIG,
-	agent: 'vercel-ai-gateway/claude-code', // requires AI_GATEWAY_API_KEY
+	agent: 'claude-code', // direct Anthropic API, requires ANTHROPIC_API_KEY
 	model: 'sonnet',
 	agentOptions: { effort: 'medium' },
 	// Runs zero evals unless EVAL_EXTRA_MODELS=1 is set, and none under

--- a/agent-eval/package.json
+++ b/agent-eval/package.json
@@ -32,6 +32,9 @@
 		"vitest": "catalog:"
 	},
 	"pnpm": {
+		"overrides": {
+			"@ai-sdk/anthropic": "^2.0.0"
+		},
 		"patchedDependencies": {
 			"@vercel/agent-eval@1.2.0": "patches/@vercel__agent-eval@1.2.0.patch"
 		}

--- a/agent-eval/patches/@vercel__agent-eval@1.2.0.patch
+++ b/agent-eval/patches/@vercel__agent-eval@1.2.0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/cli.js b/dist/cli.js
-index 62513a2..3be8fea 100644
+index 62513a2..5a50e3f 100644
 --- a/dist/cli.js
 +++ b/dist/cli.js
 @@ -230,8 +230,13 @@ program
@@ -18,6 +18,127 @@ index 62513a2..3be8fea 100644
      process.exit(result.status ?? 1);
  });
  /**
+@@ -373,10 +378,10 @@ async function runAllCommand(experimentArgs, options) {
+         }
+         // Warn if classifier is disabled
+         if (!isClassifierEnabled()) {
+-            console.log(chalk.yellow('\n⚠️  Classifier disabled: Neither AI_GATEWAY_API_KEY nor VERCEL_OIDC_TOKEN is set.\n' +
++            console.log(chalk.yellow('\n⚠️  Classifier disabled: None of ANTHROPIC_API_KEY, AI_GATEWAY_API_KEY, or VERCEL_OIDC_TOKEN is set.\n' +
+                 '  The classifier automatically identifies why evals failed (model error, infrastructure issue, or timeout).\n' +
+                 '  Without it, all failed results are kept as-is and housekeeping will not remove non-model failures.\n' +
+-                '  Set AI_GATEWAY_API_KEY or VERCEL_OIDC_TOKEN to enable classifier for cleaner result management.\n'));
++                '  Set ANTHROPIC_API_KEY, AI_GATEWAY_API_KEY, or VERCEL_OIDC_TOKEN to enable classifier for cleaner result management.\n'));
+         }
+         // Rate-limit sandbox starts across all experiments to avoid 429s (20 starts per 2 seconds)
+         const rateLimiter = new StartRateLimiter(20, 2_000);
+diff --git a/dist/lib/agents/codex/run.mjs b/dist/lib/agents/codex/run.mjs
+index 12ff2d6..a6a3c5e 100644
+--- a/dist/lib/agents/codex/run.mjs
++++ b/dist/lib/agents/codex/run.mjs
+@@ -287,12 +287,14 @@ export async function runAgent(input) {
+   const agentExitCode = res.status == null ? -1 : res.status;
+ 
+   // Capture transcript + observed model regardless of success (the old adapter did
+-  // this even on the non-zero-exit path). The inline --json on stdout is the
+-  // transcript; observedModel comes from the saved session file under ~/.codex.
+-  const transcript = extractTranscriptFromOutput(output) ?? null;
++  // this even on the non-zero-exit path). Prefer the inline --json stdout, but
++  // fall back to the saved session file under ~/.codex; newer Codex builds may
++  // write the session transcript there without echoing the full JSONL to stdout.
++  const stdoutTranscript = extractTranscriptFromOutput(output);
+   const threadId = extractCodexThreadId(output);
+   const sessionTranscript = captureCodexSessionTranscript(threadId);
+-  const observedModel = extractObservedModelFromCodexSession(sessionTranscript) ?? null;
++  const transcript = stdoutTranscript ?? sessionTranscript ?? null;
++  const observedModel = extractObservedModelFromCodexSession(sessionTranscript ?? stdoutTranscript) ?? null;
+ 
+   if (res.error || agentExitCode !== 0) {
+     // Mirror the old error string: last 5 lines of output, else a coded fallback.
+diff --git a/dist/lib/classifier.js b/dist/lib/classifier.js
+index 5a6cf9b..df8b19f 100644
+--- a/dist/lib/classifier.js
++++ b/dist/lib/classifier.js
+@@ -6,7 +6,8 @@
+  * - "infra" — infrastructure broke (API errors, rate limits, crashes)
+  * - "timeout" — the run hit its time limit
+  *
+- * Uses AI classification via the Vercel AI Gateway. Requires AI_GATEWAY_API_KEY or VERCEL_OIDC_TOKEN.
++ * Uses AI classification via the Anthropic API (ANTHROPIC_API_KEY) or the
++ * Vercel AI Gateway (AI_GATEWAY_API_KEY / VERCEL_OIDC_TOKEN).
+  */
+ import { readFileSync, readdirSync, statSync, writeFileSync } from 'fs';
+ import { join, resolve } from 'path';
+@@ -14,11 +15,13 @@ import { tool } from 'ai';
+ import { z } from 'zod';
+ /**
+  * Check if the classifier feature is enabled.
+- * The classifier requires either AI_GATEWAY_API_KEY or VERCEL_OIDC_TOKEN to be set.
+- * If neither is available, classification is disabled and housekeeping won't clean up non-model failures.
++ * The classifier requires ANTHROPIC_API_KEY, AI_GATEWAY_API_KEY, or VERCEL_OIDC_TOKEN to be set.
++ * If none is available, classification is disabled and housekeeping won't clean up non-model failures.
+  */
+ export function isClassifierEnabled() {
+-    return !!(process.env.AI_GATEWAY_API_KEY || process.env.VERCEL_OIDC_TOKEN);
++    return !!(process.env.ANTHROPIC_API_KEY ||
++        process.env.AI_GATEWAY_API_KEY ||
++        process.env.VERCEL_OIDC_TOKEN);
+ }
+ const CLASSIFIER_SYSTEM_PROMPT = `You are a failure classifier for an AI coding agent benchmark.
+ 
+@@ -193,8 +196,8 @@ export function createClassifierTools(evalResultDir) {
+     };
+ }
+ /**
+- * Classify a failure using AI via the Vercel AI Gateway.
+- * Requires AI_GATEWAY_API_KEY in the environment.
++ * Classify a failure using AI via the Anthropic API or the Vercel AI Gateway.
++ * Requires ANTHROPIC_API_KEY or AI_GATEWAY_API_KEY in the environment.
+  *
+  * Throws on AI gateway / network errors so the caller can surface them.
+  * Returns null only when the model itself failed to call classify() within
+@@ -202,7 +205,23 @@ export function createClassifierTools(evalResultDir) {
+  */
+ export async function classifyWithAI(evalResultDir, evalName, experimentName) {
+     const { generateText, hasToolCall, createGateway } = await import('ai');
+-    const gateway = createGateway({ apiKey: process.env.AI_GATEWAY_API_KEY ?? process.env.VERCEL_OIDC_TOKEN ?? '' });
++    // Prefer a direct Anthropic API key so classification doesn't consume
++    // Vercel AI Gateway credits; fall back to the gateway when only
++    // AI_GATEWAY_API_KEY / VERCEL_OIDC_TOKEN is available.
++    let model;
++    if (process.env.ANTHROPIC_API_KEY) {
++        const { createAnthropic } = await import('@ai-sdk/anthropic');
++        // ANTHROPIC_BASE_URL is commonly set host-only (Claude Code convention),
++        // but @ai-sdk/anthropic expects it to include the /v1 suffix — normalize.
++        const rawBaseURL = process.env.ANTHROPIC_BASE_URL?.replace(/\/+$/, '');
++        const baseURL = rawBaseURL && !rawBaseURL.endsWith('/v1') ? `${rawBaseURL}/v1` : rawBaseURL;
++        const anthropic = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY, baseURL });
++        model = anthropic('claude-haiku-4-5-20251001');
++    }
++    else {
++        const gateway = createGateway({ apiKey: process.env.AI_GATEWAY_API_KEY ?? process.env.VERCEL_OIDC_TOKEN ?? '' });
++        model = gateway('anthropic/claude-haiku-4-5-20251001');
++    }
+     let classification = null;
+     const explorationTools = createClassifierTools(evalResultDir);
+     const allTools = {
+@@ -224,7 +243,7 @@ export async function classifyWithAI(evalResultDir, evalName, experimentName) {
+         }),
+     };
+     await generateText({
+-        model: gateway('anthropic/claude-haiku-4-5-20251001'),
++        model,
+         system: CLASSIFIER_SYSTEM_PROMPT,
+         prompt: `Classify the failure for eval "${evalName}" (experiment: ${experimentName}). Use the exploration tools to investigate, then call classify() with your verdict.`,
+         tools: allTools,
+@@ -234,7 +253,7 @@ export async function classifyWithAI(evalResultDir, evalName, experimentName) {
+ }
+ /**
+  * Classify a failed eval result using AI.
+- * Requires AI_GATEWAY_API_KEY in the environment.
++ * Requires ANTHROPIC_API_KEY or AI_GATEWAY_API_KEY in the environment.
+  *
+  * Caches results in classification.json within the eval result directory.
+  * Throws if the AI gateway call itself fails — callers must handle.
 diff --git a/dist/lib/docker-sandbox.js b/dist/lib/docker-sandbox.js
 index 99df8fb..369c403 100644
 --- a/dist/lib/docker-sandbox.js
@@ -91,26 +212,3 @@ index 99df8fb..369c403 100644
                  try {
                      const inspection = await exec.inspect();
                      resolve({
-diff --git a/dist/lib/agents/codex/run.mjs b/dist/lib/agents/codex/run.mjs
-index c7977b8..2042324 100644
---- a/dist/lib/agents/codex/run.mjs
-+++ b/dist/lib/agents/codex/run.mjs
-@@ -286,12 +286,14 @@ export async function runAgent(input) {
-   const agentExitCode = res.status == null ? -1 : res.status;
- 
-   // Capture transcript + observed model regardless of success (the old adapter did
--  // this even on the non-zero-exit path). The inline --json on stdout is the
--  // transcript; observedModel comes from the saved session file under ~/.codex.
--  const transcript = extractTranscriptFromOutput(output) ?? null;
-+  // this even on the non-zero-exit path). Prefer the inline --json stdout, but
-+  // fall back to the saved session file under ~/.codex; newer Codex builds may
-+  // write the session transcript there without echoing the full JSONL to stdout.
-+  const stdoutTranscript = extractTranscriptFromOutput(output);
-   const threadId = extractCodexThreadId(output);
-   const sessionTranscript = captureCodexSessionTranscript(threadId);
--  const observedModel = extractObservedModelFromCodexSession(sessionTranscript) ?? null;
-+  const transcript = stdoutTranscript ?? sessionTranscript ?? null;
-+  const observedModel = extractObservedModelFromCodexSession(sessionTranscript ?? stdoutTranscript) ?? null;
- 
-   if (res.error || agentExitCode !== 0) {
-     // Mirror the old error string: last 5 lines of output, else a coded fallback.

--- a/agent-eval/pnpm-lock.yaml
+++ b/agent-eval/pnpm-lock.yaml
@@ -20,9 +20,12 @@ catalogs:
       specifier: 5.9.3
       version: 5.9.3
 
+overrides:
+  '@ai-sdk/anthropic': ^2.0.0
+
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
-    hash: 89ba52acefdb2e906edc466e8e2cdb2e61c7a028fea548eaaf5c7799dcc5bb68
+    hash: d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a
     path: patches/@vercel__agent-eval@1.2.0.patch
 
 importers:
@@ -47,7 +50,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vercel/agent-eval':
         specifier: 1.2.0
-        version: 1.2.0(patch_hash=89ba52acefdb2e906edc466e8e2cdb2e61c7a028fea548eaaf5c7799dcc5bb68)
+        version: 1.2.0(patch_hash=d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a)
       '@vercel/agent-eval-playground':
         specifier: 0.1.3
         version: 0.1.3(@opentelemetry/api@1.9.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)
@@ -72,11 +75,11 @@ importers:
 
 packages:
 
-  '@ai-sdk/anthropic@1.2.12':
-    resolution: {integrity: sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==}
+  '@ai-sdk/anthropic@2.0.85':
+    resolution: {integrity: sha512-ozfPUXb5cnXyFWXyY0hRFi8fudgNDr+FAuP2J1HTRhPjkTHTSFLbPSVRXEXCVoJhfl1IboF+xNDZs35nOHDU7w==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.0.0
+      zod: ^3.25.76 || ^4.1.8
 
   '@ai-sdk/gateway@2.0.107':
     resolution: {integrity: sha512-4Yjo7U6KqcePqsMHL7g0NcwwQQh1IQ3gyW16LEXKlBX5C4pWxXM0qUyxRnNohyVAMKDW2VSWL4BViNNVqQoIDw==}
@@ -84,21 +87,11 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@2.2.8':
-    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.23.8
-
   '@ai-sdk/provider-utils@3.0.28':
     resolution: {integrity: sha512-bXlX1WX7E50a2N+AJW+1a/x63m52aPhm+6xYe5THxWrx9vW9NR7E2Ay+1G1ndlCdMdYKo2Fnsd7kBhuyQPaphw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider@1.1.3':
-    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
-    engines: {node: '>=18'}
 
   '@ai-sdk/provider@2.0.3':
     resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
@@ -3342,9 +3335,6 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
-  secure-json-parse@2.7.0:
-    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
-
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -3824,10 +3814,10 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/anthropic@1.2.12(zod@3.25.76)':
+  '@ai-sdk/anthropic@2.0.85(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.28(zod@3.25.76)
       zod: 3.25.76
 
   '@ai-sdk/gateway@2.0.107(zod@3.25.76)':
@@ -3837,23 +3827,12 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.15
-      secure-json-parse: 2.7.0
-      zod: 3.25.76
-
   '@ai-sdk/provider-utils@3.0.28(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.1.0
       zod: 3.25.76
-
-  '@ai-sdk/provider@1.1.3':
-    dependencies:
-      json-schema: 0.4.0
 
   '@ai-sdk/provider@2.0.3':
     dependencies:
@@ -5449,9 +5428,9 @@ snapshots:
       - date-fns
       - sass
 
-  '@vercel/agent-eval@1.2.0(patch_hash=89ba52acefdb2e906edc466e8e2cdb2e61c7a028fea548eaaf5c7799dcc5bb68)':
+  '@vercel/agent-eval@1.2.0(patch_hash=d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a)':
     dependencies:
-      '@ai-sdk/anthropic': 1.2.12(zod@3.25.76)
+      '@ai-sdk/anthropic': 2.0.85(zod@3.25.76)
       '@vercel/sandbox': 1.10.2
       ai: 5.0.208(zod@3.25.76)
       chalk: 5.6.2
@@ -7004,8 +6983,6 @@ snapshots:
       - supports-color
 
   scheduler@0.27.0: {}
-
-  secure-json-parse@2.7.0: {}
 
   semver@6.3.1: {}
 

--- a/apps/internal-storybook/pnpm-lock.yaml
+++ b/apps/internal-storybook/pnpm-lock.yaml
@@ -39,7 +39,7 @@ catalogs:
 
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
-    hash: 89ba52acefdb2e906edc466e8e2cdb2e61c7a028fea548eaaf5c7799dcc5bb68
+    hash: d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a
     path: ../../agent-eval/patches/@vercel__agent-eval@1.2.0.patch
 
 importers:

--- a/apps/self-host-mcp/pnpm-lock.yaml
+++ b/apps/self-host-mcp/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
-    hash: 89ba52acefdb2e906edc466e8e2cdb2e61c7a028fea548eaaf5c7799dcc5bb68
+    hash: d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a
     path: ../../agent-eval/patches/@vercel__agent-eval@1.2.0.patch
 
 importers:

--- a/eval/pnpm-lock.yaml
+++ b/eval/pnpm-lock.yaml
@@ -24,7 +24,7 @@ catalogs:
 
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
-    hash: 89ba52acefdb2e906edc466e8e2cdb2e61c7a028fea548eaaf5c7799dcc5bb68
+    hash: d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a
     path: ../agent-eval/patches/@vercel__agent-eval@1.2.0.patch
 
 importers:

--- a/packages/addon-mcp/pnpm-lock.yaml
+++ b/packages/addon-mcp/pnpm-lock.yaml
@@ -30,7 +30,7 @@ catalogs:
 
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
-    hash: 89ba52acefdb2e906edc466e8e2cdb2e61c7a028fea548eaaf5c7799dcc5bb68
+    hash: d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a
     path: ../../agent-eval/patches/@vercel__agent-eval@1.2.0.patch
 
 importers:

--- a/packages/claude-plugin/pnpm-lock.yaml
+++ b/packages/claude-plugin/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
-    hash: 89ba52acefdb2e906edc466e8e2cdb2e61c7a028fea548eaaf5c7799dcc5bb68
+    hash: d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a
     path: ../../agent-eval/patches/@vercel__agent-eval@1.2.0.patch
 
 importers:

--- a/packages/codex-plugin/pnpm-lock.yaml
+++ b/packages/codex-plugin/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
-    hash: 89ba52acefdb2e906edc466e8e2cdb2e61c7a028fea548eaaf5c7799dcc5bb68
+    hash: d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a
     path: ../../agent-eval/patches/@vercel__agent-eval@1.2.0.patch
 
 importers:

--- a/packages/mcp/pnpm-lock.yaml
+++ b/packages/mcp/pnpm-lock.yaml
@@ -24,7 +24,7 @@ catalogs:
 
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
-    hash: 89ba52acefdb2e906edc466e8e2cdb2e61c7a028fea548eaaf5c7799dcc5bb68
+    hash: d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a
     path: ../../agent-eval/patches/@vercel__agent-eval@1.2.0.patch
 
 importers:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ catalogs:
 
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
-    hash: 89ba52acefdb2e906edc466e8e2cdb2e61c7a028fea548eaaf5c7799dcc5bb68
+    hash: d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a
     path: agent-eval/patches/@vercel__agent-eval@1.2.0.patch
 
 importers:


### PR DESCRIPTION
## What

Removes the eval pipeline's last dependencies on the Vercel AI Gateway so everything runs on `ANTHROPIC_API_KEY` directly — no Vercel credits needed.

Two halves:

### 1. Failure classifier → direct Anthropic API (pnpm patch)

The `@vercel/agent-eval` failure classifier (model/infra/timeout triage of failed runs) was hardcoded to the gateway. The existing pnpm patch is extended so it prefers a direct Anthropic call when `ANTHROPIC_API_KEY` is set, falling back to the gateway otherwise:

- `classifyWithAI` uses `createAnthropic` from `@ai-sdk/anthropic` with the same `claude-haiku-4-5-20251001` model.
- `ANTHROPIC_BASE_URL` is normalized to include the `/v1` suffix (Claude Code conventionally exports it host-only; `@ai-sdk/anthropic` reads the same variable and 404s without the suffix).
- `isClassifierEnabled` and the CLI warning accept `ANTHROPIC_API_KEY` as an enabling credential.
- pnpm override bumps `@ai-sdk/anthropic` to `^2`: the package declares `^1.2.12` (AI SDK v4 era), incompatible with the installed `ai@5`; nothing in its `dist` imported the v1 API.

### 2. Experiments → direct `claude-code` agent

Cherry-picked from #320 (`8428f60`): the four cc experiments switch from `vercel-ai-gateway/claude-code` to the direct `claude-code` agent.

With both in place, `AI_GATEWAY_API_KEY` is removed from the CI workflow env and the docs; `.env.example` keeps it documented as an optional classifier fallback.

## Verification

- Ran `classifyWithAI` against real failed eval results with `AI_GATEWAY_API_KEY`/`VERCEL_OIDC_TOKEN` explicitly unset: the full agentic loop completed via `api.anthropic.com` with correct `infra` verdicts.
- `pnpm --dir agent-eval run typecheck` passes.

## Notes

- The classifier patch also landed on `kasper/eval-coverage-324` (bundled into that branch's review-findings work); the experiment switch overlaps #320. Identical hunks on both sides, so whichever lands second merges cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made eval runs more reliable by improving transcript extraction and preventing large output corruption from sandbox logs.
  * Expanded failure classification to support direct Anthropic API usage when available, with clearer key requirements.
  * Updated Claude Code experiments to run directly against Claude Code (instead of routing through the AI Gateway).

* **Documentation**
  * Updated environment variable guidance and experiment configuration docs to use `ANTHROPIC_API_KEY` for Claude Code experiments.

* **Chores**
  * Pinned the Anthropic SDK version for consistent behavior and updated CI so the eval job no longer requires `AI_GATEWAY_API_KEY`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- agent-eval-results:start -->

### Agent eval results

**28/28 evals passed** · 12.2M tokens · $14.01 ([workflow run](https://github.com/storybookjs/mcp/actions/runs/28614138191))

Playground: https://storybook-evals-hji6ir73g-storybookjs.vercel.app

<details>
<summary>Results by experiment</summary>

#### `cc-mcp-opus-high` (2026-07-02T18-52-41.902Z)

| | Eval | Pass rate | Mean duration | Tokens | Cost | Failure |
|---|---|---|---|---|---|---|
| ✅ | `801-create-component-no-launch-config` | 1/1 (100%) | 237.3s | 597k | $0.66 |  |
| ✅ | `802-create-component` | 1/1 (100%) | 221.0s | 477k | $0.59 |  |
| ✅ | `803-edit-component` | 1/1 (100%) | 196.1s | 530k | $0.57 |  |
| ✅ | `804-write-story-for-existing-component` | 1/1 (100%) | 170.8s | 413k | $0.49 |  |
| ✅ | `805-non-visual-refactor` | 1/1 (100%) | 123.6s | 133k | $0.17 |  |
| ✅ | `806-browse-request` | 1/1 (100%) | 134.5s | 129k | $0.27 |  |
| ✅ | `807-docs-request` | 1/1 (100%) | 139.8s | 84k | $0.19 |  |

#### `cc-plugin-opus-high` (2026-07-02T18-52-41.904Z)

| | Eval | Pass rate | Mean duration | Tokens | Cost | Failure |
|---|---|---|---|---|---|---|
| ✅ | `801-create-component-no-launch-config` | 1/1 (100%) | 270.6s | 992k | $1.03 |  |
| ✅ | `802-create-component` | 1/1 (100%) | 253.8s | 1.0M | $1.12 |  |
| ✅ | `803-edit-component` | 1/1 (100%) | 240.9s | 822k | $0.82 |  |
| ✅ | `804-write-story-for-existing-component` | 1/1 (100%) | 229.8s | 654k | $0.71 |  |
| ✅ | `805-non-visual-refactor` | 1/1 (100%) | 117.1s | 86k | $0.12 |  |
| ✅ | `806-browse-request` | 1/1 (100%) | 154.7s | 321k | $0.38 |  |
| ✅ | `807-docs-request` | 1/1 (100%) | 150.8s | 262k | $0.34 |  |

#### `codex-mcp-gpt-5.5-medium` (2026-07-02T18-52-41.905Z)

| | Eval | Pass rate | Mean duration | Tokens | Cost | Failure |
|---|---|---|---|---|---|---|
| ✅ | `801-create-component-no-launch-config` | 1/1 (100%) | 177.9s | 338k | $0.40 |  |
| ✅ | `802-create-component` | 1/1 (100%) | 229.5s | 748k | $0.74 |  |
| ✅ | `803-edit-component` | 1/1 (100%) | 191.1s | 520k | $0.51 |  |
| ✅ | `804-write-story-for-existing-component` | 1/1 (100%) | 195.3s | 573k | $0.69 |  |
| ✅ | `805-non-visual-refactor` | 1/1 (100%) | 152.8s | 257k | $0.35 |  |
| ✅ | `806-browse-request` | 1/1 (100%) | 142.5s | 124k | $0.21 |  |
| ✅ | `807-docs-request` | 1/1 (100%) | 126.7s | 45k | $0.05 |  |

#### `codex-plugin-gpt-5.5-medium` (2026-07-02T18-52-41.906Z)

| | Eval | Pass rate | Mean duration | Tokens | Cost | Failure |
|---|---|---|---|---|---|---|
| ✅ | `801-create-component-no-launch-config` | 1/1 (100%) | 259.5s | 560k | $0.69 |  |
| ✅ | `802-create-component` | 1/1 (100%) | 255.7s | 588k | $0.78 |  |
| ✅ | `803-edit-component` | 1/1 (100%) | 192.1s | 543k | $0.69 |  |
| ✅ | `804-write-story-for-existing-component` | 1/1 (100%) | 208.8s | 721k | $0.72 |  |
| ✅ | `805-non-visual-refactor` | 1/1 (100%) | 186.7s | 213k | $0.25 |  |
| ✅ | `806-browse-request` | 1/1 (100%) | 167.2s | 196k | $0.23 |  |
| ✅ | `807-docs-request` | 1/1 (100%) | 163.1s | 198k | $0.23 |  |

</details>

_Cost is estimated from model token usage at provider list prices ([Vercel AI Gateway](https://vercel.com/docs/ai-gateway/pricing) adds no markup) and excludes Vercel Sandbox compute._

<!-- agent-eval-results:end -->
