### PR TITLE
Fix addon MCP agent docs link

### DIFF
--- a/packages/addon-mcp/src/template.html
+++ b/packages/addon-mcp/src/template.html
@@ -189,8 +189,8 @@
 				See how to connect to it from your coding agent in
 				<a
 					target="_blank"
-					href="https://github.com/storybookjs/mcp/tree/main/packages/addon-mcp#configuring-your-agent"
-					>the addon's README</a
+					href="https://storybook.js.org/docs/ai/mcp/overview#2-add-the-mcp-server-to-your-agent"
+					>the Storybook MCP docs</a
 				>.
 			</p>
 


### PR DESCRIPTION
## Summary
- Point the addon MCP splash-page agent setup link to the official Storybook MCP docs section.
- Update the link label from the addon's README to the Storybook MCP docs.

Fixes storybookjs/storybook#35451.

## Testing
- `git diff --check`
- Confirmed Storybook docs source includes `### 2. Add the MCP server to your agent`

Not run: package build/test. This environment has Node 22 and the repo documents Node 24+; this change is a static HTML link update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “See how to connect to it” link to direct users to the Storybook MCP documentation.
  * Revised the link text to clearly identify the documentation destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->