### PR TITLE
Make the ds-misuse judge runnable and its cost visible

### DIFF
--- a/agent-eval/lib/agentic-reference/metrics/ds-misuse/index.test.ts
+++ b/agent-eval/lib/agentic-reference/metrics/ds-misuse/index.test.ts
@@ -213,4 +213,40 @@ describe('judgeRun', () => {
 		expect(report).toBeNull();
 		expect(RUN_JUDGE).not.toHaveBeenCalled();
 	});
+
+	it('carries the judge’s nodes and what the call cost into the report', async () => {
+		const before = mkdtempSync(join(runDir, 'before-'));
+		const after = mkdtempSync(join(runDir, 'after-'));
+		writeFileSync(join(before, 'App.tsx'), 'export const App = () => <div />\n');
+		writeFileSync(join(after, 'App.tsx'), 'export const App = () => <section />\n');
+
+		const node = {
+			path: 'App/section[0]',
+			file: 'App.tsx',
+			line: 1,
+			tag: 'section',
+			kind: 'ds',
+			correctDsDecision: { score: 1, reason: 'right component' },
+			correctDsUsage: { score: 1, reason: 'no violation' },
+		};
+		const usage = { input: 12, cacheWrite: 0, cacheRead: 105_919, output: 4_096 };
+		RUN_JUDGE.mockResolvedValue({ response: { nodes: [node] }, usage });
+
+		const written = await judgeRun({
+			runDir,
+			projectDir: after,
+			baselineDir: before,
+			baselineNodes: [],
+			dsPackages: ['@droppy/*'],
+			fixtureRef: 'owner/name@ref',
+			metricsVersion: 7,
+			refCacheDir: join(runDir, 'refs'),
+		});
+
+		expect(written?.nodes).toEqual([node]);
+		// Without this the artifact cannot tell a cached corpus from a rewritten
+		// one, which is the only reason the counts are kept at all.
+		expect(written?.usage).toEqual(usage);
+		expect(written?.summary.evaluated).toEqual({ ds: 1, local: 0 });
+	});
 });

--- a/agent-eval/lib/agentic-reference/metrics/ds-misuse/index.ts
+++ b/agent-eval/lib/agentic-reference/metrics/ds-misuse/index.ts
@@ -159,9 +159,10 @@ export async function judgeRun(input: JudgeRunInput): Promise<DsMisuseReport | n
 		dsGuidelinesRef: dsDocsRefLabel(),
 		fixtureRef: input.fixtureRef,
 		diffTruncated: patch.truncated,
-		summary: summariseJudgement(judged.nodes),
+		usage: judged.usage,
+		summary: summariseJudgement(judged.response.nodes),
 		// The buckets travel with the scores: the judge chose them, so a surprising
 		// number has to be traceable to what it actually counted.
-		nodes: judged.nodes,
+		nodes: judged.response.nodes,
 	};
 }

--- a/agent-eval/lib/agentic-reference/metrics/ds-misuse/judge.test.ts
+++ b/agent-eval/lib/agentic-reference/metrics/ds-misuse/judge.test.ts
@@ -9,7 +9,7 @@ vi.mock('@anthropic-ai/sdk', () => ({
 	},
 }));
 
