### PR TITLE
State the Storybook >=10.5 (or next) requirement consistently across skills

### DIFF
--- a/agent-eval/README.md
+++ b/agent-eval/README.md
@@ -162,9 +162,10 @@ Three templates exist today:
   test setup.
 - `vite-app`: a minimal React + Vite app with **no Storybook at all**. The
   lifecycle fixtures use it directly (820 init) or layer an old Storybook on
-  top (821/822 upgrades, which also set `evals.pinStorybook: false` so the
-  harness keeps their intentionally outdated versions); 812 layers a full
-  Storybook `next` setup with zero stories on top.
+  top (821/822 upgrades and 823 setup-on-outdated, which also set
+  `evals.pinStorybook: false` so the harness keeps their intentionally
+  outdated versions); 812 layers a full Storybook `next` setup with zero
+  stories on top.
 - `monorepo`: an npm-workspaces repo where the runnable Storybook lives in the
   `packages/ui` leaf, so evals can cover agents working inside a workspace
   package. Storybook pinning and the local `file:` build detection cover

--- a/agent-eval/evals/822-upgrade-from-stable/EVAL.ts
+++ b/agent-eval/evals/822-upgrade-from-stable/EVAL.ts
@@ -18,11 +18,13 @@ test('runs the Storybook upgrade command', () => {
 	expectShellCommandMatching(/storybook(@\S+)?\s+upgrade/);
 });
 
