### PR TITLE
Assert story instructions are fetched before the first component edit

### DIFF
--- a/agent-eval/evals/801-create-component-no-launch-config/EVAL.ts
+++ b/agent-eval/evals/801-create-component-no-launch-config/EVAL.ts
@@ -9,6 +9,7 @@ import {
 	expectSkillInvoked,
 	getEvalContext,
 	expectStoryDiscoveryBeforeReview,
+	expectStoryInstructionsBeforeFirstComponentEdit,
 	expectStoryTestsRanAndPassed,
 	expectValidStorybookLaunchConfig,
 	expectWorkflowCalls,
@@ -48,6 +49,10 @@ test.runIf(review)(
 		expectStoryDiscoveryBeforeReview();
 	},
 );
+
+test('fetches the story instructions before writing the component', () => {
+	expectStoryInstructionsBeforeFirstComponentEdit({ covering: ['toggleswitch'] });
+});
 
 test('runs story tests after the change and finishes with them passing', () => {
 	expectStoryTestsRanAndPassed({ covering: ['toggleswitch'] });

--- a/agent-eval/evals/802-create-component/EVAL.ts
+++ b/agent-eval/evals/802-create-component/EVAL.ts
@@ -7,6 +7,7 @@ import {
 	expectSkillInvoked,
 	getEvalContext,
 	expectStoryDiscoveryBeforeReview,
+	expectStoryInstructionsBeforeFirstComponentEdit,
 	expectStoryTestsRanAndPassed,
 	expectValidStorybookLaunchConfig,
 	expectWorkflowCalls,
@@ -44,6 +45,10 @@ test.runIf(review)(
 		expectStoryDiscoveryBeforeReview();
 	},
 );
+
+test('fetches the story instructions before writing the component', () => {
+	expectStoryInstructionsBeforeFirstComponentEdit({ covering: ['profilecard'] });
+});
 
 test('runs story tests after the change and finishes with them passing', () => {
 	expectStoryTestsRanAndPassed({ covering: ['profilecard'] });

--- a/agent-eval/evals/803-edit-component/EVAL.ts
+++ b/agent-eval/evals/803-edit-component/EVAL.ts
@@ -7,6 +7,7 @@ import {
 	getEvalContext,
 	expectStoryDiscoveryBeforeReview,
 	expectStoryIdsInDisplayReview,
+	expectStoryInstructionsBeforeFirstComponentEdit,
 	expectStoryTestsRanAndPassed,
 	expectValidStorybookLaunchConfig,
 	expectWorkflowCalls,
@@ -42,6 +43,10 @@ test.runIf(review)(
 		expectStoryDiscoveryBeforeReview();
 	},
 );
+
+test('fetches the story instructions before editing the component', () => {
+	expectStoryInstructionsBeforeFirstComponentEdit({ covering: ['reviewcard'] });
+});
 
 test('runs story tests after the change and finishes with them passing', () => {
 	expectStoryTestsRanAndPassed({ covering: ['reviewcard'] });

--- a/agent-eval/lib/test-utils.test.ts
+++ b/agent-eval/lib/test-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import {
+	parseInstructionsAndEditTimeline,
 	parseStorybookWorkflowShellCommands,
 	parseWorkflowToolResults,
 	selectFinalRunStoryTestsReport,
@@ -263,6 +264,93 @@ describe('parseWorkflowToolResults', () => {
 		].join('\n');
 
 		expect(parseWorkflowToolResults(transcript, 'run-story-tests')).toHaveLength(0);
+	});
+});
+
+describe('parseInstructionsAndEditTimeline', () => {
+	function claudeToolUseLine(name: string, input: Record<string, unknown>): string {
+		return JSON.stringify({
+			type: 'assistant',
+			message: { content: [{ type: 'tool_use', id: 'toolu_1', name, input }] },
+		});
+	}
+
+	test('orders a late Claude MCP instructions call after the component edit', () => {
+		const transcript = [
+			claudeToolUseLine('Read', { file_path: '/workspace/src/components/ReviewCard.tsx' }),
+			claudeToolUseLine('Edit', { file_path: '/workspace/src/components/ReviewCard.tsx' }),
+			claudeToolUseLine('mcp__storybook-dev-mcp__get-storybook-story-instructions', {}),
+			claudeToolUseLine('Write', { file_path: '/workspace/stories/ReviewCard.stories.tsx' }),
+		].join('\n');
+
+		expect(parseInstructionsAndEditTimeline(transcript)).toEqual([
+			{ kind: 'file-edit', detail: '/workspace/src/components/ReviewCard.tsx' },
+			{ kind: 'instructions', detail: 'mcp__storybook-dev-mcp__get-storybook-story-instructions' },
+			{ kind: 'file-edit', detail: '/workspace/stories/ReviewCard.stories.tsx' },
+		]);
+	});
+
+	test('credits Claude plugin-path instructions fetched through storybook ai', () => {
+		const transcript = [
+			claudeToolUseLine('Bash', {
+				command: 'STORYBOOK_FEATURE_AI_CLI=1 npx storybook ai get-storybook-story-instructions',
+			}),
+			claudeToolUseLine('Write', { file_path: '/workspace/src/components/ReviewCard.tsx' }),
+		].join('\n');
+
+		expect(parseInstructionsAndEditTimeline(transcript).map((entry) => entry.kind)).toEqual([
+			'instructions',
+			'file-edit',
+		]);
+	});
+
+	test('does not report reads or unrelated shell commands', () => {
+		const transcript = [
+			claudeToolUseLine('Read', { file_path: '/workspace/src/components/ReviewCard.tsx' }),
+			claudeToolUseLine('Bash', { command: 'npm run lint' }),
+		].join('\n');
+
+		expect(parseInstructionsAndEditTimeline(transcript)).toHaveLength(0);
+	});
+
+	test('orders Codex mcp_tool_call, file_change, and command_execution items', () => {
+		const transcript = [
+			JSON.stringify({
+				type: 'item.started',
+				item: { type: 'mcp_tool_call', tool: 'get-storybook-story-instructions' },
+			}),
+			JSON.stringify({
+				type: 'item.completed',
+				item: { type: 'mcp_tool_call', tool: 'get-storybook-story-instructions' },
+			}),
+			JSON.stringify({
+				type: 'item.completed',
+				item: {
+					type: 'file_change',
+					changes: [
+						{ path: '/workspace/src/components/ReviewCard.tsx', kind: 'update' },
+						{ path: '/workspace/stories/ReviewCard.stories.tsx', kind: 'update' },
+					],
+				},
+			}),
+			JSON.stringify({
+				type: 'item.completed',
+				item: {
+					type: 'command_execution',
+					command: "/bin/bash -lc 'npx storybook ai get-storybook-story-instructions'",
+				},
+			}),
+		].join('\n');
+
+		expect(parseInstructionsAndEditTimeline(transcript)).toEqual([
+			{ kind: 'instructions', detail: 'get-storybook-story-instructions' },
+			{ kind: 'file-edit', detail: '/workspace/src/components/ReviewCard.tsx' },
+			{ kind: 'file-edit', detail: '/workspace/stories/ReviewCard.stories.tsx' },
+			{
+				kind: 'instructions',
+				detail: "/bin/bash -lc 'npx storybook ai get-storybook-story-instructions'",
+			},
+		]);
 	});
 });
 

--- a/agent-eval/lib/test-utils.ts
+++ b/agent-eval/lib/test-utils.ts
@@ -406,6 +406,169 @@ export function expectStoryDiscoveryBeforeReview(): void {
 	).toBeLessThan(lastReviewIndex);
 }
 
+// The instructions gate the component work itself, not just the stories file:
+// agents that fetch them only when they reach the stories file have already
+// designed and edited the component without the project's conventions (field
+// report in #sb-release-10-5 2026-07-06; 4 of 24 Opus MCP runs of
+// 803-edit-component in the 2026-07-02/03 batches deferred exactly this way).
+// Presence-only expectWorkflowCalls cannot see the deferral, so this asserts
+// the ordering: the first get-storybook-story-instructions call (MCP tool or
+// `storybook ai` CLI) must precede the first edit to the component under
+// test. `covering` follows the same substring convention as
+// expectStoryTestsRanAndPassed: an edit counts when its path contains one of
+// the substrings (stories files excluded — writing the story is the step the
+// instructions were designed for, editing the component is the step agents
+// skip ahead to).
+export function expectStoryInstructionsBeforeFirstComponentEdit(options: {
+	covering: string[];
+}): void {
+	const timeline = parseInstructionsAndEditTimeline(readFileSync(TRANSCRIPT_PATH, 'utf8'));
+
+	const coversComponent = (path: string) => {
+		const normalized = path.toLowerCase();
+		return (
+			!normalized.includes('.stories.') &&
+			options.covering.some((substring) => normalized.includes(substring.toLowerCase()))
+		);
+	};
+
+	const firstEditIndex = timeline.findIndex(
+		(entry) => entry.kind === 'file-edit' && coversComponent(entry.detail),
+	);
+	// Loud failure over a vacuous pass: the eval's other assertions prove the
+	// component was changed, so an invisible edit means the transcript parser
+	// has a gap that must be fixed, not ignored.
+	expect(
+		firstEditIndex,
+		`Expected the transcript to show an edit to a component file covering ${JSON.stringify(options.covering)}`,
+	).toBeGreaterThanOrEqual(0);
+
+	const firstInstructionsIndex = timeline.findIndex((entry) => entry.kind === 'instructions');
+	expect(
+		firstInstructionsIndex,
+		'Expected get-storybook-story-instructions to be called',
+	).toBeGreaterThanOrEqual(0);
+	expect(
+		firstInstructionsIndex,
+		`Expected get-storybook-story-instructions to be called before the first component edit (${timeline[firstEditIndex]?.detail})`,
+	).toBeLessThan(firstEditIndex);
+}
+
+export type InstructionsAndEditTimelineEntry = {
+	kind: 'instructions' | 'file-edit';
+	/** The tool name, shell command, or file path behind the entry, for failure messages. */
+	detail: string;
+};
+
+// Chronological get-storybook-story-instructions fetches and file edits,
+// across every path an agent can take: Claude tool_use blocks (MCP tools,
+// Write/Edit, `storybook ai` shell commands) and Codex item.completed events
+// (mcp_tool_call, file_change, command_execution). Deliberately policy-free —
+// every file edit is reported; deciding which edits matter is the caller's
+// job. Edits made through shell commands (heredocs, sed -i) are not visible
+// here.
+export function parseInstructionsAndEditTimeline(
+	rawTranscript: string,
+): InstructionsAndEditTimelineEntry[] {
+	const entries: InstructionsAndEditTimelineEntry[] = [];
+
+	for (const line of rawTranscript.split('\n')) {
+		const event = parseJson(line);
+		if (!isRecord(event)) {
+			continue;
+		}
+
+		collectClaudeTimelineEntries(event, entries);
+		collectCodexTimelineEntries(event, entries);
+	}
+
+	return entries;
+}
+
+const STORY_INSTRUCTIONS_WORKFLOW_NAME = 'get-storybook-story-instructions';
+
+// Claude edits files through these tools; a file_path on any other tool
+// (Read, Grep, ...) is not an edit.
+const CLAUDE_FILE_EDIT_TOOL_NAMES = ['Write', 'Edit', 'MultiEdit', 'NotebookEdit'];
+
+function collectClaudeTimelineEntries(
+	event: Record<string, unknown>,
+	entries: InstructionsAndEditTimelineEntry[],
+): void {
+	const message = event.message;
+	if (!isRecord(message) || !Array.isArray(message.content)) {
+		return;
+	}
+
+	for (const block of message.content) {
+		if (!isRecord(block) || block.type !== 'tool_use' || typeof block.name !== 'string') {
+			continue;
+		}
+
+		const input = isRecord(block.input) ? block.input : {};
+
+		if (normalizeStorybookWorkflowName(block.name) === STORY_INSTRUCTIONS_WORKFLOW_NAME) {
+			entries.push({ kind: 'instructions', detail: block.name });
+			continue;
+		}
+
+		const command = typeof input.command === 'string' ? input.command : undefined;
+		if (command !== undefined && shellCommandFetchesStoryInstructions(command)) {
+			entries.push({ kind: 'instructions', detail: command });
+			continue;
+		}
+
+		if (CLAUDE_FILE_EDIT_TOOL_NAMES.includes(block.name) && typeof input.file_path === 'string') {
+			entries.push({ kind: 'file-edit', detail: input.file_path });
+		}
+	}
+}
+
+function collectCodexTimelineEntries(
+	event: Record<string, unknown>,
+	entries: InstructionsAndEditTimelineEntry[],
+): void {
+	// item.completed only — Codex emits item.started for the same work too, and
+	// counting both would duplicate every entry.
+	if (event.type !== 'item.completed' || !isRecord(event.item)) {
+		return;
+	}
+
+	const item = event.item;
+
+	if (
+		item.type === 'mcp_tool_call' &&
+		typeof item.tool === 'string' &&
+		normalizeStorybookWorkflowName(item.tool) === STORY_INSTRUCTIONS_WORKFLOW_NAME
+	) {
+		entries.push({ kind: 'instructions', detail: item.tool });
+		return;
+	}
+
+	if (
+		item.type === 'command_execution' &&
+		typeof item.command === 'string' &&
+		shellCommandFetchesStoryInstructions(item.command)
+	) {
+		entries.push({ kind: 'instructions', detail: item.command });
+		return;
+	}
+
+	if (item.type === 'file_change' && Array.isArray(item.changes)) {
+		for (const change of item.changes) {
+			if (isRecord(change) && typeof change.path === 'string') {
+				entries.push({ kind: 'file-edit', detail: change.path });
+			}
+		}
+	}
+}
+
+function shellCommandFetchesStoryInstructions(command: string): boolean {
+	return parseStorybookWorkflowShellCommands([command]).some(
+		(call) => call.name === STORY_INSTRUCTIONS_WORKFLOW_NAME,
+	);
+}
+
 export type WorkflowToolResult = {
 	output: string;
 	isError: boolean;

--- a/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
+++ b/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
@@ -340,20 +340,19 @@ describe('MCP Endpoint E2E Tests', () => {
 				    "title": "Get story preview URLs",
 				  },
 				  {
-				    "description": "Get comprehensive instructions for writing, testing, and fixing Storybook stories (.stories.tsx, .stories.ts, .stories.jsx, .stories.js, .stories.svelte, .stories.vue files).
+				    "description": "Get the required instructions for UI work in this project: creating or editing components, styles, or themes, and writing and testing the Storybook stories that cover them.
 
 				CRITICAL: You MUST call this tool before:
+				- Creating or editing any UI component — even when the task says nothing about Storybook or stories
+				- Editing anything else that changes how the UI looks — styles, CSS, themes, colors, or design tokens; a shared file with no stories of its own still changes its consumers' stories
 				- Creating new Storybook stories or story files
-				- Updating or modifying existing Storybook stories
-				- Adding new story variants or exports to story files
+				- Updating existing stories, or adding story variants or exports to story files
 				- Editing any file matching *.stories.* patterns
-				- Writing components that will need stories
-				- Editing anything that changes how the UI looks — components, styles, CSS, themes, colors, or design tokens; a shared file with no stories of its own still changes its consumers' stories
 				- Running story tests or fixing test failures
 				- Handling accessibility (a11y) violations in stories (fix semantic issues directly; ask before visual/design changes)
 
-				This tool provides essential Storybook-specific guidance including:
-				- How to structure stories correctly for Storybook 9
+				This tool provides essential guidance including:
+				- How to structure stories correctly for this Storybook setup
 				- Required imports (Meta, StoryObj from framework package)
 				- Test utility imports (from 'storybook/test')
 				- Story naming conventions and best practices
@@ -362,13 +361,13 @@ describe('MCP Endpoint E2E Tests', () => {
 				- Story variants and coverage requirements
 				- How to handle test failures and accessibility violations
 
-				Even if you're familiar with Storybook, call this tool to ensure you're following the correct patterns, import paths, and conventions for this specific Storybook setup.",
+				Even if you're familiar with Storybook, call this tool first — UI work done before reading these instructions will not follow this project's patterns, import paths, and conventions.",
 				    "inputSchema": {
 				      "properties": {},
 				      "type": "object",
 				    },
 				    "name": "get-storybook-story-instructions",
-				    "title": "Storybook Story Development Instructions",
+				    "title": "UI Development Instructions (Storybook)",
 				  },
 				  {
 				    "description": "Get Storybook stories marked as new, modified, or related. Returns story metadata only (no URLs).

--- a/packages/addon-mcp/src/tools/get-storybook-story-instructions.ts
+++ b/packages/addon-mcp/src/tools/get-storybook-story-instructions.ts
@@ -54,7 +54,7 @@ export async function addGetUIBuildingInstructionsTool(
 	server.tool(
 		{
 			name: GET_UI_BUILDING_INSTRUCTIONS_TOOL_NAME,
-			title: 'Storybook Story Development Instructions',
+			title: 'UI Development Instructions (Storybook)',
 			get description() {
 				const testToolsetAvailable =
 					(server.ctx.custom?.toolsets?.test ?? true) && addonVitestAvailable;
@@ -121,18 +121,24 @@ export function getStorybookStoryInstructionsDescription({
 - How to handle test failures${a11yAvailable ? ' and accessibility violations' : ''}`
 		: '';
 
-	return `Get comprehensive instructions for writing, testing, and fixing Storybook stories (.stories.tsx, .stories.ts, .stories.jsx, .stories.js, .stories.svelte, .stories.vue files).
+	// The first sentence and the first CRITICAL bullets anchor on component
+	// work, not stories files: agents bind the trigger to whatever the headline
+	// emphasizes, and the previous stories-file-first wording made them defer
+	// the call until they started the stories file — after the component was
+	// already designed and edited without the project's conventions (field
+	// report in #sb-release-10-5 2026-07-06; 4 of 24 Opus MCP runs of
+	// 803-edit-component, 2026-07-02/03 batches).
+	return `Get the required instructions for UI work in this project: creating or editing components, styles, or themes, and writing and testing the Storybook stories that cover them.
 
 CRITICAL: You MUST call this tool before:
+- Creating or editing any UI component — even when the task says nothing about Storybook or stories
+- Editing anything else that changes how the UI looks — styles, CSS, themes, colors, or design tokens; a shared file with no stories of its own still changes its consumers' stories
 - Creating new Storybook stories or story files
-- Updating or modifying existing Storybook stories
-- Adding new story variants or exports to story files
-- Editing any file matching *.stories.* patterns
-- Writing components that will need stories
-- Editing anything that changes how the UI looks — components, styles, CSS, themes, colors, or design tokens; a shared file with no stories of its own still changes its consumers' stories${criticalTestBullets}${criticalA11yBullets}
+- Updating existing stories, or adding story variants or exports to story files
+- Editing any file matching *.stories.* patterns${criticalTestBullets}${criticalA11yBullets}
 
-This tool provides essential Storybook-specific guidance including:
-- How to structure stories correctly for Storybook 9
+This tool provides essential guidance including:
+- How to structure stories correctly for this Storybook setup
 - Required imports (Meta, StoryObj from framework package)
 - Test utility imports (from 'storybook/test')
 - Story naming conventions and best practices
@@ -140,7 +146,7 @@ This tool provides essential Storybook-specific guidance including:
 - Mocking strategies for external dependencies
 - Story variants and coverage requirements${testAndA11yGuidance}
 
-Even if you're familiar with Storybook, call this tool to ensure you're following the correct patterns, import paths, and conventions for this specific Storybook setup.`;
+Even if you're familiar with Storybook, call this tool first — UI work done before reading these instructions will not follow this project's patterns, import paths, and conventions.`;
 }
 
 export function getStorybookStoryInstructionsToolMetadata(options: {
@@ -149,7 +155,7 @@ export function getStorybookStoryInstructionsToolMetadata(options: {
 }) {
 	return {
 		name: GET_UI_BUILDING_INSTRUCTIONS_TOOL_NAME,
-		title: 'Storybook Story Development Instructions',
+		title: 'UI Development Instructions (Storybook)',
 		description: getStorybookStoryInstructionsDescription(options),
 	};
 }


### PR DESCRIPTION
## Why

Steve's field report ([#sb-release-10-5 thread](https://chromaticqa.slack.com/archives/C0BDPP3LKTR/p1783365865968709)): agents sometimes pick up `get-storybook-story-instructions` only when they start the stories file — after the component is already designed and edited without the project's conventions. Replaying our downloaded eval results confirms it locally: **4 of 24 completed Opus MCP runs of 803-edit-component** (his exact ReviewCard prompt) deferred the call past the first component edit; one run even preloaded the tool schema via ToolSearch and still waited. All pass CI today because `expectWorkflowCalls` only asserts presence.

The mechanism: the tool's title and description headline anchored on *stories files* ("instructions for writing, testing, and fixing Storybook stories (.stories.tsx, ...)"), so agents bind the trigger to stories-file work. The component bullet was buried mid-list.

## What

**1. Timing assertion** — `expectStoryInstructionsBeforeFirstComponentEdit({ covering })` in test-utils, wired into 801/802/803:
- Backed by a policy-free timeline parser over the raw transcripts (Claude `tool_use` blocks + Codex `item.completed` events; MCP tools and `storybook ai` CLI both credited), reusing the same cross-agent walk as `parseWorkflowToolResults`.
- No component-file heuristics: each eval names its component with the existing `covering` substring idiom (stories files excluded).
- A component edit the parser can't see fails loudly instead of passing vacuously.

**2. Description/title rewrite** (non-breaking) — headline and first CRITICAL bullets now anchor on component/UI work ("even when the task says nothing about Storybook or stories"); stories-file bullets follow; stale "Storybook 9" reference dropped. Title: "UI Development Instructions (Storybook)".

## Validation

- Replayed the new assertion against all downloaded results: flags exactly the 4 known late Opus runs, passes the other **207** completed runs across every experiment/agent/integration (the only other failures are already-`failed` aborted sandbox runs).
- Unit tests for the timeline parser (both agents, both integrations, late-pickup ordering); addon-mcp suite (364), agent-eval lib suite (65), e2e MCP endpoint snapshot updated — all green.

## Measuring the wording change

Baseline to beat on the eval matrix: ~17% late-rate on 803 (Opus MCP). Codex and the plugin path are already 100% instructions-first. If the rewrite doesn't move the number, the next lever is renaming the wire name (`get-storybook-story-instructions` → `get-ui-building-instructions`, matching the internal constant) — breaking cross-channel change, so it should earn its coordination cost with data first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer UI development instructions for Storybook-related workflows, including updated guidance on when to use them.
  * Improved validation to ensure instructions are retrieved before the first component edit in relevant workflows.
* **Bug Fixes**
  * Expanded test coverage for instruction ordering and filtering, helping prevent incorrect workflow sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->