### PR TITLE
Add MCP tool call debug logging via environment variables

### DIFF
--- a/.changeset/gentle-hats-listen.md
+++ b/.changeset/gentle-hats-listen.md
@@ -1,0 +1,6 @@
+---
+'@storybook/mcp': minor
+'@storybook/addon-mcp': minor
+---
+
+Add MCP tool call debug logging, gated by two new environment variables mirroring Storybook's telemetry debugging: `STORYBOOK_MCP_DEBUG` writes every tool call record (inputs, outputs, errors, timing, session/client info) to stderr as NDJSON, and `STORYBOOK_MCP_DEBUG_URL` POSTs the same records to a collector such as the `mcp-logger` dashboard from `@hipster/sb-utils`. `@storybook/mcp` exports the `instrumentMcpServerForDebug` / `getMcpDebugConfig` helpers, and both the standalone server (http + stdio) and the addon MCP server are instrumented when the variables are set.

--- a/packages/addon-mcp/README.md
+++ b/packages/addon-mcp/README.md
@@ -28,4 +28,29 @@ export default {
 
 The endpoint must be a URL pathname such as `/custom-mcp` or `/tools/mcp`.
 
+## Debugging tool calls
+
+Similar to `STORYBOOK_TELEMETRY_DEBUG` for telemetry, two environment
+variables let you inspect every MCP tool call (inputs, outputs, errors,
+timing, and session/client info):
+
+- `STORYBOOK_MCP_DEBUG` — when set to a truthy value, each record is written
+  to stderr as an NDJSON line prefixed with `[storybook-mcp-debug]`.
+- `STORYBOOK_MCP_DEBUG_URL` — when set, each record is POSTed as JSON to this
+  URL. Point it at the `mcp-logger` dashboard from
+  [`@hipster/sb-utils`](https://github.com/yannbf/sb-utils) to explore calls
+  in real time:
+
+```sh
+# Terminal 1: start the collector + dashboard
+npx @hipster/sb-utils mcp-logger
+
+# Terminal 2: start Storybook with MCP debug logging pointed at it
+STORYBOOK_MCP_DEBUG_URL=http://localhost:6008/mcp-log yarn storybook
+```
+
+Records cover session initialization (`session-start`) and tool execution
+(`tool-call-start` / `tool-call-end` with duration, result, and error
+details). Logging is fire-and-forget and never affects tool behavior.
+
 Learn more about Storybook at [storybook.js.org](https://storybook.js.org/?ref=readme).

--- a/packages/addon-mcp/src/mcp-handler.ts
+++ b/packages/addon-mcp/src/mcp-handler.ts
@@ -2,7 +2,7 @@ import { McpServer } from 'tmcp';
 import { ValibotJsonSchemaAdapter } from '@tmcp/adapter-valibot';
 import { HttpTransport } from '@tmcp/transport-http';
 import pkgJson from '../package.json' with { type: 'json' };
-import type { Source } from '@storybook/mcp';
+import { getMcpDebugConfig, instrumentMcpServerForDebug, type Source } from '@storybook/mcp';
 import type { Options } from 'storybook/internal/types';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { buffer } from 'node:stream/consumers';
@@ -77,6 +77,18 @@ const initializeMCPServer = async (options: Options, multiSource?: boolean) => {
 	if (!disableTelemetry) {
 		server.on('initialize', async () => {
 			await collectTelemetry({ event: 'session:initialized', server });
+		});
+	}
+
+	const debugConfig = getMcpDebugConfig();
+	if (debugConfig.enabled) {
+		logger.info(
+			`MCP debug logging enabled${debugConfig.url ? ` — sending tool call records to ${debugConfig.url}` : ' — writing tool call records to stderr'}`,
+		);
+		instrumentMcpServerForDebug(server, {
+			transport: 'addon',
+			serverInfo: { name: pkgJson.name, version: pkgJson.version },
+			config: debugConfig,
 		});
 	}
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -362,3 +362,29 @@ Type:
 ```
 
 Registers [story-level documentation lookup](https://storybook.js.org/docs/next/ai/mcp/overview/#get-documentation-for-story) for a specific story variant by `componentId` and `storyName`.
+
+## Debugging tool calls
+
+Similar to `STORYBOOK_TELEMETRY_DEBUG` for Storybook telemetry, two
+environment variables let you inspect every MCP tool call handled by this
+server (inputs, outputs, errors, timing, and session/client info):
+
+- `STORYBOOK_MCP_DEBUG` — when set to a truthy value, each record is written
+  to stderr as an NDJSON line prefixed with `[storybook-mcp-debug]`. Records
+  go to stderr so stdio-based servers keep a clean protocol channel on stdout.
+- `STORYBOOK_MCP_DEBUG_URL` — when set, each record is POSTed as JSON to this
+  URL, e.g. the `mcp-logger` dashboard from
+  [`@hipster/sb-utils`](https://github.com/yannbf/sb-utils):
+
+```sh
+# Terminal 1: start the collector + dashboard
+npx @hipster/sb-utils mcp-logger
+
+# Terminal 2: run your MCP server with debug logging pointed at it
+STORYBOOK_MCP_DEBUG_URL=http://localhost:6008/mcp-log node ./server.ts
+```
+
+The same instrumentation can be applied to your own `tmcp` server via the
+exported `instrumentMcpServerForDebug(server, { transport, serverInfo })`
+helper and inspected with `getMcpDebugConfig()`. Logging is fire-and-forget
+and never affects tool behavior.

--- a/packages/mcp/bin.ts
+++ b/packages/mcp/bin.ts
@@ -19,6 +19,7 @@ import pkgJson from './package.json' with { type: 'json' };
 import { addListAllDocumentationTool } from './src/tools/list-all-documentation.ts';
 import { addGetStoryDocumentationTool } from './src/tools/get-documentation-for-story.ts';
 import { addGetDocumentationTool } from './src/tools/get-documentation.ts';
+import { instrumentMcpServerForDebug } from './src/debug-log.ts';
 import type { StorybookContext } from './src/types.ts';
 import { parseArgs } from 'node:util';
 import * as fs from 'node:fs/promises';
@@ -55,6 +56,11 @@ const server = new McpServer(
 		},
 	},
 ).withContext<StorybookContext>();
+
+instrumentMcpServerForDebug(server, {
+	transport: 'stdio',
+	serverInfo: { name: pkgJson.name, version: pkgJson.version },
+});
 
 await addListAllDocumentationTool(server);
 await addGetStoryDocumentationTool(server);

--- a/packages/mcp/src/debug-log.test.ts
+++ b/packages/mcp/src/debug-log.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { McpServer } from 'tmcp';
+import { ValibotJsonSchemaAdapter } from '@tmcp/adapter-valibot';
+import * as v from 'valibot';
+import {
+	getMcpDebugConfig,
+	instrumentMcpServerForDebug,
+	type McpDebugRecord,
+} from './debug-log.ts';
+
+const SERVER_INFO = { name: 'test-server', version: '1.0.0' };
+
+function createServer() {
+	return new McpServer(
+		{ ...SERVER_INFO, description: 'Test server for debug logging' },
+		{
+			adapter: new ValibotJsonSchemaAdapter(),
+			capabilities: { tools: { listChanged: true } },
+		},
+	).withContext<Record<string, never>>();
+}
+
+async function initializeSession(server: ReturnType<typeof createServer>, sessionId: string) {
+	await server.receive(
+		{
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'initialize',
+			params: {
+				protocolVersion: '2025-06-18',
+				capabilities: {},
+				clientInfo: { name: 'test-client', version: '2.0.0' },
+			},
+		},
+		{ sessionId },
+	);
+}
+
+function callTool(
+	server: ReturnType<typeof createServer>,
+	name: string,
+	args: Record<string, unknown>,
+	sessionId = 'test-session',
+) {
+	return server.receive(
+		{
+			jsonrpc: '2.0',
+			id: 2,
+			method: 'tools/call',
+			params: { name, arguments: args },
+		},
+		{ sessionId },
+	);
+}
+
+describe('getMcpDebugConfig', () => {
+	it('is disabled when neither variable is set', () => {
+		expect(getMcpDebugConfig({})).toEqual({
+			enabled: false,
+			url: undefined,
+			logToStderr: false,
+		});
+	});
+
+	it.each(['1', 'true', 'anything'])(
+		'enables stderr logging for STORYBOOK_MCP_DEBUG=%s',
+		(value) => {
+			expect(getMcpDebugConfig({ STORYBOOK_MCP_DEBUG: value })).toEqual({
+				enabled: true,
+				url: undefined,
+				logToStderr: true,
+			});
+		},
+	);
+
+	it.each(['', '0', 'false', 'FALSE'])(
+		'stays disabled for falsy STORYBOOK_MCP_DEBUG=%j',
+		(value) => {
+			expect(getMcpDebugConfig({ STORYBOOK_MCP_DEBUG: value }).enabled).toBe(false);
+		},
+	);
+
+	it('enables capture when only STORYBOOK_MCP_DEBUG_URL is set', () => {
+		expect(getMcpDebugConfig({ STORYBOOK_MCP_DEBUG_URL: 'http://localhost:6008/mcp-log' })).toEqual(
+			{
+				enabled: true,
+				url: 'http://localhost:6008/mcp-log',
+				logToStderr: false,
+			},
+		);
+	});
+
+	it('supports both variables at once', () => {
+		expect(
+			getMcpDebugConfig({
+				STORYBOOK_MCP_DEBUG: '1',
+				STORYBOOK_MCP_DEBUG_URL: 'http://localhost:6008/mcp-log',
+			}),
+		).toEqual({
+			enabled: true,
+			url: 'http://localhost:6008/mcp-log',
+			logToStderr: true,
+		});
+	});
+});
+
+describe('instrumentMcpServerForDebug', () => {
+	let server: ReturnType<typeof createServer>;
+	let fetchMock: ReturnType<typeof vi.fn>;
+	let posted: McpDebugRecord[];
+
+	const URL_CONFIG = {
+		enabled: true,
+		url: 'http://localhost:6008/mcp-log',
+		logToStderr: false,
+	};
+
+	beforeEach(() => {
+		server = createServer();
+		posted = [];
+		fetchMock = vi.fn(async (_url: string, init: { body: string }) => {
+			posted.push(JSON.parse(init.body));
+			return new Response('OK');
+		});
+		vi.stubGlobal('fetch', fetchMock);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	function addEchoTool(handler?: (input: { message: string }) => unknown) {
+		server.tool(
+			{
+				name: 'echo',
+				description: 'Echoes the input',
+				schema: v.object({ message: v.string() }),
+			},
+			(async (input: { message: string }) =>
+				handler ? handler(input) : { content: [{ type: 'text', text: input.message }] }) as never,
+		);
+	}
+
+	it('does not patch the server when disabled', () => {
+		const originalTool = server.tool;
+		instrumentMcpServerForDebug(server, {
+			transport: 'http',
+			serverInfo: SERVER_INFO,
+			config: { enabled: false, logToStderr: false },
+		});
+		expect(server.tool).toBe(originalTool);
+	});
+
+	it('emits start and end records for a successful tool call', async () => {
+		instrumentMcpServerForDebug(server, {
+			transport: 'http',
+			serverInfo: SERVER_INFO,
+			config: URL_CONFIG,
+		});
+		addEchoTool();
+		await initializeSession(server, 'session-a');
+
+		const response = await callTool(server, 'echo', { message: 'hello' }, 'session-a');
+		expect(response.result.content).toEqual([{ type: 'text', text: 'hello' }]);
+
+		// session-start + tool-call-start + tool-call-end
+		expect(posted.map((r) => r.kind)).toEqual([
+			'session-start',
+			'tool-call-start',
+			'tool-call-end',
+		]);
+
+		const [sessionStart, start, end] = posted as [
+			Extract<McpDebugRecord, { kind: 'session-start' }>,
+			Extract<McpDebugRecord, { kind: 'tool-call-start' }>,
+			Extract<McpDebugRecord, { kind: 'tool-call-end' }>,
+		];
+
+		expect(sessionStart.client).toEqual({ name: 'test-client', version: '2.0.0' });
+		expect(sessionStart.protocolVersion).toBe('2025-06-18');
+		expect(sessionStart.sessionId).toBe('session-a');
+
+		expect(start.tool).toBe('echo');
+		expect(start.input).toEqual({ message: 'hello' });
+		expect(start.sessionId).toBe('session-a');
+		expect(start.server).toEqual({ ...SERVER_INFO, transport: 'http' });
+
+		expect(end.callId).toBe(start.callId);
+		expect(end.status).toBe('success');
+		expect(end.durationMs).toBeTypeOf('number');
+		expect(end.result).toEqual({ content: [{ type: 'text', text: 'hello' }] });
+	});
+
+	it('marks results with isError as errors', async () => {
+		instrumentMcpServerForDebug(server, {
+			transport: 'addon',
+			serverInfo: SERVER_INFO,
+			config: URL_CONFIG,
+		});
+		addEchoTool(() => ({
+			content: [{ type: 'text', text: 'Component not found' }],
+			isError: true,
+		}));
+
+		await callTool(server, 'echo', { message: 'nope' });
+
+		const end = posted.find((r) => r.kind === 'tool-call-end');
+		expect(end).toMatchObject({ status: 'error', tool: 'echo' });
+	});
+
+	it('records thrown handler errors and rethrows them', async () => {
+		instrumentMcpServerForDebug(server, {
+			transport: 'http',
+			serverInfo: SERVER_INFO,
+			config: URL_CONFIG,
+		});
+		addEchoTool(() => {
+			throw new Error('boom');
+		});
+
+		const response = await callTool(server, 'echo', { message: 'x' });
+		// tmcp surfaces uncaught handler errors as JSON-RPC errors
+		expect(response.error).toBeDefined();
+
+		const end = posted.find((r) => r.kind === 'tool-call-end');
+		expect(end).toMatchObject({ status: 'error', errorMessage: 'boom' });
+		expect((end as { result?: unknown }).result).toBeUndefined();
+	});
+
+	it('never lets collector failures break the tool call', async () => {
+		fetchMock.mockRejectedValue(new Error('collector down'));
+		instrumentMcpServerForDebug(server, {
+			transport: 'http',
+			serverInfo: SERVER_INFO,
+			config: URL_CONFIG,
+		});
+		addEchoTool();
+
+		const response = await callTool(server, 'echo', { message: 'still works' });
+		expect(response.result.content).toEqual([{ type: 'text', text: 'still works' }]);
+	});
+
+	it('writes NDJSON lines to stderr when STORYBOOK_MCP_DEBUG is on', async () => {
+		const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+		try {
+			instrumentMcpServerForDebug(server, {
+				transport: 'stdio',
+				serverInfo: SERVER_INFO,
+				config: { enabled: true, logToStderr: true },
+			});
+			addEchoTool();
+
+			await callTool(server, 'echo', { message: 'hi' });
+
+			const lines = stderrSpy.mock.calls.map(([chunk]) => String(chunk));
+			expect(lines).toHaveLength(2);
+			for (const line of lines) {
+				expect(line.startsWith('[storybook-mcp-debug] ')).toBe(true);
+				expect(() => JSON.parse(line.replace('[storybook-mcp-debug] ', ''))).not.toThrow();
+			}
+			expect(fetchMock).not.toHaveBeenCalled();
+		} finally {
+			stderrSpy.mockRestore();
+		}
+	});
+});

--- a/packages/mcp/src/debug-log.ts
+++ b/packages/mcp/src/debug-log.ts
@@ -1,0 +1,229 @@
+import type { McpServer } from 'tmcp';
+
+/**
+ * Debug logging for MCP tool calls, mirroring Storybook's telemetry debugging
+ * environment variables:
+ *
+ * - `STORYBOOK_MCP_DEBUG` — when truthy, every record is written to stderr as
+ *   an NDJSON line (stderr so stdio-based MCP servers keep a clean protocol
+ *   channel on stdout).
+ * - `STORYBOOK_MCP_DEBUG_URL` — when set, every record is POSTed to this URL
+ *   (e.g. the `mcp-logger` collector from `@hipster/sb-utils`). Setting the
+ *   URL alone enables capture without the stderr noise.
+ *
+ * Records are fire-and-forget: emitting can never fail or slow down a tool
+ * call.
+ */
+
+export type McpDebugTransport = 'addon' | 'http' | 'stdio';
+
+export type McpDebugClientInfo = {
+	name?: string;
+	version?: string;
+	title?: string;
+};
+
+type McpDebugRecordBase = {
+	timestamp: number;
+	server: { name: string; version: string; transport: McpDebugTransport };
+	sessionId?: string;
+	client?: McpDebugClientInfo;
+};
+
+export type McpDebugSessionRecord = McpDebugRecordBase & {
+	kind: 'session-start';
+	protocolVersion?: string;
+	clientCapabilities?: Record<string, unknown>;
+};
+
+export type McpDebugToolCallStartRecord = McpDebugRecordBase & {
+	kind: 'tool-call-start';
+	callId: string;
+	tool: string;
+	input?: unknown;
+};
+
+export type McpDebugToolCallEndRecord = McpDebugRecordBase & {
+	kind: 'tool-call-end';
+	callId: string;
+	tool: string;
+	input?: unknown;
+	durationMs: number;
+	status: 'success' | 'error';
+	/** The MCP tool result (content, structuredContent, isError) when the handler returned. */
+	result?: unknown;
+	/** Message of a thrown (uncaught) handler error. */
+	errorMessage?: string;
+};
+
+export type McpDebugRecord =
+	| McpDebugSessionRecord
+	| McpDebugToolCallStartRecord
+	| McpDebugToolCallEndRecord;
+
+export type McpDebugConfig = {
+	enabled: boolean;
+	/** Collector URL records are POSTed to, from `STORYBOOK_MCP_DEBUG_URL`. */
+	url?: string;
+	/** Write records to stderr, from `STORYBOOK_MCP_DEBUG`. */
+	logToStderr: boolean;
+};
+
+const FALSY_ENV_VALUES = new Set(['', '0', 'false']);
+
+export function getMcpDebugConfig(
+	env: Record<string, string | undefined> = process.env,
+): McpDebugConfig {
+	const debug = env.STORYBOOK_MCP_DEBUG?.trim().toLowerCase();
+	const url = env.STORYBOOK_MCP_DEBUG_URL?.trim();
+	const logToStderr = debug !== undefined && !FALSY_ENV_VALUES.has(debug);
+	return {
+		enabled: logToStderr || !!url,
+		url: url || undefined,
+		logToStderr,
+	};
+}
+
+/** JSON.stringify that never throws — circular references become "[circular]". */
+function safeJsonStringify(value: unknown): string {
+	const seen = new WeakSet<object>();
+	return JSON.stringify(value, (_key, val) => {
+		if (typeof val === 'object' && val !== null) {
+			if (seen.has(val)) {
+				return '[circular]';
+			}
+			seen.add(val);
+		}
+		if (typeof val === 'bigint') {
+			return val.toString();
+		}
+		return val;
+	});
+}
+
+let callCounter = 0;
+
+function nextCallId(): string {
+	return `call-${Date.now().toString(36)}-${(callCounter++).toString(36)}`;
+}
+
+function emitRecord(config: McpDebugConfig, record: McpDebugRecord): void {
+	let line: string;
+	try {
+		line = safeJsonStringify(record);
+	} catch {
+		return;
+	}
+	if (config.logToStderr) {
+		process.stderr.write(`[storybook-mcp-debug] ${line}\n`);
+	}
+	if (config.url) {
+		fetch(config.url, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: line,
+		}).catch(() => {
+			// The collector being down must never affect the MCP server.
+		});
+	}
+}
+
+export type InstrumentMcpServerOptions = {
+	transport: McpDebugTransport;
+	/** Identifies the emitting server in records (tmcp keeps its own copy private). */
+	serverInfo: { name: string; version: string };
+	/** Override for tests; defaults to reading `process.env`. */
+	config?: McpDebugConfig;
+};
+
+/**
+ * Wraps `server.tool` so every subsequently registered tool handler emits
+ * `tool-call-start` / `tool-call-end` debug records, and listens for session
+ * initialization to emit `session-start` records. Must be called before tools
+ * are registered. No-ops (and patches nothing) when debug logging is not
+ * enabled via the environment.
+ */
+export function instrumentMcpServerForDebug(
+	server: McpServer<any, any>,
+	options: InstrumentMcpServerOptions,
+): void {
+	const config = options.config ?? getMcpDebugConfig();
+	if (!config.enabled) {
+		return;
+	}
+
+	const serverInfo = {
+		name: options.serverInfo.name,
+		version: options.serverInfo.version,
+		transport: options.transport,
+	};
+
+	const baseRecord = () => ({
+		timestamp: Date.now(),
+		server: serverInfo,
+		sessionId: server.ctx.sessionId,
+		client: server.ctx.sessionInfo?.clientInfo as McpDebugClientInfo | undefined,
+	});
+
+	server.on('initialize', (params) => {
+		emitRecord(config, {
+			...baseRecord(),
+			kind: 'session-start',
+			client: params?.clientInfo as McpDebugClientInfo | undefined,
+			protocolVersion: params?.protocolVersion,
+			clientCapabilities: params?.capabilities as Record<string, unknown> | undefined,
+		});
+	});
+
+	const originalTool = server.tool.bind(server);
+	type ToolArgs = Parameters<McpServer<any, any>['tool']>;
+	type ToolHandler = (input?: unknown) => unknown;
+
+	server.tool = ((toolOrOptions: ToolArgs[0], execute?: ToolHandler) => {
+		// tmcp accepts both `tool({ ...options, execute })` and `tool(options, execute)`.
+		const handler = (execute ??
+			(toolOrOptions as { execute?: ToolHandler }).execute) as ToolHandler;
+		const toolName = toolOrOptions.name;
+
+		const wrappedHandler = async (input?: unknown) => {
+			const callId = nextCallId();
+			const startedAt = performance.now();
+			emitRecord(config, {
+				...baseRecord(),
+				kind: 'tool-call-start',
+				callId,
+				tool: toolName,
+				input,
+			});
+			const endRecord = () => ({
+				...baseRecord(),
+				kind: 'tool-call-end' as const,
+				callId,
+				tool: toolName,
+				input,
+				durationMs: Math.round(performance.now() - startedAt),
+			});
+			try {
+				const result = await (input === undefined ? handler() : handler(input));
+				emitRecord(config, {
+					...endRecord(),
+					status: (result as { isError?: boolean } | undefined)?.isError ? 'error' : 'success',
+					result,
+				});
+				return result;
+			} catch (error) {
+				emitRecord(config, {
+					...endRecord(),
+					status: 'error',
+					errorMessage: error instanceof Error ? error.message : String(error),
+				});
+				throw error;
+			}
+		};
+
+		if (execute) {
+			return originalTool(toolOrOptions as never, wrappedHandler as never);
+		}
+		return originalTool({ ...toolOrOptions, execute: wrappedHandler } as never);
+	}) as McpServer<any, any>['tool'];
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -7,8 +7,22 @@ import { addGetStoryDocumentationTool } from './tools/get-documentation-for-stor
 import { addGetDocumentationTool } from './tools/get-documentation.ts';
 import type { StorybookContext } from './types.ts';
 import serverInstructions from './instructions.md';
+import { instrumentMcpServerForDebug } from './debug-log.ts';
 
 export { serverInstructions as STORYBOOK_MCP_INSTRUCTIONS };
+
+// Debug logging of MCP tool calls (STORYBOOK_MCP_DEBUG / STORYBOOK_MCP_DEBUG_URL)
+export {
+	getMcpDebugConfig,
+	instrumentMcpServerForDebug,
+	type InstrumentMcpServerOptions,
+	type McpDebugConfig,
+	type McpDebugRecord,
+	type McpDebugSessionRecord,
+	type McpDebugToolCallEndRecord,
+	type McpDebugToolCallStartRecord,
+	type McpDebugTransport,
+} from './debug-log.ts';
 
 // Export tools for reuse by addon-mcp
 export {
@@ -126,6 +140,11 @@ export const createStorybookMcpHandler = async (
 	if (onSessionInitialize) {
 		server.on('initialize', onSessionInitialize);
 	}
+
+	instrumentMcpServerForDebug(server, {
+		transport: 'http',
+		serverInfo: { name: pkgJson.name, version: pkgJson.version },
+	});
 
 	await addListAllDocumentationTool(server);
 	await addGetStoryDocumentationTool(server);


### PR DESCRIPTION
## Summary

Adds comprehensive debug logging for MCP tool calls, mirroring Storybook's telemetry debugging pattern. Two new environment variables enable inspection of every tool call's inputs, outputs, errors, timing, and session/client information.

## Key Changes

- **New `debug-log.ts` module** with:
  - `getMcpDebugConfig()` — reads `STORYBOOK_MCP_DEBUG` and `STORYBOOK_MCP_DEBUG_URL` environment variables
  - `instrumentMcpServerForDebug()` — wraps `server.tool()` to emit debug records for every tool call
  - Type definitions for debug records: `session-start`, `tool-call-start`, `tool-call-end`

- **Environment variable support**:
  - `STORYBOOK_MCP_DEBUG` — when truthy, writes NDJSON records to stderr (prefixed with `[storybook-mcp-debug]`)
  - `STORYBOOK_MCP_DEBUG_URL` — when set, POSTs records as JSON to the specified URL (e.g., `mcp-logger` collector)
  - Both can be used simultaneously

- **Integration into existing servers**:
  - `@storybook/mcp` — automatically instruments the HTTP server
  - `@storybook/addon-mcp` — instruments the addon's MCP server with logging
  - `mcp/bin.ts` — instruments the CLI server

- **Comprehensive test coverage** (`debug-log.test.ts`) covering:
  - Config parsing for both environment variables
  - Successful and failed tool calls
  - Error handling and timing
  - Collector failures don't affect tool execution
  - Stderr logging with NDJSON format

## Implementation Details

- Records are **fire-and-forget**: collector failures never affect tool behavior
- Uses `safeJsonStringify()` to handle circular references and BigInt values
- Generates unique `callId` for correlating start/end records
- Captures both handler return values and thrown errors
- Distinguishes between handler errors (caught) and MCP result errors (`isError` flag)
- Records include server info, transport type, session ID, client info, and precise timing

https://claude.ai/code/session_01DjDP8cc4wASvZUBG8FyNtP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional MCP tool-call debugging for Storybook servers.
  * Debug records can be sent to stderr or forwarded to a collector URL, with session, timing, input, output, and error details.
  * Added documentation and examples for enabling debug logging with environment variables.
* **Bug Fixes**
  * Debug logging is non-blocking and won’t affect tool behavior, even if delivery to the collector fails.
* **Tests**
  * Added coverage for debug configuration, log output, error handling, and collector failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->