### PR TITLE
Fix multi-source documentation tool schemas

### DIFF
--- a/.changeset/multi-source-doc-schemas.md
+++ b/.changeset/multi-source-doc-schemas.md
@@ -1,0 +1,5 @@
+---
+'@storybook/mcp': patch
+---
+
+Fix multi-source documentation tool schemas to require `storybookId`.

--- a/packages/mcp/src/index.test.ts
+++ b/packages/mcp/src/index.test.ts
@@ -246,6 +246,31 @@ describe('createStorybookMcpHandler', () => {
 		);
 	});
 
+	it('should include storybookId in documentation tool schemas when handler-level sources are multi-source', async () => {
+		const manifestProvider = createManifestProviderMockWithDocs();
+		const sources = [
+			{ id: 'local', title: 'Local' },
+			{ id: 'remote', title: 'Remote', url: 'https://example.com/storybook' },
+		];
+
+		const handler = await createStorybookMcpHandler({
+			manifestProvider,
+			sources,
+		});
+		await setupClient(handler);
+
+		const tools = await client.listTools();
+		const getDocumentationTool = tools.tools.find((tool) => tool.name === 'get-documentation');
+		const getStoryDocumentationTool = tools.tools.find(
+			(tool) => tool.name === 'get-documentation-for-story',
+		);
+
+		expect(getDocumentationTool?.inputSchema.properties).toHaveProperty('storybookId');
+		expect(getDocumentationTool?.inputSchema.required).toContain('storybookId');
+		expect(getStoryDocumentationTool?.inputSchema.properties).toHaveProperty('storybookId');
+		expect(getStoryDocumentationTool?.inputSchema.required).toContain('storybookId');
+	});
+
 	it('should call onListAllDocumentation handler when tool is invoked', async () => {
 		const onListAllDocumentation = vi.fn();
 		const manifestProvider = createManifestProviderMock();

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -127,9 +127,11 @@ export const createStorybookMcpHandler = async (
 		server.on('initialize', onSessionInitialize);
 	}
 
+	const multiSource = (defaultContext.sources?.length ?? 0) > 1;
+
 	await addListAllDocumentationTool(server);
-	await addGetStoryDocumentationTool(server);
-	await addGetDocumentationTool(server);
+	await addGetStoryDocumentationTool(server, undefined, { multiSource });
+	await addGetDocumentationTool(server, undefined, { multiSource });
 
 	const transport = new HttpTransport(server, { path: null });
 


### PR DESCRIPTION
## Summary

Fixes #213.

When `createStorybookMcpHandler` is created with multiple handler-level `sources`, it already forwards those sources into the request context, but the two single-documentation tools were still registered with their single-source schemas. That meant `storybookId` was missing from `tools/list` and clients could not pass the source selector through.

This change derives `multiSource` from handler-level sources and passes it into `addGetStoryDocumentationTool` and `addGetDocumentationTool`, so both schemas include the required `storybookId` field for multi-source handlers.

## Verification

```bash
npx pnpm@10.29.2 install --frozen-lockfile
npx pnpm@10.29.2 vitest run packages/mcp/src/index.test.ts
npx pnpm@10.29.2 exec oxfmt --check packages/mcp/src/index.ts packages/mcp/src/index.test.ts
npx pnpm@10.29.2 exec tsc --noEmit --pretty false
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated documentation tool schemas to behave correctly for multi-source setups, ensuring `storybookId` is required when more than one source is configured.
* **Tests**
  * Added a Vitest case verifying that `get-documentation` and `get-documentation-for-story` include the `storybookId` property and mark it as required in multi-source mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->