### PR TITLE
Add script to download recent CI eval results locally

### DIFF
--- a/agent-eval/README.md
+++ b/agent-eval/README.md
@@ -152,6 +152,22 @@ pnpm playground
 
 Open [http://localhost:3000](http://localhost:3000) to browse results.
 
+### Download CI Results
+
+Pull the eval results produced by recent CI runs into the local
+`agent-eval/results` directory, so they can be browsed in the local playground
+and inspected by analysis tooling:
+
+```bash
+pnpm results:download        # latest 20 agent-eval-results artifacts
+pnpm results:download 5      # or any count between 1 and 100
+```
+
+Requires an authenticated GitHub CLI (`gh auth login`). Result snapshots are
+keyed by experiment name and run timestamp, so artifacts from multiple CI runs
+merge into `agent-eval/results` without colliding, and re-running the command
+is idempotent. Each artifact is roughly 20–40 MB extracted.
+
 ### Deploy Results Playground
 
 The `Agent eval` GitHub Actions workflow deploys the playground to Vercel

--- a/agent-eval/README.md
+++ b/agent-eval/README.md
@@ -163,7 +163,8 @@ pnpm results:download        # latest 20 agent-eval-results artifacts
 pnpm results:download 5      # or any count between 1 and 100
 ```
 
-Requires an authenticated GitHub CLI (`gh auth login`). Result snapshots are
+Requires an authenticated GitHub CLI (`gh auth login`) and a `tar` binary
+(preinstalled on macOS and Linux). Result snapshots are
 keyed by experiment name and run timestamp, so artifacts from multiple CI runs
 merge into `agent-eval/results` without colliding, and re-running the command
 is idempotent. Each artifact is roughly 20–40 MB extracted.

--- a/agent-eval/package.json
+++ b/agent-eval/package.json
@@ -12,6 +12,7 @@
 		"playground": "agent-eval playground",
 		"playground:build": "next build --webpack",
 		"playground:check-routes": "node ./scripts/check-playground-routes.mjs",
+		"results:download": "node ./scripts/download-ci-results.mjs",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {

--- a/agent-eval/scripts/download-ci-results.mjs
+++ b/agent-eval/scripts/download-ci-results.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// Downloads the most recent agent-eval-results artifacts from GitHub Actions
+// and extracts them into agent-eval/results, so CI runs are inspectable in the
+// local playground (pnpm playground) and by local analysis tooling.
+//
+// Usage: node scripts/download-ci-results.mjs [count]
+//   count: number of artifacts to download (default 20)
+//
+// Requires an authenticated GitHub CLI (gh auth login). Result snapshots are
+// keyed by experiment name and run timestamp, so artifacts from different CI
+// runs merge into the results directory without colliding, and re-downloading
+// the same artifact is idempotent.
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ARTIFACT_NAME = 'agent-eval-results';
+const agentEvalDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const count = Number(process.argv[2] ?? '20');
+if (!Number.isInteger(count) || count < 1 || count > 100) {
+	console.error(`Expected count between 1 and 100, got: ${process.argv[2]}`);
+	process.exit(1);
+}
+
+function gh(args, options = {}) {
+	try {
+		return execFileSync('gh', args, { maxBuffer: 1024 * 1024 * 1024, ...options });
+	} catch (error) {
+		if (error.code === 'ENOENT') {
+			console.error('The GitHub CLI (gh) is required. Install it and run: gh auth login');
+			process.exit(1);
+		}
+		throw error;
+	}
+}
+
+const artifacts = JSON.parse(
+	gh(
+		[
+			'api',
+			`repos/{owner}/{repo}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=100`,
+			'--jq',
+			'.artifacts | map(select(.expired | not))',
+		],
+		{ encoding: 'utf8' },
+	),
+)
+	.sort((a, b) => b.created_at.localeCompare(a.created_at))
+	.slice(0, count);
+
+if (artifacts.length === 0) {
+	console.error(`No unexpired ${ARTIFACT_NAME} artifacts found.`);
+	process.exit(1);
+}
+
+console.log(`Downloading ${artifacts.length} ${ARTIFACT_NAME} artifact(s) into ${path.join(agentEvalDir, 'results')}`);
+
+for (const artifact of artifacts) {
+	const run = artifact.workflow_run ?? {};
+	console.log(
+		`- artifact ${artifact.id} (${artifact.created_at}, branch ${run.head_branch ?? 'unknown'}, run ${run.id ?? 'unknown'})`,
+	);
+
+	const workDir = mkdtempSync(path.join(tmpdir(), 'agent-eval-artifact-'));
+	try {
+		const zipPath = path.join(workDir, 'artifact.zip');
+		writeFileSync(zipPath, gh(['api', `repos/{owner}/{repo}/actions/artifacts/${artifact.id}/zip`]));
+		execFileSync('unzip', ['-oq', zipPath, '-d', workDir]);
+		// The artifact wraps the results directory in a tarball; see the
+		// "Archive eval results" step in .github/workflows/agent-eval.yml.
+		execFileSync('tar', ['-xzf', path.join(workDir, `${ARTIFACT_NAME}.tgz`), '-C', agentEvalDir]);
+	} finally {
+		rmSync(workDir, { recursive: true, force: true });
+	}
+}
+
+console.log('Done. Browse the results with: pnpm playground');

--- a/agent-eval/scripts/download-ci-results.mjs
+++ b/agent-eval/scripts/download-ci-results.mjs
@@ -6,19 +6,20 @@
 // Usage: node scripts/download-ci-results.mjs [count]
 //   count: number of artifacts to download (default 20)
 //
-// Requires an authenticated GitHub CLI (gh auth login). Result snapshots are
-// keyed by experiment name and run timestamp, so artifacts from different CI
-// runs merge into the results directory without colliding, and re-downloading
-// the same artifact is idempotent.
+// Requires an authenticated GitHub CLI (gh auth login) and a tar binary.
+// Result snapshots are keyed by experiment name and run timestamp, so
+// artifacts from different CI runs merge into the results directory without
+// colliding, and re-downloading the same artifact is idempotent.
 
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ARTIFACT_NAME = 'agent-eval-results';
 const agentEvalDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const resultsDir = path.join(agentEvalDir, 'results');
 
 const count = Number(process.argv[2] ?? '20');
 if (!Number.isInteger(count) || count < 1 || count > 100) {
@@ -28,7 +29,9 @@ if (!Number.isInteger(count) || count < 1 || count > 100) {
 
 function gh(args, options = {}) {
 	try {
-		return execFileSync('gh', args, { maxBuffer: 1024 * 1024 * 1024, ...options });
+		// cwd pins gh's repo resolution to this checkout, so the script also
+		// works when invoked from outside the repository.
+		return execFileSync('gh', args, { cwd: agentEvalDir, ...options });
 	} catch (error) {
 		if (error.code === 'ENOENT') {
 			console.error('The GitHub CLI (gh) is required. Install it and run: gh auth login');
@@ -57,22 +60,35 @@ if (artifacts.length === 0) {
 	process.exit(1);
 }
 
-console.log(`Downloading ${artifacts.length} ${ARTIFACT_NAME} artifact(s) into ${path.join(agentEvalDir, 'results')}`);
+console.log(`Downloading ${artifacts.length} ${ARTIFACT_NAME} artifact(s) into ${resultsDir}`);
 
 for (const artifact of artifacts) {
-	const run = artifact.workflow_run ?? {};
+	const run = artifact.workflow_run;
+	if (!run?.id) {
+		console.warn(`- skipping artifact ${artifact.id}: no workflow run recorded`);
+		continue;
+	}
 	console.log(
-		`- artifact ${artifact.id} (${artifact.created_at}, branch ${run.head_branch ?? 'unknown'}, run ${run.id ?? 'unknown'})`,
+		`- artifact ${artifact.id} (${artifact.created_at}, branch ${run.head_branch ?? 'unknown'}, run ${run.id})`,
 	);
 
 	const workDir = mkdtempSync(path.join(tmpdir(), 'agent-eval-artifact-'));
 	try {
-		const zipPath = path.join(workDir, 'artifact.zip');
-		writeFileSync(zipPath, gh(['api', `repos/{owner}/{repo}/actions/artifacts/${artifact.id}/zip`]));
-		execFileSync('unzip', ['-oq', zipPath, '-d', workDir]);
-		// The artifact wraps the results directory in a tarball; see the
-		// "Archive eval results" step in .github/workflows/agent-eval.yml.
-		execFileSync('tar', ['-xzf', path.join(workDir, `${ARTIFACT_NAME}.tgz`), '-C', agentEvalDir]);
+		// gh streams the artifact zip to disk and unpacks it, leaving the
+		// tarball produced by the "Archive eval results" step in
+		// .github/workflows/agent-eval.yml.
+		gh(['run', 'download', String(run.id), '--name', ARTIFACT_NAME, '--dir', workDir]);
+		// Extract inside the temp directory and only the results/ subtree, so
+		// an artifact tarball can never write outside it; then merge that
+		// subtree into agent-eval/results.
+		execFileSync('tar', [
+			'-xzf',
+			path.join(workDir, `${ARTIFACT_NAME}.tgz`),
+			'-C',
+			workDir,
+			'results',
+		]);
+		cpSync(path.join(workDir, 'results'), resultsDir, { recursive: true });
 	} finally {
 		rmSync(workDir, { recursive: true, force: true });
 	}

--- a/packages/addon-mcp/src/tools/run-story-tests.test.ts
+++ b/packages/addon-mcp/src/tools/run-story-tests.test.ts
@@ -963,6 +963,49 @@ describe('runStoryTestsTool', () => {
 		`);
 	});
 
