### PR TITLE
Serve the Droppy MCP to the treatment arms

### DIFF
--- a/agent-eval/lib/agentic-reference/cases.ts
+++ b/agent-eval/lib/agentic-reference/cases.ts
@@ -23,9 +23,9 @@ export const AGENTIC_REF_EVALS: string[] = [
 	'706-new-ui-scheduled-flow',
 ];
 
-// The workflows the base-ui Storybook content variants treat; the migration
-// flows are excluded.
-const BASE_UI_APP_WORKFLOWS = AGENTIC_REF_EVALS.filter(
+// The workflows the Storybook content variants treat; the migration flows are
+// excluded.
+const DS_APP_WORKFLOWS = AGENTIC_REF_EVALS.filter(
 	(evalName) => !['705-migrate-to-ds-flow'].includes(evalName),
 );
 
@@ -59,18 +59,22 @@ export interface AgenticRefCase {
 }
 
 // The design-system repo's MCP preview package: its storybook-mcp-preview
-// workflow publishes @storybook-tmp/baseui-mcp (the repo's MCP server with the
-// branch's Storybook manifests baked in) to pkg.pr.new on every push to
-// experiment/*. Cases select a branch; setup pins its head sha,
-// so each experiment runs against one immutable build — unlike the Chromatic
-// branch permalinks these cases previously pointed at.
-const BASE_UI_MCP_PACKAGE = {
-	repo: 'storybook-tmp/base-ui',
-	packageName: '@storybook-tmp/baseui-mcp',
+// workflow publishes @droppy/mcp (the repo's MCP server with the branch's
+// Storybook manifests baked in) to pkg.pr.new on every push to experiment/*.
+// Cases select a branch; setup pins its head sha, so each experiment runs
+// against one immutable build — unlike the Chromatic branch permalinks these
+// cases previously pointed at.
+//
+// The fixtures under evals/ pin a MealDrop built on Droppy, so the served
+// documentation has to be Droppy's: an agent handed another system's docs finds
+// nothing installed under those names and falls back to reading source.
+const DROPPY_MCP_PACKAGE = {
+	repo: 'yannbf/droppy-ds',
+	packageName: '@droppy/mcp',
 } as const;
 
-function baseUiMcpPackage(branch: string): StorybookMcpPackageSpec {
-	return { ...BASE_UI_MCP_PACKAGE, branch };
+function droppyMcpPackage(branch: string): StorybookMcpPackageSpec {
+	return { ...DROPPY_MCP_PACKAGE, branch };
 }
 
 /** Build a case `editPrompt` that appends eval-specific context after the fixture's task prompt. */
@@ -115,9 +119,9 @@ function storybookVariantCases(): AgenticRefCase[] {
 			return {
 				name: `${prefix}-${variant}-${modelSuffix}`,
 				description: `Design-system Storybook MCP served in-sandbox, content variant "${variant}".`,
-				storybookMcpPackage: baseUiMcpPackage(branchName),
+				storybookMcpPackage: droppyMcpPackage(branchName),
 				agent,
-				evals: BASE_UI_APP_WORKFLOWS,
+				evals: DS_APP_WORKFLOWS,
 				editPrompt: appendToPrompt(
 					'This app uses a Design System. Use the Storybook MCP to fetch documentation and API reference for UI components. Abort with an error if the MCP is not reachable.',
 				),

--- a/agent-eval/lib/agentic-reference/local-mcp.test.ts
+++ b/agent-eval/lib/agentic-reference/local-mcp.test.ts
@@ -148,7 +148,36 @@ describe('resolveStorybookMcpPackage', () => {
 		const spec = { ...SPEC, branch: 'experiment/cache-test' };
 		await resolveStorybookMcpPackage(spec);
 		await resolveStorybookMcpPackage(spec);
-		expect(fetchMock).toHaveBeenCalledTimes(1);
+		// One commits-API call plus one publish pre-flight, for the first resolve only.
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('fails when the branch head has no published package', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (input: string | URL | Request, init?: RequestInit) =>
+				init?.method === 'HEAD'
+					? new Response(null, { status: 404 })
+					: new Response(JSON.stringify({ sha: SHA }), { status: 200 }),
+			),
+		);
+
+		await expect(
+			resolveStorybookMcpPackage({ ...SPEC, branch: 'experiment/unpublished-test' }),
+		).rejects.toThrow(/was never published for that commit/);
+	});
+
+	it('lets the download step decide when the pre-flight cannot reach the registry', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+				if (init?.method === 'HEAD') throw new Error('network down');
+				return new Response(JSON.stringify({ sha: SHA }), { status: 200 });
+			}),
+		);
+
+		const spec = { ...SPEC, branch: 'experiment/preflight-offline-test' };
+		await expect(resolveStorybookMcpPackage(spec)).resolves.toEqual({ ...spec, sha: SHA });
 	});
 
 	it('reports the branch and the publish prerequisite on an API error', async () => {

--- a/agent-eval/lib/agentic-reference/local-mcp.ts
+++ b/agent-eval/lib/agentic-reference/local-mcp.ts
@@ -3,7 +3,7 @@
 // preview package — the design-system repo's MCP server with that branch's
 // Storybook manifests baked in, published by its storybook-mcp-preview
 // workflow on every push to research/experiment/* (see
-// storybook-tmp/base-ui/apps/mcp-server). Each run gets a private server, so
+// yannbf/droppy-ds/apps/mcp-server). Each run gets a private server, so
 // parallel runs cannot contend on a remote endpoint; the only external
 // dependency left is the one-time tarball download at setup.
 //
@@ -16,9 +16,9 @@ import { NODE_DOWNLOAD_SCRIPT } from './sandbox-fetch.ts';
 
 /** A design-system MCP preview package published to pkg.pr.new, selected by branch. */
 export interface StorybookMcpPackageSpec {
-	/** GitHub repo the package publishes from, e.g. 'storybook-tmp/base-ui'. */
+	/** GitHub repo the package publishes from, e.g. 'yannbf/droppy-ds'. */
 	repo: string;
-	/** npm package name, e.g. '@storybook-tmp/baseui-mcp'. */
+	/** npm package name, e.g. '@droppy/mcp'. */
 	packageName: string;
 	/** Branch whose latest published commit to serve, e.g. 'experiment/empty'. */
 	branch: string;
@@ -111,8 +111,38 @@ export async function resolveStorybookMcpPackage(
 		);
 	}
 
+	await assertPackagePublished(spec, body.sha);
+
 	resolutionCache.set(resolutionKey(spec), body.sha);
 	return { ...spec, sha: body.sha };
+}
+
+/**
+ * Fail host-side when the branch head has no published package, rather than
+ * letting the sandbox discover it as a download failure after a sandbox has
+ * already been created. A branch that predates the design-system repo's
+ * storybook-mcp-preview workflow resolves to a perfectly good sha whose package
+ * was never built, which is the shape a regenerated experiment branch takes
+ * before its first push.
+ *
+ * Only a definitive 404 fails: any other status, or a transport error, leaves
+ * the decision to the download step, which retries.
+ */
+async function assertPackagePublished(spec: StorybookMcpPackageSpec, sha: string): Promise<void> {
+	const url = packageTarballUrl(spec, sha);
+	let status: number;
+	try {
+		status = (await fetch(url, { method: 'HEAD', signal: AbortSignal.timeout(30_000) })).status;
+	} catch {
+		return;
+	}
+	if (status === 404) {
+		throw new Error(
+			`resolveStorybookMcpPackage: ${spec.repo}@${spec.branch} resolved to ${sha.slice(0, 12)}, ` +
+				`but ${spec.packageName} was never published for that commit (404 at ${url}). ` +
+				`Push the branch so its storybook-mcp-preview workflow publishes, then re-run.`,
+		);
+	}
 }
 
 const DOWNLOAD_ATTEMPTS = 3;


### PR DESCRIPTION
Stacked on `agentic-reference-eval`. Depends on https://github.com/yannbf/droppy-ds/pull/295, which adds the package this points at.

## Why

The fixtures under `agent-eval/evals/70x/` pin `yannbf/mealdrop@refs/tags/agentic-reference/droppy-v2`, whose only design-system dependency is `@droppy/design-system`. The variant cases registered `@storybook-tmp/baseui-mcp`, so the treatment arms served documentation for a library the project does not install.

It is visible in the last run's transcripts (`agentic-ref-cc-docs-full-opus-high`, run 1, events 22-25): `get-documentation {"id":"actions-button"}` returns `import { Button } from "@base-ui/react/button"`, the agent runs `ls node_modules/@base-ui… || echo "NO @base-ui"`, then falls back to `sed -n '30,60p' …/@droppy/design-system/dist/index.d.ts`. All four documentation calls per run resolved to Base UI ids, against an `editPrompt` instructing the agent to use the MCP for API reference. A treatment measured that way reports the MCP as unhelpful for a wiring reason.

## What

- `DROPPY_MCP_PACKAGE` (`yannbf/droppy-ds` / `@droppy/mcp`) replaces `BASE_UI_MCP_PACKAGE`; `BASE_UI_APP_WORKFLOWS` becomes `DS_APP_WORKFLOWS`. Branch names, facet lists and case names are unchanged, so results directories and fingerprints keep their shape.
- `resolveStorybookMcpPackage` now fails host-side when the resolved branch head has no published package. Only a definitive 404 fails; any other status or a transport error defers to the download step, which retries.

## Sequencing

The `experiment/*` branches on `yannbf/droppy-ds` were frozen before the MCP server existed, so no package is published for their current heads. After droppy-ds#295 merges, regenerate the branches (`pnpm experiment:freeze` from the new `main`, then `pnpm experiment:publish-branches`); each push publishes that branch's package. Until then the new pre-flight reports it directly:

```
resolveStorybookMcpPackage: yannbf/droppy-ds@experiment/docs-full resolved to 56bb97074342,
but @droppy/mcp was never published for that commit (404 at https://pkg.pr.new/…).
Push the branch so its storybook-mcp-preview workflow publishes, then re-run.
```

## Verification

`pnpm --dir agent-eval typecheck`, `pnpm lint` (0 errors), `pnpm format:check` (900 files) and the agentic-reference suite (417 tests, 17 files) all pass. `pnpm eval:agentic-ref:dry` resolves the same 3 cases × 5 workflows as before.

Serving droppy-ds#295's package from a packed tarball, `get-documentation` for `actions-button` returns 15,128 characters containing `import { Button } from "@droppy/design-system"` and no `@base-ui/react`.