### PR TITLE
Gate the review-off docs/validation eval checks per the verification-run data

### DIFF
--- a/agent-eval/evals/801-create-component-no-launch-config/EVAL.ts
+++ b/agent-eval/evals/801-create-component-no-launch-config/EVAL.ts
@@ -28,11 +28,13 @@ const review = isReviewEnabled();
 // instructions agents read node_modules/reshaped/dist/*.d.ts instead (0/2 in
 // the 2026-07-01T22-53 cc-mcp and cc-plugin runs); the slimming is iterated
 // in #320.
-// Review-off runs (the default) assert this: the restored legacy
-// instructions — untruncated, with the CRITICAL never-hallucinate rule in
-// the Documentation Workflow — are the last known working state for
-// docs-tool usage, and restoring them is only proven by checking it.
-test.skipIf(review)('uses the documentation tooling', () => {
+// Review-off runs (the default) assert this on the Claude experiments, where
+// the restored legacy instructions — untruncated, with the CRITICAL
+// never-hallucinate rule in the Documentation Workflow — demonstrably work:
+// cc-mcp and cc-plugin both called get-documentation in the 2026-07-03 run
+// 28660377980. Accepted known failure on codex: GPT-5.5 skipped the docs
+// tools on both integrations in that same run (storybookjs/mcp#315).
+test.skipIf(review || getEvalContext().agent === 'codex')('uses the documentation tooling', () => {
 	expectWorkflowCalls(['get-documentation']);
 });
 

--- a/agent-eval/evals/807-docs-request/EVAL.ts
+++ b/agent-eval/evals/807-docs-request/EVAL.ts
@@ -1,27 +1,23 @@
 import { test } from 'vitest';
-import {
-	expectFinalResponseContains,
-	expectWorkflowCalls,
-	getEvalContext,
-	isReviewEnabled,
-} from '#test-utils';
+import { expectFinalResponseContains, expectWorkflowCalls, getEvalContext } from '#test-utils';
 
 // Documentation request: a props/usage question about an existing component
 // must be answered through the documentation tools, grounded in the live
 // Storybook index (list-all-documentation for IDs, get-documentation for
 // props and usage), not by grepping component source and guessing.
 
-// On the review-on instructions MCP-path agents consistently bypassed the
-// docs tools (2026-07-02 full-grid run: 0/2 on cc-mcp and codex-mcp, while
-// both plugin experiments passed) — that gate stays for review-on runs until
-// the instruction steering lands (storybookjs/mcp#315, slimming in #320).
-// Review-off runs (the default) assert every integration: the restored
-// legacy instructions are untruncated and are the last known working state
-// for docs-tool usage, which restoring them is meant to prove.
+// Accepted known failure — MCP-path agents bypass the docs tools regardless
+// of instruction shape: 0/2 on cc-mcp and codex-mcp under the review-on
+// instructions (2026-07-02 full-grid run, storybookjs/mcp#315), and still
+// 0/2 under the restored untruncated legacy instructions with the CRITICAL
+// never-hallucinate rule (2026-07-03 run 28660377980: both answered from
+// grep/file reads; codex even called list-all-documentation and
+// get-documentation-for-story but never get-documentation). Truncation was
+// therefore not the cause — MCP docs steering needs its own fix. Gated to
+// the plugin integration in both review modes.
 const { integration } = getEvalContext();
-const review = isReviewEnabled();
 
-test.skipIf(review && integration === 'mcp')(
+test.skipIf(integration === 'mcp')(
 	'uses the documentation tooling to resolve props and usage',
 	() => {
 		expectWorkflowCalls(['list-all-documentation', 'get-documentation']);

--- a/agent-eval/evals/808-shared-infra-fallback/EVAL.ts
+++ b/agent-eval/evals/808-shared-infra-fallback/EVAL.ts
@@ -45,9 +45,18 @@ test.runIf(review)('the review surfaces the consumer stories, not the token file
 // consumer. Any-of rather than both: the review-off instructions say to
 // preview "selected" storyIds from the discovery results, so surfacing one
 // consumer's stories is a legitimate selection.
-test.runIf(!review)('previews the consumer stories for the visual token change', () => {
-	expectPreviewStoriesWithFinalLinks({ coveringAnyOf: ['badge', 'statuspill'] });
-});
+// Accepted known failure on codex-mcp: after a shared-token edit GPT-5.5
+// verifies via shell commands and never calls preview-stories — consistent
+// across the 2026-07-03 runs 28659851504 and 28660377980 (the only
+// review-off failures in both runs' codex-mcp lines).
+const codexMcp = getEvalContext().agent === 'codex' && getEvalContext().integration === 'mcp';
+
+test.runIf(!review && !codexMcp)(
+	'previews the consumer stories for the visual token change',
+	() => {
+		expectPreviewStoriesWithFinalLinks({ coveringAnyOf: ['badge', 'statuspill'] });
+	},
+);
 
 test.runIf(review)(
 	'discovers stories through the workflow tools before publishing the review',
@@ -96,15 +105,16 @@ test.runIf(review)(
 // run-story-tests calls in the 2026-07-02 cc-mcp QA run, while the same
 // fixture passes on cc-plugin and codex-plugin). Re-enable on the review-on
 // MCP path once #320 lands.
-// Review-off runs (the default) assert every integration: the restored
-// legacy instructions fit under the truncation limit, so the Validation
-// Workflow reaches MCP agents again.
-test.skipIf(isReviewEnabled() && getEvalContext().integration === 'mcp')(
-	'runs story tests after the change and finishes with them passing',
-	() => {
-		expectStoryTestsRanAndPassed({ covering: ['badge', 'statuspill'] });
-	},
-);
+// Review-off runs (the default) assert this where it demonstrably works: the
+// restored legacy instructions fit under the truncation limit and cc-mcp
+// passed in the 2026-07-03 run 28660377980. Accepted known failure on
+// codex-mcp, which still verified via shell only in that same run.
+test.skipIf(
+	(isReviewEnabled() || getEvalContext().agent === 'codex') &&
+		getEvalContext().integration === 'mcp',
+)('runs story tests after the change and finishes with them passing', () => {
+	expectStoryTestsRanAndPassed({ covering: ['badge', 'statuspill'] });
+});
 
 // The plugin path must engage the stories skill (Claude: via the Skill tool;
 // Codex: by reading its SKILL.md). Skipped on the MCP integration, where no


### PR DESCRIPTION
Follow-up to #329 — this commit was pushed just after that PR merged, so it missed the train. Without it, labeled `ci:eval` runs on main fail on the checks that [verification run 28660377980](https://github.com/storybookjs/mcp/actions/runs/28660377980) (46/54, review off) showed are not yet met:

- **807**: MCP-path agents bypass the docs tools even with the untruncated legacy instructions + CRITICAL rule (0/2 again — codex even called `list-all-documentation` and `get-documentation-for-story` but never `get-documentation`). Truncation was therefore **not** the cause; restored the unconditional MCP gate with that evidence (#315).
- **801**: the docs check passes on both Claude experiments (the legacy instructions demonstrably work there) but GPT-5.5 skipped the docs tools on both integrations — keep asserting on Claude, accepted known failure on codex.
- **808**: cc-mcp now passes validation with the legacy instructions (the truncation theory holds there), but codex-mcp still verifies via shell only and never calls preview-stories (consistent across both runs) — accepted known failures on codex-mcp.

One-off cc-plugin failures in that run (808 `npm run test:stories` instead of the workflow tool, 811 self-fixed contrast, 813 no preview_start) are pre-existing checks that passed in run 28659851504; left untouched as behavioral flakes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated test expectations to better handle known failure cases in MCP-based and Codex-based runs.
  * Adjusted review-off checks so documentation and preview-related assertions only run when they are expected to pass.
  * Refined skip conditions for story and workflow validation to match current behavior more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- agent-eval-results:start -->

### Agent eval results

**53/53 evals passed** · 19.4M tokens · $22.81 ([workflow run](https://github.com/storybookjs/mcp/actions/runs/28661397469))

Playground: https://storybook-evals-70tth0shj-storybookjs.vercel.app

<details>
<summary>Results by experiment</summary>

#### `cc-mcp-opus-high` (2026-07-03T12-45-19.700Z)

| | Eval | Pass rate | Mean duration | Tokens | Cost | Failure |
|---|---|---|---|---|---|---|
| ✅ | `801-create-component-no-launch-config` | 1/1 (100%) | 266.5s | 644k | $0.69 |  |
| ✅ | `802-create-component` | 1/1 (100%) | 253.7s | 721k | $0.82 |  |
| ✅ | `803-edit-component` | 1/1 (100%) | 180.6s | 416k | $0.49 |  |
| ✅ | `804-write-story-for-existing-component` | 1/1 (100%) | 162.6s | 264k | $0.39 |  |
| ✅ | `805-non-visual-refactor` | 1/1 (100%) | 119.2s | 85k | $0.12 |  |
| ✅ | `806-browse-request` | 1/1 (100%) | 136.8s | 99k | $0.17 |  |
| ✅ | `807-docs-request` | 1/1 (100%) | 139.3s | 63k | $0.11 |  |
| ✅ | `808-shared-infra-fallback` | 1/1 (100%) | 184.3s | 212k | $0.30 |  |
| ✅ | `810-fix-failing-tests` | 1/1 (100%) | 185.1s | 256k | $0.35 |  |
| ✅ | `811-fix-a11y-violations` | 1/1 (100%) | 181.6s | 241k | $0.36 |  |
| ✅ | `812-first-story-empty-project` | 1/1 (100%) | 139.1s | 278k | $0.37 |  |
| ✅ | `813-monorepo-leaf-create-component` | 1/1 (100%) | 111.5s | 108k | $0.15 |  |

#### `cc-plugin-opus-high` (2026-07-03T12-45-19.703Z)

| | Eval | Pass rate | Mean duration | Tokens | Cost | Failure |
|---|---|---|---|---|---|---|
| ✅ | `801-create-component-no-launch-config` | 1/1 (100%) | 325.6s | 874k | $0.93 |  |
| ✅ | `802-create-component` | 1/1 (100%) | 375.6s | 1.1M | $1.12 |  |
| ✅ | `803-edit-component` | 1/1 (100%) | 263.6s | 609k | $0.70 |  |
| ✅ | `804-write-story-for-existing-component` | 1/1 (100%) | 214.2s | 521k | $0.59 |  |
| ✅ | `805-non-visual-refactor` | 1/1 (100%) | 122.7s | 86k | $0.12 |  |
| ✅ | `806-browse-request` | 1/1 (100%) | 192.6s | 380k | $0.42 |  |
| ✅ | `807-docs-request` | 1/1 (100%) | 190.4s | 308k | $0.36 |  |
| ✅ | `808-shared-infra-fallback` | 1/1 (100%) | 254.2s | 740k | $0.70 |  |
| ✅ | `810-fix-failing-tests` | 1/1 (100%) | 192.3s | 390k | $0.42 |  |
| ✅ | `811-fix-a11y-violations` | 1/1 (100%) | 218.8s | 444k | $0.56 |  |
| ✅ | `812-first-story-empty-project` | 1/1 (100%) | 214.8s | 390k | $0.49 |  |
| ✅ | `813-monorepo-leaf-create-component` | 1/1 (100%) | 213.2s | 604k | $0.68 |  |
| ✅ | `820-init-no-storybook` | 1/1 (100%) | 305.6s | 1.1M | $1.11 |  |
| ✅ | `821-upgrade-from-sb9` | 1/1 (100%) | 174.2s | 162k | $0.24 |  |
| ✅ | `822-upgrade-from-stable` | 1/1 (100%) | 193.6s | 238k | $0.29 |  |

#### `codex-mcp-gpt-5.5-medium` (2026-07-03T12-45-19.705Z)

| | Eval | Pass rate | Mean duration | Tokens | Cost | Failure |
|---|---|---|---|---|---|---|
| ✅ | `801-create-component-no-launch-config` | 1/1 (100%) | 216.0s | 288k | $0.40 |  |
| ✅ | `802-create-component` | 1/1 (100%) | 239.2s | 368k | $0.53 |  |
| ✅ | `803-edit-component` | 1/1 (100%) | 208.8s | 457k | $0.53 |  |
| ✅ | `804-write-story-for-existing-component` | 1/1 (100%) | 193.0s | 384k | $0.39 |  |
| ✅ | `805-non-visual-refactor` | 1/1 (100%) | 123.3s | 101k | $0.14 |  |
| ✅ | `806-browse-request` | 1/1 (100%) | 121.8s | 74k | $0.11 |  |
| ✅ | `807-docs-request` | 1/1 (100%) | 119.3s | 74k | $0.10 |  |
| ✅ | `808-shared-infra-fallback` | 1/1 (100%) | 124.8s | 53k | $0.10 |  |
| ✅ | `810-fix-failing-tests` | 1/1 (100%) | 159.0s | 209k | $0.32 |  |
| ✅ | `811-fix-a11y-violations` | 1/1 (100%) | 198.4s | 301k | $0.32 |  |
| ✅ | `812-first-story-empty-project` | 1/1 (100%) | 174.8s | 219k | $0.27 |  |
| ✅ | `813-monorepo-leaf-create-component` | 1/1 (100%) | 152.5s | 257k | $0.33 |  |

#### `codex-plugin-gpt-5.5-medium` (2026-07-03T12-45-19.708Z)

| | Eval | Pass rate | Mean duration | Tokens | Cost | Failure |
|---|---|---|---|---|---|---|
| ✅ | `801-create-component-no-launch-config` | 1/1 (100%) | 263.9s | 505k | $0.71 |  |
| ✅ | `802-create-component` | 1/1 (100%) | 229.9s | 435k | $0.52 |  |
| ✅ | `803-edit-component` | 1/1 (100%) | 277.7s | 618k | $0.61 |  |
| ✅ | `804-write-story-for-existing-component` | 1/1 (100%) | 251.2s | 419k | $0.49 |  |
| ✅ | `805-non-visual-refactor` | 1/1 (100%) | 123.9s | 73k | $0.09 |  |
| ✅ | `806-browse-request` | 1/1 (100%) | 186.6s | 384k | $0.54 |  |
| ✅ | `807-docs-request` | 1/1 (100%) | 150.5s | 191k | $0.23 |  |
| ✅ | `810-fix-failing-tests` | 1/1 (100%) | 256.5s | 450k | $0.49 |  |
| ✅ | `811-fix-a11y-violations` | 1/1 (100%) | 174.7s | 245k | $0.31 |  |
| ✅ | `812-first-story-empty-project` | 1/1 (100%) | 165.9s | 264k | $0.31 |  |
| ✅ | `813-monorepo-leaf-create-component` | 1/1 (100%) | 222.9s | 463k | $0.53 |  |
| ✅ | `820-init-no-storybook` | 1/1 (100%) | 319.7s | 727k | $0.81 |  |
| ✅ | `821-upgrade-from-sb9` | 1/1 (100%) | 187.7s | 300k | $0.37 |  |
| ✅ | `822-upgrade-from-stable` | 1/1 (100%) | 154.8s | 204k | $0.26 |  |

</details>

_Cost is estimated from model token usage at provider list prices ([Vercel AI Gateway](https://vercel.com/docs/ai-gateway/pricing) adds no markup) and excludes Vercel Sandbox compute._

<!-- agent-eval-results:end -->
