### PR TITLE
Enable review by default for the plugin (storybook ai CLI channel)

### DIFF
--- a/.changeset/plugin-review-default.md
+++ b/.changeset/plugin-review-default.md
@@ -1,0 +1,5 @@
+---
+'@storybook/addon-mcp': minor
+---
+
+Enabled the review workflow by default for the `storybook ai` CLI channel (the Claude/Codex plugins). Requests carrying the trusted local-client header get `display-review` and the review instructions without setting `experimentalReview`; direct MCP clients keep the opt-in flag, and `experimentalReview: false` turns review off for both channels.

--- a/agent-eval/README.md
+++ b/agent-eval/README.md
@@ -96,11 +96,14 @@ regressed since the last stable release:
 EVAL_STORYBOOK_LATEST=1 pnpm eval
 ```
 
-The review workflow is opt-in: the `experimentalReview` feature flag defaults
-to off, so default runs assert the review-off workflow (preview-stories links,
-no display-review). Set `EVAL_REVIEW=1` to enable the flag in every sandbox
-Storybook and flip the EVAL.ts assertions to the review workflow instead
-(display-review published, review section in the final response):
+Review mode follows the integration. The plugin experiments always run — and
+assert — the review workflow (display-review published, review section in the
+final response), because review is on by default for the `storybook ai` CLI
+channel the plugins use. The MCP experiments run review-off by default
+(preview-stories links, no display-review), matching direct MCP clients where
+the `experimentalReview` feature flag is opt-in. Set `EVAL_REVIEW=1` to enable
+the flag in every sandbox Storybook and flip the MCP assertions to the review
+workflow too:
 
 ```bash
 EVAL_REVIEW=1 pnpm eval

--- a/agent-eval/lib/templates.test.ts
+++ b/agent-eval/lib/templates.test.ts
@@ -4,9 +4,22 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import { enableExperimentalReview } from './templates.ts';
+import { enableExperimentalReview, isReviewEnabledFor } from './templates.ts';
 
 const AGENT_EVAL_ROOT = join(fileURLToPath(import.meta.url), '..', '..');