-import { runJudge, type JudgeRequest } from './judge.ts';
+import { isAccountFailure, runJudge, type JudgeRequest } from './judge.ts';
 
 const REQUEST = {
 	model: 'claude-opus-4-8',
@@ -40,8 +40,33 @@ describe('runJudge', () => {
 		FINAL_MESSAGE.mockResolvedValue({
 			stop_reason: 'end_turn',
 			content: [{ type: 'text', text: JSON.stringify({ nodes: [node] }) }],
+			usage: {
+				input_tokens: 12,
+				cache_creation_input_tokens: 34,
+				cache_read_input_tokens: 56,
+				output_tokens: 78,
+			},
 		});
-		await expect(runJudge(REQUEST)).resolves.toEqual({ nodes: [node] });
+		await expect(runJudge(REQUEST)).resolves.toEqual({
+			response: { nodes: [node] },
+			usage: { input: 12, cacheWrite: 34, cacheRead: 56, output: 78 },
+		});
+	});
+
+	// The cache fields are absent rather than zero on a response that used no
+	// caching, and a missing count must read as none rather than as NaN — the
+	// whole point of recording them is to tell a cache read from a rewrite.
+	it('reads absent cache counts as zero', async () => {
+		process.env.ANTHROPIC_API_KEY = 'sk-test';
+		FINAL_MESSAGE.mockResolvedValue({
+			stop_reason: 'end_turn',
+			content: [{ type: 'text', text: '{"nodes":[]}' }],
+			usage: { input_tokens: 5, output_tokens: 7 },
+		});
+		await expect(runJudge(REQUEST)).resolves.toEqual({
+			response: { nodes: [] },
+			usage: { input: 5, cacheWrite: 0, cacheRead: 0, output: 7 },
+		});
 	});
 
 	// A refusal returns HTTP 200 with no usable content. Reading content[0] blindly
@@ -59,6 +84,27 @@ describe('runJudge', () => {
 			content: [{ type: 'text', text: '{"nodes":[' }],
 		});
 		await expect(runJudge(REQUEST)).rejects.toThrow(/max_tokens/);
+	});
+});
+
+describe('isAccountFailure', () => {
+	it.each([
+		'ds-misuse: ANTHROPIC_API_KEY is not set, and the judge cannot run without it.',
+		'400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API."}}',
+		'401 {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}',
+		'403 {"type":"error","error":{"type":"permission_error","message":"not allowed"}}',
+	])('stops the sweep on %s', (message) => {
+		expect(isAccountFailure(message)).toBe(true);
+	});
+
+	// These are failures of one run. Treating them as account failures would
+	// abandon every run after the first awkward diff.
+	it.each([
+		'ds-misuse: the judge hit max_tokens and returned incomplete JSON.',
+		'ds-misuse: the judge refused this request (no category).',
+		'529 {"type":"error","error":{"type":"overloaded_error"}}',
+	])('keeps going on %s', (message) => {
+		expect(isAccountFailure(message)).toBe(false);
 	});
 });
 

--- a/agent-eval/lib/agentic-reference/metrics/ds-misuse/judge.ts
+++ b/agent-eval/lib/agentic-reference/metrics/ds-misuse/judge.ts
@@ -6,7 +6,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 
 import type { buildJudgeRequest } from './context.ts';
-import type { JudgeResponse } from './types.ts';
+import type { JudgeResponse, JudgeUsage } from './types.ts';
 
 /** Exactly what buildJudgeRequest produces, so no cast is needed at the call site. */
 export type JudgeRequest = ReturnType<typeof buildJudgeRequest>;
@@ -25,12 +25,35 @@ export function assertApiKey(): void {
 }
 
 /**
- * Call the judge and return its structured answer.
+ * Whether a failure belongs to the account rather than to the run being judged.
+ *
+ * An exhausted balance arrives as an ordinary per-run error — the API reports it
+ * as a 400 on whichever request happened to hit it, not as a distinct status —
+ * so a caller that treats it as one bad run walks the rest of the selection into
+ * the same wall, one paid attempt at a time. Matched on the message because that
+ * is all the SDK's error carries by the time a caller sees it.
+ */
+export function isAccountFailure(message: string): boolean {
+	return (
+		message.includes('ANTHROPIC_API_KEY') ||
+		message.includes('credit balance') ||
+		message.includes('authentication_error') ||
+		message.includes('permission_error')
+	);
+}
+
+export interface JudgeResult {
+	response: JudgeResponse;
+	usage: JudgeUsage;
+}
+
+/**
+ * Call the judge and return its structured answer, with what the call cost.
  *
  * The response is schema-constrained by output_config.format, so the only
  * failures worth naming are the ones that produce no usable content at all.
  */
-export async function runJudge(request: JudgeRequest): Promise<JudgeResponse> {
+export async function runJudge(request: JudgeRequest): Promise<JudgeResult> {
 	assertApiKey();
 	const client = new Anthropic();
 
@@ -60,5 +83,13 @@ export async function runJudge(request: JudgeRequest): Promise<JudgeResponse> {
 		);
 	}
 
-	return JSON.parse(text.text) as JudgeResponse;
+	return {
+		response: JSON.parse(text.text) as JudgeResponse,
+		usage: {
+			input: message.usage.input_tokens,
+			cacheWrite: message.usage.cache_creation_input_tokens ?? 0,
+			cacheRead: message.usage.cache_read_input_tokens ?? 0,
+			output: message.usage.output_tokens,
+		},
+	};
 }

