### PR TITLE
Stabilize the 8xx eval line across both review modes

### DIFF
--- a/agent-eval/evals/801-create-component-no-launch-config/EVAL.ts
+++ b/agent-eval/evals/801-create-component-no-launch-config/EVAL.ts
@@ -23,17 +23,23 @@ const review = isReviewEnabled();
 
 // The template composes the Reshaped Storybook (refs in .storybook/main.ts)
 // so get-documentation can serve its components.
-// Asserted on every experiment in both review modes. Agents used to skip the
-// docs tools (review-on: reading node_modules/reshaped/dist/*.d.ts under the
-// truncated instructions, 2026-07-01T22-53 runs; review-off: GPT-5.5 on both
-// integrations in the 2026-07-03 run 28660377980, storybookjs/mcp#315). The
-// get-documentation/list-all-documentation descriptions and the story-
-// instructions Design-System Documentation section now make discovery
-// unconditional for new UI work, and tool descriptions survive the client
-// truncation that motivated the review-on gate.
-test('uses the documentation tooling', () => {
-	expectWorkflowCalls(['get-documentation']);
-});
+// Asserted on both review modes, but skipped on the Codex MCP experiment:
+// GPT-5.5 on the MCP path intermittently builds the Reshaped component from
+// prior knowledge without ever calling get-documentation (review-off runs
+// 28673251562 on 2026-07-03 and the local 2026-07-03T14-12 run; roughly one
+// run in four across the 07-02/07-03 history), even though the docs tool
+// descriptions and server instructions both demand a docs lookup — the same
+// accepted Codex docs gap already gated in 802. Codex-plugin runs pass this
+// consistently (the stories skill forces reading the full workflow help), so
+// only the codex+mcp cell is gated. Re-enable when Codex MCP runs reliably
+// consult the docs tools, e.g. after a Codex-side change to how MCP tool
+// descriptions are surfaced.
+test.skipIf(getEvalContext().agent === 'codex' && getEvalContext().integration === 'mcp')(
+	'uses the documentation tooling',
+	() => {
+		expectWorkflowCalls(['get-documentation']);
+	},
+);
 
 test.runIf(review)('uses Storybook story instructions and publishes a display review', () => {
 	expectWorkflowCalls(['get-storybook-story-instructions', 'display-review']);

--- a/agent-eval/evals/808-shared-infra-fallback/EVAL.ts
+++ b/agent-eval/evals/808-shared-infra-fallback/EVAL.ts
@@ -25,6 +25,23 @@ import {
 // preview links for the consumer stories.
 const review = isReviewEnabled();
 
+// Known failure on the Codex MCP experiment with review on: GPT-5.5 edits the
+// token file and ends the turn with zero MCP calls roughly every other run
+// (local runs 2026-07-03T18-14 and 2026-07-03T18-23, plus the
+// 2026-07-03T13-28 review-on run) — no story instructions, no discovery, no
+// tests, no review. Codex surfaces MCP server instructions only as the tool namespace
+// description (codex-rs rmcp_client maps InitializeResult.instructions to
+// namespace_description), so for an edit it judges trivial it never reads the
+// storybook namespace and no instruction wording can reach it; the same runs
+// pass whenever Codex enters the workflow at all. Codex review-off runs and
+// the codex-plugin path (where the stories skill forces the workflow help
+// into context) pass 808 consistently and stay asserted. Re-enable when the
+// review-on workflow reliably reaches Codex at turn start — e.g. Codex
+// injecting server instructions turn-level, or the Storybook docs shipping a
+// Codex agent-instructions snippet the MCP fixtures adopt.
+const codexMcpReviewGap =
+	review && getEvalContext().agent === 'codex' && getEvalContext().integration === 'mcp';
+
 // Guard against a vacuous pass: skipping the fallback only counts if the token
 // change was actually performed.
 test('changes the accent color token', () => {
@@ -33,13 +50,19 @@ test('changes the accent color token', () => {
 	expect(colors, 'Expected the old accent value #2563eb to be gone').not.toMatch(/#2563eb/i);
 });
 
-test.runIf(review)('publishes a display review for the visual token change', () => {
-	expectDisplayReviewForVisualChange();
-});
+test.runIf(review && !codexMcpReviewGap)(
+	'publishes a display review for the visual token change',
+	() => {
+		expectDisplayReviewForVisualChange();
+	},
+);
 
-test.runIf(review)('the review surfaces the consumer stories, not the token file', () => {
-	expectStoryIdsInDisplayReview(['badge', 'statuspill']);
-});
+test.runIf(review && !codexMcpReviewGap)(
+	'the review surfaces the consumer stories, not the token file',
+	() => {
+		expectStoryIdsInDisplayReview(['badge', 'statuspill']);
+	},
+);
 
 // The token file has no stories of its own, so the previews must cover a
 // consumer. Any-of rather than both: the review-off instructions say to
@@ -55,7 +78,7 @@ test.runIf(!review)('previews the consumer stories for the visual token change',
 	expectPreviewStoriesWithFinalLinks({ coveringAnyOf: ['badge', 'statuspill'] });
 });
 
-test.runIf(review)(
+test.runIf(review && !codexMcpReviewGap)(
 	'discovers stories through the workflow tools before publishing the review',
 	() => {
 		expectStoryDiscoveryBeforeReview();
@@ -71,7 +94,7 @@ test.runIf(review)(
 // from the diff alone (observed in the 2026-07-02 cc-mcp QA run — one
 // get-changed-stories call covering badge + statuspill, zero fallback calls),
 // and punishing that correct behavior would fight the spec.
-test.runIf(review)(
+test.runIf(review && !codexMcpReviewGap)(
 	'falls back to get-stories-by-component when the diff does not cover the consumers',
 	() => {
 		const changedStoriesResults = getWorkflowToolResults('get-changed-stories');
@@ -102,9 +125,13 @@ test.runIf(review)(
 // description now carries the trigger ("after editing anything that changes
 // how the UI looks... typecheck, lint, or package.json test scripts do not
 // replace this") and tool descriptions survive client truncation.
-test('runs story tests after the change and finishes with them passing', () => {
-	expectStoryTestsRanAndPassed({ covering: ['badge', 'statuspill'] });
-});
+// The codex+mcp review-on cell is the one exception — see codexMcpReviewGap.
+test.skipIf(codexMcpReviewGap)(
+	'runs story tests after the change and finishes with them passing',
+	() => {
+		expectStoryTestsRanAndPassed({ covering: ['badge', 'statuspill'] });
+	},
+);
 
 // The plugin path must engage the stories skill (Claude: via the Skill tool;
 // Codex: by reading its SKILL.md). Skipped on the MCP integration, where no

--- a/agent-eval/evals/808-shared-infra-fallback/EVAL.ts
+++ b/agent-eval/evals/808-shared-infra-fallback/EVAL.ts
@@ -100,8 +100,8 @@ test.runIf(review)(
 // instruction truncation eating the Validation Workflow (0 run-story-tests
 // calls in the 2026-07-02 cc-mcp QA run), but the run-story-tests
 // description now carries the trigger ("after editing anything that changes
-// how the UI looks... typecheck or lint do not replace this") and tool
-// descriptions survive client truncation.
+// how the UI looks... typecheck, lint, or package.json test scripts do not
+// replace this") and tool descriptions survive client truncation.
 test('runs story tests after the change and finishes with them passing', () => {
 	expectStoryTestsRanAndPassed({ covering: ['badge', 'statuspill'] });
 });

--- a/agent-eval/lib/test-utils.test.ts
+++ b/agent-eval/lib/test-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 import {
 	parseStorybookWorkflowShellCommands,
 	parseWorkflowToolResults,
+	selectFinalRunStoryTestsReport,
 	workflowCallIncludesStory,
 	workflowCallUsesStoryId,
 } from './test-utils.ts';
@@ -262,5 +263,34 @@ describe('parseWorkflowToolResults', () => {
 		].join('\n');
 
 		expect(parseWorkflowToolResults(transcript, 'run-story-tests')).toHaveLength(0);
+	});
+});
+
+describe('selectFinalRunStoryTestsReport', () => {
+	const passingReport = {
+		output: '## Passing Stories\n\n- example-button--primary',
+		isError: false,
+	};
+
+	test('skips trailing shell-filtered fragments and picks the last real report', () => {
+		const filteredFragment = { output: 'exit-check-done', isError: false };
+		const failedGrep = { output: '', isError: true };
+
+		expect(selectFinalRunStoryTestsReport([passingReport, filteredFragment, failedGrep])).toBe(
+			passingReport,
+		);
+	});
+
+	test('prefers a later real report over an earlier one', () => {
+		const failingReport = { output: '## Failing Stories\n\n### a--c', isError: false };
+
+		expect(selectFinalRunStoryTestsReport([passingReport, failingReport])).toBe(failingReport);
+	});
+
+	test('falls back to the raw last result when no output is recognizable', () => {
+		const errorResult = { output: 'Error: dev server unreachable', isError: true };
+
+		expect(selectFinalRunStoryTestsReport([errorResult])).toBe(errorResult);
+		expect(selectFinalRunStoryTestsReport([])).toBeUndefined();
 	});
 });

--- a/agent-eval/lib/test-utils.ts
+++ b/agent-eval/lib/test-utils.ts
@@ -434,7 +434,7 @@ export function expectStoryTestsRanAndPassed(options?: { covering?: string[] }):
 		'Expected at least one run-story-tests result in the transcript',
 	).toBeGreaterThan(0);
 
-	const lastResult = results[results.length - 1];
+	const lastResult = selectFinalRunStoryTestsReport(results);
 	if (lastResult === undefined) {
 		expect.fail('Expected a final run-story-tests result');
 	}
@@ -465,6 +465,37 @@ export function expectStoryTestsRanAndPassed(options?: { covering?: string[] }):
 			`Final run-story-tests result must cover the changed component (one of: ${covering.join(', ')}). Output: ${truncateForMessage(lastResult.output)}`,
 		).toBe(true);
 	}
+}
+
+// The run-story-tests result formatter (packages/addon-mcp) always emits at
+// least one of these markers. A captured output with none of them is a
+// shell-filtered fragment of the real report, not the report itself. isError
+// deliberately does not count as recognizable: a piped `… | grep` exits
+// non-zero when the filter simply matches nothing, so an errored markerless
+// result is exactly the filtered-fragment case this selection skips.
+const RUN_STORY_TESTS_REPORT_MARKERS = [
+	'## Passing Stories',
+	'## Failing Stories',
+	'## Accessibility Violations',
+	'## Unhandled Errors',
+	'No stories found matching',
+];
+
+// On the plugin path agents pipe the `storybook ai run-story-tests` CLI output
+// through grep/sed/tail, so the chronologically last captured output can be a
+// filtered fragment (cc-plugin 802 in run 28672627415, 2026-07-03: eight
+// correct CLI runs, but the final one grepped for a11y lines and printed only
+// "exit-check-done"). Judge the last output that still looks like a
+// run-story-tests report; only when no output is recognizable does the raw
+// last result stand, so fully-filtered transcripts still fail loud.
+export function selectFinalRunStoryTestsReport(
+	results: WorkflowToolResult[],
+): WorkflowToolResult | undefined {
+	return (
+		results.findLast((result) =>
+			RUN_STORY_TESTS_REPORT_MARKERS.some((marker) => result.output.includes(marker)),
+		) ?? results.at(-1)
+	);
 }
 
 // Chronological outputs of a Storybook workflow tool, across every path an

--- a/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
+++ b/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
@@ -593,7 +593,7 @@ describe('MCP Endpoint E2E Tests', () => {
 				  },
 				  {
 				    "description": "Run story tests.
-				Run them after editing anything that changes how the UI looks — components, stories, styles, CSS, themes, colors, or design tokens — shell-level checks like typecheck or lint do not replace this.
+				Run them after editing anything that changes how the UI looks — components, stories, styles, CSS, themes, colors, or design tokens — shell-level substitutes like typecheck, lint, or package.json test scripts do not replace this.
 				Provide stories for focused runs (faster while iterating),
 				or omit stories to run all tests for full-project verification.
 				Use this continuously to monitor test results as you work on your UI components and stories.

--- a/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
+++ b/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
@@ -348,6 +348,7 @@ describe('MCP Endpoint E2E Tests', () => {
 				- Adding new story variants or exports to story files
 				- Editing any file matching *.stories.* patterns
 				- Writing components that will need stories
+				- Editing anything that changes how the UI looks — components, styles, CSS, themes, colors, or design tokens; a shared file with no stories of its own still changes its consumers' stories
 				- Running story tests or fixing test failures
 				- Handling accessibility (a11y) violations in stories (fix semantic issues directly; ask before visual/design changes)
 

--- a/packages/addon-mcp/src/instructions/build-server-instructions.test.ts
+++ b/packages/addon-mcp/src/instructions/build-server-instructions.test.ts
@@ -56,7 +56,7 @@ describe('buildServerInstructions', () => {
 
 			## Validation Workflow
 
-			- After editing anything that changes how the UI looks, run **run-story-tests**.
+			- After editing anything that changes how the UI looks, run **run-story-tests** — never a package.json test script.
 			- Never report completion while story tests are failing.
 
 			## Documentation Workflow
@@ -241,9 +241,9 @@ describe('buildServerInstructions', () => {
 
 			## Validation Workflow
 
-			- After editing anything that changes how the UI looks, run **run-story-tests**.
+			- After editing anything that changes how the UI looks, run **run-story-tests** — never a package.json test script.
 			- Use focused runs while iterating, then a broad pass before handoff when scope is unclear or wide.
-			- Fix failing tests before reporting success. Do not report completion while story tests are failing."
+			- Fix failing tests; never report completion while they are failing."
 		`);
 	});
 

--- a/packages/addon-mcp/src/instructions/build-server-instructions.ts
+++ b/packages/addon-mcp/src/instructions/build-server-instructions.ts
@@ -91,8 +91,10 @@ export function buildServerInstructions(options: BuildServerInstructionsOptions)
 
 	// The test and docs sections follow the same split as the dev section:
 	// with review off (the default) they are the shipping texts — the legacy
-	// Validation Workflow verbatim from the latest release, and the shared
-	// @storybook/mcp Documentation Workflow. With review on, the whole
+	// Validation Workflow from the latest release (plus the run-story-tests-only
+	// rule added after agents substituted `npm run test:stories`, run
+	// 28673251562), and the shared @storybook/mcp Documentation Workflow. With
+	// review on, the whole
 	// instruction set must fit under the 2,048-char client truncation limit
 	// alongside the review workflow, so slimmed variants (same rules, terser
 	// wording) are used instead.

--- a/packages/addon-mcp/src/instructions/legacy-test-instructions.md
+++ b/packages/addon-mcp/src/instructions/legacy-test-instructions.md
@@ -1,5 +1,5 @@
 ## Validation Workflow
 
-- After editing anything that changes how the UI looks, run **run-story-tests**.
+- After editing anything that changes how the UI looks, run **run-story-tests** — never a package.json test script.
 - Use focused runs while iterating, then a broad pass before handoff when scope is unclear or wide.
-- Fix failing tests before reporting success. Do not report completion while story tests are failing.
+- Fix failing tests; never report completion while they are failing.

--- a/packages/addon-mcp/src/instructions/story-testing-instructions.md
+++ b/packages/addon-mcp/src/instructions/story-testing-instructions.md
@@ -1,6 +1,6 @@
 ## Story Testing Requirements
 
-**Run `{{RUN_STORY_TESTS_TOOL_NAME}}` after EVERY component or story change.** This includes creating, modifying, or refactoring components, stories, or their dependencies.
+**Run `{{RUN_STORY_TESTS_TOOL_NAME}}` after EVERY component or story change.** This includes creating, modifying, or refactoring components, stories, or their dependencies. It is the only way to run story tests — never run package.json test scripts (like `npm run test:stories`) instead.
 
 ### Workflow
 

--- a/packages/addon-mcp/src/instructions/test-instructions.md
+++ b/packages/addon-mcp/src/instructions/test-instructions.md
@@ -1,4 +1,4 @@
 ## Validation Workflow
 
-- After editing anything that changes how the UI looks, run **run-story-tests**.
+- After editing anything that changes how the UI looks, run **run-story-tests** — never a package.json test script.
 - Never report completion while story tests are failing.

--- a/packages/addon-mcp/src/tools/get-storybook-story-instructions.ts
+++ b/packages/addon-mcp/src/tools/get-storybook-story-instructions.ts
@@ -122,7 +122,8 @@ CRITICAL: You MUST call this tool before:
 - Updating or modifying existing Storybook stories
 - Adding new story variants or exports to story files
 - Editing any file matching *.stories.* patterns
-- Writing components that will need stories${criticalTestBullets}${criticalA11yBullets}
+- Writing components that will need stories
+- Editing anything that changes how the UI looks — components, styles, CSS, themes, colors, or design tokens; a shared file with no stories of its own still changes its consumers' stories${criticalTestBullets}${criticalA11yBullets}
 
 This tool provides essential Storybook-specific guidance including:
 - How to structure stories correctly for Storybook 9

--- a/packages/addon-mcp/src/tools/run-story-tests.ts
+++ b/packages/addon-mcp/src/tools/run-story-tests.ts
@@ -60,7 +60,7 @@ Use { absoluteStoryPath + exportName } only when you're currently working in a s
 export function getRunStoryTestsToolDescription(a11yEnabled: boolean) {
 	return (
 		`Run story tests.
-Run them after editing anything that changes how the UI looks — components, stories, styles, CSS, themes, colors, or design tokens — shell-level checks like typecheck or lint do not replace this.
+Run them after editing anything that changes how the UI looks — components, stories, styles, CSS, themes, colors, or design tokens — shell-level substitutes like typecheck, lint, or package.json test scripts do not replace this.
 Provide stories for focused runs (faster while iterating),
 or omit stories to run all tests for full-project verification.
 Use this continuously to monitor test results as you work on your UI components and stories.


### PR DESCRIPTION
Gets every 8xx eval to 3 consecutive green runs per experiment in both review modes, based on the failures in the review-on matrix run [28672627415](https://github.com/storybookjs/mcp/actions/runs/28672627415), the review-off dispatch run [28673251562](https://github.com/storybookjs/mcp/actions/runs/28673251562), and the pass/fail history across the last ~30 CI artifacts.

## Fixes

**Harness: tolerate shell-filtered `run-story-tests` output (802 cc-plugin, review on).**
The agent ran the CLI correctly eight times but piped the final call through `grep`, so the last captured output was `exit-check-done` and the `## Passing Stories` assertion failed. `expectStoryTestsRanAndPassed` now judges the last output that is a recognizable run-story-tests report (unit-tested); fully-filtered transcripts still fail loud.

**Steering: package.json test scripts are not a substitute for `run-story-tests` (803 codex-mcp + 808 cc-plugin, review off).**
Agents occasionally validated via `npm run test:stories` instead of the workflow tool. The rule now lives in both Validation Workflow variants, the story-instructions testing section, and the `run-story-tests` tool description. The legacy text was trimmed to stay under the 2,048-char client truncation cap.

**Steering: shared UI files trigger the story workflow (808 codex-plugin/codex-mcp, review on).**
The `get-storybook-story-instructions` CRITICAL trigger list only named story files and new components, so a bare theme-token edit matched none of its bullets. It now carries the same shared-file wording as `run-story-tests` and the review-off preview-stories step. Every passing 808 run enters the workflow through this tool.

**Known-failure gates (per the code-comment policy, no tracking issues):**
- 801: the docs-tooling assertion is skipped on the codex+mcp cell (~1-in-4 flake; same accepted Codex docs gap as 802's existing gate). Codex-plugin and both Claude paths stay asserted.
- 808: the review-on workflow assertions are skipped on the codex+mcp cell. GPT-5.5 edits the token and ends the turn with zero MCP calls roughly every other run — Codex surfaces MCP server instructions only as the tool-namespace description (`codex-rs` `rmcp_client` maps `InitializeResult.instructions` to `namespace_description`), so no wording reaches an edit it judges trivial. The token-change guard and all other cells keep the full assertions.

## Local verification (no eval CI spent)

All runs on Vercel Sandbox via `EVAL_ONLY=… pnpm exec agent-eval <experiment>`; cells already at 3 consecutive CI greens were counted and not rerun.

| Cell | Runs |
|---|---|
| 801+803 codex-mcp (off) | local P·P·P |
| 808 cc-plugin (off) | local P·P·P |
| 802 cc-plugin (on) | local P·P·P |
| 808 codex-plugin (on) | local P·P·P |
| 808 codex-mcp (on, gated) | local P·P·P |
| 806/807/808 cc-mcp (on), 806/807 codex-mcp (on) | CI P·P + local P |
| 810/811 codex-plugin (on + off) | CI P + local P·P |
| 813 cc-plugin (off) | CI P·P + local P |

Unit tests, the 2,048-char instruction-limit tests, and the internal-storybook e2e suite (44/44, snapshots updated) all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified story-testing guidance so UI changes more clearly prompt the right follow-up checks.
  * Added stronger direction on when to use story tests versus other project scripts.
  * Expanded Storybook guidance for updates that affect appearance, components, styles, themes, colors, or design tokens.

* **Bug Fixes**
  * Improved how test results are interpreted when partial or filtered output appears, making pass/fail detection more reliable.

* **Tests**
  * Updated end-to-end and unit coverage to match the revised guidance and result selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- agent-eval-results:start -->

### Agent eval results

**54/54 evals passed** · 21.0M tokens · $25.20 ([workflow run](https://github.com/storybookjs/mcp/actions/runs/28678120690))

Playground: https://storybook-evals-b1xcdotcg-storybookjs.vercel.app

<details>
<summary>Results by experiment</summary>

#### `cc-mcp-opus-high` (2026-07-03T18-44-02.402Z)

| | Eval | Pass rate | Mean duration | Tokens | Cost | Failure |
|---|---|---|---|---|---|---|
| ✅ | `801-create-component-no-launch-config` | 1/1 (100%) | 239.6s | 655k | $0.70 |  |
| ✅ | `802-create-component` | 1/1 (100%) | 227.4s | 745k | $0.86 |  |
| ✅ | `803-edit-component` | 1/1 (100%) | 174.7s | 567k | $0.61 |  |
| ✅ | `804-write-story-for-existing-component` | 1/1 (100%) | 153.0s | 259k | $0.37 |  |
| ✅ | `805-non-visual-refactor` | 1/1 (100%) | 121.1s | 86k | $0.13 |  |
| ✅ | `806-browse-request` | 1/1 (100%) | 115.3s | 125k | $0.25 |  |
| ✅ | `807-docs-request` | 1/1 (100%) | 123.3s | 64k | $0.12 |  |
| ✅ | `808-shared-infra-fallback` | 1/1 (100%) | 190.4s | 223k | $0.30 |  |
| ✅ | `810-fix-failing-tests` | 1/1 (100%) | 160.2s | 227k | $0.30 |  |
| ✅ | `811-fix-a11y-violations` | 1/1 (100%) | 178.5s | 291k | $0.40 |  |
| ✅ | `812-first-story-empty-project` | 1/1 (100%) | 156.8s | 218k | $0.33 |  |
| ✅ | `813-monorepo-leaf-create-component` | 1/1 (100%) | 168.6s | 389k | $0.44 |  |

#### `cc-plugin-opus-high` (2026-07-03T18-44-02.405Z)

| | Eval | Pass rate | Mean duration | Tokens | Cost | Failure |
|---|---|---|---|---|---|---|
| ✅ | `801-create-component-no-launch-config` | 1/1 (100%) | 265.4s | 691k | $0.83 |  |
| ✅ | `802-create-component` | 1/1 (100%) | 324.8s | 900k | $0.97 |  |
| ✅ | `803-edit-component` | 1/1 (100%) | 243.5s | 743k | $0.77 |  |
| ✅ | `804-write-story-for-existing-component` | 1/1 (100%) | 235.0s | 545k | $0.61 |  |
| ✅ | `805-non-visual-refactor` | 1/1 (100%) | 138.0s | 85k | $0.12 |  |
| ✅ | `806-browse-request` | 1/1 (100%) | 155.2s | 258k | $0.33 |  |
| ✅ | `807-docs-request` | 1/1 (100%) | 169.7s | 228k | $0.31 |  |
| ✅ | `808-shared-infra-fallback` | 1/1 (100%) | 181.5s | 417k | $0.49 |  |
| ✅ | `810-fix-failing-tests` | 1/1 (100%) | 235.7s | 388k | $0.48 |  |
| ✅ | `811-fix-a11y-violations` | 1/1 (100%) | 218.8s | 257k | $0.44 |  |
| ✅ | `812-first-story-empty-project` | 1/1 (100%) | 172.3s | 409k | $0.50 |  |
| ✅ | `813-monorepo-leaf-create-component` | 1/1 (100%) | 210.0s | 484k | $0.58 |  |
| ✅ | `820-init-no-storybook` | 1/1 (100%) | 282.0s | 1.1M | $1.11 |  |
| ✅ | `821-upgrade-from-sb9` | 1/1 (100%) | 137.2s | 160k | $0.22 |  |
| ✅ | `822-upgrade-from-stable` | 1/1 (100%) | 146.4s | 210k | $0.27 |  |

#### `codex-mcp-gpt-5.5-medium` (2026-07-03T18-44-02.408Z)

| | Eval | Pass rate | Mean duration | Tokens | Cost | Failure |
|---|---|---|---|---|---|---|
| ✅ | `801-create-component-no-launch-config` | 1/1 (100%) | 202.8s | 560k | $0.67 |  |
| ✅ | `802-create-component` | 1/1 (100%) | 225.2s | 708k | $0.76 |  |
| ✅ | `803-edit-component` | 1/1 (100%) | 164.9s | 429k | $0.58 |  |
| ✅ | `804-write-story-for-existing-component` | 1/1 (100%) | 157.8s | 384k | $0.50 |  |
| ✅ | `805-non-visual-refactor` | 1/1 (100%) | 156.4s | 103k | $0.13 |  |
| ✅ | `806-browse-request` | 1/1 (100%) | 136.7s | 75k | $0.11 |  |
| ✅ | `807-docs-request` | 1/1 (100%) | 128.1s | 75k | $0.14 |  |
| ✅ | `808-shared-infra-fallback` | 1/1 (100%) | 163.2s | 319k | $0.41 |  |
| ✅ | `810-fix-failing-tests` | 1/1 (100%) | 143.7s | 317k | $0.31 |  |
| ✅ | `811-fix-a11y-violations` | 1/1 (100%) | 159.6s | 285k | $0.46 |  |
| ✅ | `812-first-story-empty-project` | 1/1 (100%) | 137.4s | 222k | $0.34 |  |
| ✅ | `813-monorepo-leaf-create-component` | 1/1 (100%) | 163.3s | 311k | $0.36 |  |

#### `codex-plugin-gpt-5.5-medium` (2026-07-03T18-44-02.411Z)

| | Eval | Pass rate | Mean duration | Tokens | Cost | Failure |
|---|---|---|---|---|---|---|
| ✅ | `801-create-component-no-launch-config` | 1/1 (100%) | 263.9s | 900k | $1.12 |  |
| ✅ | `802-create-component` | 1/1 (100%) | 248.6s | 994k | $0.95 |  |
| ✅ | `803-edit-component` | 1/1 (100%) | 242.9s | 889k | $0.86 |  |
| ✅ | `804-write-story-for-existing-component` | 1/1 (100%) | 203.2s | 432k | $0.58 |  |
| ✅ | `805-non-visual-refactor` | 1/1 (100%) | 110.1s | 70k | $0.07 |  |
| ✅ | `806-browse-request` | 1/1 (100%) | 154.2s | 219k | $0.26 |  |
| ✅ | `807-docs-request` | 1/1 (100%) | 153.5s | 132k | $0.22 |  |
| ✅ | `808-shared-infra-fallback` | 1/1 (100%) | 270.7s | 468k | $0.47 |  |
| ✅ | `810-fix-failing-tests` | 1/1 (100%) | 200.8s | 289k | $0.32 |  |
| ✅ | `811-fix-a11y-violations` | 1/1 (100%) | 218.4s | 327k | $0.55 |  |
| ✅ | `812-first-story-empty-project` | 1/1 (100%) | 169.6s | 339k | $0.37 |  |
| ✅ | `813-monorepo-leaf-create-component` | 1/1 (100%) | 151.6s | 261k | $0.38 |  |
| ✅ | `820-init-no-storybook` | 1/1 (100%) | 351.9s | 709k | $0.78 |  |
| ✅ | `821-upgrade-from-sb9` | 1/1 (100%) | 165.0s | 186k | $0.33 |  |
| ✅ | `822-upgrade-from-stable` | 1/1 (100%) | 171.0s | 223k | $0.31 |  |

</details>

_Cost is estimated from model token usage at provider list prices ([Vercel AI Gateway](https://vercel.com/docs/ai-gateway/pricing) adds no markup) and excludes Vercel Sandbox compute._

<!-- agent-eval-results:end -->
