### PR TITLE
Remove plugin-only changesets so the addon-mcp 0.7.0 publish can run

### DIFF
--- a/.changeset/codex-dev-server-in-app-browser.md
+++ b/.changeset/codex-dev-server-in-app-browser.md
@@ -1,5 +1,0 @@
----
-'@storybook/codex-plugin': patch
----
-
-The Codex stories skill now steers the dev-server flow: reuse a running Storybook or start one in the background via the project's existing `storybook` script, leave it running when the work is done, and open the resulting Storybook link in Codex's in-app browser through the `control-in-app-browser` skill so the user sees the result side by side inside Codex.

--- a/.changeset/monorepo-same-directory.md
+++ b/.changeset/monorepo-same-directory.md
@@ -1,6 +1,0 @@
----
-'@storybook/claude-code-plugin': patch
-'@storybook/codex-plugin': patch
----
-
-The stories skill now directs agents to run the Storybook dev server and every `storybook ai` command from the same working directory — the package where Storybook is installed. In monorepos where Storybook lives in a leaf package, agents previously ran `storybook ai` from the repo root, hit the degraded `--help` of storybookjs/storybook#35359, and missed the entire workflow.

--- a/apps/internal-storybook/pnpm-lock.yaml
+++ b/apps/internal-storybook/pnpm-lock.yaml
@@ -7,20 +7,20 @@ settings:
 catalogs:
   default:
     '@storybook/addon-a11y':
-      specifier: 10.5.0-beta.0
-      version: 10.5.0-beta.0
+      specifier: 10.6.0-alpha.0
+      version: 10.6.0-alpha.0
     '@storybook/addon-docs':
-      specifier: 10.5.0-beta.0
-      version: 10.5.0-beta.0
+      specifier: 10.6.0-alpha.0
+      version: 10.6.0-alpha.0
     '@storybook/addon-themes':
-      specifier: 10.5.0-beta.0
-      version: 10.5.0-beta.0
+      specifier: 10.6.0-alpha.0
+      version: 10.6.0-alpha.0
     '@storybook/addon-vitest':
-      specifier: 10.5.0-beta.0
-      version: 10.5.0-beta.0
+      specifier: 10.6.0-alpha.0
+      version: 10.6.0-alpha.0
     '@storybook/react-vite':
-      specifier: 10.5.0-beta.0
-      version: 10.5.0-beta.0
+      specifier: 10.6.0-alpha.0
+      version: 10.6.0-alpha.0
     '@vitest/browser-playwright':
       specifier: 4.0.6
       version: 4.0.6
@@ -28,8 +28,8 @@ catalogs:
       specifier: 1.56.1
       version: 1.56.1
     storybook:
-      specifier: 10.5.0-beta.0
-      version: 10.5.0-beta.0
+      specifier: 10.6.0-alpha.0
+      version: 10.6.0-alpha.0
     vite:
       specifier: 7.2.2
       version: 7.2.2
@@ -48,22 +48,22 @@ importers:
     devDependencies:
       '@storybook/addon-a11y':
         specifier: 'catalog:'
