### PR TITLE
Add a dispatch-only workflow for agentic-reference evals

### DIFF
--- a/.github/workflows/agentic-ref-eval.yml
+++ b/.github/workflows/agentic-ref-eval.yml
@@ -1,0 +1,144 @@
+name: Agentic-reference eval
+
+# Runs the agentic-reference (70x) case matrix. Dispatch-only: running these
+# evals is a spend decision, so there is no PR/label trigger — a human picks
+# the selection and repetition count each time.
+
+on:
+  workflow_dispatch:
+    inputs:
+      cases:
+        description: 'Space-separated case names or globs, e.g. agentic-ref-cc-control-none-opus-high agentic-ref-cc-docs-full-opus-high — empty runs every case'
+        type: string
+        default: ''
+      flows:
+        description: "Comma-separated workflow fixtures (AGENTIC_REF_FLOW), e.g. 703-fix-bug-flow — empty runs each case's full workflow set"
+        type: string
+        default: ''
+      runs:
+        description: 'Repetitions per (case, workflow) cell (AGENTIC_REF_RUNS)'
+        type: string
+        default: '1'
+      force:
+        description: 'Re-run cells the fingerprint cache already marks complete'
+        type: boolean
+        default: false
+      dry:
+        description: 'Dry run: resolve the selection and print the plan without spending'
+        type: boolean
+        default: false
+
+env:
+  TURBO_ENV_MODE: loose
+
+# Dispatches queue rather than cancel: each one is paid work, and a cancelled
+# run loses the cells it had already completed.
+concurrency:
+  group: agentic-ref-eval
+  cancel-in-progress: false
+
+jobs:
+  eval:
+    name: Run agentic-reference cases
+    runs-on: ubuntu-latest
+    # Near the 360-minute ceiling for hosted runners; a single run may take up
+    # to 3 hours (see AGENTIC_REF timeout in lib/agentic-reference/experiment.ts),
+    # so a large matrix can outlast the job. Completed cells are
+    # fingerprint-cached, so re-dispatching the same selection resumes.
+    timeout-minutes: 300
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js and Install Dependencies
+        uses: ./.github/actions/setup-node-and-install
+
+      - name: Build local MCP packages
+        run: pnpm --filter @storybook/addon-mcp... run build
+
+      - name: Type check agent eval config
+        run: pnpm --dir agent-eval run typecheck
+
+      - name: Validate Vercel credentials
+        shell: bash
+        env:
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+        run: |
+          missing=0
+
+          for name in VERCEL_PROJECT_ID VERCEL_TOKEN VERCEL_TEAM_ID; do
+            if [[ -z "${!name}" ]]; then
+              echo "::error title=Missing Vercel secret::$name is required for Vercel Sandbox evals."
+              missing=1
+            fi
+          done
+
+          exit "$missing"
+
+      - name: Run agentic-reference evals
+        shell: bash
+        env:
+          CASES: ${{ inputs.cases }}
+          DRY: ${{ inputs.dry }}
+          FORCE: ${{ inputs.force }}
+          AGENTIC_REF_FLOW: ${{ inputs.flows }}
+          AGENTIC_REF_RUNS: ${{ inputs.runs }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          # The :dry variant is a separate script rather than a --dry argument:
+          # pnpm consumes leading dashes before the script sees them.
+          script=eval:agentic-ref
+          [[ "$DRY" == "true" ]] && script=eval:agentic-ref:dry
+
+          args=()
+          [[ "$FORCE" == "true" ]] && args+=(--force)
+          # Unquoted on purpose: multiple cases arrive space-separated and each
+          # must reach run-all as its own argument.
+          [[ -n "$CASES" ]] && args+=($CASES)
+
+          pnpm --dir agent-eval run "$script" -- "${args[@]}"
+
+      - name: Compute metrics and archive results
+        if: ${{ always() && inputs.dry == false }}
+        # Metrics are best-effort; an analysis failure must still leave the raw
+        # results archivable. Missing results surface at upload instead.
+        continue-on-error: true
+        working-directory: agent-eval
+        run: |
+          # Writes analysis.json next to each run's result.json so the metrics
+          # ride along in the uploaded artifact.
+          pnpm results:analyze || echo "::warning title=Analysis failed::Archiving raw results without offline metrics."
+
+          # Tar before upload: result files may contain characters that
+          # actions/upload-artifact rejects.
+          tar -czf ../agent-eval-results.tgz results
+
+      - name: Upload eval results
+        if: ${{ always() && inputs.dry == false }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          # One artifact per dispatch, so every triggered run keeps its own
+          # downloadable snapshot. scripts/download-ci-results.mjs matches on
+          # the shared agent-eval-results prefix and merges them by experiment
+          # name and timestamp.
+          name: agent-eval-results-${{ github.run_id }}
+          path: agent-eval-results.tgz
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Write run summary
+        if: ${{ always() && inputs.dry == false }}
+        continue-on-error: true
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node agent-eval/scripts/render-results-summary.mjs >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/agentic-ref-eval.yml
+++ b/.github/workflows/agentic-ref-eval.yml
@@ -3,6 +3,12 @@ name: Agentic-reference eval
 # Runs the agentic-reference (70x) case matrix. Dispatch-only: running these
 # evals is a spend decision, so there is no PR/label trigger — a human picks
 # the selection and repetition count each time.
+#
+# Dispatch this against a ref that carries the agentic-reference eval line —
+# the agent-eval eval:agentic-ref and results:analyze scripts and the case
+# registry they read. workflow_dispatch registers a workflow from the default
+# branch but runs the file from the selected ref, so this workflow lives here
+# while that line is still on a feature branch.
 
 on:
   workflow_dispatch:
@@ -41,10 +47,9 @@ jobs:
   eval:
     name: Run agentic-reference cases
     runs-on: ubuntu-latest
-    # Near the 360-minute ceiling for hosted runners; a single run may take up
-    # to 3 hours (see AGENTIC_REF timeout in lib/agentic-reference/experiment.ts),
-    # so a large matrix can outlast the job. Completed cells are
-    # fingerprint-cached, so re-dispatching the same selection resumes.
+    # Near the 360-minute ceiling for hosted runners, while a single eval run is
+    # allowed up to 3 hours, so a large matrix can outlast the job. Completed
+    # cells are fingerprint-cached, so re-dispatching the same selection resumes.
     timeout-minutes: 300
     permissions:
       contents: read
@@ -102,9 +107,15 @@ jobs:
 
           args=()
           [[ "$FORCE" == "true" ]] && args+=(--force)
-          # Unquoted on purpose: multiple cases arrive space-separated and each
-          # must reach run-all as its own argument.
-          [[ -n "$CASES" ]] && args+=($CASES)
+
+          # Split on whitespace so each case reaches run-all as its own
+          # argument, without the pathname expansion an unquoted $CASES would
+          # get: a case glob like agentic-ref-cc-* must stay literal for
+          # run-all to match it against experiment names.
+          if [[ -n "$CASES" ]]; then
+            read -r -a case_args <<< "$CASES"
+            args+=("${case_args[@]}")
+          fi
 
           pnpm --dir agent-eval run "$script" -- "${args[@]}"
 

--- a/agent-eval/scripts/download-ci-results.mjs
+++ b/agent-eval/scripts/download-ci-results.mjs
@@ -17,7 +17,11 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+// Workflows upload either the bare name (agent-eval.yml) or a per-dispatch
+// name suffixed with the run id (agentic-ref-eval.yml); both carry the same
+// agent-eval-results.tgz payload.
 const ARTIFACT_NAME = 'agent-eval-results';
+const ARTIFACT_PREFIX = `${ARTIFACT_NAME}-`;
 const agentEvalDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const resultsDir = path.join(agentEvalDir, 'results');
 
@@ -41,17 +45,23 @@ function gh(args, options = {}) {
 	}
 }
 
-const artifacts = JSON.parse(
-	gh(
-		[
-			'api',
-			`repos/{owner}/{repo}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=100`,
-			'--jq',
-			'.artifacts | map(select(.expired | not))',
-		],
-		{ encoding: 'utf8' },
-	),
+// Artifact names now vary per dispatch, so the API's exact-match `name=` filter
+// no longer selects them; page through everything and match the prefix here.
+// With --paginate, --jq runs per page and emits one JSON object per line.
+const artifacts = gh(
+	[
+		'api',
+		'--paginate',
+		'repos/{owner}/{repo}/actions/artifacts?per_page=100',
+		'--jq',
+		'.artifacts[] | select(.expired | not)',
+	],
+	{ encoding: 'utf8' },
 )
+	.split('\n')
+	.filter((line) => line.trim() !== '')
+	.map((line) => JSON.parse(line))
+	.filter(({ name }) => name === ARTIFACT_NAME || name.startsWith(ARTIFACT_PREFIX))
 	.sort((a, b) => b.created_at.localeCompare(a.created_at))
 	.slice(0, count);
 
@@ -69,15 +79,14 @@ for (const artifact of artifacts) {
 		continue;
 	}
 	console.log(
-		`- artifact ${artifact.id} (${artifact.created_at}, branch ${run.head_branch ?? 'unknown'}, run ${run.id})`,
+		`- ${artifact.name} (${artifact.created_at}, branch ${run.head_branch ?? 'unknown'}, run ${run.id})`,
 	);
 
 	const workDir = mkdtempSync(path.join(tmpdir(), 'agent-eval-artifact-'));
 	try {
 		// gh streams the artifact zip to disk and unpacks it, leaving the
-		// tarball produced by the "Archive eval results" step in
-		// .github/workflows/agent-eval.yml.
-		gh(['run', 'download', String(run.id), '--name', ARTIFACT_NAME, '--dir', workDir]);
+		// agent-eval-results.tgz that the eval workflows archive.
+		gh(['run', 'download', String(run.id), '--name', artifact.name, '--dir', workDir]);
 		// Extract inside the temp directory and only the results/ subtree, so
 		// an artifact tarball can never write outside it; then merge that
 		// subtree into agent-eval/results.

--- a/agent-eval/scripts/download-ci-results.mjs
+++ b/agent-eval/scripts/download-ci-results.mjs
@@ -20,8 +20,13 @@ import { fileURLToPath } from 'node:url';
 // Workflows upload either the bare name (agent-eval.yml) or a per-dispatch
 // name suffixed with the run id (agentic-ref-eval.yml); both carry the same
 // agent-eval-results.tgz payload.
+//
+// The run-id form is matched exactly rather than by prefix: a retired naming
+// scheme used agent-eval-results-<run id>-<run attempt> for artifacts holding
+// an unpacked results tree with no tarball in it, and extraction here would
+// fail on one.
 const ARTIFACT_NAME = 'agent-eval-results';
-const ARTIFACT_PREFIX = `${ARTIFACT_NAME}-`;
+const PER_RUN_ARTIFACT = /^agent-eval-results-\d+$/;
 const agentEvalDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const resultsDir = path.join(agentEvalDir, 'results');
 
@@ -61,7 +66,7 @@ const artifacts = gh(
 	.split('\n')
 	.filter((line) => line.trim() !== '')
 	.map((line) => JSON.parse(line))
-	.filter(({ name }) => name === ARTIFACT_NAME || name.startsWith(ARTIFACT_PREFIX))
+	.filter(({ name }) => name === ARTIFACT_NAME || PER_RUN_ARTIFACT.test(name))
 	.sort((a, b) => b.created_at.localeCompare(a.created_at))
 	.slice(0, count);
 


### PR DESCRIPTION
The agentic-reference (70x) case matrix has no CI entry point today — only the CORE eval line runs in Actions. This adds one.

Running these cases is a spend decision, so the workflow is `workflow_dispatch`-only: no PR or label trigger, and a human picks the selection each time.

## Inputs

| Input | Purpose |
|---|---|
| `cases` | Space-separated case names or globs; empty runs every case |
| `flows` | Workflow fixtures to narrow to (`AGENTIC_REF_FLOW`) |
| `runs` | Repetitions per (case, workflow) cell (`AGENTIC_REF_RUNS`) |
| `force` | Re-run cells the fingerprint cache marks complete |
| `dry` | Resolve the selection and print the plan without spending |

```
gh workflow run agentic-ref-eval.yml --ref <branch> \
  -f runs=2 -f flows=701-new-ui-flow \
  -f cases="agentic-ref-cc-control-none-opus-high agentic-ref-cc-docs-full-opus-high"
```

## Results

Each dispatch uploads its own `agent-eval-results-<run_id>` artifact, so every triggered run keeps a downloadable snapshot of its own results rather than sharing one name.

That makes artifact names vary, and the artifacts API only filters `name` by exact match, so `download-ci-results.mjs` now pages through artifacts and matches the shared prefix. It still picks up the bare `agent-eval-results` name that `agent-eval.yml` uploads, and results stay keyed by experiment name and timestamp, so snapshots from both workflows merge into `agent-eval/results` without colliding.

A run summary is written to the job summary via the existing `render-results-summary.mjs`.

## Notes

- The workflow needs to exist on the default branch for `workflow_dispatch` to register it; dispatching with `--ref` then runs that ref's version of the file.
- Dispatches queue rather than cancel each other, since a cancelled run discards cells that have already been paid for.
- `timeout-minutes` sits near the hosted-runner ceiling. A large matrix can still outlast it; completed cells are fingerprint-cached, so re-dispatching the same selection resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)