+	it('should ignore responses for other trigger requests', async () => {
+		const testContext = createTestContext();
+
+		mockChannel.emit.mockImplementation((event, payload: any) => {
+			if (event === 'storybook/test/trigger-test-run-request') {
+				const onCallback = mockChannel.on.mock.calls.find(
+					(call) => call[0] === 'storybook/test/trigger-test-run-response',
+				)?.[1];
+				if (onCallback) {
+					setTimeout(() => {
+						/* A response for a different request must not settle this one. */
+						onCallback({
+							requestId: 'some-other-request',
+							status: 'error',
+							error: { message: 'Failure from another test run' },
+						});
+						onCallback({
+							requestId: payload.requestId,
+							status: 'cancelled',
+						});
+					}, 0);
+				}
+			}
+		});
+
+		const response = await callTool(
+			[{ exportName: 'Primary', relativePath: 'src/Button.stories.tsx' }],
+			testContext,
+		);
+
+		expect(response.result).toMatchInlineSnapshot(`
+			{
+			  "content": [
+			    {
+			      "text": "Error: Test run was cancelled",
+			      "type": "text",
+			    },
+			  ],
+			  "isError": true,
+			}
+		`);
+	});
+
 	it('should clean up listener after matching completed response', async () => {
 		const testContext = createTestContext();
 


### PR DESCRIPTION
## What

Adds `agent-eval/scripts/download-ci-results.mjs`, exposed as `pnpm results:download` in `agent-eval`, which downloads the latest N (default 20, 1–100) unexpired `agent-eval-results` artifacts from GitHub Actions and extracts them into `agent-eval/results`.

## Why

CI eval runs upload their results as workflow artifacts, but until now inspecting them locally meant manually downloading and untarring each one. With this script the recent CI runs land directly in the local results directory, so they are browsable in the local playground (`pnpm playground`) and inspectable by AI analysis tooling.

## Notes

- Requires an authenticated GitHub CLI (`gh auth login`).
- Result snapshots are keyed as `results/<experiment>/<timestamp>/`, so artifacts from multiple runs merge without colliding and re-running the command is idempotent.
- Each artifact logs its source branch and workflow run id when downloaded.
- Verified end-to-end: downloaded the latest 20 artifacts (~350 MB, 78 experiment/run snapshots) into a clean results directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `results:download` to fetch the latest CI-generated evaluation artifacts into the local `agent-eval/results` directory.
  * Added README documentation for the new “Download CI Results” workflow, including prerequisites and optional control over how many recent runs to download.

* **Bug Fixes**
  * Improves collision-safe importing by organizing snapshots using experiment name and run time, with safer handling for incomplete/expired artifacts and clearer validation messaging.

* **Tests**
  * Added a test to ensure story test runs respond only to matching request events (avoiding cross-talk).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->