### PR TITLE
Restore require_escalated guidance to the Codex plugin stories skill

### DIFF
--- a/packages/claude-plugin/skills/stories/SKILL.md
+++ b/packages/claude-plugin/skills/stories/SKILL.md
@@ -18,3 +18,5 @@ Some commands require a running Storybook dev server. When Claude preview toolin
 
 1. Ensure there is a Storybook launch entry in `.claude/launch.json` (the `preview_start` tool description documents the file format) with `autoPort: true` and `port: 6006`. Use the project's preferred package manager and existing `package.json` Storybook script instead of inventing a new command whenever possible.
 2. Start the Storybook launch entry with the `preview_start` tool.
+
+If a Storybook CLI command fails because the sandbox blocks network access or port binding (e.g. `NoFreePortError`, or `EPERM` when listening on localhost), re-run it with sandbox escalation/approval — this is a sandbox restriction, not a Storybook bug.

--- a/packages/claude-plugin/skills/stories/SKILL.md
+++ b/packages/claude-plugin/skills/stories/SKILL.md
@@ -18,5 +18,3 @@ Some commands require a running Storybook dev server. When Claude preview toolin
 
 1. Ensure there is a Storybook launch entry in `.claude/launch.json` (the `preview_start` tool description documents the file format) with `autoPort: true` and `port: 6006`. Use the project's preferred package manager and existing `package.json` Storybook script instead of inventing a new command whenever possible.
 2. Start the Storybook launch entry with the `preview_start` tool.
-
-If a Storybook CLI command fails because the sandbox blocks network access or port binding (e.g. `NoFreePortError`, or `EPERM` when listening on localhost), re-run it with sandbox escalation/approval — this is a sandbox restriction, not a Storybook bug.

--- a/packages/codex-plugin/plugins/storybook/skills/stories/SKILL.md
+++ b/packages/codex-plugin/plugins/storybook/skills/stories/SKILL.md
@@ -10,6 +10,8 @@ Prerequisites:
    explicitly approved a Storybook upgrade.
 3. Ensure `@storybook/addon-mcp` is installed. If it is missing, install it with `npx storybook add @storybook/addon-mcp`.
 
+In sandboxed Codex environments, run every Storybook CLI command with `require_escalated` — sandbox network/port restrictions can otherwise cause confusing failures (e.g. the dev server finds no free port to bind to).
+
 Run `STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai --help` and read the output in its **entirety** to get the **mandatory, ordered workflow** for working on UI changes, writing stories, and keeping stories in sync with every frontend component you create, modify, or delete. This workflow explains how to write stories, preview stories, and display a curated Storybook review.
 
 Before invoking any `storybook ai` command for the first time in a session, run `STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai <command> --help` and read it fully. The top-level help only lists the commands; each command's payload shape and usage rules (which fields to include when) live in its own help output. Never guess a `--json` payload from the command name — a validation error only reports missing required fields, not the optional fields the workflow expects you to provide.


### PR DESCRIPTION
## What

Re-adds the agent-sandbox escalation guidance to the Codex plugin `stories` skill, as a single workflow-rule line (not the per-command repetition that e6fc6e0's simplification deliberately removed): in sandboxed Codex environments, run every Storybook CLI command with `require_escalated`.

Verified against current Codex docs: the shell tool still takes `sandbox_permissions: "require_escalated"`, so the wording from #290 remains correct.

Codex only — the Claude plugin has not hit this problem (Claude Code handles sandbox escalation through its own permission prompts), so its skill is untouched.

## Why

#290 added this guidance for Codex, but e6fc6e0 ("Simplify Storybook plugin skills") dropped it entirely. Without it, sandboxed agents hit confusing failures: when the sandbox denies every port bind, `storybook dev` crashed with "Invariant failed: expected options to have a port" ([Slack report](https://chromaticqa.slack.com/archives/C0BDPP3LKTR/p1783416520371859)). The CLI-side error message is being fixed in storybookjs/storybook#35388 (`NoFreePortError`, SB_CORE-SERVER_0017); this PR restores the plugin-side half so Codex escalates instead of misdiagnosing.

No changeset: the plugin packages are in the changesets ignore list.

## Verification

`pnpm vitest run --project=@storybook/codex-plugin --project=@storybook/claude-code-plugin` — 9/9 pass, including the skill-description budget/sync checks and `claude plugin validate`.