### PR TITLE
Drop the stale issue reference from the docs-bypass gate comments

### DIFF
--- a/agent-eval/CLAUDE.md
+++ b/agent-eval/CLAUDE.md
@@ -1,0 +1,21 @@
+# Agent eval suite — contributor rules
+
+## Known failures: code comments, never tracking issues
+
+When you relax or gate an eval assertion (`test.skip`, `test.skipIf(...)`,
+narrowing a run condition), document it **only as a code comment directly
+above that assertion**. Never create a GitHub issue for an eval failure and
+never reference one from a gate comment — there is no issue-based
+known-failure list (the old #317 tracker is retired).
+
+The comment must be self-contained:
+
+- the observed behavior (what the agent did instead),
+- the evidence (CI run id and date),
+- the condition for re-enabling.
+
+Referencing a _causal_ change is fine (the PR that will fix the behavior, or
+an upstream Storybook bug the assertion waits on) — that is a pointer to the
+fix, not a tracker for the failure. See `evals/807-docs-request/EVAL.ts` and
+`evals/808-shared-infra-fallback/EVAL.ts` for the expected shape, and the
+"Known Failures" section in `README.md`.

--- a/agent-eval/README.md
+++ b/agent-eval/README.md
@@ -124,6 +124,27 @@ Configured experiments:
 - `cc-mcp-sonnet-medium`: Claude Code (Sonnet at medium effort) MCP variant; runs zero evals unless `EVAL_EXTRA_MODELS=1` is set.
 - `codex-plugin-gpt-5.5-medium`: Codex (gpt-5.5 at medium reasoning effort) with Storybook plugin skills copied to `.agents/skills`.
 
+## Known Failures
+
+Accepted eval failures are documented **only as a code comment directly above
+the relaxed assertion** in the affected `EVAL.ts` — never as a tracking issue.
+Do not create a GitHub issue for an eval failure, and do not reference one
+from a gate comment; there is no issue-based known-failure list (the old #317
+tracker is retired).
+
+When relaxing or gating an assertion (`test.skip`, `test.skipIf(...)`,
+narrowing a condition), the comment above it must be self-contained:
+
+- the observed behavior (what the agent did instead),
+- the evidence (CI run id and date),
+- the condition for re-enabling.
+
+Referencing a _causal_ change is fine (e.g. the PR that will fix the behavior,
+or an upstream Storybook bug the assertion waits on) — that is a pointer to
+the fix, not a tracker for the failure. See the gates in
+`evals/807-docs-request/EVAL.ts` and `evals/808-shared-infra-fallback/EVAL.ts`
+for the expected shape.
+
 ## Shared Templates
 
 Fixtures can opt into a shared starter project with package metadata:

--- a/agent-eval/evals/801-create-component-no-launch-config/EVAL.ts
+++ b/agent-eval/evals/801-create-component-no-launch-config/EVAL.ts
@@ -33,7 +33,7 @@ const review = isReviewEnabled();
 // never-hallucinate rule in the Documentation Workflow — demonstrably work:
 // cc-mcp and cc-plugin both called get-documentation in the 2026-07-03 run
 // 28660377980. Accepted known failure on codex: GPT-5.5 skipped the docs
-// tools on both integrations in that same run (storybookjs/mcp#315).
+// tools on both integrations in that same run.
 test.skipIf(review || getEvalContext().agent === 'codex')('uses the documentation tooling', () => {
 	expectWorkflowCalls(['get-documentation']);
 });

--- a/agent-eval/evals/807-docs-request/EVAL.ts
+++ b/agent-eval/evals/807-docs-request/EVAL.ts
@@ -8,7 +8,7 @@ import { expectFinalResponseContains, expectWorkflowCalls, getEvalContext } from
 
 // Accepted known failure — MCP-path agents bypass the docs tools regardless
 // of instruction shape: 0/2 on cc-mcp and codex-mcp under the review-on
-// instructions (2026-07-02 full-grid run, storybookjs/mcp#315), and still
+// instructions (2026-07-02 full-grid run), and still
 // 0/2 under the restored untruncated legacy instructions with the CRITICAL
 // never-hallucinate rule (2026-07-03 run 28660377980: both answered from
 // grep/file reads; codex even called list-all-documentation and


### PR DESCRIPTION
Comment-only cleanup after #331, plus codifying the known-failure policy.

## 1. Drop the stale issue reference from the docs-bypass gate comments

The known-failure gate comments in 801 and 807 pointed at #315 — the closed 9xx-port issue, unrelated to the docs-bypass behavior (the pointer predates #331; it was carried along). The run evidence in the comments stands on its own, so the reference is dropped rather than replaced.

## 2. Write the policy down where eval authors see it

Accepted eval failures are documented **only as a self-contained code comment directly above the relaxed assertion** — observed behavior, run evidence (CI run id/date), and the re-enable condition. No GitHub issues are created or referenced for eval failures (the old #317 tracker is retired). Causal references remain fine: the PR that will fix the behavior, or an upstream Storybook bug the assertion waits on.

Now written down in:
- a new **Known Failures** section in `agent-eval/README.md`
- `agent-eval/CLAUDE.md`, so coding agents working in this directory get the rule injected at the moment they gate an assertion

A sweep confirms no gate comment references a tracking issue anymore; the remaining `#320`/`#324`/`storybook#35359` mentions are causal/provenance pointers, which the policy explicitly allows.

No behavior change, deliberately unlabeled (no `ci:eval`).