### PR TITLE
agent-eval: use NO_COLOR to remove noise

### DIFF
--- a/agent-eval/patches/@vercel__agent-eval@1.2.0.patch
+++ b/agent-eval/patches/@vercel__agent-eval@1.2.0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/cli.js b/dist/cli.js
-index 62513a2..5a50e3f 100644
+index 62513a2fa69ed14348fac25528074ad7415abae5..5a50e3f011bac2d034c369cc30ff9b06b3d23dde 100644
 --- a/dist/cli.js
 +++ b/dist/cli.js
 @@ -230,8 +230,13 @@ program
@@ -32,7 +32,7 @@ index 62513a2..5a50e3f 100644
          // Rate-limit sandbox starts across all experiments to avoid 429s (20 starts per 2 seconds)
          const rateLimiter = new StartRateLimiter(20, 2_000);
 diff --git a/dist/lib/agents/codex/run.mjs b/dist/lib/agents/codex/run.mjs
-index 12ff2d6..a6a3c5e 100644
+index 12ff2d6758852593b29792c9b7ad0e7fdb9b56d2..a6a3c5e0d3764cc0b83757988299b5ff32c35195 100644
 --- a/dist/lib/agents/codex/run.mjs
 +++ b/dist/lib/agents/codex/run.mjs
 @@ -287,12 +287,14 @@ export async function runAgent(input) {
@@ -54,8 +54,33 @@ index 12ff2d6..a6a3c5e 100644
  
    if (res.error || agentExitCode !== 0) {
      // Mirror the old error string: last 5 lines of output, else a coded fallback.
+diff --git a/dist/lib/agents/shared.js b/dist/lib/agents/shared.js
+index 70edef2bf63387b457d39bcfd9122c39fb198593..9a0c8201a0b375db9883a780112f34dc8d4cbee9 100644
+--- a/dist/lib/agents/shared.js
++++ b/dist/lib/agents/shared.js
+@@ -62,7 +62,10 @@ env) {
+         // Detect which eval file exists (EVAL.ts or EVAL.tsx)
+         const evalFile = await detectEvalFile(sandbox);
+         // Always run vitest for the eval file (explicitly specify the file)
+-        const testResult = await sandbox.runCommand('npx', ['vitest', 'run', evalFile], env ? { env } : undefined);
++        // NO_COLOR: these outputs are captured to outputs/*.txt, never shown on a
++        // live terminal — ANSI codes only make the saved artifacts unreadable.
++        const outputEnv = { NO_COLOR: '1', ...env };
++        const testResult = await sandbox.runCommand('npx', ['vitest', 'run', evalFile], { env: outputEnv });
+         results.test = {
+             success: testResult.exitCode === 0,
+             output: testResult.stdout + testResult.stderr,
+@@ -73,7 +76,7 @@ env) {
+     }
+     // Run configured scripts
+     for (const script of scripts) {
+-        const scriptResult = await sandbox.runCommand('npm', ['run', script]);
++        const scriptResult = await sandbox.runCommand('npm', ['run', script], { env: { NO_COLOR: '1' } });
+         const result = {
+             success: scriptResult.exitCode === 0,
+             output: scriptResult.stdout + scriptResult.stderr,
 diff --git a/dist/lib/classifier.js b/dist/lib/classifier.js
-index 5a6cf9b..df8b19f 100644
+index 5a6cf9b66c7b1f44ca074c2383f4df5666508205..df8b19f3350492459e9b9ac93ed6ae23c99bb2e6 100644
 --- a/dist/lib/classifier.js
 +++ b/dist/lib/classifier.js
 @@ -6,7 +6,8 @@
@@ -140,7 +165,7 @@ index 5a6cf9b..df8b19f 100644
   * Caches results in classification.json within the eval result directory.
   * Throws if the AI gateway call itself fails — callers must handle.
 diff --git a/dist/lib/docker-sandbox.js b/dist/lib/docker-sandbox.js
-index 99df8fb..369c403 100644
+index 99df8fb3ab72003144926f19243baf6b2102f050..369c4033d491105a97d95f7e86290553ef5c01b6 100644
 --- a/dist/lib/docker-sandbox.js
 +++ b/dist/lib/docker-sandbox.js
 @@ -3,6 +3,7 @@

--- a/agent-eval/pnpm-lock.yaml
+++ b/agent-eval/pnpm-lock.yaml
@@ -25,7 +25,7 @@ overrides:
 
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
-    hash: d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a
+    hash: 520e4f098b755dc01fa085794294d8a8eeaeeb3201772fff6eccb717edaf62e4
     path: patches/@vercel__agent-eval@1.2.0.patch
 
 importers:
@@ -50,7 +50,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vercel/agent-eval':
         specifier: 1.2.0
-        version: 1.2.0(patch_hash=d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a)
+        version: 1.2.0(patch_hash=520e4f098b755dc01fa085794294d8a8eeaeeb3201772fff6eccb717edaf62e4)
       '@vercel/agent-eval-playground':
         specifier: 0.1.3
         version: 0.1.3(@opentelemetry/api@1.9.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)
@@ -5428,7 +5428,7 @@ snapshots:
       - date-fns
       - sass
 
-  '@vercel/agent-eval@1.2.0(patch_hash=d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a)':
+  '@vercel/agent-eval@1.2.0(patch_hash=520e4f098b755dc01fa085794294d8a8eeaeeb3201772fff6eccb717edaf62e4)':
     dependencies:
       '@ai-sdk/anthropic': 2.0.85(zod@3.25.76)
       '@vercel/sandbox': 1.10.2

--- a/apps/internal-storybook/pnpm-lock.yaml
+++ b/apps/internal-storybook/pnpm-lock.yaml
@@ -37,9 +37,12 @@ catalogs:
       specifier: 4.0.6
       version: 4.0.6
 
+overrides:
+  '@ai-sdk/anthropic': ^2.0.0
+
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
-    hash: d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a
+    hash: 520e4f098b755dc01fa085794294d8a8eeaeeb3201772fff6eccb717edaf62e4
     path: ../../agent-eval/patches/@vercel__agent-eval@1.2.0.patch
 
 importers:

--- a/apps/internal-storybook/pnpm-lock.yaml
+++ b/apps/internal-storybook/pnpm-lock.yaml
@@ -37,9 +37,6 @@ catalogs:
       specifier: 4.0.6
       version: 4.0.6
 
-overrides:
-  '@ai-sdk/anthropic': ^2.0.0
-
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
     hash: 520e4f098b755dc01fa085794294d8a8eeaeeb3201772fff6eccb717edaf62e4

--- a/apps/self-host-mcp/pnpm-lock.yaml
+++ b/apps/self-host-mcp/pnpm-lock.yaml
@@ -4,9 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@ai-sdk/anthropic': ^2.0.0
+
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
-    hash: d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a
+    hash: 520e4f098b755dc01fa085794294d8a8eeaeeb3201772fff6eccb717edaf62e4
     path: ../../agent-eval/patches/@vercel__agent-eval@1.2.0.patch
 
 importers:

--- a/apps/self-host-mcp/pnpm-lock.yaml
+++ b/apps/self-host-mcp/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@ai-sdk/anthropic': ^2.0.0
-
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
     hash: 520e4f098b755dc01fa085794294d8a8eeaeeb3201772fff6eccb717edaf62e4

--- a/eval/pnpm-lock.yaml
+++ b/eval/pnpm-lock.yaml
@@ -22,9 +22,12 @@ catalogs:
       specifier: 1.2.0
       version: 1.2.0
 
+overrides:
+  '@ai-sdk/anthropic': ^2.0.0
+
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
-    hash: d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a
+    hash: 520e4f098b755dc01fa085794294d8a8eeaeeb3201772fff6eccb717edaf62e4
     path: ../agent-eval/patches/@vercel__agent-eval@1.2.0.patch
 
 importers:

--- a/eval/pnpm-lock.yaml
+++ b/eval/pnpm-lock.yaml
@@ -22,9 +22,6 @@ catalogs:
       specifier: 1.2.0
       version: 1.2.0
 
-overrides:
-  '@ai-sdk/anthropic': ^2.0.0
-
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
     hash: 520e4f098b755dc01fa085794294d8a8eeaeeb3201772fff6eccb717edaf62e4

--- a/packages/addon-mcp/pnpm-lock.yaml
+++ b/packages/addon-mcp/pnpm-lock.yaml
@@ -28,9 +28,12 @@ catalogs:
       specifier: 1.2.0
       version: 1.2.0
 
+overrides:
+  '@ai-sdk/anthropic': ^2.0.0
+
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
-    hash: d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a
+    hash: 520e4f098b755dc01fa085794294d8a8eeaeeb3201772fff6eccb717edaf62e4
     path: ../../agent-eval/patches/@vercel__agent-eval@1.2.0.patch
 
 importers:

--- a/packages/addon-mcp/pnpm-lock.yaml
+++ b/packages/addon-mcp/pnpm-lock.yaml
@@ -28,9 +28,6 @@ catalogs:
       specifier: 1.2.0
       version: 1.2.0
 
-overrides:
-  '@ai-sdk/anthropic': ^2.0.0
-
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
     hash: 520e4f098b755dc01fa085794294d8a8eeaeeb3201772fff6eccb717edaf62e4

--- a/packages/claude-plugin/pnpm-lock.yaml
+++ b/packages/claude-plugin/pnpm-lock.yaml
@@ -4,9 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@ai-sdk/anthropic': ^2.0.0
+
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
-    hash: d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a
+    hash: 520e4f098b755dc01fa085794294d8a8eeaeeb3201772fff6eccb717edaf62e4
     path: ../../agent-eval/patches/@vercel__agent-eval@1.2.0.patch
 
 importers:

--- a/packages/claude-plugin/pnpm-lock.yaml
+++ b/packages/claude-plugin/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@ai-sdk/anthropic': ^2.0.0
-
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
     hash: 520e4f098b755dc01fa085794294d8a8eeaeeb3201772fff6eccb717edaf62e4

--- a/packages/codex-plugin/pnpm-lock.yaml
+++ b/packages/codex-plugin/pnpm-lock.yaml
@@ -4,9 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@ai-sdk/anthropic': ^2.0.0
+
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
-    hash: d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a
+    hash: 520e4f098b755dc01fa085794294d8a8eeaeeb3201772fff6eccb717edaf62e4
     path: ../../agent-eval/patches/@vercel__agent-eval@1.2.0.patch
 
 importers:

--- a/packages/codex-plugin/pnpm-lock.yaml
+++ b/packages/codex-plugin/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@ai-sdk/anthropic': ^2.0.0
-
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
     hash: 520e4f098b755dc01fa085794294d8a8eeaeeb3201772fff6eccb717edaf62e4

--- a/packages/mcp/pnpm-lock.yaml
+++ b/packages/mcp/pnpm-lock.yaml
@@ -22,9 +22,12 @@ catalogs:
       specifier: 1.2.0
       version: 1.2.0
 
+overrides:
+  '@ai-sdk/anthropic': ^2.0.0
+
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
-    hash: d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a
+    hash: 520e4f098b755dc01fa085794294d8a8eeaeeb3201772fff6eccb717edaf62e4
     path: ../../agent-eval/patches/@vercel__agent-eval@1.2.0.patch
 
 importers:

--- a/packages/mcp/pnpm-lock.yaml
+++ b/packages/mcp/pnpm-lock.yaml
@@ -22,9 +22,6 @@ catalogs:
       specifier: 1.2.0
       version: 1.2.0
 
-overrides:
-  '@ai-sdk/anthropic': ^2.0.0
-
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
     hash: 520e4f098b755dc01fa085794294d8a8eeaeeb3201772fff6eccb717edaf62e4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,9 +10,12 @@ catalogs:
       specifier: 7.2.2
       version: 7.2.2
 
+overrides:
+  '@ai-sdk/anthropic': ^2.0.0
+
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
-    hash: d10a497bc5c244513d5d3d00aca32ee76678d0e760b01a5fe5bd993f4da02b8a
+    hash: 520e4f098b755dc01fa085794294d8a8eeaeeb3201772fff6eccb717edaf62e4
     path: agent-eval/patches/@vercel__agent-eval@1.2.0.patch
 
 importers:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,9 +10,6 @@ catalogs:
       specifier: 7.2.2
       version: 7.2.2
 
-overrides:
-  '@ai-sdk/anthropic': ^2.0.0
-
 patchedDependencies:
   '@vercel/agent-eval@1.2.0':
     hash: 520e4f098b755dc01fa085794294d8a8eeaeeb3201772fff6eccb717edaf62e4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,12 +8,7 @@ packages:
   - '!eval/templates/project'
   - '!eval/tasks/*/trials/*/project'
 
-# @vercel/agent-eval is only a dependency of the agent-eval project, which keeps its
-# own lockfile (shared-workspace-lockfile=false). allowUnusedPatches stops sibling
-# projects that lack the dep from erroring on this root-level patch.
 allowUnusedPatches: true
-patchedDependencies:
-  '@vercel/agent-eval@1.2.0': agent-eval/patches/@vercel__agent-eval@1.2.0.patch
 
 catalog:
   '@storybook/addon-a11y': 10.6.0-alpha.0
@@ -21,16 +16,16 @@ catalog:
   '@storybook/addon-themes': 10.6.0-alpha.0
   '@storybook/addon-vitest': 10.6.0-alpha.0
   '@storybook/react-vite': 10.6.0-alpha.0
-  '@types/semver': 7.7.1
   '@tmcp/adapter-valibot': ^0.1.5
   '@tmcp/transport-http': ^0.8.5
   '@tmcp/transport-stdio': ^0.4.3
+  '@types/semver': 7.7.1
   '@vitest/browser-playwright': 4.0.6
   eslint-plugin-storybook: 10.6.0-alpha.0
   playwright: 1.56.1
+  semver: 7.8.1
   storybook: 10.6.0-alpha.0
   tmcp: ^1.19.4
-  semver: 7.8.1
   tsdown: ^0.15.12
   typescript: ^5.9.3
   valibot: 1.2.0
@@ -65,3 +60,6 @@ catalogs:
 onlyBuiltDependencies:
   - '@swc/core'
   - esbuild
+
+patchedDependencies:
+  '@vercel/agent-eval@1.2.0': patches/@vercel__agent-eval@1.2.0.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,12 @@ packages:
   - '!eval/templates/project'
   - '!eval/tasks/*/trials/*/project'
 
+# @vercel/agent-eval is only a dependency of the agent-eval project, which keeps its
+# own lockfile (shared-workspace-lockfile=false). allowUnusedPatches stops sibling
+# projects that lack the dep from erroring on this root-level patch.
 allowUnusedPatches: true
+patchedDependencies:
+  '@vercel/agent-eval@1.2.0': agent-eval/patches/@vercel__agent-eval@1.2.0.patch
 
 catalog:
   '@storybook/addon-a11y': 10.6.0-alpha.0
@@ -16,16 +21,16 @@ catalog:
   '@storybook/addon-themes': 10.6.0-alpha.0
   '@storybook/addon-vitest': 10.6.0-alpha.0
   '@storybook/react-vite': 10.6.0-alpha.0
+  '@types/semver': 7.7.1
   '@tmcp/adapter-valibot': ^0.1.5
   '@tmcp/transport-http': ^0.8.5
   '@tmcp/transport-stdio': ^0.4.3
-  '@types/semver': 7.7.1
   '@vitest/browser-playwright': 4.0.6
   eslint-plugin-storybook: 10.6.0-alpha.0
   playwright: 1.56.1
-  semver: 7.8.1
   storybook: 10.6.0-alpha.0
   tmcp: ^1.19.4
+  semver: 7.8.1
   tsdown: ^0.15.12
   typescript: ^5.9.3
   valibot: 1.2.0
@@ -60,6 +65,3 @@ catalogs:
 onlyBuiltDependencies:
   - '@swc/core'
   - esbuild
-
-patchedDependencies:
-  '@vercel/agent-eval@1.2.0': patches/@vercel__agent-eval@1.2.0.patch


### PR DESCRIPTION
The eval runs produce an `eval.txt` file that is unreadable (like below). So this PR modifies the patch to fix that.

```
[1m[30m[46m RUN [49m[39m[22m [36mv4.1.10 [39m[90m/workspace[39m

 [31m❯[39m EVAL.ts [2m([22m[2m3 tests[22m[2m | [22m[31m1 failed[39m[2m)[22m[32m 13[2mms[22m[39m
   [32m✓[39m agent produced a transcript[32m 4[2mms[22m[39m
   [32m✓[39m Footer.tsx uses the app's own Button component[32m 1[2mms[22m[39m
[31m   [31m×[31m agent consulted the design system Storybook MCP documentation tools[39m[32m 7[2mms[22m[39m

[2m Test Files [22m [1m[31m1 failed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[31m1 failed[39m[22m[2m | [22m[1m[32m2 passed[39m[22m[90m (3)[39m
[2m   Start at [22m 14:58:13
[2m   Duration [22m 731ms[2m (transform 114ms, setup 41ms, import 519ms, tests 13ms, environment 0ms)[22m


[31m⎯⎯⎯⎯⎯⎯⎯[39m[1m[41m Failed Tests 1 [49m[22m[31m⎯⎯⎯⎯⎯⎯⎯[39m

[41m[1m FAIL [22m[49m EVAL.ts[2m > [22magent consulted the design system Storybook MCP documentation tools
[31m[1mAssertionError[22m: Expected at least one documentation tool call (get-documentation, get-documentation-for-story, list-all-documentation): expected 0 to be greater than 0[39m
[36m [2m❯[22m expectDocumentationToolingCalled __agent_eval__/test-utils.ts:[2m784:4[22m[39m
    [90m782|[39m   documentationCalls[33m.[39mlength[33m,[39m
    [90m783|[39m   `Expected at least one documentation tool call (${DOCUMENTATION_WORK…
    [90m784|[39m  )[33m.[39m[34mtoBeGreaterThan[39m([34m0[39m)[33m;[39m
    [90m   |[39m    [31m^[39m
    [90m785|[39m }
    [90m786|[39m
[90m [2m❯[22m EVAL.ts:[2m40:2[22m[39m

[31m[2m⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯[22m[39m
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using Anthropic API credentials directly for failure classification, with automatic fallback to the Vercel AI Gateway.
  * Improved CLI runtime compatibility by pinning the playground and Next.js versions.

* **Bug Fixes**
  * Improved Codex transcript detection and model reporting.
  * Prevented color codes from appearing in captured test and script output.
  * Improved Docker output capture to prevent missing or corrupted logs.
  * Updated warnings to recognize Anthropic API configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->