--- a/agent-eval/lib/agentic-reference/metrics/ds-misuse/judge.ts
+++ b/agent-eval/lib/agentic-reference/metrics/ds-misuse/judge.ts
@@ -25,13 +25,10 @@ export function assertApiKey(): void {
 }
 
 /**
- * Whether a failure belongs to the account rather than to the run being judged.
- *
- * An exhausted balance arrives as an ordinary per-run error — the API reports it
- * as a 400 on whichever request happened to hit it, not as a distinct status —
- * so a caller that treats it as one bad run walks the rest of the selection into
- * the same wall, one paid attempt at a time. Matched on the message because that
- * is all the SDK's error carries by the time a caller sees it.
+ * Whether a failure belongs to the account rather than to the run being
+ * judged. If the judge runs out of credit, there's no point in continuing
+ * to try to judge. We must abort the run. So account-related failures
+ * must be isolated.
  */
 export function isAccountFailure(message: string): boolean {
 	return (

--- a/agent-eval/lib/agentic-reference/metrics/ds-misuse/types.ts
+++ b/agent-eval/lib/agentic-reference/metrics/ds-misuse/types.ts
@@ -54,12 +54,6 @@ export interface JudgeResponse {
 /**
  * What one judge call cost, in the four token classes that are priced
  * differently.
- *
- * Recorded because the guideline corpus is the whole cost story and there is no
- * other way to see it: a request that reads the corpus from cache and one that
- * rewrites it differ by about twentyfold, and are indistinguishable from the
- * scores alone. `cacheRead` near zero on a second run against an unchanged pin
- * means the prefix is being rewritten every time.
  */
 export interface JudgeUsage {
 	input: number;

--- a/agent-eval/lib/agentic-reference/metrics/ds-misuse/types.ts
+++ b/agent-eval/lib/agentic-reference/metrics/ds-misuse/types.ts
@@ -82,12 +82,7 @@ export interface DsMisuseReport {
 	/** `repo@ref` of the tree the run worked on. */
 	fixtureRef: string;
 	diffTruncated: boolean;
-	/**
-	 * What the call cost. Absent on artifacts written before this was recorded,
-	 * which is why it is optional rather than a schema-version bump: the scores in
-	 * those artifacts are still valid, and re-judging to acquire a token count
-	 * would cost more than the count is worth.
-	 */
+  /** Helps understand the cost structure of the LLM judge. */
 	usage?: JudgeUsage;
 	summary: DsMisuseSummary;
 	nodes: JudgedNode[];

--- a/agent-eval/lib/agentic-reference/metrics/ds-misuse/types.ts
+++ b/agent-eval/lib/agentic-reference/metrics/ds-misuse/types.ts
@@ -51,6 +51,23 @@ export interface JudgeResponse {
 	nodes: JudgedNode[];
 }
 
+/**
+ * What one judge call cost, in the four token classes that are priced
+ * differently.
+ *
+ * Recorded because the guideline corpus is the whole cost story and there is no
+ * other way to see it: a request that reads the corpus from cache and one that
+ * rewrites it differ by about twentyfold, and are indistinguishable from the
+ * scores alone. `cacheRead` near zero on a second run against an unchanged pin
+ * means the prefix is being rewritten every time.
+ */
+export interface JudgeUsage {
+	input: number;
+	cacheWrite: number;
+	cacheRead: number;
+	output: number;
+}
+
 export interface DsMisuseSummary {
 	/** Mean over DS nodes, or null when none were evaluated. */
 	correctDsDecision: number | null;
@@ -71,6 +88,13 @@ export interface DsMisuseReport {
 	/** `repo@ref` of the tree the run worked on. */
 	fixtureRef: string;
 	diffTruncated: boolean;
+	/**
+	 * What the call cost. Absent on artifacts written before this was recorded,
+	 * which is why it is optional rather than a schema-version bump: the scores in
+	 * those artifacts are still valid, and re-judging to acquire a token count
+	 * would cost more than the count is worth.
+	 */
+	usage?: JudgeUsage;
 	summary: DsMisuseSummary;
 	nodes: JudgedNode[];
 }

--- a/agent-eval/package.json
+++ b/agent-eval/package.json
@@ -20,7 +20,7 @@
 		"playground:check-routes": "node ./scripts/check-playground-routes.mjs",
 		"results:download": "node ./scripts/download-ci-results.mjs",
 		"results:analyze": "pnpm gen:agentic-ref && node ./scripts/analyze-results.ts",
-		"judge:ds-misuse": "node ./scripts/judge-ds-misuse.ts",
+		"judge:ds-misuse": "pnpm gen:agentic-ref && node --env-file-if-exists=.env.local ./scripts/judge-ds-misuse.ts",
 		"test": "vitest",
 		"test:run": "vitest run",
 		"test:coverage": "vitest run --coverage",

--- a/agent-eval/scripts/judge-ds-misuse.ts
+++ b/agent-eval/scripts/judge-ds-misuse.ts
@@ -51,7 +51,7 @@ import {
 	readMisuseReport,
 	writeMisuseReport,
 } from '#lib/agentic-reference/metrics/ds-misuse/index';
-import { assertApiKey } from '#lib/agentic-reference/metrics/ds-misuse/judge';
+import { assertApiKey, isAccountFailure } from '#lib/agentic-reference/metrics/ds-misuse/judge';
 import { selectionFlags } from '#lib/agentic-reference/selection';
 import { readDsCoverageNodeList } from '#lib/post-analysis/baseline';
 import {
@@ -112,7 +112,10 @@ async function judgeOne(
 	postAnalysis: PostAnalysis,
 	options: Options,
 ): Promise<'judged' | 'reused' | 'skipped'> {
-	const label = `${run.experiment}/${run.evalName}/run-${run.run}`;
+	// The timestamp is part of the address, not decoration: one experiment can hold
+	// several result directories, each with its own run-1, and a label without it
+	// names two different runs identically.
+	const label = `${run.experiment}/${run.timestamp}/${run.evalName}/run-${run.run}`;
 
 	const pin = pinOfResult(readJson(join(run.runDir, 'result.json')));
 	if (pin === null) {
@@ -214,12 +217,16 @@ async function main() {
 		try {
 			counts[await judgeOne(run, postAnalysis, options)] += 1;
 		} catch (error) {
-			// One broken run must not cost us the others — but an absent API key
-			// will fail every remaining run identically, so stop on it.
+			// One broken run must not cost us the others — but a failure of the
+			// account rather than of the run will repeat identically on every run
+			// left, so stop on it rather than walking the whole selection into the
+			// same wall.
 			counts.failed += 1;
 			const message = messageOf(error);
-			console.error(`${run.experiment}/${run.evalName}/run-${run.run}: ${message}`);
-			if (message.includes('ANTHROPIC_API_KEY')) throw error;
+			console.error(
+				`${run.experiment}/${run.timestamp}/${run.evalName}/run-${run.run}: ${message}`,
+			);
+			if (isAccountFailure(message)) throw error;
 		}
 	}
 


### PR DESCRIPTION
Found while exercising #398's judge against the 13–15 Aug runs. Four fixes, all small; the first two are the ones that block using the metric.

### `pnpm judge:ds-misuse` could not be run as documented

Two separate reasons, both silent:

- **`.env.local` was never loaded.** The script's header comment says it runs under `node --env-file-if-exists=.env.local`, and justifies it at length — without the flag the missing-key abort would name a fix that does not work. The package script was a plain `node ./scripts/…`. So it named exactly that fix: put the key in `agent-eval/.env.local`, follow the advice, get the same error. Only `export` worked.
- **`gen:agentic-ref` was never run**, unlike `results:analyze`. On a checkout without the generated experiment definitions, every agentic-reference run resolves no `postAnalysis` and is skipped — `Skipped 5 runs whose experiment carries no postAnalysis.`, exit 0, nothing judged. Correct behaviour for a deleted arm, misleading for one that was simply never generated.

### The cost was unmeasurable

The PR asks reviewers to "check `usage.cache_read_input_tokens` on the second run to confirm the ~95k-token doc prefix is being read rather than rewritten". `runJudge` discarded `message.usage` and `DsMisuseReport` had no field for it, so that check could not be performed from anything the judge stored.

The four token counts now travel in the artifact. `usage` is optional rather than a `schemaVersion` bump: artifacts written before this carry valid scores, and re-judging one to acquire a token count costs more than the count is worth.

### An exhausted balance did not stop the sweep

A missing API key stops it, on the stated reasoning that it "will fail every remaining run identically". A spent balance is identical in that respect but arrives as a 400 on whichever request happened to hit it, so it was treated as one bad run. Observed: five runs attempted, five identical `credit balance is too low` failures. `isAccountFailure` covers missing key, spent balance, auth and permission errors; genuine per-run failures (`max_tokens`, refusal, `overloaded_error`) still let the sweep continue.

### Run labels were ambiguous

One experiment can hold several result directories, each with its own `run-1`. Labels omitted the timestamp, so `agentic-ref-cc-full-opus-high/703-fix-bug-flow/run-1` named two different runs and an error line could not be traced to a directory. `Run` already carries `timestamp`; the label now uses it.

### Tests

`judgeRun`'s happy path had no test — only the null-patch path did — so the report assembly this touches was uncovered. Added, plus the usage mapping (including absent cache fields reading as `0`, not `NaN`) and the account-failure classification.

778 passing, typecheck clean, lint clean, formatted.

### Still not exercised

**No real API call has been made here either.** Both the AI Gateway and the Anthropic account were out of credit on 17 Aug, so the judge's first live run is still ahead. What these fixes do is make that run possible and make its cost legible when it happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)