+
+// EVAL_REVIEW is unset in unit-test runs, so this asserts the default gate:
+// plugin sandboxes are always review-on (the addon enables review for the
+// `storybook ai` CLI channel by default), MCP sandboxes review-off.
+describe('isReviewEnabledFor', () => {
+	it('is always on for the plugin integration', () => {
+		expect(isReviewEnabledFor('plugin')).toBe(true);
+	});
+
+	it('is off for the mcp integration without EVAL_REVIEW=1', () => {
+		expect(isReviewEnabledFor('mcp')).toBe(false);
+	});
+});
 
 describe('enableExperimentalReview', () => {
 	it('injects the experimentalReview feature into a Storybook main.ts', () => {

--- a/agent-eval/lib/templates.ts
+++ b/agent-eval/lib/templates.ts
@@ -87,11 +87,20 @@ const SHELL_PARSE_SOURCE_PATH = path.join(AGENT_EVAL_ROOT, 'lib', 'shell-parse.t
 const SHELL_PARSE_SANDBOX_PATH = path.posix.join('__agent_eval__', 'shell-parse.ts');
 const AGENT_CONTEXT_SANDBOX_PATH = path.posix.join('__agent_eval__', 'agent.json');
 const TEMPLATE_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
-// EVAL_REVIEW=1 enables the opt-in `experimentalReview` feature flag in
-// every sandbox Storybook; default runs leave it off, matching released
-// users. EVAL.ts assertions read the same signal from the agent context
-// (see isReviewEnabled in test-utils).
+// EVAL_REVIEW=1 enables the `experimentalReview` feature flag in every
+// sandbox Storybook, turning review on for the MCP integration too. Plugin
+// runs don't need it: review is on by default for the `storybook ai` CLI
+// channel, so plugin sandboxes always run review-on, matching released
+// users of either integration. EVAL.ts assertions read the effective
+// per-run signal from the agent context (see isReviewEnabled in test-utils).
 const REVIEW_ENABLED = process.env.EVAL_REVIEW === '1';
+
+// The review mode a sandbox actually runs in: the plugin integration gets
+// review by default from the addon; the MCP integration only with the
+// EVAL_REVIEW=1 feature-flag override.
+export function isReviewEnabledFor(integration: EvalIntegration): boolean {
+	return REVIEW_ENABLED || integration === 'plugin';
+}
 const STORYBOOK_MAIN_PATTERN = /(^|\/)\.storybook\/main\.ts$/;
 const STORYBOOK_CONFIG_OBJECT_OPENER = 'const config: StorybookConfig = {';
 const STORYBOOK_MCP_SERVER_NAME = 'storybook-dev-mcp';
@@ -186,7 +195,7 @@ async function writeEvalSupportFiles(
 			{
 				agent: options.agent,
 				integration: options.integration,
-				review: REVIEW_ENABLED,
+				review: isReviewEnabledFor(options.integration),
 			},
 			null,
 			2,

--- a/agent-eval/lib/test-utils.ts
+++ b/agent-eval/lib/test-utils.ts
@@ -33,7 +33,7 @@ type AgentContext = {
 type EvalContext = {
 	agent: string;
 	integration: 'mcp' | 'plugin';
-	/** Whether the sandbox Storybook runs with the `experimentalReview` feature flag on. */
+	/** Whether the sandbox runs review-on: always for the plugin integration, via EVAL_REVIEW=1 for MCP. */
 	review: boolean;
 };
 
@@ -75,11 +75,13 @@ export function getEvalContext(): EvalContext {
 	return { agent, integration, review: agentContext.review === true };
 }
 
-// Review mode of this run: EVAL_REVIEW=1 (the ci:review PR label) enables the
-// opt-in `experimentalReview` feature flag in the sandbox Storybook. EVAL.ts
+// Review mode of this run. Plugin runs are always review-on — the addon
+// enables review by default for the `storybook ai` CLI channel — while MCP
+// runs are review-on only when EVAL_REVIEW=1 (the ci:review PR label) sets
+// the `experimentalReview` feature flag in the sandbox Storybook. EVAL.ts
 // files branch on this — with review on, visual work must end in a published
-// display-review; with review off (the default), display-review is not even
-// registered and the workflow ends in preview-stories links.
+// display-review; with review off, display-review is not even exposed and
+// the workflow ends in preview-stories links.
 export function isReviewEnabled(): boolean {
 	return getEvalContext().review;
 }

--- a/packages/addon-mcp/scripts/generate-tools-api-doc.ts
+++ b/packages/addon-mcp/scripts/generate-tools-api-doc.ts
@@ -32,6 +32,7 @@ const availability = (reviewEnabled: boolean): ToolAvailability => ({
 	moduleGraphSupported: true,
 	changeDetectionEnabled: true,
 	reviewEnabled,
+	reviewEnabledForCli: reviewEnabled,
 	docsEnabled: true,
 	docsHasManifests: true,
 	docsFeatureEnabled: true,

--- a/packages/addon-mcp/src/constants.ts
+++ b/packages/addon-mcp/src/constants.ts
@@ -12,6 +12,14 @@ export const PUSH_REVIEW_EVENT = 'storybook/review/push-review';
 export const REVIEW_PAGE_PATH = '/review/';
 
 /**
+ * Request header the `storybook ai` CLI (and the Claude/Codex plugins built on
+ * it) sends on every MCP request to mark itself as a trusted local Storybook
+ * client. Mirrors `STORYBOOK_MCP_PROXY_HEADER` in Storybook core's
+ * `cli/ai/mcp/client.ts` — the two must stay in sync.
+ */
+export const STORYBOOK_MCP_PROXY_HEADER = 'X-Storybook-MCP-Proxy';
+
+/**
  * Default path the MCP server is mounted at on the Storybook dev server.
  * The user can override this via the addon's `endpoint` option; everywhere
  * else in the codebase that needs to compare against or fall back to the

--- a/packages/addon-mcp/src/mcp-handler.test.ts
+++ b/packages/addon-mcp/src/mcp-handler.test.ts
@@ -237,14 +237,15 @@ describe('mcpServerHandler', () => {
 	async function getRegisteredToolNames(
 		mockOptions: any,
 		port: number,
-		handlerOptions: { sources?: any[] } = {},
+		handlerOptions: { sources?: any[]; headers?: Record<string, string> } = {},
 	): Promise<string[]> {
 		const host = `localhost:${port}`;
 		const addonOptions = { toolsets: { dev: true, docs: true } };
+		const { headers: extraHeaders = {}, ...restHandlerOptions } = handlerOptions;
 
 		const initReq = createMockIncomingMessage({
 			method: 'POST',
-			headers: { 'content-type': 'application/json', host },
+			headers: { 'content-type': 'application/json', host, ...extraHeaders },
 			body: createMCPInitializeRequest(),
 		});
 		const { response: initResponse } = createMockServerResponse();
@@ -254,12 +255,12 @@ describe('mcpServerHandler', () => {
 			options: mockOptions,
 			addonOptions,
 			compositionAuth: new CompositionAuth(),
-			...handlerOptions,
+			...restHandlerOptions,
 		});
 
 		const listReq = createMockIncomingMessage({
 			method: 'POST',
-			headers: { 'content-type': 'application/json', host },
+			headers: { 'content-type': 'application/json', host, ...extraHeaders },
 			body: { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
 		});
 		const { response: listResponse, getResponseData } = createMockServerResponse();
@@ -269,7 +270,7 @@ describe('mcpServerHandler', () => {
 			options: mockOptions,
 			addonOptions,
 			compositionAuth: new CompositionAuth(),
-			...handlerOptions,
+			...restHandlerOptions,
 		});
 
 		const { body } = getResponseData();
@@ -568,7 +569,7 @@ describe('mcpServerHandler', () => {
 		expect(toolNames).toContain('display-review');
 	});
 
-	it('does not register display-review when only the changeDetection feature flag is on', async () => {
+	it('does not list display-review for direct MCP clients when only the changeDetection feature flag is on', async () => {
 		const mockOptions = createMockOptions({
 			port: 6013,
 			presets: {
@@ -582,6 +583,42 @@ describe('mcpServerHandler', () => {
 
 		const toolNames = await getRegisteredToolNames(mockOptions, 6013);
 		expect(toolNames).toContain('get-changed-stories');
+		expect(toolNames).not.toContain('display-review');
+	});
+
+	it('lists display-review for storybook ai CLI requests when only the changeDetection feature flag is on', async () => {
+		const mockOptions = createMockOptions({
+			port: 6014,
+			presets: {
+				apply: vi.fn(async (key: string, defaultValue?: any) => {
+					if (key === 'core') return { disableTelemetry: false };
+					if (key === 'features') return { changeDetection: true };
+					return defaultValue;
+				}),
+			},
+		});
+
+		const toolNames = await getRegisteredToolNames(mockOptions, 6014, {
+			headers: { 'x-storybook-mcp-proxy': 'true' },
+		});
+		expect(toolNames).toContain('display-review');
+	});
+
+	it('does not list display-review for CLI requests when experimentalReview is explicitly false', async () => {
+		const mockOptions = createMockOptions({
+			port: 6015,
+			presets: {
+				apply: vi.fn(async (key: string, defaultValue?: any) => {
+					if (key === 'core') return { disableTelemetry: false };
+					if (key === 'features') return { changeDetection: true, experimentalReview: false };
+					return defaultValue;
+				}),
+			},
+		});
+
+		const toolNames = await getRegisteredToolNames(mockOptions, 6015, {
+			headers: { 'x-storybook-mcp-proxy': 'true' },
+		});
 		expect(toolNames).not.toContain('display-review');
 	});
 });

--- a/packages/addon-mcp/src/mcp-handler.ts
+++ b/packages/addon-mcp/src/mcp-handler.ts
@@ -16,7 +16,7 @@ import {
 import { estimateTokens } from './utils/estimate-tokens.ts';
 import type { CompositionAuth } from './auth/index.ts';
 import { buildServerInstructions } from './instructions/build-server-instructions.ts';
-import { DEFAULT_MCP_ENDPOINT } from './constants.ts';
+import { DEFAULT_MCP_ENDPOINT, STORYBOOK_MCP_PROXY_HEADER } from './constants.ts';
 import { registerAddonMcpTools } from './tools/tool-registry.ts';
 import type { DocgenServerManifestAccess } from './manifests/in-process-provider.ts';
 
@@ -26,6 +26,7 @@ let origin: string | undefined;
 let initialize: Promise<McpServer<any, AddonContext>> | undefined;
 let disableTelemetry: boolean | undefined;
 let a11yEnabled: boolean | undefined;
+let reviewGates: { reviewEnabled: boolean; reviewEnabledForCli: boolean } | undefined;
 
 const initializeMCPServer = async (options: Options, multiSource?: boolean) => {
 	const core = await options.presets.apply('core', {});
@@ -39,6 +40,10 @@ const initializeMCPServer = async (options: Options, multiSource?: boolean) => {
 	const rawAvailability = await getToolAvailability(options, { features });
 	const availability = getEffectiveToolAvailability(rawAvailability, { multiSource });
 	a11yEnabled = availability.a11yEnabled;
+	reviewGates = {
+		reviewEnabled: availability.reviewEnabled,
+		reviewEnabledForCli: availability.reviewEnabledForCli,
+	};
 
 	let server: McpServer<any, AddonContext>;
 
@@ -51,7 +56,7 @@ const initializeMCPServer = async (options: Options, multiSource?: boolean) => {
 				docsEnabled: (server?.ctx.custom?.toolsets?.docs ?? true) && availability.docsEnabled,
 				changeDetectionEnabled: availability.changeDetectionEnabled,
 				moduleGraphSupported: availability.moduleGraphSupported,
-				reviewEnabled: availability.reviewEnabled,
+				reviewEnabled: server?.ctx.custom?.reviewEnabled ?? availability.reviewEnabled,
 			});
 		},
 		capabilities: {
@@ -145,6 +150,7 @@ export const mcpServerHandler = async ({
 		options,
 		endpoint,
 		toolsets: getToolsets(webRequest, addonOptions),
+		reviewEnabled: isReviewEnabledForRequest(webRequest, reviewGates!),
 		origin: origin!,
 		disableTelemetry: disableTelemetry!,
 		a11yEnabled,
@@ -247,6 +253,22 @@ export async function webResponseToServerResponse(
 	}
 
 	nodeResponse.end();
+}
+
+/**
+ * Review is on for a request when the `experimentalReview` flag enables it
+ * globally, or when the request marks itself as coming from the `storybook ai`
+ * CLI (the Claude/Codex plugins) via {@link STORYBOOK_MCP_PROXY_HEADER} —
+ * that channel gets review by default, direct MCP clients stay opt-in.
+ */
+export function isReviewEnabledForRequest(
+	request: Request,
+	gates: { reviewEnabled: boolean; reviewEnabledForCli: boolean },
+): boolean {
+	return (
+		gates.reviewEnabled ||
+		(gates.reviewEnabledForCli && request.headers.get(STORYBOOK_MCP_PROXY_HEADER) === 'true')
+	);
 }
 
 export function getToolsets(

--- a/packages/addon-mcp/src/preset.ts
+++ b/packages/addon-mcp/src/preset.ts
@@ -124,6 +124,7 @@ export const experimental_devServer: PresetPropertyFn<
 		moduleGraphSupported,
 		changeDetectionEnabled,
 		reviewEnabled,
+		reviewEnabledForCli,
 		docsEnabled,
 		docsHasManifests,
 		docsFeatureEnabled,
@@ -195,7 +196,9 @@ export const experimental_devServer: PresetPropertyFn<
 					!changeDetectionEnabled &&
 						`<code>get-changed-stories</code> requires enabling the <code>changeDetection</code> feature flag.`,
 					!reviewEnabled &&
-						`<code>display-review</code> requires the <code>experimentalReview</code> feature flag (on top of <code>changeDetection</code>).`,
+						(reviewEnabledForCli
+							? `<code>display-review</code> is enabled for <code>storybook ai</code> CLI clients (the Claude/Codex plugins); direct MCP clients need the <code>experimentalReview</code> feature flag.`
+							: `<code>display-review</code> requires the <code>changeDetection</code> feature flag and is off when <code>experimentalReview</code> is set to <code>false</code>.`),
 				].filter(Boolean);
 		const devNotice = devNoticeLines.length
 			? `<div class="toolset-notice">${devNoticeLines.join('<br>')}</div>`
@@ -210,7 +213,7 @@ export const experimental_devServer: PresetPropertyFn<
 				statusWord(isDevEnabled && moduleGraphSupported),
 			)
 			.replaceAll('{{CHANGE_DETECTION_STATUS}}', statusWord(isDevEnabled && changeDetectionEnabled))
-			.replaceAll('{{REVIEW_STATUS}}', statusWord(isDevEnabled && reviewEnabled))
+			.replaceAll('{{REVIEW_STATUS}}', statusWord(isDevEnabled && reviewEnabledForCli))
 			.replace('{{DEV_NOTICE}}', devNotice)
 			.replaceAll('{{DOCS_STATUS}}', isDocsEnabled ? 'enabled' : 'disabled')
 			.replace('{{DOCS_NOTICE}}', docsNotice)

--- a/packages/addon-mcp/src/storybook-ai-metadata.test.ts
+++ b/packages/addon-mcp/src/storybook-ai-metadata.test.ts
@@ -11,6 +11,7 @@ import { isAddonA11yEnabled } from './utils/is-addon-a11y-enabled.ts';
 import { getReviewStatus } from './utils/is-review-available.ts';
 import { isModuleGraphSupported, isModuleGraphSupportedByBuilder } from './utils/module-graph.ts';
 import {
+	DISPLAY_REVIEW_TOOL_NAME,
 	GET_STORIES_BY_COMPONENT_TOOL_NAME,
 	GET_UI_BUILDING_INSTRUCTIONS_TOOL_NAME,
 	PREVIEW_STORIES_TOOL_NAME,
@@ -52,6 +53,7 @@ describe('buildStorybookAiMetadata', () => {
 		vi.mocked(isModuleGraphSupportedByBuilder).mockResolvedValue(true);
 		vi.mocked(getReviewStatus).mockResolvedValue({
 			available: true,
+			availableForCli: true,
 			hasFeatureFlag: true,
 		});
 		vi.mocked(getManifestStatus).mockResolvedValue({
@@ -392,6 +394,33 @@ describe('buildStorybookAiMetadata', () => {
 		expect(simplifyTools(metadata.tools)).toEqual(simplifyTools(liveTools));
 	});
 
+	it('defaults review on for the CLI channel when experimentalReview is unset', async () => {
+		// What getReviewStatus returns when changeDetection is on and
+		// experimentalReview is neither true nor false.
+		vi.mocked(getReviewStatus).mockResolvedValue({
+			available: false,
+			availableForCli: true,
+			hasFeatureFlag: false,
+		});
+
+		const metadata = await buildStorybookAiMetadata(createOptions());
+
+		expect(metadata.tools.map((tool) => tool.name)).toContain(DISPLAY_REVIEW_TOOL_NAME);
+		expect(metadata.instructions).toContain('display-review');
+	});
+
+	it('keeps review off everywhere when experimentalReview is explicitly false', async () => {
+		vi.mocked(getReviewStatus).mockResolvedValue({
+			available: false,
+			availableForCli: false,
+			hasFeatureFlag: false,
+		});
+
+		const metadata = await buildStorybookAiMetadata(createOptions());
+
+		expect(metadata.tools.map((tool) => tool.name)).not.toContain(DISPLAY_REVIEW_TOOL_NAME);
+	});
+
 	it('uses builder support instead of the live module-graph service for metadata', async () => {
 		vi.mocked(isModuleGraphSupported).mockResolvedValue(false);
 		vi.mocked(isModuleGraphSupportedByBuilder).mockResolvedValue(true);
@@ -466,6 +495,7 @@ function createAvailability(overrides: Partial<ToolAvailability> = {}): ToolAvai
 		moduleGraphSupported: true,
 		changeDetectionEnabled: true,
 		reviewEnabled: true,
+		reviewEnabledForCli: true,
 		docsEnabled: true,
 		docsHasManifests: true,
 		docsFeatureEnabled: true,

--- a/packages/addon-mcp/src/storybook-ai-metadata.ts
+++ b/packages/addon-mcp/src/storybook-ai-metadata.ts
@@ -49,10 +49,18 @@ export async function buildStorybookAiMetadata(
 		| undefined;
 	const devEnabled = toolsets?.dev ?? true;
 	const moduleGraphSupported = await isModuleGraphSupportedByBuilder(options);
-	const availability = await getToolAvailability(options, {
+	const rawAvailability = await getToolAvailability(options, {
 		features,
 		moduleGraphSupported,
 	});
+	// This metadata is only ever consumed by the `storybook ai` CLI (the
+	// Claude/Codex plugins), where review is on by default — so the CLI gate
+	// drives everything derived from it: instructions, tool descriptions, and
+	// which tools are included.
+	const availability = {
+		...rawAvailability,
+		reviewEnabled: rawAvailability.reviewEnabledForCli,
+	};
 	const testEnabled = (toolsets?.test ?? true) && availability.testSupported;
 	const docsToolsetEnabled = toolsets?.docs ?? true;
 	const multiSource = docsToolsetEnabled

--- a/packages/addon-mcp/src/tools/get-storybook-story-instructions.test.ts
+++ b/packages/addon-mcp/src/tools/get-storybook-story-instructions.test.ts
@@ -324,6 +324,51 @@ describe('getUIBuildingInstructionsTool', () => {
 		expect(instructions).not.toContain('first, then use `preview-stories`');
 	});
 
+	// The per-request context override must win over the feature-flag gate:
+	// this is the CLI path, where review is on by default even though the
+	// explicit experimentalReview flag (and thus getReviewStatus().available)
+	// is off.
+	it('uses the review instructions when the request context enables review despite the flag being unset', async () => {
+		vi.mocked(getReviewStatus).mockResolvedValue({
+			available: false,
+			availableForCli: true,
+			hasFeatureFlag: false,
+		});
+
+		const mockOptions = {
+			presets: {
+				apply: vi.fn(async (presetName: string) => {
+					if (presetName === 'framework') return '@storybook/react-vite';
+					if (presetName === 'features') return { changeDetection: true };
+					return undefined;
+				}),
+			},
+		};
+
+		const response = await server.receive(
+			{
+				jsonrpc: '2.0' as const,
+				id: 1,
+				method: 'tools/call',
+				params: { name: GET_UI_BUILDING_INSTRUCTIONS_TOOL_NAME, arguments: {} },
+			},
+			{
+				sessionId: 'test-session',
+				custom: {
+					origin: 'http://localhost:6006',
+					options: mockOptions as any,
+					disableTelemetry: true,
+					reviewEnabled: true,
+				},
+			},
+		);
+
+		const instructions = response.result?.content[0].text as string;
+
+		expect(instructions).toContain('## 👀 Review your changes');
+		expect(instructions).toContain('Feed the discovered IDs into **display-review**');
+	});
+
 	it('tells the agent to include preview URLs when review is disabled', async () => {
 		vi.mocked(getReviewStatus).mockResolvedValue({
 			available: false,

--- a/packages/addon-mcp/src/tools/get-storybook-story-instructions.test.ts
+++ b/packages/addon-mcp/src/tools/get-storybook-story-instructions.test.ts
@@ -33,6 +33,7 @@ describe('getUIBuildingInstructionsTool', () => {
 
 		vi.mocked(getReviewStatus).mockResolvedValue({
 			available: false,
+			availableForCli: false,
 			hasFeatureFlag: false,
 		});
 
@@ -273,6 +274,7 @@ describe('getUIBuildingInstructionsTool', () => {
 	it('tells the agent to show only the review section when review is enabled', async () => {
 		vi.mocked(getReviewStatus).mockResolvedValue({
 			available: true,
+			availableForCli: true,
 			hasFeatureFlag: true,
 		});
 
@@ -325,6 +327,7 @@ describe('getUIBuildingInstructionsTool', () => {
 	it('tells the agent to include preview URLs when review is disabled', async () => {
 		vi.mocked(getReviewStatus).mockResolvedValue({
 			available: false,
+			availableForCli: false,
 			hasFeatureFlag: false,
 		});
 

--- a/packages/addon-mcp/src/tools/get-storybook-story-instructions.ts
+++ b/packages/addon-mcp/src/tools/get-storybook-story-instructions.ts
@@ -22,6 +22,11 @@ type BuildStorybookStoryInstructionsOptions = {
 	addonVitestAvailable?: boolean;
 	/** Whether the documentation tools (list-all-documentation etc.) are registered. */
 	docsAvailable?: boolean;
+	/**
+	 * Per-channel review gate override (per-request context on the MCP path, the
+	 * CLI default on the metadata path). Defaults to the explicit feature-flag gate.
+	 */
+	reviewEnabled?: boolean;
 };
 
 /**
@@ -82,6 +87,7 @@ export async function addGetUIBuildingInstructionsTool(
 					a11yEnabled: server.ctx.custom?.a11yEnabled,
 					addonVitestAvailable,
 					docsAvailable,
+					reviewEnabled: server.ctx.custom?.reviewEnabled,
 				});
 
 				return {
@@ -155,13 +161,14 @@ export async function buildStorybookStoryInstructions(
 		a11yEnabled = false,
 		addonVitestAvailable,
 		docsAvailable = false,
+		reviewEnabled: reviewEnabledOverride,
 	}: BuildStorybookStoryInstructionsOptions = {},
 ): Promise<string> {
 	const frameworkPreset = await options.presets.apply('framework');
 	const featuresPreset = await options.presets.apply('features', {});
 	const changeDetectionEnabled = featuresPreset?.changeDetection ?? false;
 	const reviewStatus = await getReviewStatus(options, { features: featuresPreset });
-	const reviewEnabled = reviewStatus.available;
+	const reviewEnabled = reviewEnabledOverride ?? reviewStatus.available;
 	const framework = typeof frameworkPreset === 'string' ? frameworkPreset : frameworkPreset?.name;
 	const renderer = frameworkToRendererMap[framework!];
 	// Mirrors the review-aware rewrite in build-server-instructions.ts:

--- a/packages/addon-mcp/src/tools/tool-registry.ts
+++ b/packages/addon-mcp/src/tools/tool-registry.ts
@@ -124,6 +124,7 @@ const addonToolDefinitions: AddonToolDefinition[] = [
 					a11yEnabled: availability.a11yEnabled,
 					addonVitestAvailable: availability.testSupported,
 					docsAvailable: isToolsetEnabled('docs', toolsets) && availability.docsEnabled,
+					reviewEnabled: availability.reviewEnabled,
 				});
 				return { content: [{ type: 'text', text }] };
 			},
@@ -151,9 +152,18 @@ const addonToolDefinitions: AddonToolDefinition[] = [
 	{
 		name: DISPLAY_REVIEW_TOOL_NAME,
 		toolset: 'dev',
-		available: ({ availability }) => availability.reviewEnabled,
+		// Registered whenever the CLI default could turn review on; the per-request
+		// `reviewEnabled` context (explicit flag, or the trusted local-client header)
+		// decides whether a given MCP client actually sees the tool.
+		available: ({ availability }) => availability.reviewEnabledForCli,
 		getMetadata: () => getDisplayReviewToolMetadata(),
-		register: (server, _context, enabled) => addDisplayReviewTool(server, enabled),
+		register: (server, { availability }, enabled) =>
+			addDisplayReviewTool(
+				server,
+				async () =>
+					((await enabled?.()) ?? true) &&
+					(server.ctx.custom?.reviewEnabled ?? availability.reviewEnabled),
+			),
 	},
 	{
 		name: RUN_STORY_TESTS_TOOL_NAME,

--- a/packages/addon-mcp/src/types.ts
+++ b/packages/addon-mcp/src/types.ts
@@ -71,6 +71,14 @@ export type AddonContext = StorybookContext & {
 	a11yEnabled?: boolean;
 
 	toolsets?: NonNullable<AddonOptionsOutput>['toolsets'];
+
+	/**
+	 * Effective review gate for the current request: the explicit
+	 * `experimentalReview` feature flag, or the CLI default when the request
+	 * carries the trusted local-client header (`storybook ai` / the plugins).
+	 * Gates the `display-review` tool and the instruction variant.
+	 */
+	reviewEnabled?: boolean;
 };
 
 const StoryInputProps = {

--- a/packages/addon-mcp/src/utils/get-tool-availability.ts
+++ b/packages/addon-mcp/src/utils/get-tool-availability.ts
@@ -10,8 +10,15 @@ export interface ToolAvailability {
 	moduleGraphSupported: boolean;
 	/** The `changeDetection` feature flag is enabled. Gates `get-changed-stories`. */
 	changeDetectionEnabled: boolean;
-	/** The `experimentalReview` AND `changeDetection` feature flags are enabled. Gates `display-review`. */
+	/** The `experimentalReview` AND `changeDetection` feature flags are enabled. Gates `display-review` for direct MCP clients. */
 	reviewEnabled: boolean;
+	/**
+	 * Same gate for the `storybook ai` CLI channel (the Claude/Codex plugins),
+	 * where review is on by default: `changeDetection` on and `experimentalReview`
+	 * not explicitly `false`. Gates `display-review` for CLI-marked requests and
+	 * everything derived from the storybook-ai metadata preset.
+	 */
+	reviewEnabledForCli: boolean;
 	/** Component-manifest feature is on AND manifests were found. Gates the `docs` toolset. */
 	docsEnabled: boolean;
 	/** Any component manifests were found (drives the docs "why disabled" copy). */
@@ -97,6 +104,7 @@ export async function getToolAvailability(
 		moduleGraphSupported,
 		changeDetectionEnabled: resolvedFeatures?.changeDetection ?? false,
 		reviewEnabled: reviewStatus.available,
+		reviewEnabledForCli: reviewStatus.availableForCli,
 		docsEnabled: manifestStatus.available,
 		docsHasManifests: manifestStatus.hasManifests,
 		docsFeatureEnabled: manifestStatus.hasFeatureFlag,

--- a/packages/addon-mcp/src/utils/is-review-available.test.ts
+++ b/packages/addon-mcp/src/utils/is-review-available.test.ts
@@ -5,7 +5,7 @@ import { getReviewStatus } from './is-review-available.ts';
 
 function createMockOptions({
 	changeDetection = false,
-	experimentalReview = false,
+	experimentalReview,
 	hasFeaturesObject = true,
 	configDir = '/project/.storybook',
 }: {
@@ -33,25 +33,33 @@ describe('getReviewStatus', () => {
 			createMockOptions({ changeDetection: true, experimentalReview: true }),
 		);
 
-		expect(result).toEqual({ available: true, hasFeatureFlag: true });
+		expect(result).toEqual({ available: true, availableForCli: true, hasFeatureFlag: true });
 	});
 
-	it('is unavailable by default when only changeDetection is on', async () => {
+	it('is unavailable to direct MCP clients but available to the CLI when only changeDetection is on', async () => {
 		const result = await getReviewStatus(createMockOptions({ changeDetection: true }));
 
-		expect(result).toEqual({ available: false, hasFeatureFlag: false });
+		expect(result).toEqual({ available: false, availableForCli: true, hasFeatureFlag: false });
+	});
+
+	it('is unavailable everywhere when experimentalReview is explicitly false', async () => {
+		const result = await getReviewStatus(
+			createMockOptions({ changeDetection: true, experimentalReview: false }),
+		);
+
+		expect(result).toEqual({ available: false, availableForCli: false, hasFeatureFlag: false });
 	});
 
 	it('is unavailable when experimentalReview is on but changeDetection is off', async () => {
 		const result = await getReviewStatus(createMockOptions({ experimentalReview: true }));
 
-		expect(result).toEqual({ available: false, hasFeatureFlag: true });
+		expect(result).toEqual({ available: false, availableForCli: false, hasFeatureFlag: true });
 	});
 
 	it('returns hasFeatureFlag=false when features object is missing the flag', async () => {
 		const result = await getReviewStatus(createMockOptions({ hasFeaturesObject: false }));
 
-		expect(result).toEqual({ available: false, hasFeatureFlag: false });
+		expect(result).toEqual({ available: false, availableForCli: false, hasFeatureFlag: false });
 	});
 
 	it('uses pre-resolved features when provided and skips presets.apply', async () => {
@@ -63,7 +71,7 @@ describe('getReviewStatus', () => {
 			features: { changeDetection: true, experimentalReview: true },
 		});
 
-		expect(result).toEqual({ available: true, hasFeatureFlag: true });
+		expect(result).toEqual({ available: true, availableForCli: true, hasFeatureFlag: true });
 		expect(mockOptions.presets.apply).not.toHaveBeenCalledWith('features', expect.anything());
 	});
 });

--- a/packages/addon-mcp/src/utils/is-review-available.ts
+++ b/packages/addon-mcp/src/utils/is-review-available.ts
@@ -2,6 +2,11 @@ import type { Options } from 'storybook/internal/types';
 
 export type ReviewStatus = {
 	available: boolean;
+	/**
+	 * Review gate for the `storybook ai` CLI channel (the Claude/Codex plugins):
+	 * on by default, `experimentalReview: false` is the explicit opt-out.
+	 */
+	availableForCli: boolean;
 	hasFeatureFlag: boolean;
 };
 
@@ -19,11 +24,13 @@ export const getReviewStatus = async (
 			| { changeDetection?: boolean; experimentalReview?: boolean }
 			| undefined);
 	const hasFeatureFlag = !!resolvedFeatures?.experimentalReview;
+	const changeDetection = !!resolvedFeatures?.changeDetection;
 
 	return {
-		// Review is opt-in via `experimentalReview` and builds on the
-		// change-detection pipeline, so it needs both flags.
-		available: hasFeatureFlag && !!resolvedFeatures?.changeDetection,
+		// Review is opt-in via `experimentalReview` for direct MCP clients and
+		// builds on the change-detection pipeline, so it needs both flags.
+		available: hasFeatureFlag && changeDetection,
+		availableForCli: resolvedFeatures?.experimentalReview !== false && changeDetection,
 		hasFeatureFlag,
 	};
 };


### PR DESCRIPTION
## What

Makes the agentic review workflow on by default **for the plugin channel only** — when the MCP tools are consumed through the `experimental_storybookAi` preset / `storybook ai` CLI (what the Claude and Codex plugins use) — while keeping it opt-in for agents connected directly to the MCP endpoint.

Semantics of `features.experimentalReview` (with `changeDetection` on, which is core's default):

| `experimentalReview` | plugin / `storybook ai` CLI | direct MCP client |
| --- | --- | --- |
| unset | **on (new)** | off (unchanged) |
| `true` | on | on |
| `false` | off | off |

## How

The plugin channel is identified in two places:

- **Metadata preset** (`buildStorybookAiMetadata`): only the `storybook ai` CLI consumes it, so the CLI review gate (`reviewEnabledForCli`) drives the embedded instructions, tool descriptions, `display-review` inclusion, and the local `get-ui-building-instructions` output.
- **Live MCP endpoint**: the CLI already marks every request with `X-Storybook-MCP-Proxy: true` (Storybook core `cli/ai/mcp/client.ts`). `display-review` is now registered whenever the CLI gate could enable it, with a per-request tmcp `enabled` callback reading a new `reviewEnabled` context computed from that header — mirroring the existing `X-MCP-Toolsets` pattern. Server instructions use the same per-request gate.

Direct MCP clients without the flag see no change: no `display-review` in `tools/list`, legacy instructions, non-review tool descriptions. The `/mcp` landing page badge now reflects the CLI gate, with a notice explaining the direct-client opt-in.

## Notes

- The header is already trusted (it skips composition auth flows), so no new trust surface.
- **agent-eval**: review mode is now gated by integration — plugin sandboxes always run (and assert) review-on, while `EVAL_REVIEW=1` still forces the flag so MCP-integration runs can assert the review workflow. `EVAL_STORYBOOK_LATEST=1` runs are unaffected (they run zero plugin evals).

Context: [Slack — QA guide thread](https://chromaticqa.slack.com/archives/C0BDPP3LKTR/p1783351575756119?thread_ts=1783349975.837659&cid=C0BDPP3LKTR) (auto-enabling review in the plugin for 10.5.0 QA).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “Review” enablement is now split between Storybook AI CLI requests and direct MCP clients.
  * Trusted local CLI requests can surface `display-review` and review instructions without affecting direct client behavior.
  * Story instruction generation can now respect an effective per-request review gate.
* **Bug Fixes**
  * Review gating/availability is now propagated consistently across tool lists and generated instructions.
  * Updated header handling in tests to ensure request-scoped review behavior matches production.
* **Documentation / Tests**
  * Refreshed evaluation and guidance docs for default review behavior, with expanded test coverage for CLI vs direct clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