-        version: 10.5.0-beta.0(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 10.6.0-alpha.0(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-docs':
         specifier: 'catalog:'
-        version: 10.5.0-beta.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+        version: 10.6.0-alpha.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
       '@storybook/addon-mcp':
         specifier: workspace:*
         version: link:../../packages/addon-mcp
       '@storybook/addon-themes':
         specifier: 'catalog:'
-        version: 10.5.0-beta.0(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 10.6.0-alpha.0(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-vitest':
         specifier: 'catalog:'
-        version: 10.5.0-beta.0(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)
+        version: 10.6.0-alpha.0(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 10.5.0-beta.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)
+        version: 10.6.0-alpha.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)
       '@types/react':
         specifier: ^18.2.65
         version: 18.3.28
@@ -87,7 +87,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       storybook:
         specifier: 'catalog:'
-        version: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tinyexec:
         specifier: ^1.0.2
         version: 1.0.2
@@ -942,32 +942,32 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@storybook/addon-a11y@10.5.0-beta.0':
-    resolution: {integrity: sha512-LaGu6qZ0bSCH03qH2g135hf18mt/J/ezF4Z52WJje7jcJZ4jy3vkaBSvvKRl6OjA/L2iAAe9bnrlSVOpJleRHg==}
+  '@storybook/addon-a11y@10.6.0-alpha.0':
+    resolution: {integrity: sha512-k5T/1uTMYRbjvRW4fT1veTKSCkVe6Qtm9jjbuquqZWuVHeUKUXn+1zPaslFkUybqZlR643aJNrD6mwFeuuTBLw==}
     peerDependencies:
-      storybook: ^10.5.0-beta.0
+      storybook: ^10.6.0-alpha.0
 
-  '@storybook/addon-docs@10.5.0-beta.0':
-    resolution: {integrity: sha512-SK5KDM9I1i80Z5iGXEPIBEhrSmL9YNN53YrgGX9FjUcKkkYJJdNv4kMNAZ1C1Fl1VIHC+V5928y0+w9gpyeSPg==}
+  '@storybook/addon-docs@10.6.0-alpha.0':
+    resolution: {integrity: sha512-CxE5AkHzGZ4zv58mI/egISbMkDNSanDVX+0yKjme2kZt2N15HGJLQujFPvTma4TrhqclzQCwXzn9hrK04aGf6g==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-beta.0
+      storybook: ^10.6.0-alpha.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
 
-  '@storybook/addon-themes@10.5.0-beta.0':
-    resolution: {integrity: sha512-mjn81n7553Fwp5pzvBidycRuS8W9QdxDxBbKrmPGY4kIeM0nQRoJO1gwdVs3+HeoBfY3EEv/AtnjuKh8XlnbDg==}
+  '@storybook/addon-themes@10.6.0-alpha.0':
+    resolution: {integrity: sha512-kyuZbm770vf6ZRKo6PwpO4b7luENGlMCpJEGAb5PcjZTrkWWe2e/RsblikA7ba8xmZApyY9YR+Blj93baJpk1A==}
     peerDependencies:
-      storybook: ^10.5.0-beta.0
+      storybook: ^10.6.0-alpha.0
 
-  '@storybook/addon-vitest@10.5.0-beta.0':
-    resolution: {integrity: sha512-EjhBGi3DsDklTrFdfGzq7OBNrUI+BQyVvdovhzJt4wTy9Um9f7UGnEVCdgEdpo40sHrC/WiLtSN1uBpXfvgeow==}
+  '@storybook/addon-vitest@10.6.0-alpha.0':
+    resolution: {integrity: sha512-rYFD7LXng42B8lKnSX/rKsNRvrweT8P5sG/2lAz7s9cgYApb+Z2eBY5IyhynE6zTS77bA3f8gYO3QVjosDkMeg==}
     peerDependencies:
       '@vitest/browser': ^3.0.0 || ^4.0.0
       '@vitest/browser-playwright': ^4.0.0
       '@vitest/runner': ^3.0.0 || ^4.0.0
-      storybook: ^10.5.0-beta.0
+      storybook: ^10.6.0-alpha.0
       vitest: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       '@vitest/browser':
@@ -979,18 +979,18 @@ packages:
       vitest:
         optional: true
 
-  '@storybook/builder-vite@10.5.0-beta.0':
-    resolution: {integrity: sha512-aBA0yp+WdtTFXT5iAUDMbUkywzhTBgpTJrmJpwd7E050hYf21Ey8whivr48aGpKTaRL7dHaGXYMSBpYOJeTcSw==}
+  '@storybook/builder-vite@10.6.0-alpha.0':
+    resolution: {integrity: sha512-b2kCzYuTvACkgMXh/s+H8lgR9FIxM0DcySi//ff+1V9FZr+EjZx3QDAf7B/SjpnecKEmCCCU6co4rEe7aqIXOw==}
     peerDependencies:
-      storybook: ^10.5.0-beta.0
+      storybook: ^10.6.0-alpha.0
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@storybook/csf-plugin@10.5.0-beta.0':
-    resolution: {integrity: sha512-bK2SX/01FS+NiTFPZaDSmHTZ6I3rcNCEt/y/opE9wHIQpitZ/Zf2QF2zj1dxB5hNZ72oIz1AlC6YuYn/krMmPg==}
+  '@storybook/csf-plugin@10.6.0-alpha.0':
+    resolution: {integrity: sha512-d0KK+2M1sLGmIFWPafLMoh3sIxJ5j6tPNKsKur9bi9MgQRJrciLqfWhK/tA81uD3vyeifkbXv6P5Lz2v5XBu+g==}
     peerDependencies:
       esbuild: '*'
       rollup: '*'
-      storybook: ^10.5.0-beta.0
+      storybook: ^10.6.0-alpha.0
       vite: '*'
       webpack: '*'
     peerDependenciesMeta:
@@ -1012,40 +1012,40 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@storybook/react-dom-shim@10.5.0-beta.0':
-    resolution: {integrity: sha512-YXL4tU/dUvmHoFvw+52Y7EgWpyqdbGlvsw0A1yANS2DL4/X/1omMdsgZVOmn1suyjV7CkDWdrBUdaHNxAoNa6Q==}
+  '@storybook/react-dom-shim@10.6.0-alpha.0':
+    resolution: {integrity: sha512-Q2akoa4yzhdhCTH9xlcT13kJ9jNbcNb7qnvGYcq/3WWFa8OVlCKuab0ljtBq7rAFIeSz+OPXSv6Lavzzt5gUbA==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-beta.0
+      storybook: ^10.6.0-alpha.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
       '@types/react-dom':
         optional: true
 
-  '@storybook/react-vite@10.5.0-beta.0':
-    resolution: {integrity: sha512-F3zHi8ca8Wmn9Ncxm1ML9N2vggzzqvWR2iGNoPJyC7w/uChLlirqq+Fs8mHjRaEptCeNPccEMQBPhKoCLUEvVQ==}
+  '@storybook/react-vite@10.6.0-alpha.0':
+    resolution: {integrity: sha512-VD2zdBNBPFVQ57rmafVEmWr9N5M46YCU1Mq+wFXota9Yg/kpF8LC0HWTeePXAeVoVKeyX9pZNUmn0KpbOaPTYg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-beta.0
+      storybook: ^10.6.0-alpha.0
       typescript: '>= 4.9.x'
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@storybook/react@10.5.0-beta.0':
-    resolution: {integrity: sha512-UQd/RwZpfizK0qSO/XTHEyjP2wrBaDKtKoATxq7llGqKxIOJCzvZaLuAGsFzCoK114NEJ9GDurKhTlQxPpNJZQ==}
+  '@storybook/react@10.6.0-alpha.0':
+    resolution: {integrity: sha512-iB7WeGbnivNeW+jrO9ppIZ02ydjRtVxm4snfDI30yT4ve0MgRcZ5zk27QHhZNFq19s3B4MQ2kJabO8dMdmX7UQ==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-beta.0
+      storybook: ^10.6.0-alpha.0
       typescript: '>= 4.9.x'
     peerDependenciesMeta:
       '@types/react':
@@ -1405,6 +1405,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -1594,8 +1597,8 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
-  storybook@10.5.0-beta.0:
-    resolution: {integrity: sha512-7ZCzN/fe57/Y994PruVpT1VutXRANMfyg3dcVKGYMqldeyA4+AfIOrtORv5sthcHRjZKMm/r4QGZssoshNba6w==}
+  storybook@10.6.0-alpha.0:
+    resolution: {integrity: sha512-9oWutn84qsg2F6zipU+u0FCGOPvDHHS9yQQI3bWEHoBTH6ws/AOgkh36bB6vU0Mu9/h/7L8KqvEoj3XyG5MwxQ==}
     hasBin: true
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2340,21 +2343,21 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-a11y@10.5.0-beta.0(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-a11y@10.6.0-alpha.0(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.1
-      storybook: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@storybook/addon-docs@10.5.0-beta.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
+  '@storybook/addon-docs@10.6.0-alpha.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@storybook/csf-plugin': 10.5.0-beta.0(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+      '@storybook/csf-plugin': 10.6.0-alpha.0(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/react-dom-shim': 10.5.0-beta.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/react-dom-shim': 10.6.0-alpha.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
     optionalDependencies:
       '@types/react': 18.3.28
@@ -2365,16 +2368,16 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-themes@10.5.0-beta.0(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-themes@10.6.0-alpha.0(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
-      storybook: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-vitest@10.5.0-beta.0(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)':
+  '@storybook/addon-vitest@10.6.0-alpha.0(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(vite@7.2.2)(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.6)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      storybook: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       '@vitest/browser': 4.0.6(vite@7.2.2)(vitest@4.0.6)
       '@vitest/browser-playwright': 4.0.6(playwright@1.56.1)(vite@7.2.2)(vitest@4.0.6)
@@ -2384,10 +2387,10 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.5.0-beta.0(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
+  '@storybook/builder-vite@10.6.0-alpha.0(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
     dependencies:
-      '@storybook/csf-plugin': 10.5.0-beta.0(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
-      storybook: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/csf-plugin': 10.6.0-alpha.0(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+      storybook: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
       vite: 7.2.2
     transitivePeerDependencies:
@@ -2395,9 +2398,9 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.5.0-beta.0(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
+  '@storybook/csf-plugin@10.6.0-alpha.0(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)':
     dependencies:
-      storybook: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.3
@@ -2411,28 +2414,28 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/react-dom-shim@10.5.0-beta.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/react-dom-shim@10.6.0-alpha.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@storybook/react-vite@10.5.0-beta.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)':
+  '@storybook/react-vite@10.6.0-alpha.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.57.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.2.2)':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@7.2.2)
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
-      '@storybook/builder-vite': 10.5.0-beta.0(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
-      '@storybook/react': 10.5.0-beta.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+      '@storybook/builder-vite': 10.6.0-alpha.0(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.2.2)
+      '@storybook/react': 10.6.0-alpha.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 18.3.1
       react-docgen: 8.0.2
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.11
-      storybook: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tsconfig-paths: 4.2.0
       vite: 7.2.2
     optionalDependencies:
@@ -2445,15 +2448,15 @@ snapshots:
       - supports-color
       - webpack
 
-  '@storybook/react@10.5.0-beta.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
+  '@storybook/react@10.6.0-alpha.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.5.0-beta.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/react-dom-shim': 10.6.0-alpha.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-docgen: 8.0.2
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
@@ -2853,6 +2856,8 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonc-parser@3.3.1: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -3097,7 +3102,7 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3108,6 +3113,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@webcontainer/env': 1.1.1
       esbuild: 0.27.3
+      jsonc-parser: 3.3.1
       open: 10.2.0
       oxc-parser: 0.127.0
       oxc-resolver: 11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)

--- a/eval/pnpm-lock.yaml
+++ b/eval/pnpm-lock.yaml
@@ -7,17 +7,17 @@ settings:
 catalogs:
   default:
     '@storybook/addon-a11y':
-      specifier: 10.5.0-beta.0
-      version: 10.5.0-beta.0
+      specifier: 10.6.0-alpha.0
+      version: 10.6.0-alpha.0
     '@storybook/react-vite':
-      specifier: 10.5.0-beta.0
-      version: 10.5.0-beta.0
+      specifier: 10.6.0-alpha.0
+      version: 10.6.0-alpha.0
     playwright:
       specifier: 1.56.1
       version: 1.56.1
     storybook:
-      specifier: 10.5.0-beta.0
-      version: 10.5.0-beta.0
+      specifier: 10.6.0-alpha.0
+      version: 10.6.0-alpha.0
     valibot:
       specifier: 1.2.0
       version: 1.2.0
@@ -54,13 +54,13 @@ importers:
         version: 1.1.11(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/addon-a11y':
         specifier: 'catalog:'
-        version: 10.5.0-beta.0(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 10.6.0-alpha.0(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/mcp':
         specifier: workspace:*
         version: link:../packages/mcp
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 10.5.0-beta.0(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))
+        version: 10.6.0-alpha.0(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))
       '@tsconfig/node-ts':
         specifier: ^23.6.1
         version: 23.6.3
@@ -132,10 +132,10 @@ importers:
         version: 5.83.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook:
         specifier: 'catalog:'
-        version: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook-addon-test-codegen:
         specifier: ^3.0.0
-        version: 3.0.1(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 3.0.1(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       tinyexec:
         specifier: ^1.0.1
         version: 1.0.2
@@ -1767,23 +1767,23 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@storybook/addon-a11y@10.5.0-beta.0':
-    resolution: {integrity: sha512-LaGu6qZ0bSCH03qH2g135hf18mt/J/ezF4Z52WJje7jcJZ4jy3vkaBSvvKRl6OjA/L2iAAe9bnrlSVOpJleRHg==}
+  '@storybook/addon-a11y@10.6.0-alpha.0':
+    resolution: {integrity: sha512-k5T/1uTMYRbjvRW4fT1veTKSCkVe6Qtm9jjbuquqZWuVHeUKUXn+1zPaslFkUybqZlR643aJNrD6mwFeuuTBLw==}
     peerDependencies:
-      storybook: ^10.5.0-beta.0
+      storybook: ^10.6.0-alpha.0
 
-  '@storybook/builder-vite@10.5.0-beta.0':
-    resolution: {integrity: sha512-aBA0yp+WdtTFXT5iAUDMbUkywzhTBgpTJrmJpwd7E050hYf21Ey8whivr48aGpKTaRL7dHaGXYMSBpYOJeTcSw==}
+  '@storybook/builder-vite@10.6.0-alpha.0':
+    resolution: {integrity: sha512-b2kCzYuTvACkgMXh/s+H8lgR9FIxM0DcySi//ff+1V9FZr+EjZx3QDAf7B/SjpnecKEmCCCU6co4rEe7aqIXOw==}
     peerDependencies:
-      storybook: ^10.5.0-beta.0
+      storybook: ^10.6.0-alpha.0
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@storybook/csf-plugin@10.5.0-beta.0':
-    resolution: {integrity: sha512-bK2SX/01FS+NiTFPZaDSmHTZ6I3rcNCEt/y/opE9wHIQpitZ/Zf2QF2zj1dxB5hNZ72oIz1AlC6YuYn/krMmPg==}
+  '@storybook/csf-plugin@10.6.0-alpha.0':
+    resolution: {integrity: sha512-d0KK+2M1sLGmIFWPafLMoh3sIxJ5j6tPNKsKur9bi9MgQRJrciLqfWhK/tA81uD3vyeifkbXv6P5Lz2v5XBu+g==}
     peerDependencies:
       esbuild: '*'
       rollup: '*'
-      storybook: ^10.5.0-beta.0
+      storybook: ^10.6.0-alpha.0
       vite: '*'
       webpack: '*'
     peerDependenciesMeta:
@@ -1805,40 +1805,40 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@storybook/react-dom-shim@10.5.0-beta.0':
-    resolution: {integrity: sha512-YXL4tU/dUvmHoFvw+52Y7EgWpyqdbGlvsw0A1yANS2DL4/X/1omMdsgZVOmn1suyjV7CkDWdrBUdaHNxAoNa6Q==}
+  '@storybook/react-dom-shim@10.6.0-alpha.0':
+    resolution: {integrity: sha512-Q2akoa4yzhdhCTH9xlcT13kJ9jNbcNb7qnvGYcq/3WWFa8OVlCKuab0ljtBq7rAFIeSz+OPXSv6Lavzzt5gUbA==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-beta.0
+      storybook: ^10.6.0-alpha.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
       '@types/react-dom':
         optional: true
 
-  '@storybook/react-vite@10.5.0-beta.0':
-    resolution: {integrity: sha512-F3zHi8ca8Wmn9Ncxm1ML9N2vggzzqvWR2iGNoPJyC7w/uChLlirqq+Fs8mHjRaEptCeNPccEMQBPhKoCLUEvVQ==}
+  '@storybook/react-vite@10.6.0-alpha.0':
+    resolution: {integrity: sha512-VD2zdBNBPFVQ57rmafVEmWr9N5M46YCU1Mq+wFXota9Yg/kpF8LC0HWTeePXAeVoVKeyX9pZNUmn0KpbOaPTYg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-beta.0
+      storybook: ^10.6.0-alpha.0
       typescript: '>= 4.9.x'
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@storybook/react@10.5.0-beta.0':
-    resolution: {integrity: sha512-UQd/RwZpfizK0qSO/XTHEyjP2wrBaDKtKoATxq7llGqKxIOJCzvZaLuAGsFzCoK114NEJ9GDurKhTlQxPpNJZQ==}
+  '@storybook/react@10.6.0-alpha.0':
+    resolution: {integrity: sha512-iB7WeGbnivNeW+jrO9ppIZ02ydjRtVxm4snfDI30yT4ve0MgRcZ5zk27QHhZNFq19s3B4MQ2kJabO8dMdmX7UQ==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.5.0-beta.0
+      storybook: ^10.6.0-alpha.0
       typescript: '>= 4.9.x'
     peerDependenciesMeta:
       '@types/react':
@@ -2602,6 +2602,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -3161,8 +3164,8 @@ packages:
     peerDependencies:
       storybook: ^0.0.0-0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0
 
-  storybook@10.5.0-beta.0:
-    resolution: {integrity: sha512-7ZCzN/fe57/Y994PruVpT1VutXRANMfyg3dcVKGYMqldeyA4+AfIOrtORv5sthcHRjZKMm/r4QGZssoshNba6w==}
+  storybook@10.6.0-alpha.0:
+    resolution: {integrity: sha512-9oWutn84qsg2F6zipU+u0FCGOPvDHHS9yQQI3bWEHoBTH6ws/AOgkh36bB6vU0Mu9/h/7L8KqvEoj3XyG5MwxQ==}
     hasBin: true
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -4757,16 +4760,16 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/addon-a11y@10.5.0-beta.0(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/addon-a11y@10.6.0-alpha.0(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.1
-      storybook: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/builder-vite@10.5.0-beta.0(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
+  '@storybook/builder-vite@10.6.0-alpha.0(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
     dependencies:
-      '@storybook/csf-plugin': 10.5.0-beta.0(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
-      storybook: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@storybook/csf-plugin': 10.6.0-alpha.0(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
+      storybook: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
       vite: 7.3.1(@types/node@24.10.12)
     transitivePeerDependencies:
@@ -4774,9 +4777,9 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.5.0-beta.0(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
+  '@storybook/csf-plugin@10.6.0-alpha.0(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))':
     dependencies:
-      storybook: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.3
@@ -4790,27 +4793,27 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/react-dom-shim@10.5.0-beta.0(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/react-dom-shim@10.6.0-alpha.0(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@storybook/react-vite@10.5.0-beta.0(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))':
+  '@storybook/react-vite@10.6.0-alpha.0(@types/react@18.3.28)(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.57.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.12))
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
-      '@storybook/builder-vite': 10.5.0-beta.0(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
-      '@storybook/react': 10.5.0-beta.0(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+      '@storybook/builder-vite': 10.6.0-alpha.0(esbuild@0.27.3)(rollup@4.57.1)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.12))
+      '@storybook/react': 10.6.0-alpha.0(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 19.2.4
       react-docgen: 8.0.2
       react-dom: 19.2.4(react@19.2.4)
       resolve: 1.22.11
-      storybook: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tsconfig-paths: 4.2.0
       vite: 7.3.1(@types/node@24.10.12)
     optionalDependencies:
@@ -4823,15 +4826,15 @@ snapshots:
       - supports-color
       - webpack
 
-  '@storybook/react@10.5.0-beta.0(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
+  '@storybook/react@10.6.0-alpha.0(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.5.0-beta.0(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@storybook/react-dom-shim': 10.6.0-alpha.0(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react: 19.2.4
       react-docgen: 8.0.2
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     optionalDependencies:
       '@types/react': 18.3.28
       typescript: 5.9.3
@@ -5557,6 +5560,8 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonc-parser@3.3.1: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -6232,11 +6237,11 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  storybook-addon-test-codegen@3.0.1(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+  storybook-addon-test-codegen@3.0.1(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
-      storybook: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -6247,6 +6252,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@webcontainer/env': 1.1.1
       esbuild: 0.27.3
+      jsonc-parser: 3.3.1
       open: 10.2.0
       oxc-parser: 0.127.0
       oxc-resolver: 11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)

--- a/packages/addon-mcp/pnpm-lock.yaml
+++ b/packages/addon-mcp/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     '@storybook/addon-a11y':
-      specifier: 10.5.0-beta.0
-      version: 10.5.0-beta.0
+      specifier: 10.6.0-alpha.0
+      version: 10.6.0-alpha.0
     '@storybook/addon-vitest':
-      specifier: 10.5.0-beta.0
-      version: 10.5.0-beta.0
+      specifier: 10.6.0-alpha.0
+      version: 10.6.0-alpha.0
     '@tmcp/adapter-valibot':
       specifier: ^0.1.5
       version: 0.1.5
@@ -19,8 +19,8 @@ catalogs:
       specifier: ^0.8.5
       version: 0.8.5
     storybook:
-      specifier: 10.5.0-beta.0
-      version: 10.5.0-beta.0
+      specifier: 10.6.0-alpha.0
+      version: 10.6.0-alpha.0
     tmcp:
       specifier: ^1.19.4
       version: 1.19.4
@@ -58,13 +58,13 @@ importers:
     devDependencies:
       '@storybook/addon-a11y':
         specifier: 'catalog:'
-        version: 10.5.0-beta.0(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 10.6.0-alpha.0(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/addon-vitest':
         specifier: 'catalog:'
-        version: 10.5.0-beta.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 10.6.0-alpha.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       storybook:
         specifier: 'catalog:'
-        version: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
 packages:
 
@@ -495,18 +495,18 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@storybook/addon-a11y@10.5.0-beta.0':
-    resolution: {integrity: sha512-LaGu6qZ0bSCH03qH2g135hf18mt/J/ezF4Z52WJje7jcJZ4jy3vkaBSvvKRl6OjA/L2iAAe9bnrlSVOpJleRHg==}
+  '@storybook/addon-a11y@10.6.0-alpha.0':
+    resolution: {integrity: sha512-k5T/1uTMYRbjvRW4fT1veTKSCkVe6Qtm9jjbuquqZWuVHeUKUXn+1zPaslFkUybqZlR643aJNrD6mwFeuuTBLw==}
     peerDependencies:
-      storybook: ^10.5.0-beta.0
+      storybook: ^10.6.0-alpha.0
 
-  '@storybook/addon-vitest@10.5.0-beta.0':
-    resolution: {integrity: sha512-EjhBGi3DsDklTrFdfGzq7OBNrUI+BQyVvdovhzJt4wTy9Um9f7UGnEVCdgEdpo40sHrC/WiLtSN1uBpXfvgeow==}
+  '@storybook/addon-vitest@10.6.0-alpha.0':
+    resolution: {integrity: sha512-rYFD7LXng42B8lKnSX/rKsNRvrweT8P5sG/2lAz7s9cgYApb+Z2eBY5IyhynE6zTS77bA3f8gYO3QVjosDkMeg==}
     peerDependencies:
       '@vitest/browser': ^3.0.0 || ^4.0.0
       '@vitest/browser-playwright': ^4.0.0
       '@vitest/runner': ^3.0.0 || ^4.0.0
-      storybook: ^10.5.0-beta.0
+      storybook: ^10.6.0-alpha.0
       vitest: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       '@vitest/browser':
@@ -698,6 +698,9 @@ packages:
   json-rpc-2.0@1.7.1:
     resolution: {integrity: sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==}
 
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -773,8 +776,8 @@ packages:
   sqids@0.3.0:
     resolution: {integrity: sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==}
 
-  storybook@10.5.0-beta.0:
-    resolution: {integrity: sha512-7ZCzN/fe57/Y994PruVpT1VutXRANMfyg3dcVKGYMqldeyA4+AfIOrtORv5sthcHRjZKMm/r4QGZssoshNba6w==}
+  storybook@10.6.0-alpha.0:
+    resolution: {integrity: sha512-9oWutn84qsg2F6zipU+u0FCGOPvDHHS9yQQI3bWEHoBTH6ws/AOgkh36bB6vU0Mu9/h/7L8KqvEoj3XyG5MwxQ==}
     hasBin: true
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -1089,17 +1092,17 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-a11y@10.5.0-beta.0(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/addon-a11y@10.6.0-alpha.0(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.1
-      storybook: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/addon-vitest@10.5.0-beta.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/addon-vitest@10.6.0-alpha.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      storybook: 10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -1294,6 +1297,8 @@ snapshots:
 
   json-rpc-2.0@1.7.1: {}
 
+  jsonc-parser@3.3.1: {}
+
   loupe@3.2.1: {}
 
   lz-string@1.5.0: {}
@@ -1402,7 +1407,7 @@ snapshots:
 
   sqids@0.3.0: {}
 
-  storybook@10.5.0-beta.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  storybook@10.6.0-alpha.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1413,6 +1418,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@webcontainer/env': 1.1.1
       esbuild: 0.27.3
+      jsonc-parser: 3.3.1
       open: 10.2.0
       oxc-parser: 0.127.0
       oxc-resolver: 11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,19 +16,19 @@ patchedDependencies:
   '@vercel/agent-eval@1.2.0': agent-eval/patches/@vercel__agent-eval@1.2.0.patch
 
 catalog:
-  '@storybook/addon-a11y': 10.5.0-beta.0
-  '@storybook/addon-docs': 10.5.0-beta.0
-  '@storybook/addon-themes': 10.5.0-beta.0
-  '@storybook/addon-vitest': 10.5.0-beta.0
-  '@storybook/react-vite': 10.5.0-beta.0
+  '@storybook/addon-a11y': 10.6.0-alpha.0
+  '@storybook/addon-docs': 10.6.0-alpha.0
+  '@storybook/addon-themes': 10.6.0-alpha.0
+  '@storybook/addon-vitest': 10.6.0-alpha.0
+  '@storybook/react-vite': 10.6.0-alpha.0
   '@types/semver': 7.7.1
   '@tmcp/adapter-valibot': ^0.1.5
   '@tmcp/transport-http': ^0.8.5
   '@tmcp/transport-stdio': ^0.4.3
   '@vitest/browser-playwright': 4.0.6
-  eslint-plugin-storybook: 10.5.0-beta.0
+  eslint-plugin-storybook: 10.6.0-alpha.0
   playwright: 1.56.1
-  storybook: 10.5.0-beta.0
+  storybook: 10.6.0-alpha.0
   tmcp: ^1.19.4
   semver: 7.8.1
   tsdown: ^0.15.12
@@ -40,10 +40,10 @@ catalog:
 catalogs:
   trials:
     '@eslint/js': 9.39.1
-    '@storybook/addon-a11y': 10.5.0-beta.0
-    '@storybook/addon-docs': 10.5.0-beta.0
-    '@storybook/addon-vitest': 10.5.0-beta.0
-    '@storybook/react-vite': 10.5.0-beta.0
+    '@storybook/addon-a11y': 10.6.0-alpha.0
+    '@storybook/addon-docs': 10.6.0-alpha.0
+    '@storybook/addon-vitest': 10.6.0-alpha.0
+    '@storybook/react-vite': 10.6.0-alpha.0
     '@types/node': 24.10.1
     '@types/react': 19.2.6
     '@types/react-dom': 19.2.3
@@ -52,11 +52,11 @@ catalogs:
     eslint: 9.39.1
     eslint-plugin-react-hooks: 7.0.1
     eslint-plugin-react-refresh: 0.4.24
-    eslint-plugin-storybook: 10.5.0-beta.0
+    eslint-plugin-storybook: 10.6.0-alpha.0
     globals: 16.5.0
     react: 19.2.0
     react-dom: 19.2.0
-    storybook: 10.5.0-beta.0
+    storybook: 10.6.0-alpha.0
     typescript: 5.9.3
     typescript-eslint: 8.47.0
     vite: 7.2.2


### PR DESCRIPTION
## Why

[#361](https://github.com/storybookjs/mcp/pull/361) merged and tagged `@storybook/addon-mcp@0.7.0`, but npm is still on 0.6.0. The Release workflow run after the merge went into **version mode** instead of publishing (it opened the empty #362), because two changesets were still on `main`:

- `codex-dev-server-in-app-browser.md` (from #354) — targets `@storybook/codex-plugin`
- `monorepo-same-directory.md` (from #350) — targets both plugins

Both packages are in the `ignore` list in `.changeset/config.json`, so `changeset version` never consumes these files — they'd block every future publish. The same trap required the park/restore dance in #356/#357 for the `@storybook/mcp@0.8.0` cut.

## What

Deletes the two plugin-only changesets. They are no-ops for ignored packages, so nothing is lost. On merge, the Release workflow finds zero changesets, runs `pnpm changeset publish`, and publishes `@storybook/addon-mcp@0.7.0` (whose version on `main` is already ahead of npm).

## Follow-up

We should stop adding changesets for the ignored plugin packages (or remove them from `ignore`) so this can't recur.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal release notes by removing guidance about reusing/starting a Storybook dev server and opening the result in Codex’s in-app browser.
  * Removed monorepo run-in-same-directory guidance for Storybook and `storybook ai`.
  * Updated Storybook-related package catalog versions to newer preview releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->