-// 10.4.6 is the stable release at fixture-authoring time; the seeded 10.4.0
-// must move all the way to the current release, not just past 10.4.0. Bump
-// alongside future stables.
-test('upgrades the Storybook packages to the current release', () => {
-	expectStorybookDependenciesAtLeast('10.4.6', ['storybook', '@storybook/react-vite'], {
+// The plugin requires Storybook >= 10.5 (or `next` while 10.5 is unreleased),
+// so the seeded 10.4.0 must land at or above that — settling on the 10.4.x
+// stable is exactly the bug this guards against. Prerelease specs like
+// 10.5.0-beta.0 parse as (10,5,0) and satisfy the floor. Bump alongside
+// future requirement changes.
+test('upgrades the Storybook packages to the plugin-required release', () => {
+	expectStorybookDependenciesAtLeast('10.5.0', ['storybook', '@storybook/react-vite'], {
 		// Storybook 10 absorbs @storybook/react — a correct upgrade removes it,
 		// but a stale seeded copy left behind must fail the floor.
 		ifPresent: ['@storybook/react'],

--- a/agent-eval/evals/823-setup-outdated-storybook/.storybook/main.ts
+++ b/agent-eval/evals/823-setup-outdated-storybook/.storybook/main.ts
@@ -1,0 +1,8 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+	stories: ['../@(stories|src)/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+	addons: [],
+	framework: '@storybook/react-vite',
+};
+export default config;

--- a/agent-eval/evals/823-setup-outdated-storybook/.storybook/preview.ts
+++ b/agent-eval/evals/823-setup-outdated-storybook/.storybook/preview.ts
@@ -1,0 +1,7 @@
+import type { Preview } from '@storybook/react-vite';
+
+const preview: Preview = {
+	parameters: {},
+};
+
+export default preview;

--- a/agent-eval/evals/823-setup-outdated-storybook/EVAL.ts
+++ b/agent-eval/evals/823-setup-outdated-storybook/EVAL.ts
@@ -6,11 +6,15 @@ import {
 	expectStorybookDependenciesAtLeast,
 } from '#test-utils';
 
-// Only the lifecycle outcome is asserted; the story/review workflow is owned
-// by the 80x evals. The fixture opts out of the harness version pinning
-// (evals.pinStorybook: false) to keep the seeded 9.1.20.
+// Regression fixture for a setup request against an already-installed but
+// outdated Storybook (seeded 10.4.0, evals.pinStorybook: false): the agent
+// must notice the version is below the plugin requirement and route through
+// the upgrade skill instead of setting up on the old version. Same prompt as
+// 820-init-no-storybook — only the seeded state differs. Which entry skill
+// handles the request (setup vs stories) is deliberately not asserted; the
+// upgrade routing is the behavior under test.
 
-test('invokes the storybook-upgrade skill', () => {
+test('routes to the storybook-upgrade skill', () => {
 	expectSkillInvoked('storybook-upgrade');
 });
 
@@ -19,9 +23,10 @@ test('runs the Storybook upgrade command', () => {
 });
 
 // The plugin requires Storybook >= 10.5 (or `next` while 10.5 is unreleased),
-// so an under-upgrade (e.g. landing on 10.0.0 or the 10.4.x stable) must not
-// count. Prerelease specs like 10.5.0-beta.0 parse as (10,5,0) and satisfy
-// the floor. Bump alongside future requirement changes.
+// so the seeded 10.4.0 must land at or above that — settling on the 10.4.x
+// stable is exactly the bug this guards against. Prerelease specs like
+// 10.5.0-beta.0 parse as (10,5,0) and satisfy the floor. Bump alongside
+// future requirement changes.
 test('upgrades the Storybook packages to the plugin-required release', () => {
 	expectStorybookDependenciesAtLeast('10.5.0', ['storybook', '@storybook/react-vite'], {
 		// Storybook 10 absorbs @storybook/react — a correct upgrade removes it,

--- a/agent-eval/evals/823-setup-outdated-storybook/PROMPT.md
+++ b/agent-eval/evals/823-setup-outdated-storybook/PROMPT.md
@@ -1,0 +1,1 @@
+Set up Storybook for this project so I can develop and preview the components in `src/components` in isolation.

--- a/agent-eval/evals/823-setup-outdated-storybook/package.json
+++ b/agent-eval/evals/823-setup-outdated-storybook/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "823-setup-outdated-storybook",
+	"type": "module",
+	"scripts": {
+		"storybook": "storybook dev",
+		"build-storybook": "storybook build"
+	},
+	"devDependencies": {
+		"@storybook/react": "10.4.0",
+		"@storybook/react-vite": "10.4.0",
+		"storybook": "10.4.0"
+	},
+	"evals": {
+		"template": "vite-app",
+		"pinStorybook": false
+	}
+}

--- a/agent-eval/evals/823-setup-outdated-storybook/stories/Button.stories.tsx
+++ b/agent-eval/evals/823-setup-outdated-storybook/stories/Button.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Button from '../src/components/Button';
+
+const meta = {
+	title: 'Example/Button',
+	component: Button,
+	args: {
+		label: 'Click me',
+	},
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};
+
+export const Secondary: Story = {
+	args: {
+		variant: 'secondary',
+	},
+};
+
+export const Disabled: Story = {
+	args: {
+		disabled: true,
+	},
+};

--- a/agent-eval/lib/experiment.ts
+++ b/agent-eval/lib/experiment.ts
@@ -25,6 +25,7 @@ const LIFECYCLE_STORYBOOK_EVALS = [
 	'820-init-no-storybook',
 	'821-upgrade-from-sb9',
 	'822-upgrade-from-stable',
+	'823-setup-outdated-storybook',
 ] as const;
 
 // The 9xx line: ports from the old /eval system, written for the MCP-only

--- a/packages/claude-plugin/skills/stories/SKILL.md
+++ b/packages/claude-plugin/skills/stories/SKILL.md
@@ -6,7 +6,7 @@ description: Invoke FIRST, before creating, editing, or deleting components, sto
 Prerequisites:
 
 1. Storybook must be installed in the project. Invoke the `/storybook-init` skill to set up Storybook, but only if the user explicitly invoked this skill and approves a Storybook installation.
-2. Storybook must be >= 10.5 (or an alpha/canary version). Invoke the `/storybook-upgrade` skill to upgrade it, but only if the user
+2. Storybook must be at least 10.5 (or `next` while 10.5 is not yet released). Invoke the `/storybook-upgrade` skill to upgrade it, but only if the user
    explicitly approved a Storybook upgrade.
 3. Ensure `@storybook/addon-mcp` is installed. If it is missing, install it with `npx storybook add @storybook/addon-mcp`.
 

--- a/packages/claude-plugin/skills/storybook-setup/SKILL.md
+++ b/packages/claude-plugin/skills/storybook-setup/SKILL.md
@@ -6,7 +6,7 @@ description: Use this skill when Storybook is already installed and the user wan
 Prerequisites:
 
 1. Confirm Storybook exists (`package.json`, `.storybook/`). If not, switch to `/storybook-init`.
-2. If Storybook is outdated or upgrade/repair is needed first, switch to `/storybook-upgrade`.
+2. Storybook must be at least 10.5 (or `next` while 10.5 is not yet released). If it is older, or upgrade/repair is needed first, switch to `/storybook-upgrade`.
 
 Run `npx storybook ai setup` from the project root (or the Storybook package in a monorepo).
 

--- a/packages/claude-plugin/skills/storybook-upgrade/SKILL.md
+++ b/packages/claude-plugin/skills/storybook-upgrade/SKILL.md
@@ -3,4 +3,8 @@ name: storybook-upgrade
 description: Use this skill when Storybook exists but needs an upgrade.
 ---
 
+Storybook must end up at version 10.5 or later (or `next` while 10.5 is not yet released).
+
 Read https://storybook.js.org/docs/releases/upgrading.md in its **entirety** to get the latest Storybook upgrade instructions.
+
+If the latest stable release is still below 10.5, upgrade to the prerelease instead with `npx storybook@next upgrade`.

--- a/packages/codex-plugin/plugins/storybook/skills/setup/SKILL.md
+++ b/packages/codex-plugin/plugins/storybook/skills/setup/SKILL.md
@@ -6,7 +6,7 @@ description: Use this skill when Storybook is already installed and the user wan
 Prerequisites:
 
 1. Confirm Storybook exists (`package.json`, `.storybook/`). If not, switch to `$storybook:init`.
-2. If Storybook is outdated or upgrade/repair is needed first, switch to `$storybook:upgrade`.
+2. Storybook must be at least 10.5 (or `next` while 10.5 is not yet released). If it is older, or upgrade/repair is needed first, switch to `$storybook:upgrade`.
 
 Run `npx storybook ai setup` from the project root (or the Storybook package in a monorepo).
 

--- a/packages/codex-plugin/plugins/storybook/skills/stories/SKILL.md
+++ b/packages/codex-plugin/plugins/storybook/skills/stories/SKILL.md
@@ -6,7 +6,7 @@ description: Invoke FIRST, before creating, editing, or deleting components, sto
 Prerequisites:
 
 1. Storybook must be installed in the project. Invoke the `$storybook:init` skill to set up Storybook, but only if the user explicitly invoked this skill and approves a Storybook installation.
-2. Storybook must be >= 10.5 (or an alpha/canary version). Invoke the `$storybook:upgrade` skill to upgrade it, but only if the user
+2. Storybook must be at least 10.5 (or `next` while 10.5 is not yet released). Invoke the `$storybook:upgrade` skill to upgrade it, but only if the user
    explicitly approved a Storybook upgrade.
 3. Ensure `@storybook/addon-mcp` is installed. If it is missing, install it with `npx storybook add @storybook/addon-mcp`.
 

--- a/packages/codex-plugin/plugins/storybook/skills/upgrade/SKILL.md
+++ b/packages/codex-plugin/plugins/storybook/skills/upgrade/SKILL.md
@@ -3,4 +3,8 @@ name: upgrade
 description: Use this skill when Storybook exists but needs an upgrade.
 ---
 
+Storybook must end up at version 10.5 or later (or `next` while 10.5 is not yet released).
+
 Read https://storybook.js.org/docs/releases/upgrading.md in its **entirety** to get the latest Storybook upgrade instructions.
+
+If the latest stable release is still below 10.5, upgrade to the prerelease instead with `npx storybook@next upgrade`.


### PR DESCRIPTION
Lightweight alternative to #343, addressing the two failures Michael hit during Astryx QA ([Slack thread](https://chromaticqa.slack.com/archives/C0BDPP3LKTR/p1783412775.806039)):

1. **`/setup` left Storybook on 10.4.6.** The setup skill said "if Storybook is outdated, switch to the upgrade skill" but never defined *outdated* — the >=10.5 threshold only existed in the stories skill, and 10.4.6 is the latest stable, so the agent had no reason to upgrade.
2. **The upgrade path couldn't satisfy the requirement.** The upgrade skill targets `storybook@latest`, which is still 10.4.x, so even when the version check fired the agent ended up below 10.5 (Michael's `/stories`-on-medium failure).

Instead of duplicating the full prerequisite block into every skill, this states the version requirement with one consistent phrase in each skill that needs it — "at least 10.5 (or `next` while 10.5 is not yet released)" — and teaches the upgrade skill the prerelease fallback:

- **stories** (claude + codex): prerequisite 2 now uses the shared wording (replaces "or an alpha/canary version" — same meaning, since that's what `next` installs).
- **setup** (claude + codex): prerequisite 2 defines the threshold and routes to the upgrade skill.
- **upgrade** (claude + codex): states the target version and adds: if the latest stable release is still below 10.5, run `npx storybook@next upgrade` instead.

The "while 10.5 is not yet released" phrasing self-retires once 10.5 ships — nothing to remember to remove, only the version number to bump on the next requirement change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Storybook version requirements across setup and upgrade guidance.
  * Setup now directs users to upgrade first if their Storybook version is too old.
  * Upgrade instructions now explicitly target Storybook 10.5 or later, with `next` recommended until 10.5 is available.
  * Updated wording to make the supported version range easier to follow and reduce setup confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->