### PR TITLE
fix(addon-mcp): add display-review description

### DIFF
--- a/.changeset/display-review-collections-description.md
+++ b/.changeset/display-review-collections-description.md
@@ -1,0 +1,5 @@
+---
+'@storybook/addon-mcp': patch
+---
+
+Add a schema description to the `collections` argument of the `display-review` tool. The field now documents that collections are groups of stories to show in the review, ordered most-relevant-first, with a preferred 2-5 range. Previously it carried no description, so MCP clients and the `storybook ai display-review` help had no guidance on the argument's shape or intent.

--- a/apps/internal-storybook/tests/helpers.ts
+++ b/apps/internal-storybook/tests/helpers.ts
@@ -1,6 +1,7 @@
 import { x } from 'tinyexec';
+import { fileURLToPath } from 'node:url';
 
-export const STORYBOOK_DIR = new URL('..', import.meta.url).pathname;
+export const STORYBOOK_DIR = fileURLToPath(new URL('..', import.meta.url));
 
 export function createMCPRequestBody(method: string, params: any = {}, id: number = 1) {
 	return {

--- a/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
+++ b/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
@@ -532,6 +532,7 @@ describe('MCP Endpoint E2E Tests', () => {
 				          "type": "array",
 				        },
 				        "collections": {
+				          "description": "Groups of stories to show in the review, most relevant first. Prefer 2-5 groups. Each item is an object with three required fields: \`title\` (string, what the group is), \`rationale\` (string, why it is relevant), and \`storyIds\` (array of story ID strings the group renders). Note the field is \`storyIds\` (a plain array of ID strings), not \`stories\`.",
 				          "items": {
 				            "properties": {
 				              "rationale": {

--- a/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
+++ b/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
@@ -532,7 +532,7 @@ describe('MCP Endpoint E2E Tests', () => {
 				          "type": "array",
 				        },
 				        "collections": {
-				          "description": "Groups of stories to show in the review, most relevant first. Prefer 2-5 groups. Each item is an object with three required fields: \`title\` (string, what the group is), \`rationale\` (string, why it is relevant), and \`storyIds\` (array of story ID strings the group renders). Note the field is \`storyIds\` (a plain array of ID strings), not \`stories\`.",
+				          "description": "Groups of stories to show in the review, most relevant first. Prefer 2-5 groups.",
 				          "items": {
 				            "properties": {
 				              "rationale": {

--- a/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
+++ b/apps/internal-storybook/tests/mcp-endpoint.e2e.test.ts
@@ -772,7 +772,7 @@ describe('MCP Endpoint E2E Tests', () => {
 
 	describe('Tool: preview-stories', () => {
 		it('should return story URLs for valid stories', async () => {
-			const cwd = process.cwd();
+			const cwd = process.cwd().replaceAll('\\', '/');
 			const storyPath = cwd.endsWith('/apps/internal-storybook')
 				? `${cwd}/stories/components/Button.stories.ts`
 				: `${cwd}/apps/internal-storybook/stories/components/Button.stories.ts`;
@@ -955,7 +955,7 @@ describe('MCP Endpoint E2E Tests', () => {
 		});
 
 		it('should run tests for a story and report accessibility violations', async () => {
-			const cwd = process.cwd();
+			const cwd = process.cwd().replaceAll('\\', '/');
 			const storyPath = cwd.endsWith('/apps/internal-storybook')
 				? `${cwd}/stories/components/Button.stories.ts`
 				: `${cwd}/apps/internal-storybook/stories/components/Button.stories.ts`;
@@ -981,7 +981,7 @@ describe('MCP Endpoint E2E Tests', () => {
 		});
 
 		it('should run tests for multiple stories', async () => {
-			const cwd = process.cwd();
+			const cwd = process.cwd().replaceAll('\\', '/');
 			const storyPath = cwd.endsWith('/apps/internal-storybook')
 				? `${cwd}/stories/components/Button.stories.ts`
 				: `${cwd}/apps/internal-storybook/stories/components/Button.stories.ts`;
@@ -1029,7 +1029,7 @@ describe('MCP Endpoint E2E Tests', () => {
 		});
 
 		it('should sequentialize 4 concurrent calls to run-story-tests', async () => {
-			const cwd = process.cwd();
+			const cwd = process.cwd().replaceAll('\\', '/');
 			const storyPath = cwd.endsWith('/apps/internal-storybook')
 				? `${cwd}/stories/components/Button.stories.ts`
 				: `${cwd}/apps/internal-storybook/stories/components/Button.stories.ts`;

--- a/packages/addon-mcp/src/tools/display-review.ts
+++ b/packages/addon-mcp/src/tools/display-review.ts
@@ -71,7 +71,12 @@ export const ReviewStateSchema = v.object({
 			"Description of the review scope, including what's there, why it's relevant, and what to look for. Preferably one or two sentences. At most 2 paragraphs for reviews spanning multiple topics. Markdown formatting restricted to **bold**, _italic_, and `code` (backticks). Use emphasis for the key **what** and _why_, and backticks for literal source code references like component or token names.",
 		),
 	),
-	collections: v.array(ReviewCollectionSchema),
+	collections: v.pipe(
+		v.array(ReviewCollectionSchema),
+		v.description(
+			'Groups of stories to show in the review, most relevant first. Prefer 2-5 groups. Each item is an object with three required fields: `title` (string, what the group is), `rationale` (string, why it is relevant), and `storyIds` (array of story ID strings the group renders). Note the field is `storyIds` (a plain array of ID strings), not `stories`.',
+		),
+	),
 	changedFiles: v.pipe(
 		v.array(v.string()),
 		v.description(

--- a/packages/addon-mcp/src/tools/display-review.ts
+++ b/packages/addon-mcp/src/tools/display-review.ts
@@ -74,7 +74,7 @@ export const ReviewStateSchema = v.object({
 	collections: v.pipe(
 		v.array(ReviewCollectionSchema),
 		v.description(
-			'Groups of stories to show in the review, most relevant first. Prefer 2-5 groups. Each item is an object with three required fields: `title` (string, what the group is), `rationale` (string, why it is relevant), and `storyIds` (array of story ID strings the group renders). Note the field is `storyIds` (a plain array of ID strings), not `stories`.',
+			'Groups of stories to show in the review, most relevant first. Prefer 2-5 groups.',
 		),
 	),
 	changedFiles: v.pipe(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved the `display-review` tool’s `collections` schema metadata, clarifying that it’s an ordered list of story groups (preferred 2–5) and that each group is provided via a `storyIds` array.
* **Tests**
  * Updated end-to-end snapshots to match the clarified `display-review` tool contract.
  * Improved cross-platform test stability by normalizing path separators when constructing Storybook story paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->